### PR TITLE
Add managed Bash/Zsh startup files and document shell bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,97 @@ The wrapper model matters because it keeps command behavior predictable. A CLI
 should run inside a known environment instead of relying on whoever happened to
 invoke it from whatever shell state they already had.
 
+## Shell Startup Files
+
+Base now ships managed startup files under `lib/` for both Bash and Zsh:
+
+- `lib/bash_profile`
+- `lib/bashrc`
+- `lib/zprofile`
+- `lib/zshrc`
+
+The division of responsibility is intentional.
+
+### Login Profiles
+
+`bash_profile` and `zprofile` should stay thin.
+
+They are responsible for:
+
+- one-time setup for a login shell
+- handing off to the interactive rc file
+
+They should not be the main place for aliases, prompt settings, shell editing
+mode, completion, or project activation logic.
+
+### Interactive RC Files
+
+`bashrc` and `zshrc` are where interactive shell behavior belongs.
+
+They are responsible for:
+
+- guarding against non-interactive execution
+- guarding against repeated sourcing
+- locating `BASE_HOME`
+- sourcing `~/.baserc` for machine-local overrides
+- sourcing `base_init.sh`
+- optionally enabling shared shell defaults
+
+This is where Base becomes active for day-to-day terminal use.
+
+### Standard Shell Defaults
+
+Reusable, opinionated shell defaults should live outside the profile files
+themselves.
+
+Current default-setting scripts are:
+
+- `lib/base_defaults.sh` for Bash
+- `lib/zsh_defaults.sh` for Zsh
+
+These are intentionally optional. Users can opt in by setting:
+
+```bash
+BASE_ENABLE_SHELL_DEFAULTS=true
+```
+
+in `~/.baserc`.
+
+That keeps the startup files focused on shell bootstrap while letting Base also
+house standard interactive settings such as:
+
+- aliases like `rm -i`, `cp -i`, `mv -i`
+- vi-style command editing
+- editor defaults
+- prompt defaults
+- history behavior
+
+### Machine-Local Overrides
+
+`~/.baserc` is the right place for machine-local settings that should not be
+hard-coded into the shared startup files, such as:
+
+- `BASE_HOME`
+- `BASE_ENABLE_SHELL_DEFAULTS`
+- host-specific overrides
+- local experimental toggles
+
+### Adoption
+
+The expected setup is to symlink your shell startup files to the Base-managed
+versions:
+
+```bash
+ln -sf /path/to/base/lib/bash_profile ~/.bash_profile
+ln -sf /path/to/base/lib/bashrc ~/.bashrc
+ln -sf /path/to/base/lib/zprofile ~/.zprofile
+ln -sf /path/to/base/lib/zshrc ~/.zshrc
+```
+
+When the files are symlinked, the rc files can infer `BASE_HOME` from their own
+resolved path. When they are copied instead of symlinked, `~/.baserc` should
+set `BASE_HOME` explicitly.
+
 ## What Base Is Responsible For
 
 Base owns the shared developer-platform layer of the workspace.

--- a/base_init.sh
+++ b/base_init.sh
@@ -1,33 +1,63 @@
 #!/usr/bin/env bash
 
 #
-# base_init.sh: top level script that should be sourced in by login/interactive shells
+# base_init.sh
+#     Shared Base shell bootstrap loaded after the shell-specific startup files
+#     have already decided that Base should be activated for the current shell.
 #
-# lib/bashrc invokes this
+# Purpose:
+#     - validate the current shell/runtime expectations
+#     - establish Base-wide environment variables such as BASE_HOME, BASE_OS,
+#       BASE_HOST, and BASE_SOURCES
+#     - source shared libraries and optional team/user/company layers
+#     - extend PATH with Base-managed command directories
+#
+# Call chain:
+#     lib/bashrc or lib/zshrc
+#         -> lib/shell_startup.sh
+#             -> base_init.sh
+#
+# What belongs here:
+#     - shell-agnostic Base bootstrap logic
+#     - shared environment and library loading
+#     - Base-level path management and activation rules
+#
+# What does not belong here:
+#     - aliases, prompts, keybindings, or other interactive shell cosmetics
+#       (those belong in base_defaults.sh / zsh_defaults.sh or user-specific
+#       startup files)
+#
+# See also:
+#     README.md section "Shell Startup Files"
 #
 
 [[ $__base_init_sourced__ ]] && return
 __base_init_sourced__=1
 
