### PR TITLE
Rename Base env contract and trim exported shell variables

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -123,7 +123,7 @@ Small framework-level singleton files may remain flat when they are not really
 "modules" in the same sense. Examples include:
 
 - `cli/bash/bin/base-wrapper`
-- `cli/env/banyanenv.sh`
+- `cli/env/baseenv.sh`
 
 ### Index documentation
 

--- a/bin/base-wrapper
+++ b/bin/base-wrapper
@@ -121,7 +121,7 @@ resolve_base_paths() {
     CLI_ROOT="$REPO_ROOT/cli"
     BASH_ROOT="$CLI_ROOT/bash"
     COMMANDS_DIR="$BASH_ROOT/commands"
-    ENV_SCRIPT="$CLI_ROOT/env/banyanenv.sh"
+    ENV_SCRIPT="$CLI_ROOT/env/baseenv.sh"
 }
 
 resolve_dispatch_target() {
@@ -191,22 +191,22 @@ load_base_environment() {
     [[ -f "$ENV_SCRIPT" ]] || die "Required environment bootstrap '$ENV_SCRIPT' was not found."
     source "$ENV_SCRIPT" || die "Failed to initialize Base CLI environment from '$ENV_SCRIPT'."
 
-    BASH_ROOT="${BANYAN_BASH_ROOT:-$BASH_ROOT}"
-    CLI_ROOT="${BANYAN_CLI_ROOT:-$CLI_ROOT}"
-    REPO_ROOT="${BANYAN_REPO_ROOT:-$REPO_ROOT}"
-    BASH_BIN_DIR="${BANYAN_BASH_BIN_DIR:-$CLI_ROOT/bash/bin}"
-    COMMANDS_DIR="${BANYAN_BASH_COMMANDS_DIR:-$COMMANDS_DIR}"
-    ENV_SCRIPT="${BANYAN_CLI_ENV_SCRIPT:-$ENV_SCRIPT}"
+    BASH_ROOT="${BASE_BASH_ROOT:-$BASH_ROOT}"
+    CLI_ROOT="${BASE_CLI_ROOT:-$CLI_ROOT}"
+    REPO_ROOT="${BASE_REPO_ROOT:-$REPO_ROOT}"
+    BASH_BIN_DIR="${BASE_BASH_BIN_DIR:-$CLI_ROOT/bash/bin}"
+    COMMANDS_DIR="${BASE_BASH_COMMANDS_DIR:-$COMMANDS_DIR}"
+    ENV_SCRIPT="${BASE_CLI_ENV_SCRIPT:-$ENV_SCRIPT}"
 
-    export BANYAN_REPO_ROOT="$REPO_ROOT"
-    export BANYAN_CLI_ROOT="$CLI_ROOT"
-    export BANYAN_BASH_ROOT="$BASH_ROOT"
-    export BANYAN_BASH_BIN_DIR="$BASH_BIN_DIR"
-    export BANYAN_BASH_COMMANDS_DIR="$COMMANDS_DIR"
-    export BANYAN_CLI_ENV_SCRIPT="$ENV_SCRIPT"
-    export BANYAN_BASH_COMMAND_NAME="$COMMAND_NAME"
-    export BANYAN_BASH_COMMAND_DIR="$COMMAND_DIR"
-    export BANYAN_BASH_COMMAND_SCRIPT="$COMMAND_SCRIPT"
+    BASE_REPO_ROOT="$REPO_ROOT"
+    BASE_CLI_ROOT="$CLI_ROOT"
+    BASE_BASH_ROOT="$BASH_ROOT"
+    BASE_BASH_BIN_DIR="$BASH_BIN_DIR"
+    BASE_BASH_COMMANDS_DIR="$COMMANDS_DIR"
+    BASE_CLI_ENV_SCRIPT="$ENV_SCRIPT"
+    BASE_BASH_COMMAND_NAME="$COMMAND_NAME"
+    BASE_BASH_COMMAND_DIR="$COMMAND_DIR"
+    BASE_BASH_COMMAND_SCRIPT="$COMMAND_SCRIPT"
 
     STDLIB_PATH="$BASH_ROOT/lib/std/lib_std.sh"
     [[ -f "$STDLIB_PATH" ]] || die "Required stdlib '$STDLIB_PATH' was not found."
@@ -223,9 +223,9 @@ main() {
     set -- "${COMMAND_ARGS[@]}"
     load_base_environment
 
-    export BANYAN_BASH_BOOTSTRAP_SOURCE="$COMMAND_SCRIPT"
+    BASE_BASH_BOOTSTRAP_SOURCE="$COMMAND_SCRIPT"
     source "$STDLIB_PATH"
-    unset BANYAN_BASH_BOOTSTRAP_SOURCE
+    unset BASE_BASH_BOOTSTRAP_SOURCE
 
     source "$COMMAND_SCRIPT" "$@"
 }

--- a/cli/bash/bin/README.md
+++ b/cli/bash/bin/README.md
@@ -33,27 +33,27 @@ Behavior:
 
 Before sourcing the command script, `base-wrapper`:
 
-- sources `../../env/banyanenv.sh` to initialize the shared CLI environment
+- sources `../../env/baseenv.sh` to initialize the shared CLI environment
 - resolves the repository, CLI, and Bash root directories
-- exports wrapper metadata:
-  - `BANYAN_REPO_ROOT`
-  - `BANYAN_CLI_ROOT`
-  - `BANYAN_BASH_ROOT`
-  - `BANYAN_BASH_BIN_DIR`
-  - `BANYAN_CLI_ENV_SCRIPT`
-  - `BANYAN_BASH_COMMAND_NAME`
-  - `BANYAN_BASH_COMMAND_DIR`
-  - `BANYAN_BASH_COMMAND_SCRIPT`
+- makes wrapper metadata available to sourced command scripts:
+  - `BASE_REPO_ROOT`
+  - `BASE_CLI_ROOT`
+  - `BASE_BASH_ROOT`
+  - `BASE_BASH_BIN_DIR`
+  - `BASE_CLI_ENV_SCRIPT`
+  - `BASE_BASH_COMMAND_NAME`
+  - `BASE_BASH_COMMAND_DIR`
+  - `BASE_BASH_COMMAND_SCRIPT`
 - preloads `../lib/std/lib_std.sh`
 
-That means command scripts inherit both the shared environment and the stdlib helpers without having to source them directly.
+That means command scripts inherit both the shared environment and the stdlib helpers without having to source them directly. The wrapper metadata is available in the wrapper shell because Base commands are sourced, but it is not part of the stable exported environment contract for child processes.
 
-The wrapper also sets `BANYAN_BASH_BOOTSTRAP_SOURCE` before loading the stdlib so stdlib path detection still treats the command script as the real caller.
+The wrapper also sets `BASE_BASH_BOOTSTRAP_SOURCE` before loading the stdlib so stdlib path detection still treats the command script as the real caller.
 
-`banyanenv.sh` is also meant to be sourced from a user's shell startup file:
+`baseenv.sh` is also meant to be sourced from a user's shell startup file:
 
 ```bash
-source /path/to/base/cli/env/banyanenv.sh
+source /path/to/base/cli/env/baseenv.sh
 ```
 
 That keeps interactive shells and wrapper-launched commands on the same environment contract.

--- a/cli/bash/bin/tests/base-wrapper.bats
+++ b/cli/bash/bin/tests/base-wrapper.bats
@@ -10,9 +10,9 @@ create_bare_wrapper_layout() {
     repo_root="$(dirname "$cli_root")"
 
     mkdir -p "$repo_root/bin" "$layout_root/bin" "$layout_root/commands" "$layout_root/lib/std" "$cli_root/env" "$cli_root/python"
-    cp "$BANYAN_REPO_ROOT/cli/env/banyanenv.sh" "$cli_root/env/banyanenv.sh"
-    cp "$BANYAN_REPO_ROOT/bin/base-wrapper" "$repo_root/bin/base-wrapper"
-    cp "$BANYAN_BASH_DIR/lib/std/lib_std.sh" "$layout_root/lib/std/lib_std.sh"
+    cp "$BASE_REPO_ROOT/cli/env/baseenv.sh" "$cli_root/env/baseenv.sh"
+    cp "$BASE_REPO_ROOT/bin/base-wrapper" "$repo_root/bin/base-wrapper"
+    cp "$BASE_BASH_DIR/lib/std/lib_std.sh" "$layout_root/lib/std/lib_std.sh"
     chmod +x "$repo_root/bin/base-wrapper"
     ln -s ../../../bin/base-wrapper "$layout_root/bin/base-wrapper"
 }
@@ -29,14 +29,17 @@ create_wrapper_layout() {
 #!/usr/bin/env bash
 printf 'script_dir=%s\n' "${__SCRIPT_DIR__:-}"
 printf 'orig_args=%s\n' "${__SCRIPT_ARGS__[*]:-}"
-printf 'command=%s\n' "${BANYAN_BASH_COMMAND_NAME:-}"
-printf 'repo=%s\n' "${BANYAN_REPO_ROOT:-}"
-printf 'bash_root=%s\n' "${BANYAN_BASH_ROOT:-}"
-printf 'bin_dir=%s\n' "${BANYAN_BASH_BIN_DIR:-}"
-printf 'env_script=%s\n' "${BANYAN_CLI_ENV_SCRIPT:-}"
-printf 'script=%s\n' "${BANYAN_BASH_COMMAND_SCRIPT:-}"
+printf 'command=%s\n' "${BASE_BASH_COMMAND_NAME:-}"
+printf 'repo=%s\n' "${BASE_REPO_ROOT:-}"
+printf 'bash_root=%s\n' "${BASE_BASH_ROOT:-}"
+printf 'bin_dir=%s\n' "${BASE_BASH_BIN_DIR:-}"
+printf 'env_script=%s\n' "${BASE_CLI_ENV_SCRIPT:-}"
+printf 'script=%s\n' "${BASE_BASH_COMMAND_SCRIPT:-}"
+printf 'command_exported=%s\n' "$(env | grep -c '^BASE_BASH_COMMAND_NAME=')"
+printf 'script_exported=%s\n' "$(env | grep -c '^BASE_BASH_COMMAND_SCRIPT=')"
+printf 'bin_dir_exported=%s\n' "$(env | grep -c '^BASE_BASH_BIN_DIR=')"
 case ":$PATH:" in
-    *":${BANYAN_BASH_BIN_DIR:-__missing__}:"*) printf 'path_has_bin=yes\n' ;;
+    *":${BASE_BASH_BIN_DIR:-__missing__}:"*) printf 'path_has_bin=yes\n' ;;
     *) printf 'path_has_bin=no\n' ;;
 esac
 printf 'argv=%s\n' "$*"