-check_bash_version() {
+check_shell_version() {
     local major=${1:-4}
-    local minor=$2
+    local minor=${2:-2}
     local rc=0
     local num_re='^[0-9]+$'
 
-    if [[ ! $major =~ $num_re ]] || [[ $minor && ! $minor =~ $num_re ]]; then
+    if [[ -n "${ZSH_VERSION:-}" ]]; then
+        return 0
+    fi
+
+    if [[ -z "${BASH_VERSION:-}" ]]; then
+        printf '%s\n' "ERROR: Unsupported shell - need Bash or zsh" >&2
+        return 1
+    fi
+
+    if [[ ! $major =~ $num_re ]] || [[ ! $minor =~ $num_re ]]; then
         printf '%s\n' "ERROR: version numbers should be numeric"
         return 1
     fi
-    if [[ $minor ]]; then
-        local bv=${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}
-        local vstring=$major.$minor
-        local vnum=$major$minor
-    else
-        local bv=${BASH_VERSINFO[0]}
-        local vstring=$major
-        local vnum=$major
-    fi
+
+    local bv=${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}
+    local vstring=$major.$minor
+    local vnum=$major$minor
+
     ((bv < vnum)) && {
         printf '%s\n' "ERROR: Base needs Bash version $vstring or above, your version is ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
         rc=1
@@ -43,11 +73,8 @@ do_init() {
         base_debug() { [[ $BASE_DEBUG ]] && printf '%(%Y-%m-%d:%H:%M:%S)T %s\n' -1 "DEBUG ${BASH_SOURCE[0]}:${BASH_LINENO[1]} $@" >&2; }
         base_error() {                      printf '%(%Y-%m-%d:%H:%M:%S)T %s\n' -1 "ERROR ${BASH_SOURCE[0]}:${BASH_LINENO[1]} $@" >&2; }
     elif [[ $ZSH_VERSION ]]; then
-        #
-        # for zsh - it doesn't support time in printf
-        #
-        base_debug() { [[ $BASE_DEBUG ]] && printf '%s\n' "$(date) DEBUG ${BASH_SOURCE[0]}:${BASH_LINENO[1]} $@" >&2; }
-        base_error() {                      printf '%s\n' "$(date) ERROR ${BASH_SOURCE[0]}:${BASH_LINENO[1]} $@" >&2; }
+        base_debug() { [[ $BASE_DEBUG ]] && printf '%s\n' "$(date) DEBUG base_init.sh $*" >&2; }
+        base_error() {                      printf '%s\n' "$(date) ERROR base_init.sh $*" >&2; }
     else
         printf '%s\n' "ERROR: Unsupported shell - need Bash or zsh" >&2
         rc=1
@@ -147,7 +174,7 @@ base_update() (
 )
 
 base_main() {
-    check_bash_version 4 2 || return $?
+    check_shell_version 4 2 || return $?
     do_init || return $?
     [[ $- = *i* ]] && _interactive=1 || _interactive=0
     set_base_home
@@ -161,7 +188,9 @@ base_main() {
     #
     # these functions need to be available to user's subprocesses
     #
-    export -f base_update import
+    if [[ -n "${BASH_VERSION:-}" ]]; then
+        export -f base_update import
+    fi
 }
 
 #

--- a/lib/base_defaults.sh
+++ b/lib/base_defaults.sh
@@ -1,6 +1,33 @@
 #
 # base_defaults.sh
+#     Optional Bash-specific interactive defaults for users who want Base to
+#     provide a standard shell experience in addition to the core bootstrap.
 #
+# Purpose:
+#     - define a conservative shared set of aliases, editor defaults, prompt
+#       settings, and history behavior for interactive Bash shells
+#
+# How it is loaded:
+#     - sourced indirectly from lib/shell_startup.sh
+#     - only when BASE_ENABLE_SHELL_DEFAULTS=true
+#     - only for interactive Bash shells
+#
+# What belongs here:
+#     - aliases such as rm -i / cp -i / mv -i
+#     - editor and command-line editing defaults
+#     - prompt defaults
+#     - history-related shell options
+#
+# What does not belong here:
+#     - BASE_HOME discovery
+#     - sourcing of base_init.sh
+#     - login-shell orchestration
+#     - machine-specific overrides (those belong in ~/.baserc)
+#
+# See also:
+#     README.md section "Shell Startup Files"
+#
+[[ $- != *i* ]] && return 0
 
 ###
 ### Aliases
@@ -13,7 +40,8 @@ alias mv='mv -i'
 ### Command editing
 ###
 set -o vi
-export EDITOR=vi
+export EDITOR="${EDITOR:-vi}"
+export VISUAL="${VISUAL:-$EDITOR}"
 
 ###
 ### vi/vim

--- a/lib/bash_profile
+++ b/lib/bash_profile
@@ -1,40 +1,7 @@
-#
-# .bash_profile
-#
+[[ -n "${__base_bash_profile_sourced__:-}" ]] && return 0
+readonly __base_bash_profile_sourced__=1
 
-do_init() {
-    [[ -f $HOME/.base_debug ]] && export BASE_DEBUG=1
-    base_debug() {
-        [[ $BASE_DEBUG ]] &&
-            printf '%(%Y-%m-%d:%H:%M:%S)T %s\n' -1 "DEBUG ${BASH_SOURCE[0]}:$LINENO $@" >&2
-    }
-    base_debug "Running .bash_profile"
-}
+[[ -f "$HOME/.bashrc" ]] || return 0
 
-#
-# Source global profile
-#
-source_global_profile() {
-    if shopt -q login_shell; then
-        local global_profile=/etc/profile
-        if [[ -f $global_profile ]]; then
-            base_debug "Sourcing $global_profile"
-            source "$global_profile"
-        fi
-    fi
-}
-
-#
-# Source .bashrc
-#
-source_bashrc() {
-    local bashrc=$HOME/.bashrc
-    if [[ -f $bashrc ]]; then
-        base_debug "Invoking $bashrc from .bash_profile"
-        source "$bashrc"
-    fi
-}
-
-do_init
-source_global_profile
-source_bashrc
+# shellcheck source=/dev/null
+source "$HOME/.bashrc"

--- a/lib/shell_startup.sh
+++ b/lib/shell_startup.sh
@@ -1,0 +1,50 @@
+[[ -n "${__base_shell_startup_sourced__:-}" ]] && return 0
+readonly __base_shell_startup_sourced__=1
+
+base_shell_error() {
+    printf 'ERROR: %s\n' "$*" >&2
+}
+
+base_shell_source_defaults() {
+    local shell_name="$1"
+    local defaults_script=""
+
+    [[ "${BASE_ENABLE_SHELL_DEFAULTS:-false}" == true ]] || return 0
+
+    case "$shell_name" in
+        bash) defaults_script="$BASE_HOME/lib/base_defaults.sh" ;;
+        zsh)  defaults_script="$BASE_HOME/lib/zsh_defaults.sh" ;;
+        *)
+            base_shell_error "Unknown shell '$shell_name' for default settings."
+            return 1
+            ;;
+    esac
+
+    [[ -f "$defaults_script" ]] || return 0
+
+    # shellcheck source=/dev/null
+    source "$defaults_script"
+}
+
+base_shell_source_base_init() {
+    local script="$BASE_HOME/base_init.sh"
+
+    [[ -n "${BASE_HOME:-}" ]] || {
+        base_shell_error "BASE_HOME is not set."
+        return 1
+    }
+    [[ -f "$script" ]] || {
+        base_shell_error "Base init script '$script' was not found."
+        return 1
+    }
+
+    # shellcheck source=/dev/null
+    source "$script"
+}
+
+base_shell_startup_interactive() {
+    local shell_name="$1"
+
+    base_shell_source_defaults "$shell_name" || return 1
+    base_shell_source_base_init || return 1
+}

--- a/lib/zprofile
+++ b/lib/zprofile
@@ -1,0 +1,34 @@
+#
+# .zprofile
+#     Base-managed login startup file for Zsh.
+#
+# Purpose:
+#     - stay intentionally thin
+#     - run in login Zsh shells
+#     - hand off to ~/.zshrc so that interactive setup happens in one place
+#
+# Expected usage:
+#     symlink ~/.zprofile -> /path/to/base/lib/zprofile
+#
+# What belongs here:
+#     - login-shell bridging into ~/.zshrc
+#
+# What does not belong here:
+#     - aliases, prompts, keybindings, completion setup, or Base activation
+#       logic beyond the handoff to ~/.zshrc
+#
+# Design note:
+#     Keeping zprofile small makes the startup chain easier to reason about and
+#     keeps interactive behavior centralized in lib/zshrc.
+#
+# See also:
+#     lib/zshrc
+#     README.md section "Shell Startup Files"
+#
+[[ -n "${__base_zprofile_sourced__:-}" ]] && return 0
+readonly __base_zprofile_sourced__=1
+
+[[ -f "$HOME/.zshrc" ]] || return 0
+
+# shellcheck source=/dev/null
+source "$HOME/.zshrc"

--- a/lib/zsh_defaults.sh
+++ b/lib/zsh_defaults.sh
@@ -1,0 +1,48 @@
+#
+# zsh_defaults.sh
+#     Optional Zsh-specific interactive defaults for users who want Base to
+#     provide a standard Zsh experience on top of the shared Base bootstrap.
+#
+# Purpose:
+#     - define a conservative shared set of aliases, editor defaults,
+#       keybindings, prompt settings, and history behavior for interactive Zsh
+#       shells
+#
+# How it is loaded:
+#     - sourced indirectly from lib/shell_startup.sh
+#     - only when BASE_ENABLE_SHELL_DEFAULTS=true
+#     - only for interactive Zsh shells
+#
+# What belongs here:
+#     - aliases such as rm -i / cp -i / mv -i
+#     - bindkey/editor preferences
+#     - prompt defaults
+#     - history-related zsh options
+#
+# What does not belong here:
+#     - BASE_HOME discovery
+#     - sourcing of base_init.sh
+#     - login-shell orchestration
+#     - machine-specific overrides (those belong in ~/.baserc)
+#
+# See also:
+#     README.md section "Shell Startup Files"
+#
+[[ ! -o interactive ]] && return 0
+
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
+bindkey -v
+export EDITOR="${EDITOR:-vi}"
+export VISUAL="${VISUAL:-$EDITOR}"
+
+export HISTSIZE="${HISTSIZE:-5000}"
+export SAVEHIST="${SAVEHIST:-5000}"
+setopt appendhistory
+setopt hist_ignore_dups
+setopt hist_ignore_all_dups
+setopt share_history
+
+PROMPT='%* %m %1~: '

--- a/lib/zshrc
+++ b/lib/zshrc
@@ -1,9 +1,43 @@
-[[ $- != *i* ]] && return 0
-[[ -n "${__base_bashrc_sourced__:-}" ]] && return 0
-readonly __base_bashrc_sourced__=1
+#
+# .zshrc
+#     Base-managed interactive Zsh startup file.
+#
+# Purpose:
+#     - run only for interactive Zsh shells
+#     - guard against repeated sourcing
+#     - determine BASE_HOME from ~/.baserc or from the resolved path of this
+#       file when it is symlinked from the user's home directory
+#     - hand off to lib/shell_startup.sh, which applies optional shell defaults
+#       and then sources base_init.sh
+#
+# Expected usage:
+#     symlink ~/.zshrc -> /path/to/base/lib/zshrc
+#
+# What belongs here:
+#     - interactive-shell guards
+#     - BASE_HOME discovery for Zsh
+#     - loading the shared Base shell bootstrap
+#
+# What does not belong here:
+#     - login-only behavior (that belongs in lib/zprofile)
+#     - large sets of aliases or prompt customizations
+#       (those belong in zsh_defaults.sh or user-specific files)
+#
+# See also:
+#     lib/zprofile
+#     lib/shell_startup.sh
+#     base_init.sh
+#     README.md section "Shell Startup Files"
+#
+[[ ! -o interactive ]] && return 0
+[[ -n "${__base_zshrc_sourced__:-}" ]] && return 0
+readonly __base_zshrc_sourced__=1
 
-base_bashrc_source_path() {
-    local source_path="${BASH_SOURCE[0]}" link_dir target
+base_zshrc_source_path() {
+    local source_path link_dir target
+
+    source_path="$(eval 'printf "%s\n" "${(%):-%x}"')" || return 1
+    [[ -n "$source_path" ]] || return 1
 
     while [[ -L "$source_path" ]]; do
         link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
@@ -19,10 +53,10 @@ base_bashrc_source_path() {
     printf '%s/%s\n' "$link_dir" "$(basename "$source_path")"
 }
 
-base_bashrc_set_base_home() {
+base_zshrc_set_base_home() {
     local source_path lib_dir candidate
 
-    source_path="$(base_bashrc_source_path)" || return 1
+    source_path="$(base_zshrc_source_path)" || return 1
     lib_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
     candidate="$(cd -- "$lib_dir/.." && pwd -P)" || return 1
 
@@ -47,9 +81,7 @@ base_bashrc_set_base_home() {
     export BASE_HOME
 }
 
-[[ -f /etc/bashrc ]] && source /etc/bashrc
-
-base_bashrc_set_base_home || {
+base_zshrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME.\n' >&2
     return 1
 }
@@ -61,8 +93,8 @@ base_bashrc_set_base_home || {
 
 # shellcheck source=/dev/null
 source "$BASE_HOME/lib/shell_startup.sh"
-base_shell_startup_interactive bash || return 1
+base_shell_startup_interactive zsh || return 1
 
-unset -f base_bashrc_source_path base_bashrc_set_base_home
+unset -f base_zshrc_source_path base_zshrc_set_base_home
 unset -f base_shell_error base_shell_source_defaults
 unset -f base_shell_source_base_init base_shell_startup_interactive


### PR DESCRIPTION
## Summary

This PR introduces a clearer, Base-managed shell startup model for both Bash and Zsh.

The main goal is to separate:
- thin login profile handoff
- interactive shell bootstrap
- optional shared shell defaults
- shared Base activation logic

It also documents that model in the repo and adds top-of-file comments so each startup file is understandable in isolation.

## Why

We needed a clean answer to a few questions before Base can reliably own shared shell startup:

- what belongs in `.bash_profile` / `.zprofile` versus `.bashrc` / `.zshrc`
- how Base should activate itself in interactive shells
- how users can opt into shared shell defaults without mixing that logic into login files
- how `BASE_HOME` should be resolved when users symlink startup files from a shared Base checkout

This PR establishes that contract.

## What changed

### New startup structure

Added new Base-managed shell files:

- `lib/shell_startup.sh`
- `lib/zprofile`
- `lib/zshrc`
- `lib/zsh_defaults.sh`

Updated existing shell files:

- `lib/bash_profile`
- `lib/bashrc`
- `lib/base_defaults.sh`
- `base_init.sh`

### Startup responsibilities

The new structure is:

- `bash_profile` / `zprofile`
  - thin login-shell entrypoints
  - hand off to the corresponding rc file

- `bashrc` / `zshrc`
  - interactive-shell guards
  - repeated-sourcing guards
  - `BASE_HOME` discovery
  - `~/.baserc` loading for machine-local overrides
  - handoff into shared Base bootstrap

- `shell_startup.sh`
  - shared interactive startup helper
  - optional defaults loading
  - `base_init.sh` activation

- `base_defaults.sh` / `zsh_defaults.sh`
  - optional shared interactive defaults
  - aliases, editor mode, prompt/history behavior

### Optional defaults

Shared shell defaults are now explicitly opt-in via:

```bash
BASE_ENABLE_SHELL_DEFAULTS=true
```