@@ -54,7 +57,7 @@ EOF
     expected_repo_root="$(cd "$repo_root" && pwd -P)"
     expected_bash_root="$(cd "$layout" && pwd -P)"
     expected_bin_dir="$(cd "$layout/bin" && pwd -P)"
-    expected_env_script="$(cd "$repo_root/cli/env" && pwd -P)/banyanenv.sh"
+    expected_env_script="$(cd "$repo_root/cli/env" && pwd -P)/baseenv.sh"
     expected_command_dir="$(cd "$layout/commands/demo" && pwd -P)"
     expected_script_path="$(cd "$layout/commands/demo" && pwd -P)/demo.sh"
 
@@ -69,6 +72,9 @@ EOF
     [[ "$output" == *"bin_dir=$expected_bin_dir"* ]]
     [[ "$output" == *"env_script=$expected_env_script"* ]]
     [[ "$output" == *"script=$expected_script_path"* ]]
+    [[ "$output" == *"command_exported=0"* ]]
+    [[ "$output" == *"script_exported=0"* ]]
+    [[ "$output" == *"bin_dir_exported=0"* ]]
     [[ "$output" == *"path_has_bin=yes"* ]]
     [[ "$output" == *"argv=alpha beta"* ]]
 }
@@ -216,12 +222,12 @@ EOF
     [[ "$output" == *"Required stdlib"* ]]
 }
 
-@test "wrapper errors when banyanenv is missing" {
+@test "wrapper errors when baseenv is missing" {
     local repo_root="$BATS_TEST_TMPDIR/repo"
     local layout="$repo_root/cli/bash"
 
     create_wrapper_layout "$layout" demo
-    rm -f "$repo_root/cli/env/banyanenv.sh"
+    rm -f "$repo_root/cli/env/baseenv.sh"
 
     run "$layout/bin/base-wrapper" demo
 
@@ -302,18 +308,18 @@ EOF
     cat > "$external_script" <<'EOF'
 #!/usr/bin/env bash
 printf 'script_dir=%s\n' "${__SCRIPT_DIR__:-}"
-printf 'command=%s\n' "${BANYAN_BASH_COMMAND_NAME:-}"
-printf 'repo=%s\n' "${BANYAN_REPO_ROOT:-}"
-printf 'bin_dir=%s\n' "${BANYAN_BASH_BIN_DIR:-}"
-printf 'env_script=%s\n' "${BANYAN_CLI_ENV_SCRIPT:-}"
-printf 'script=%s\n' "${BANYAN_BASH_COMMAND_SCRIPT:-}"
+printf 'command=%s\n' "${BASE_BASH_COMMAND_NAME:-}"
+printf 'repo=%s\n' "${BASE_REPO_ROOT:-}"
+printf 'bin_dir=%s\n' "${BASE_BASH_BIN_DIR:-}"
+printf 'env_script=%s\n' "${BASE_CLI_ENV_SCRIPT:-}"
+printf 'script=%s\n' "${BASE_BASH_COMMAND_SCRIPT:-}"
 printf 'argv=%s\n' "$*"
 EOF
     chmod +x "$external_script"
 
     expected_repo_root="$(cd "$repo_root" && pwd -P)"
     expected_bin_dir="$(cd "$layout/bin" && pwd -P)"
-    expected_env_script="$(cd "$repo_root/cli/env" && pwd -P)/banyanenv.sh"
+    expected_env_script="$(cd "$repo_root/cli/env" && pwd -P)/baseenv.sh"
     expected_script="$(cd "$external_dir" && pwd -P)/external-demo.sh"
 
     run "$repo_root/bin/base-wrapper" "$external_script" alpha beta

--- a/cli/bash/commands/setup/README.md
+++ b/cli/bash/commands/setup/README.md
@@ -9,7 +9,7 @@ The command is intentionally small and idempotent.
 ## Commands
 
 - `install`
-  Installs Homebrew, Xcode Command Line Tools, Python 3.13, BATS, and creates `$HOME/.banyanlabs.d/.venv`.
+  Installs Homebrew, Xcode Command Line Tools, Python 3.13, BATS, and creates `$HOME/.base.d/.venv`.
 - `check`
   Verifies the required local CLI setup without making changes. Exits non-zero if anything is missing.
 - `update-profile`
@@ -23,10 +23,7 @@ The `install` command performs these steps:
 2. install Xcode Command Line Tools if they are not already installed
 3. install Python 3.13 via Homebrew if it is not already installed
 4. install BATS via Homebrew if it is not already installed
-5. create `$HOME/.banyanlabs.d/.venv` if it does not already exist
-
-The current implementation still uses `.banyanlabs.d` as its state directory
-for compatibility during the migration into `base`.
+5. create `$HOME/.base.d/.venv` if it does not already exist
 
 ## Check Behavior
 
@@ -36,7 +33,7 @@ The `check` command verifies the same base requirements as `install`:
 2. Xcode Command Line Tools are installed
 3. Python 3.13 is installed via Homebrew
 4. BATS is installed via Homebrew
-5. `$HOME/.banyanlabs.d/.venv` exists
+5. `$HOME/.base.d/.venv` exists
 
 It exits with status `0` when everything is present and `1` when any required item is missing.
 
@@ -88,13 +85,13 @@ cli/bash/bin/setup.sh -v install
 
 The command supports a few environment-variable overrides, mainly for automation and tests:
 
-- `BANYAN_SETUP_VENV_DIR`
-- `BANYAN_SETUP_PYTHON_FORMULA`
-- `BANYAN_SETUP_BATS_FORMULA`
-- `BANYAN_SETUP_PYTHON_BIN`
-- `BANYAN_SETUP_BREW_BIN`
-- `BANYAN_SETUP_HOMEBREW_INSTALLER_SCRIPT`
-- `BANYAN_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR`
+- `BASE_SETUP_VENV_DIR`
+- `BASE_SETUP_PYTHON_FORMULA`
+- `BASE_SETUP_BATS_FORMULA`
+- `BASE_SETUP_PYTHON_BIN`
+- `BASE_SETUP_BREW_BIN`
+- `BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT`
+- `BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR`
 
 ## Tests
 

--- a/cli/bash/commands/setup/setup.sh
+++ b/cli/bash/commands/setup/setup.sh
@@ -7,7 +7,7 @@ Usage:
 
 Commands:
   install
-    Install Homebrew, Xcode Command Line Tools, Python, BATS, and ~/.banyanlabs.d/.venv.
+    Install Homebrew, Xcode Command Line Tools, Python, BATS, and ~/.base.d/.venv.
   check
     Verify the required local CLI setup without making changes.
   update-profile
@@ -26,14 +26,14 @@ Install does:
   2. Install Xcode Command Line Tools if needed.
   3. Install Python 3.13 via Homebrew if needed.
   4. Install BATS via Homebrew if needed.
-  5. Create ~/.banyanlabs.d/.venv if it does not already exist.
+  5. Create ~/.base.d/.venv if it does not already exist.
 
 Check does:
   1. Verify Homebrew is installed.
   2. Verify Xcode Command Line Tools are installed.
   3. Verify Python 3.13 is installed via Homebrew.
   4. Verify BATS is installed via Homebrew.
-  5. Verify ~/.banyanlabs.d/.venv exists.
+  5. Verify ~/.base.d/.venv exists.
 
 Notes:
   - This command is intentionally idempotent.
@@ -53,39 +53,39 @@ setup_virtualenv_exists() {
 }
 
 setup_venv_dir() {
-    printf '%s\n' "${BANYAN_SETUP_VENV_DIR:-$HOME/.banyanlabs.d/.venv}"
+    printf '%s\n' "${BASE_SETUP_VENV_DIR:-$HOME/.base.d/.venv}"
 }
 
 setup_python_formula() {
-    printf '%s\n' "${BANYAN_SETUP_PYTHON_FORMULA:-python@3.13}"
+    printf '%s\n' "${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
 }
 
 setup_bats_formula() {
-    printf '%s\n' "${BANYAN_SETUP_BATS_FORMULA:-bats-core}"
+    printf '%s\n' "${BASE_SETUP_BATS_FORMULA:-bats-core}"
 }
 
 setup_xcode_tools_dir() {
-    printf '%s\n' "${BANYAN_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR:-/Library/Developer/CommandLineTools}"
+    printf '%s\n' "${BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR:-/Library/Developer/CommandLineTools}"
 }
 
 setup_xcode_wait_timeout_seconds() {
-    printf '%s\n' "${BANYAN_SETUP_XCODE_WAIT_TIMEOUT_SECONDS:-1800}"
+    printf '%s\n' "${BASE_SETUP_XCODE_WAIT_TIMEOUT_SECONDS:-1800}"
 }
 
 setup_xcode_wait_interval_seconds() {
-    printf '%s\n' "${BANYAN_SETUP_XCODE_WAIT_INTERVAL_SECONDS:-5}"
+    printf '%s\n' "${BASE_SETUP_XCODE_WAIT_INTERVAL_SECONDS:-5}"
 }
 
 setup_allow_noninteractive_xcode_install() {
-    [[ "${BANYAN_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL:-false}" == true ]]
+    [[ "${BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL:-false}" == true ]]
 }
 
 setup_find_brew_bin() {
     local candidate
 
-    if [[ -n "${BANYAN_SETUP_BREW_BIN+x}" ]]; then
-        if [[ -x "${BANYAN_SETUP_BREW_BIN}" ]]; then
-            printf '%s\n' "${BANYAN_SETUP_BREW_BIN}"
+    if [[ -n "${BASE_SETUP_BREW_BIN+x}" ]]; then
+        if [[ -x "${BASE_SETUP_BREW_BIN}" ]]; then
+            printf '%s\n' "${BASE_SETUP_BREW_BIN}"
             return 0
         fi
         return 1
@@ -129,8 +129,8 @@ setup_install_homebrew() {
 
     log_info "Installing Homebrew."
 
-    if [[ -n "${BANYAN_SETUP_HOMEBREW_INSTALLER_SCRIPT:-}" ]]; then
-        run "$BANYAN_SETUP_HOMEBREW_INSTALLER_SCRIPT"
+    if [[ -n "${BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT:-}" ]]; then
+        run "$BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT"
     else
         command -v curl >/dev/null 2>&1 || fatal_error "curl is required to install Homebrew."
         /bin/bash -c "$(curl -fsSL "$installer_url")"
@@ -247,8 +247,8 @@ setup_install_bats() {
 setup_find_python_bin() {
     local formula prefix candidate candidates=()
 
-    if [[ -n "${BANYAN_SETUP_PYTHON_BIN:-}" && -x "${BANYAN_SETUP_PYTHON_BIN}" ]]; then
-        printf '%s\n' "${BANYAN_SETUP_PYTHON_BIN}"
+    if [[ -n "${BASE_SETUP_PYTHON_BIN:-}" && -x "${BASE_SETUP_PYTHON_BIN}" ]]; then
+        printf '%s\n' "${BASE_SETUP_PYTHON_BIN}"
         return 0
     fi
 

--- a/cli/bash/commands/setup/tests/setup.bats
+++ b/cli/bash/commands/setup/tests/setup.bats
@@ -16,8 +16,8 @@ setup() {
 create_xcode_stubs() {
     cat > "$TEST_MOCKBIN/xcode-select" <<'EOF'
 #!/usr/bin/env bash
-tools_dir="${BANYAN_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR:?}"
-state_dir="${BANYAN_SETUP_TEST_STATE_DIR:?}"
+tools_dir="${BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR:?}"
+state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
 installed_file="$state_dir/xcode-installed"
 
 case "${1:-}" in
@@ -43,7 +43,7 @@ EOF
 
     cat > "$TEST_MOCKBIN/xcrun" <<'EOF'
 #!/usr/bin/env bash
-state_dir="${BANYAN_SETUP_TEST_STATE_DIR:?}"
+state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
 installed_file="$state_dir/xcode-installed"
 
 if [[ "${1:-}" == "-f" && "${2:-}" == "clang" && -f "$installed_file" ]]; then
@@ -59,10 +59,10 @@ EOF
 create_brew_stub() {
     cat > "$TEST_MOCKBIN/brew" <<'EOF'
 #!/usr/bin/env bash
-state_dir="${BANYAN_SETUP_TEST_STATE_DIR:?}"
-python_prefix="${BANYAN_SETUP_TEST_PYTHON_PREFIX:?}"
-python_formula="${BANYAN_SETUP_PYTHON_FORMULA:-python@3.13}"
-bats_formula="${BANYAN_SETUP_BATS_FORMULA:-bats-core}"
+state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
+python_prefix="${BASE_SETUP_TEST_PYTHON_PREFIX:?}"
+python_formula="${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
+bats_formula="${BASE_SETUP_BATS_FORMULA:-bats-core}"
 
 case "${1:-}" in
     list)
@@ -126,13 +126,13 @@ create_homebrew_installer_stub() {
 
     cat > "$installer" <<'EOF'
 #!/usr/bin/env bash
-touch "${BANYAN_SETUP_TEST_STATE_DIR:?}/homebrew-install-ran"
-cat > "${BANYAN_SETUP_TEST_MOCKBIN:?}/brew" <<'BREWEOF'
+touch "${BASE_SETUP_TEST_STATE_DIR:?}/homebrew-install-ran"
+cat > "${BASE_SETUP_TEST_MOCKBIN:?}/brew" <<'BREWEOF'
 #!/usr/bin/env bash
-state_dir="${BANYAN_SETUP_TEST_STATE_DIR:?}"
-python_prefix="${BANYAN_SETUP_TEST_PYTHON_PREFIX:?}"
-python_formula="${BANYAN_SETUP_PYTHON_FORMULA:-python@3.13}"
-bats_formula="${BANYAN_SETUP_BATS_FORMULA:-bats-core}"
+state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
+python_prefix="${BASE_SETUP_TEST_PYTHON_PREFIX:?}"
+python_formula="${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
+bats_formula="${BASE_SETUP_BATS_FORMULA:-bats-core}"
 
 case "${1:-}" in
     list)
@@ -188,7 +188,7 @@ PYEOF
         ;;
 esac
 BREWEOF
-chmod +x "${BANYAN_SETUP_TEST_MOCKBIN:?}/brew"
+chmod +x "${BASE_SETUP_TEST_MOCKBIN:?}/brew"
 EOF
     chmod +x "$installer"
 
@@ -203,18 +203,18 @@ run_setup() {
         HOME="$TEST_HOME" \
         PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         OSTYPE="${OSTYPE_OVERRIDE:-darwin24}" \
-        BANYAN_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
-        BANYAN_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        BANYAN_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
-        BANYAN_SETUP_TEST_PYTHON_PREFIX="$python_prefix" \
-        BANYAN_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$xcode_dir" \
-        BANYAN_SETUP_XCODE_WAIT_TIMEOUT_SECONDS=5 \
-        BANYAN_SETUP_XCODE_WAIT_INTERVAL_SECONDS=0 \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$python_prefix" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$xcode_dir" \
+        BASE_SETUP_XCODE_WAIT_TIMEOUT_SECONDS=5 \
+        BASE_SETUP_XCODE_WAIT_INTERVAL_SECONDS=0 \
         "$@"
 }
 
 @test "setup prints usage for help" {
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" --help
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
@@ -224,7 +224,7 @@ run_setup() {
 }
 
 @test "setup requires an explicit command" {
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh"
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh"
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"A setup command is required."* ]]
@@ -233,14 +233,14 @@ run_setup() {
 @test "setup fails on unsupported operating systems" {
     OSTYPE_OVERRIDE="linux-gnu"
 
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" install
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" install
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"supports macOS only"* ]]
 }
 
 @test "setup is idempotent when brew, xcode tools, python, and the venv already exist" {
-    local venv_dir="$TEST_HOME/.banyanlabs.d/.venv"
+    local venv_dir="$TEST_HOME/.base.d/.venv"
 
     create_brew_stub
     create_xcode_stubs
@@ -251,7 +251,7 @@ run_setup() {
     mkdir -p "$venv_dir/bin"
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
 
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" install
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" install
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Homebrew is already installed."* ]]
@@ -263,17 +263,17 @@ run_setup() {
     [ ! -f "$TEST_STATE_DIR/bats-install-ran" ]
 }
 
-@test "setup installs missing dependencies and creates the Banyan virtual environment" {
+@test "setup installs missing dependencies and creates the Base virtual environment" {
     local installer
-    local venv_dir="$TEST_HOME/.banyanlabs.d/.venv"
+    local venv_dir="$TEST_HOME/.base.d/.venv"
 
     create_xcode_stubs
     installer="$(create_homebrew_installer_stub)"
 
     run_setup \
-        BANYAN_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
-        BANYAN_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
-        "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" install
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
+        "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" install
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Installing Homebrew."* ]]
@@ -290,20 +290,20 @@ run_setup() {
 }
 
 @test "setup install supports dry-run without making changes" {
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" install --dry-run
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" install --dry-run
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would install Homebrew using the official installer."* ]]
     [[ "$output" == *"[DRY-RUN] Would wait for Xcode Command Line Tools installation to complete."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python formula 'python@3.13' via Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would install BATS formula 'bats-core' via Homebrew."* ]]
-    [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.banyanlabs.d/.venv'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/.venv'."* ]]
     [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
-    [ ! -e "$TEST_HOME/.banyanlabs.d/.venv" ]
+    [ ! -e "$TEST_HOME/.base.d/.venv" ]
 }
 
 @test "setup check passes when all required components are present" {
-    local venv_dir="$TEST_HOME/.banyanlabs.d/.venv"
+    local venv_dir="$TEST_HOME/.base.d/.venv"
 
     create_brew_stub
     create_xcode_stubs
@@ -314,7 +314,7 @@ run_setup() {
     mkdir -p "$venv_dir/bin"
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
 
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" check
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" check
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Homebrew is installed."* ]]
@@ -326,19 +326,19 @@ run_setup() {
 }
 
 @test "setup check fails when required components are missing" {
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" check
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" check
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"Homebrew is not installed."* ]]
     [[ "$output" == *"Xcode Command Line Tools are not installed."* ]]
     [[ "$output" == *"Python formula 'python@3.13' is not installed via Homebrew."* ]]
     [[ "$output" == *"BATS formula 'bats-core' is not installed via Homebrew."* ]]
-    [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.banyanlabs.d/.venv'."* ]]
+    [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/.venv'."* ]]
     [[ "$output" == *"Base CLI environment check found missing requirements."* ]]
 }
 
 @test "setup install enables DEBUG logs with -v" {
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" -v install --dry-run
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" -v install --dry-run
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"DEBUG"* ]]
@@ -346,7 +346,7 @@ run_setup() {
 }
 
 @test "setup update-profile is reserved for later work" {
-    run_setup "$BANYAN_REPO_ROOT/cli/bash/bin/setup.sh" update-profile
+    run_setup "$BASE_REPO_ROOT/cli/bash/bin/setup.sh" update-profile
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"update-profile"* ]]

--- a/cli/bash/lib/file/tests/lib_file.bats
+++ b/cli/bash/lib/file/tests/lib_file.bats
@@ -4,8 +4,8 @@ load ../../../tests/test_helper.bash
 
 setup() {
     setup_test_tmpdir
-    source "$BANYAN_BASH_DIR/lib/std/lib_std.sh"
-    source "$BANYAN_BASH_DIR/lib/file/lib_file.sh"
+    source "$BASE_BASH_DIR/lib/std/lib_std.sh"
+    source "$BASE_BASH_DIR/lib/file/lib_file.sh"
 }
 
 @test "update_file_section appends a new marked block when markers are absent" {

--- a/cli/bash/lib/git/tests/lib_git.bats
+++ b/cli/bash/lib/git/tests/lib_git.bats
@@ -4,8 +4,8 @@ load ../../../tests/test_helper.bash
 
 setup() {
     setup_test_tmpdir
-    source "$BANYAN_BASH_DIR/lib/std/lib_std.sh"
-    source "$BANYAN_BASH_DIR/lib/git/lib_git.sh"
+    source "$BASE_BASH_DIR/lib/std/lib_std.sh"
+    source "$BASE_BASH_DIR/lib/git/lib_git.sh"
 }
 
 @test "git_get_current_branch returns the current branch name" {

--- a/cli/bash/lib/std/README.md
+++ b/cli/bash/lib/std/README.md
@@ -32,7 +32,7 @@ run echo "hello"
 - Requires Bash 4.0 or newer.
 - Sourcing the file runs `__stdlib_init__`.
 - `cli/bash/bin/base-wrapper` preloads this library for command scripts so commands do not need per-command stdlib sourcing boilerplate.
-- The wrapper sets `BANYAN_BASH_BOOTSTRAP_SOURCE` before sourcing this file so `__SCRIPT_DIR__` still points at the command script rather than the wrapper.
+- The wrapper sets `BASE_BASH_BOOTSTRAP_SOURCE` before sourcing this file so `__SCRIPT_DIR__` still points at the command script rather than the wrapper.
 - Wrapper-level flags such as `--debug-wrapper` and `--verbose-wrapper` are consumed during initialization.
 - Other Bash libraries in this tree rely on this file for logging and error handling.
 

--- a/cli/bash/lib/std/lib_std.sh
+++ b/cli/bash/lib/std/lib_std.sh
@@ -40,7 +40,7 @@
 #
 # Notes:
 #   - Global options --debug-wrapper/--verbose-wrapper/--utc-wrapper/--color are stripped from "$@" automatically.
-#   - Wrappers may override the caller path seen by this library through BANYAN_BASH_BOOTSTRAP_SOURCE.
+#   - Wrappers may override the caller path seen by this library through BASE_BASH_BOOTSTRAP_SOURCE.
 #
 
 ################################################# INITIALIZATION #######################################################
@@ -58,12 +58,12 @@ readonly __LIB_STD_PATH__="${BASH_SOURCE[0]}"
 # This allows the library to parse global options before the main script does.
 # We retain the original arguments in __SCRIPT_ARGS__ and the script source directory in __SCRIPT_DIR__ as readonly
 # variables which could be used by the caller. When a wrapper preloads this library on behalf of another script, it can
-# provide BANYAN_BASH_BOOTSTRAP_SOURCE so __SCRIPT_DIR__ still resolves to the real command script.
+# provide BASE_BASH_BOOTSTRAP_SOURCE so __SCRIPT_DIR__ still resolves to the real command script.
 #
 readonly __SCRIPT_ARGS__=("$@")
 __new_args__=()
 __SCRIPT_DIR__=$(
-    cd -- "$(dirname -- "${BANYAN_BASH_BOOTSTRAP_SOURCE:-${BASH_SOURCE[1]}}" )" &>/dev/null && pwd -P
+    cd -- "$(dirname -- "${BASE_BASH_BOOTSTRAP_SOURCE:-${BASH_SOURCE[1]}}" )" &>/dev/null && pwd -P
 )
 readonly __SCRIPT_DIR__
 

--- a/cli/bash/lib/std/tests/lib_std.bats
+++ b/cli/bash/lib/std/tests/lib_std.bats
@@ -2,7 +2,7 @@
 
 load ../../../tests/test_helper.bash
 
-readonly STDLIB_PATH="$BANYAN_BASH_DIR/lib/std/lib_std.sh"
+readonly STDLIB_PATH="$BASE_BASH_DIR/lib/std/lib_std.sh"
 
 create_script() {
     local script_path="$1"
@@ -34,13 +34,13 @@ run_tty_script() {
 
 setup() {
     setup_test_tmpdir
-    PATH="$BANYAN_TEST_ORIG_PATH"
-    unset DRY_RUN dry_run LOG_DEBUG LOG_UTC BANYAN_BASH_BOOTSTRAP_SOURCE
+    PATH="$BASE_TEST_ORIG_PATH"
+    unset DRY_RUN dry_run LOG_DEBUG LOG_UTC BASE_BASH_BOOTSTRAP_SOURCE
     source "$STDLIB_PATH"
 }
 
 teardown() {
-    PATH="$BANYAN_TEST_ORIG_PATH"
+    PATH="$BASE_TEST_ORIG_PATH"
 }
 
 @test "sourcing stdlib preserves original args and strips wrapper flags" {
@@ -75,7 +75,7 @@ EOF
 
     create_script "$script" <<EOF
 #!/usr/bin/env bash
-export BANYAN_BASH_BOOTSTRAP_SOURCE="$command_dir/demo.sh"
+export BASE_BASH_BOOTSTRAP_SOURCE="$command_dir/demo.sh"
 source "$STDLIB_PATH"
 printf 'script_dir=%s\n' "\$__SCRIPT_DIR__"
 EOF

--- a/cli/bash/tests/test_helper.bash
+++ b/cli/bash/tests/test_helper.bash
@@ -5,10 +5,10 @@ if declare -f run >/dev/null 2>&1; then
     eval "$(declare -f run | sed '1 s/^run /bats_run /')"
 fi
 
-readonly BANYAN_BASH_TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-readonly BANYAN_BASH_DIR="$(cd "$BANYAN_BASH_TESTS_DIR/.." && pwd -P)"
-readonly BANYAN_REPO_ROOT="$(cd "$BANYAN_BASH_DIR/../.." && pwd -P)"
-readonly BANYAN_TEST_ORIG_PATH="$PATH"
+readonly BASE_BASH_TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly BASE_BASH_DIR="$(cd "$BASE_BASH_TESTS_DIR/.." && pwd -P)"
+readonly BASE_REPO_ROOT="$(cd "$BASE_BASH_DIR/../.." && pwd -P)"
+readonly BASE_TEST_ORIG_PATH="$PATH"
 
 setup_test_tmpdir() {
     TEST_TMPDIR="${BATS_TEST_TMPDIR}/workspace"

--- a/cli/env/README.md
+++ b/cli/env/README.md
@@ -2,12 +2,9 @@
 
 This directory holds the shared CLI environment bootstrap.
 
-The script currently keeps its historical name, `banyanenv.sh`, during the
-migration from the old `banyanlabs` repo into `base`.
-
 ## Purpose
 
-`banyanenv.sh` defines the common shell environment used by:
+`baseenv.sh` defines the common shell environment used by:
 
 - `cli/bash/bin/base-wrapper`
 - interactive shells that source it from `~/.bashrc` or `~/.zshrc`
@@ -18,33 +15,42 @@ migration from the old `banyanlabs` repo into `base`.
 Source it from a shell startup file or from another script:
 
 ```bash
-source /path/to/base/cli/env/banyanenv.sh
+source /path/to/base/cli/env/baseenv.sh
 ```
 
 It must be sourced rather than executed.
 
-## What It Exports
+## Stable Exports
 
-- `BANYAN_REPO_ROOT`
-- `BANYAN_CLI_ROOT`
-- `BANYAN_CLI_ENV_DIR`
-- `BANYAN_CLI_ENV_SCRIPT`
-- `BANYAN_BASH_ROOT`
-- `BANYAN_BASH_BIN_DIR`
-- `BANYAN_BASH_LIB_DIR`
-- `BANYAN_BASH_COMMANDS_DIR`
-- `BANYAN_PYTHON_ROOT`
+- `BASE_REPO_ROOT`
+- `BASE_CLI_ROOT`
+- `BASE_CLI_ENV_SCRIPT`
+- `BASE_BASH_ROOT`
+- `BASE_PYTHON_ROOT`
 
-It also prepends `cli/bash/bin` to `PATH` when that directory exists, without duplicating the entry on repeated sourcing.
+These are the environment variables that Base treats as the public cross-process contract.
+
+## Additional Shell Variables
+
+`baseenv.sh` also defines a few derived shell variables for the current shell session:
+
+- `BASE_CLI_ENV_DIR`
+- `BASE_BASH_BIN_DIR`
+- `BASE_BASH_LIB_DIR`
+- `BASE_BASH_COMMANDS_DIR`
+
+These are intentionally not exported to child processes by default. They are easy to derive from the stable roots and are mainly convenience values for sourced scripts and interactive inspection.
+
+`baseenv.sh` also prepends `cli/bash/bin` to `PATH` when that directory exists, without duplicating the entry on repeated sourcing.
 
 ## Compatibility
 
-`banyanenv.sh` is designed to work in both Bash and zsh.
+`baseenv.sh` is designed to work in both Bash and zsh.
 
 ## Tests
 
 Run the environment bootstrap test suite with:
 
 ```bash
-bats cli/env/tests/banyanenv.bats
+bats cli/env/tests/baseenv.bats
 ```

--- a/cli/env/baseenv.sh
+++ b/cli/env/baseenv.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
 #
-# banyanenv.sh
+# baseenv.sh
 #     Sets up the Base CLI shell environment.
 #     Source this file from base-wrapper or from ~/.bashrc / ~/.zshrc:
-#         source /path/to/base/cli/env/banyanenv.sh
+#         source /path/to/base/cli/env/baseenv.sh
 #     Compatible with both bash and zsh.
 #
 
-banyanenv_error() {
+baseenv_error() {
     printf 'ERROR: %s\n' "$*" >&2
 }
 
-banyanenv_is_sourced() {
+baseenv_is_sourced() {
     if [[ -n "${BASH_VERSION:-}" ]]; then
         [[ "${BASH_SOURCE[0]}" != "$0" ]]
         return
@@ -26,7 +26,7 @@ banyanenv_is_sourced() {
     return 1
 }
 
-banyanenv_get_source_path() {
+baseenv_get_source_path() {
     if [[ -n "${BASH_VERSION:-}" ]]; then
         printf '%s\n' "${BASH_SOURCE[0]}"
         return 0
@@ -40,7 +40,7 @@ banyanenv_get_source_path() {
     return 1
 }
 
-banyanenv_prepend_path() {
+baseenv_prepend_path() {
     local dir="$1"
 
     [[ -n "$dir" && -d "$dir" ]] || return 0
@@ -58,59 +58,60 @@ banyanenv_prepend_path() {
     esac
 }
 
-banyanenv_main() {
+baseenv_main() {
     local source_path env_dir cli_root repo_root bash_root python_root
 
-    source_path="$(banyanenv_get_source_path)" || {
-        banyanenv_error "Unable to determine the path to banyanenv.sh."
+    source_path="$(baseenv_get_source_path)" || {
+        baseenv_error "Unable to determine the path to baseenv.sh."
         return 1
     }
     [[ -n "$source_path" ]] || {
-        banyanenv_error "Unable to determine the path to banyanenv.sh."
+        baseenv_error "Unable to determine the path to baseenv.sh."
         return 1
     }
 
     env_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || {
-        banyanenv_error "Unable to resolve cli/env root from '$source_path'."
+        baseenv_error "Unable to resolve cli/env root from '$source_path'."
         return 1
     }
     cli_root="$(cd -- "$env_dir/.." && pwd -P)" || {
-        banyanenv_error "Unable to resolve cli root from '$env_dir'."
+        baseenv_error "Unable to resolve cli root from '$env_dir'."
         return 1
     }
     repo_root="$(cd -- "$cli_root/.." && pwd -P)" || {
-        banyanenv_error "Unable to resolve repository root from '$cli_root'."
+        baseenv_error "Unable to resolve repository root from '$cli_root'."
         return 1
     }
 
     bash_root="$cli_root/bash"
     python_root="$cli_root/python"
 
-    export BANYAN_REPO_ROOT="$repo_root"
-    export BANYAN_CLI_ROOT="$cli_root"
-    export BANYAN_CLI_ENV_DIR="$env_dir"
-    export BANYAN_CLI_ENV_SCRIPT="$env_dir/banyanenv.sh"
-    export BANYAN_BASH_ROOT="$bash_root"
-    export BANYAN_BASH_BIN_DIR="$bash_root/bin"
-    export BANYAN_BASH_LIB_DIR="$bash_root/lib"
-    export BANYAN_BASH_COMMANDS_DIR="$bash_root/commands"
-    export BANYAN_PYTHON_ROOT="$python_root"
+    export BASE_REPO_ROOT="$repo_root"
+    export BASE_CLI_ROOT="$cli_root"
+    export BASE_CLI_ENV_SCRIPT="$env_dir/baseenv.sh"
+    export BASE_BASH_ROOT="$bash_root"
+    export BASE_PYTHON_ROOT="$python_root"
 
-    banyanenv_prepend_path "$BANYAN_BASH_BIN_DIR"
+    BASE_CLI_ENV_DIR="$env_dir"
+    BASE_BASH_BIN_DIR="$bash_root/bin"
+    BASE_BASH_LIB_DIR="$bash_root/lib"
+    BASE_BASH_COMMANDS_DIR="$bash_root/commands"
+
+    baseenv_prepend_path "$BASE_BASH_BIN_DIR"
 
     return 0
 }
 
-if ! banyanenv_is_sourced; then
-    banyanenv_error "banyanenv.sh must be sourced, not executed."
-    banyanenv_error "Use: source /path/to/base/cli/env/banyanenv.sh"
+if ! baseenv_is_sourced; then
+    baseenv_error "baseenv.sh must be sourced, not executed."
+    baseenv_error "Use: source /path/to/base/cli/env/baseenv.sh"
     exit 1
 fi
 
-banyanenv_main
-_banyanenv_rc=$?
-unset -f banyanenv_error banyanenv_is_sourced banyanenv_get_source_path banyanenv_prepend_path banyanenv_main
-if [[ $_banyanenv_rc -ne 0 ]]; then
-    return "$_banyanenv_rc"
+baseenv_main
+_baseenv_rc=$?
+unset -f baseenv_error baseenv_is_sourced baseenv_get_source_path baseenv_prepend_path baseenv_main
+if [[ $_baseenv_rc -ne 0 ]]; then
+    return "$_baseenv_rc"
 fi
-unset _banyanenv_rc
+unset _baseenv_rc

--- a/cli/env/tests/baseenv.bats
+++ b/cli/env/tests/baseenv.bats
@@ -2,23 +2,23 @@
 
 load ../../bash/tests/test_helper.bash
 
-readonly BANYAN_ENV_SCRIPT="$BANYAN_REPO_ROOT/cli/env/banyanenv.sh"
+readonly BASE_ENV_SCRIPT="$BASE_REPO_ROOT/cli/env/baseenv.sh"
 
 create_env_layout() {
     local repo_root="$1"
 
     mkdir -p "$repo_root/cli/env" "$repo_root/cli/bash/bin" "$repo_root/cli/bash/lib" "$repo_root/cli/bash/commands" "$repo_root/cli/python"
-    cp "$BANYAN_ENV_SCRIPT" "$repo_root/cli/env/banyanenv.sh"
+    cp "$BASE_ENV_SCRIPT" "$repo_root/cli/env/baseenv.sh"
 }
 
-@test "banyanenv must be sourced rather than executed" {
-    run bash "$BANYAN_ENV_SCRIPT"
+@test "baseenv must be sourced rather than executed" {
+    run bash "$BASE_ENV_SCRIPT"
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"banyanenv.sh must be sourced, not executed."* ]]
+    [[ "$output" == *"baseenv.sh must be sourced, not executed."* ]]
 }
 
-@test "sourcing banyanenv under bash exports shared CLI roots and updates PATH once" {
+@test "sourcing baseenv defines shared CLI roots and exports only the stable contract" {
     local repo_root="$BATS_TEST_TMPDIR/repo"
     local script="$BATS_TEST_TMPDIR/check-bash-env.sh"
     local expected_repo_root expected_cli_root expected_env_dir expected_bash_root expected_bash_bin expected_python_root
@@ -33,19 +33,28 @@ create_env_layout() {
 
     cat > "$script" <<EOF
 #!/usr/bin/env bash
-source "$repo_root/cli/env/banyanenv.sh"
-source "$repo_root/cli/env/banyanenv.sh"
-printf 'repo=%s\n' "\$BANYAN_REPO_ROOT"
-printf 'cli=%s\n' "\$BANYAN_CLI_ROOT"
-printf 'env_dir=%s\n' "\$BANYAN_CLI_ENV_DIR"
-printf 'env_script=%s\n' "\$BANYAN_CLI_ENV_SCRIPT"
-printf 'bash_root=%s\n' "\$BANYAN_BASH_ROOT"
-printf 'bash_bin=%s\n' "\$BANYAN_BASH_BIN_DIR"
-printf 'python_root=%s\n' "\$BANYAN_PYTHON_ROOT"
+source "$repo_root/cli/env/baseenv.sh"
+source "$repo_root/cli/env/baseenv.sh"
+printf 'repo=%s\n' "\$BASE_REPO_ROOT"
+printf 'cli=%s\n' "\$BASE_CLI_ROOT"
+printf 'env_dir=%s\n' "\$BASE_CLI_ENV_DIR"
+printf 'env_script=%s\n' "\$BASE_CLI_ENV_SCRIPT"
+printf 'bash_root=%s\n' "\$BASE_BASH_ROOT"
+printf 'bash_bin=%s\n' "\$BASE_BASH_BIN_DIR"
+printf 'python_root=%s\n' "\$BASE_PYTHON_ROOT"
+printf 'export_repo=%s\n' "\$(env | grep -c '^BASE_REPO_ROOT=')"
+printf 'export_cli=%s\n' "\$(env | grep -c '^BASE_CLI_ROOT=')"
+printf 'export_env_script=%s\n' "\$(env | grep -c '^BASE_CLI_ENV_SCRIPT=')"
+printf 'export_bash_root=%s\n' "\$(env | grep -c '^BASE_BASH_ROOT=')"
+printf 'export_python_root=%s\n' "\$(env | grep -c '^BASE_PYTHON_ROOT=')"
+printf 'export_env_dir=%s\n' "\$(env | grep -c '^BASE_CLI_ENV_DIR=')"
+printf 'export_bash_bin=%s\n' "\$(env | grep -c '^BASE_BASH_BIN_DIR=')"
+printf 'export_bash_lib=%s\n' "\$(env | grep -c '^BASE_BASH_LIB_DIR=')"
+printf 'export_commands=%s\n' "\$(env | grep -c '^BASE_BASH_COMMANDS_DIR=')"
 count=0
 IFS=':'
 for entry in \$PATH; do
-    if [[ "\$entry" == "\$BANYAN_BASH_BIN_DIR" ]]; then
+    if [[ "\$entry" == "\$BASE_BASH_BIN_DIR" ]]; then
         count=\$((count + 1))
     fi
 done
@@ -60,14 +69,23 @@ EOF
     [[ "$output" == *"repo=$expected_repo_root"* ]]
     [[ "$output" == *"cli=$expected_cli_root"* ]]
     [[ "$output" == *"env_dir=$expected_env_dir"* ]]
-    [[ "$output" == *"env_script=$expected_env_dir/banyanenv.sh"* ]]
+    [[ "$output" == *"env_script=$expected_env_dir/baseenv.sh"* ]]
     [[ "$output" == *"bash_root=$expected_bash_root"* ]]
     [[ "$output" == *"bash_bin=$expected_bash_bin"* ]]
     [[ "$output" == *"python_root=$expected_python_root"* ]]
+    [[ "$output" == *"export_repo=1"* ]]
+    [[ "$output" == *"export_cli=1"* ]]
+    [[ "$output" == *"export_env_script=1"* ]]
+    [[ "$output" == *"export_bash_root=1"* ]]
+    [[ "$output" == *"export_python_root=1"* ]]
+    [[ "$output" == *"export_env_dir=0"* ]]
+    [[ "$output" == *"export_bash_bin=0"* ]]
+    [[ "$output" == *"export_bash_lib=0"* ]]
+    [[ "$output" == *"export_commands=0"* ]]
     [[ "$output" == *"bin_count=1"* ]]
 }
 
-@test "sourcing banyanenv under zsh exports shared CLI roots and updates PATH once" {
+@test "sourcing baseenv under zsh defines shared CLI roots and updates PATH once" {
     local repo_root="$BATS_TEST_TMPDIR/repo"
     local expected_repo_root expected_cli_root expected_env_dir expected_bash_root expected_bash_bin expected_python_root
 
@@ -80,18 +98,18 @@ EOF
     expected_python_root="$(cd "$repo_root/cli/python" && pwd -P)"
 
     run zsh -lc "
-        source '$repo_root/cli/env/banyanenv.sh'
-        source '$repo_root/cli/env/banyanenv.sh'
-        print -r -- repo:\$BANYAN_REPO_ROOT
-        print -r -- cli:\$BANYAN_CLI_ROOT
-        print -r -- env_dir:\$BANYAN_CLI_ENV_DIR
-        print -r -- env_script:\$BANYAN_CLI_ENV_SCRIPT
-        print -r -- bash_root:\$BANYAN_BASH_ROOT
-        print -r -- bash_bin:\$BANYAN_BASH_BIN_DIR
-        print -r -- python_root:\$BANYAN_PYTHON_ROOT
+        source '$repo_root/cli/env/baseenv.sh'
+        source '$repo_root/cli/env/baseenv.sh'
+        print -r -- repo:\$BASE_REPO_ROOT
+        print -r -- cli:\$BASE_CLI_ROOT
+        print -r -- env_dir:\$BASE_CLI_ENV_DIR
+        print -r -- env_script:\$BASE_CLI_ENV_SCRIPT
+        print -r -- bash_root:\$BASE_BASH_ROOT
+        print -r -- bash_bin:\$BASE_BASH_BIN_DIR
+        print -r -- python_root:\$BASE_PYTHON_ROOT
         count=0
         for entry in \${(s/:/)PATH}; do
-            [[ \"\$entry\" == \"\$BANYAN_BASH_BIN_DIR\" ]] && ((count++))
+            [[ \"\$entry\" == \"\$BASE_BASH_BIN_DIR\" ]] && ((count++))
         done
         print -r -- bin_count:\$count
     "
@@ -100,7 +118,7 @@ EOF
     [[ "$output" == *"repo:$expected_repo_root"* ]]
     [[ "$output" == *"cli:$expected_cli_root"* ]]
     [[ "$output" == *"env_dir:$expected_env_dir"* ]]
-    [[ "$output" == *"env_script:$expected_env_dir/banyanenv.sh"* ]]
+    [[ "$output" == *"env_script:$expected_env_dir/baseenv.sh"* ]]
     [[ "$output" == *"bash_root:$expected_bash_root"* ]]
     [[ "$output" == *"bash_bin:$expected_bash_bin"* ]]
     [[ "$output" == *"python_root:$expected_python_root"* ]]


### PR DESCRIPTION
## Summary

- rename the shared environment bootstrap from `banyanenv.sh` to `baseenv.sh`
- replace `BANYAN_*` names with `BASE_*` across the Base shell contract
- switch setup state from `~/.banyanlabs.d/.venv` to `~/.base.d/.venv`
- trim the exported environment contract to a smaller set of stable Base roots
- keep derived paths and wrapper metadata shell-local instead of exporting them
- update tests and docs to reflect the cleaned-up Base-native contract

## Why

This PR finishes the Base-native rename for the shell environment layer and narrows the environment surface that Base exports.

Before this change, the repo still exposed legacy Banyan naming in the bootstrap script, wrapper environment, setup flow, and docs. It also exported more `BASE_*` variables than we want to treat as long-term public contract.

That would make future work harder in two ways:

1. peer repos and users would start depending on legacy names
2. too many exported variables would quietly become API surface

This change establishes a cleaner contract before more features build on top of it.

## What changed

### Environment bootstrap

- renamed:
  - `cli/env/banyanenv.sh` -> `cli/env/baseenv.sh`
- renamed the matching test:
  - `cli/env/tests/banyanenv.bats` -> `cli/env/tests/baseenv.bats`

### Environment variable contract

Replaced `BANYAN_*` variables with `BASE_*` names across:

- `bin/base-wrapper`
- `cli/env/baseenv.sh`
- `cli/bash/commands/setup/setup.sh`
- BATS suites
- README and standards docs

### Setup state directory

Updated the setup command and tests to use:

```text
~/.base.d/.venv
```