### PR TITLE
Trim legacy base commands and align docs with current CLI design

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ The current contents include useful shell-oriented building blocks from the
 older version of Base. The goal now is to evolve those foundations into a more
 general multi-project workspace tool.
 
+For the evolving architecture and product-direction notes behind that refactor,
+see [docs/design.md](docs/design.md).
+
 The first migration pass has already started: the shared Bash wrapper,
 environment bootstrap, setup command, and Bash libraries formerly living in the
 `banyanlabs` repo now live under `base/cli/`.

--- a/cli/bash/commands/base/README.md
+++ b/cli/bash/commands/base/README.md
@@ -23,19 +23,14 @@ Bash stdlib loading path as other wrapped commands.
 - `update-profile`
 - `install`
 - `embrace`
-- `update`
-- `run`
-- `status`
 - `shell`
-- `set-team`
-- `set-shared-teams`
 - `version`
-- `man`
 - `help`
 
 ## Notes
 
 - `base setup` is the default local bootstrap path.
 - `base check` verifies the same local requirements without making changes.
+- `embrace` and `shell` are the remaining shell-management entrypoints.
 - Base-specific bootstrap subcommands live under `cli/bash/commands/base/subcommands/`.
 - Shared tests for Base subcommands live under `cli/bash/commands/tests/`.

--- a/cli/bash/commands/base/base.sh
+++ b/cli/bash/commands/base/base.sh
@@ -19,29 +19,15 @@ Commands:
     Install Base into BASE_HOME.
   embrace
     Symlink shell startup files from Base into the user's home directory.
-  update
-    Run git pull in BASE_HOME.
-  run <command> [args...]
-    Initialize Base and run the given command.
-  status
-    Check whether Base is installed at BASE_HOME.
   shell
     Start an interactive Bash shell using Base's managed startup files.
-  set-team TEAM
-    Set BASE_TEAM in ~/.baserc.
-  set-shared-teams TEAM...
-    Set BASE_SHARED_TEAMS in ~/.baserc.
   version
     Show the Base CLI version.
-  man
-    Print one-line summaries for wrapped Base scripts.
   help
     Show this help text.
 
 Options:
   -b DIR   Use DIR as BASE_HOME.
-  -t TEAM  Use TEAM as BASE_TEAM.
-  -s TEAM  Use TEAM as BASE_SHARED_TEAMS (space-delimited for multiple teams).
   -f       Force install by moving aside an existing BASE_HOME directory.
   -v       Enable DEBUG logging for the selected command.
   -V       Show the CLI version.
@@ -262,9 +248,7 @@ base_cli_do_install() {
     }
     printf "Installed Base at '%s'\n" "$BASE_HOME"
 
-    BASE_TEAM="${base_team:-${BASE_TEAM:-}}"
-    BASE_SHARED_TEAMS="${base_shared_teams:-${BASE_SHARED_TEAMS:-}}"
-    base_cli_patch_baserc BASE_HOME BASE_TEAM BASE_SHARED_TEAMS || return 1
+    base_cli_patch_baserc BASE_HOME || return 1
 
     return 0
 }
@@ -332,56 +316,6 @@ base_cli_do_embrace() {
     return 0
 }
 
-base_cli_do_update() {
-    if ! base_cli_verify_repo "$BASE_HOME"; then
-        if base_cli_verify_repo "$BASE_REPO_ROOT"; then
-            BASE_HOME="$BASE_REPO_ROOT"
-            export BASE_HOME
-        else
-            base_cli_error "$BASE_CLI_ERROR_MESSAGE"
-            return 1
-        fi
-    fi
-
-    git -C "$BASE_HOME" pull
-}
-
-base_cli_do_run() {
-    local repo_root
-
-    (($# > 0)) || {
-        base_cli_usage_error "Usage: base run COMMAND [ARGS ...]"
-        return $?
-    }
-
-    repo_root="$(base_cli_runtime_repo_root)" || {
-        base_cli_error "$BASE_CLI_ERROR_MESSAGE"
-        return 1
-    }
-
-    BASE_HOME="$repo_root"
-    export BASE_HOME
-
-    # shellcheck source=/dev/null
-    source "$repo_root/base_init.sh" || return 1
-    "$@"
-}
-
-base_cli_do_status() {
-    if [[ ! -d "$BASE_HOME" ]]; then
-        printf "Base is not installed at '%s'\n" "$BASE_HOME"
-        return 1
-    fi
-
-    if ! base_cli_verify_repo "$BASE_HOME"; then
-        base_cli_error "$BASE_CLI_ERROR_MESSAGE"
-        return 1
-    fi
-
-    printf 'Base is installed at %s\n' "$BASE_HOME"
-    return 0
-}
-
 base_cli_do_shell() {
     local shell_profile
 
@@ -396,83 +330,6 @@ base_cli_do_shell() {
     exec bash --rcfile "$shell_profile"
 }
 
-base_cli_do_man() {
-    local repo_root dir bin desc team
-    local -a dirs
-    local -A teams=()
-
-    repo_root="$(base_cli_runtime_repo_root)" || {
-        base_cli_error "$BASE_CLI_ERROR_MESSAGE"
-        return 1
-    }
-
-    add_to_path -p "$repo_root/bin"
-    if ! command -v base-wrapper >/dev/null 2>&1; then
-        base_cli_error "base-wrapper needs to be in your PATH to run this command."
-        return 1
-    fi
-
-    dirs=(bin company/bin)
-    [[ -n "${base_team:-}" ]] || base_team="${BASE_TEAM:-}"
-    if [[ -n "${base_team:-}" ]]; then
-        dirs+=(team/"$base_team"/bin)
-        teams["$base_team"]=1
-    fi
-
-    for team in ${BASE_SHARED_TEAMS:-} "${BASE_SHARED_TEAMS[@]:-}"; do
-        [[ -n "$team" ]] || continue
-        [[ -n "${teams[$team]:-}" ]] && continue
-        dirs+=(team/"$team"/bin)
-        teams["$team"]=1
-    done
-
-    for dir in "${dirs[@]}"; do
-        dir="$repo_root/$dir"
-        [[ -d "$dir" ]] || continue
-        cd -- "$dir" || continue
-        printf '%s\n' "${dir#$repo_root/}:"
-        for bin in *; do
-            [[ -f "$bin" ]] || continue
-            if head -1 "$bin" | grep -Eq '!/usr/bin/env[[:space:]]+base-wrapper[[:space:]]*'; then
-                desc="$(./"$bin" --describe 2>/dev/null || true)"
-                printf '\t\t%s\n' "$bin: $desc"
-            fi
-        done
-    done
-}
-
-base_cli_do_set_team() {
-    if (($# > 1)); then
-        base_cli_usage_error "Got too many arguments for set-team."
-        return $?
-    fi
-
-    if (($# == 1)); then
-        BASE_TEAM="$1"
-    else
-        BASE_TEAM="${base_team:-}"
-    fi
-
-    [[ -n "${BASE_TEAM:-}" ]] || {
-        base_cli_usage_error "Usage: base set-team TEAM"
-        return $?
-    }
-
-    base_cli_patch_baserc BASE_TEAM
-}
-
-base_cli_do_set_shared_teams() {
-    if (($# > 0)); then
-        BASE_SHARED_TEAMS="$*"
-    elif [[ -n "${base_shared_teams:-}" ]]; then
-        BASE_SHARED_TEAMS="$base_shared_teams"
-    else
-        base_cli_usage_error "Usage: base set-shared-teams TEAM ..."
-        return $?
-    fi
-
-    base_cli_patch_baserc BASE_SHARED_TEAMS
-}
 
 base_cli_main() {
     local base_debug=0 bash_version current_time_fmt command=""
@@ -503,11 +360,9 @@ base_cli_main() {
     fi
 
     OPTIND=1
-    while getopts "fhb:s:t:vVx" opt; do
+    while getopts "fhb:vVx" opt; do
         case "$opt" in
             b) export BASE_HOME="$OPTARG" ;;
-            t) export base_team="$OPTARG" ;;
-            s) export base_shared_teams="$OPTARG" ;;
             f) force_install=1 ;;
             v) base_debug=1 ;;
             V)
@@ -540,13 +395,7 @@ base_cli_main() {
         embrace)          base_cli_do_embrace ;;
         help)             base_cli_show_help ;;
         install)          base_cli_do_install ;;
-        man)              base_cli_do_man ;;
-        run)              base_cli_do_run "$@" ;;
-        set-shared-teams) base_cli_do_set_shared_teams "$@" ;;
-        set-team)         base_cli_do_set_team "$@" ;;
         shell)            base_cli_do_shell ;;
-        status)           base_cli_do_status ;;
-        update)           base_cli_do_update ;;
         update-profile)   base_cli_do_update_profile "$@" ;;
         version)          base_cli_do_version ;;
         "")

--- a/cli/bash/commands/tests/base.bats
+++ b/cli/bash/commands/tests/base.bats
@@ -5,15 +5,11 @@ load ../../../../lib/bash/tests/test_helper.bash
 setup() {
     setup_test_tmpdir
     TEST_HOME="$TEST_TMPDIR/home"
-    TEST_BASE_HOME="$TEST_TMPDIR/install-target"
     mkdir -p "$TEST_HOME"
 }
 
 run_base() {
-    run env \
-        HOME="$TEST_HOME" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/base" "$@"
+    run env         HOME="$TEST_HOME"         PATH="/usr/bin:/bin:/usr/sbin:/sbin"         "$BASE_REPO_ROOT/bin/base" "$@"
 }
 
 @test "base prints help with --help" {
@@ -22,7 +18,19 @@ run_base() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage: base [options] <command> [args...]"* ]]
     [[ "$output" == *"setup [options]"* ]]
-    [[ "$output" == *"check"* ]]
+    [[ "$output" == *"check [options]"* ]]
+}
+
+@test "base help omits legacy leftover commands" {
+    run_base --help
+
+    [ "$status" -eq 0 ]
+    ! grep -Fqx '  update' <<<"$output"
+    ! grep -Fqx '  run <command> [args...]' <<<"$output"
+    ! grep -Fqx '  status' <<<"$output"
+    ! grep -Fqx '  set-team TEAM' <<<"$output"
+    ! grep -Fqx '  set-shared-teams TEAM...' <<<"$output"
+    ! grep -Fqx '  man' <<<"$output"
 }
 
 @test "base prints help when no command is given in a non-interactive shell" {
@@ -33,11 +41,7 @@ run_base() {
 }
 
 @test "base --version uses BASE_VERSION when provided" {
-    run env \
-        HOME="$TEST_HOME" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        BASE_VERSION="test-version" \
-        "$BASE_REPO_ROOT/bin/base" --version
+    run env         HOME="$TEST_HOME"         PATH="/usr/bin:/bin:/usr/sbin:/sbin"         BASE_VERSION="test-version"         "$BASE_REPO_ROOT/bin/base" --version
 
     [ "$status" -eq 0 ]
     [[ "$output" == "base version test-version" ]]
@@ -52,34 +56,12 @@ run_base() {
     [[ "$output" == *"Prepare the local Base CLI environment on macOS."* ]]
 }
 
-@test "base status reports a valid Base checkout" {
-    run_base -b "$BASE_REPO_ROOT" status
+@test "base rejects removed legacy commands" {
+    local legacy_command
 
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Base is installed at $BASE_REPO_ROOT"* ]]
-}
-
-@test "base status reports when Base is not installed at BASE_HOME" {
-    run_base -b "$TEST_BASE_HOME" status
-
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"Base is not installed at '$TEST_BASE_HOME'"* ]]
-}
-
-@test "base set-team writes BASE_TEAM to .baserc" {
-    run_base set-team alpha
-
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_HOME/.baserc" ]
-    run grep -F 'export BASE_TEAM="alpha" # BASE_MARKER, do not delete' "$TEST_HOME/.baserc"
-    [ "$status" -eq 0 ]
-}
-
-@test "base set-shared-teams writes BASE_SHARED_TEAMS to .baserc" {
-    run_base set-shared-teams alpha beta
-
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_HOME/.baserc" ]
-    run grep -F 'export BASE_SHARED_TEAMS="alpha beta" # BASE_MARKER, do not delete' "$TEST_HOME/.baserc"
-    [ "$status" -eq 0 ]
+    for legacy_command in status update run set-team set-shared-teams man; do
+        run_base "$legacy_command"
+        [ "$status" -eq 2 ]
+        [[ "$output" == *"Unrecognized command: $legacy_command"* ]]
+    done
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,408 @@
+# Base — Design Document
+
+## Overview
+
+Base is an opinionated Mac development orchestrator. It provides a unified, declarative
+foundation for bootstrapping a Mac development environment and managing multiple projects
+through a single CLI interface. Base is Mac-only by deliberate design choice. Windows
+support is not in scope.
+
+The governing philosophy: **solve your own problem elegantly first**. Base is built for
+a specific workflow — multiple peer GitHub repositories under a shared parent directory,
+each declaring their dependencies through a simple manifest, all managed through a
+unified interface. If it works well for its author, it will work well for others with
+similar constraints.
+
+---
+
+## Core Principles
+
+- **Opinionated over flexible** — Base makes decisions for you. Fewer choices means
+  less complexity and easier maintenance. If you disagree with the decisions, use a
+  different tool.
+- **Problem-first** — technology choices follow real problems encountered during
+  development, not the other way around.
+- **Ship incrementally** — start minimal, use it yourself, let the tool grow organically
+  through real use.
+- **Idempotent by design** — running any setup command multiple times should produce
+  the same result safely.
+
+---
+
+## Repository Structure
+
+Base is a public GitHub repository. All projects managed by Base are also GitHub
+repositories, checked out as peers under a shared parent directory:
+
+```
+~/projects/          ← shared parent directory
+  base/              ← the Base repository itself
+  myproject-a/       ← peer project with a base manifest
+  myproject-b/       ← peer project with a base manifest
+  banyanlabs/        ← peer project with a base manifest
+```
+
+Base discovers peer repositories by scanning the parent directory for repos that contain
+a base manifest file.
+
+---
+
+## Shell Support
+
+Base supports two shells:
+
+- **bash** — primary scripting shell. All orchestration scripts run in bash. Default for
+  all base internals.
+- **zsh** — supported for interactive use. Power users who prefer zsh for their
+  interactive shell are accommodated.
+
+Fish, tcsh, ksh, and other shells are explicitly out of scope for now. If real demand
+emerges, support can be added later.
+
+---
+
+## Command Surface — `base` First
+
+The most important command-surface decision in Base: **one canonical public command**.
+
+### `base` — The Primary CLI
+
+`base` is the public entrypoint. It is a normal executable command that runs through the
+Base wrapper/bootstrap path. This keeps the product surface simple:
+
+- `base setup`
+- `base check`
+- `base install`
+- `base embrace`
+- `base shell`
+- future commands such as `base projects list`, `base test`, and `base activate`
+
+For now, Base does **not** introduce a separate `basectl` command. A second top-level
+name adds conceptual weight before we have a real need for it.
+
+### Why a Separate `basectl` Is Not Needed Yet
+
+Most orchestration work does not need to mutate the current shell, so a normal CLI is
+sufficient. Even project activation can still be initiated from the `base` executable if
+it works by validating the target project and spawning a subshell with the desired
+project environment.
+
+That means the important split is not between two product names. The important split is
+between:
+
+- commands that perform orchestration and exit normally
+- commands that may launch a subshell for interactive project work
+
+Both can still live under the same `base` command surface.
+
+### Optional Future Shell Function
+
+If Base later needs functionality that truly must mutate the current shell process, an
+optional shell function can be added. If that happens, it should be a thin wrapper around
+`base`, not a separate conceptual tool with a different name.
+
+---
+
+## Project Activation Model — Subshell Design
+
+### Why Subshells
+
+Activating a project environment means setting shell variables, aliases, functions, and
+activating a Python virtual environment. The naive approach of activate/deactivate
+(like Python venv) does not scale to the full richness of a shell environment. Tracking
+and restoring arbitrary shell state on deactivation is complex and error-prone.
+
+The solution: **spawn a subshell** when activating a project. The project environment
+lives inside the subshell. The user works in that subshell. When done, they `exit` (or
+Ctrl-D) and return to their base shell. No deactivation logic required. No state
+restoration complexity.
+
+This does not require a distinct shell function. A normal `base activate <project>`
+command can validate the target and launch the configured subshell.
+
+### Activation Flow
+
+```
+base activate myproject
+  ↓
+1. Look up BASE_HOME, scan known projects
+2. Validate myproject exists and has a valid manifest
+3. Set BASE_PROJECT=myproject
+4. Spawn a new subshell
+5. In the subshell: source the project's shell environment script
+6. In the subshell: activate the project's Python virtual environment
+7. Update the prompt to reflect the active project
+8. User works in subshell
+9. User exits → returns to base shell, prompt resets
+```
+
+### `base activate` — Intelligence
+
+- Takes a project name as argument (not a directory path)
+- Works from any current directory — the user does not need to be in the project folder
+- Base looks in `$BASE_HOME` to locate and validate the project
+- Validates that the target is a recognized Base project with a valid manifest
+
+---
+
+## Shell Environment Layers
+
+There are two layers of shell environment, clearly separated:
+
+### Layer 1 — Base Global Environment
+
+Applied once when the shell starts, using Base-managed startup files and machine-local overrides.
+Contains:
+- Shell prompt (PS1) defaults
+- History settings (size, format, file location)
+- Default aliases and utility functions
+- PATH additions for Base's own tools
+- Shell options appropriate for bash or zsh
+- `BASE_PROJECT` set to `"base"` by default
+- `BASE_HOME` pointing to the base project root
+
+This layer is currently installed by adopting the Base-managed startup files under `lib/shell/`, typically through symlinks or a helper such as `base embrace`. Machine-local overrides belong in `~/.baserc`.
+
+### Layer 2 — Project-Specific Environment
+
+Applied inside the project subshell when `base activate <project>` is run.
+Contains:
+- Project-specific PATH additions
+- Project-specific environment variables
+- Project-specific aliases and functions
+- Project-specific Python virtual environment activation
+- `BASE_PROJECT` updated to the project name
+
+Project-specific settings layer on top of the base global environment. Settings not
+overridden by the project inherit from the base global layer. When the subshell exits,
+the project layer disappears naturally — no explicit deactivation needed.
+
+### Dotfile Management
+
+Base currently ships managed shell startup files instead of injecting a large managed block into user dotfiles. The preferred adoption model is:
+
+| File | Purpose |
+|---|---|
+| `lib/shell/bashrc` | Interactive bash shell settings |
+| `lib/shell/bash_profile` | Login bash shell settings |
+| `lib/shell/zshrc` | Interactive zsh shell settings |
+| `lib/shell/zprofile` | Login zsh shell settings |
+
+Users can symlink these into place, and Base can provide helper commands such as `base embrace` to make that easier. `~/.baserc` remains the machine-local override file for settings such as `BASE_HOME`.
+
+---
+
+## Directory Change Behavior
+
+**Changing directory does not trigger environment changes.**
+
+This is a deliberate design decision. Auto-activating environments on `cd` is confusing
+because the intent behind a `cd` is ambiguous — the user may be casually navigating,
+not intending to switch project context. Background logic running on every `cd` also
+slows the shell and is error-prone.
+
+The only things that change on `cd`:
+- `$PWD` updates (built-in shell behavior)
+- The directory portion of the prompt updates
+- The git branch portion of the prompt updates dynamically (see Prompt section)
+
+Everything else stays stable until the user explicitly runs `base activate <project>`.
+
+---
+
+## Prompt Design
+
+The prompt shows three things, always:
+
+```
+[myproject: main] ~/projects/myproject/src $
+```
+
+| Element | Source | Behavior |
+|---|---|---|
+| Project name | `$BASE_PROJECT` | Static — set at activation, stays until subshell exits |
+| Git branch | Dynamic query | Updates on every prompt render |
+| Current directory | `$PWD` | Updates on every `cd` |
+
+### Project Name in Prompt
+
+`BASE_PROJECT` is set by `base activate`. Default value is `"base"`. It does not change
+based on directory. Once you activate a project, the project name shows consistently
+regardless of where you `cd` inside the subshell.
+
+### Git Branch in Prompt
+
+The git branch is **not stored in a variable**. It is queried dynamically each time the
+prompt renders. This ensures the prompt reflects reality when the user runs `git
+checkout` to switch branches inside the subshell.
+
+Implementation in PS1:
+
+```bash
+_base_git_branch() {
+  git -C "$BASE_PROJECT_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo "detached"
+}
+
+PS1='[${BASE_PROJECT}: $(_base_git_branch)] \w $ '
+```
+
+Key decision: the branch is always queried against `$BASE_PROJECT_ROOT` (the project's
+root directory), not the current working directory. This means even if you `cd /tmp`,
+the prompt shows the project's branch, not whatever git repo happens to be at `/tmp`.
+
+### Why Not Show Python Venv in Prompt
+
+The project name in the prompt implies the Python virtual environment — if a project is
+active, its venv is active. Showing both would be redundant. The prompt stays clean.
+
+---
+
+## Python Virtual Environments
+
+### Base Venv
+
+- Created once during `base setup`
+- Lives at `~/.base.d/.venv`
+- Used to run Base's own Python orchestration code (manifest parsing, project discovery,
+  etc.)
+- Not activated in the user's interactive shell by default — it runs internally when
+  Base needs it
+
+### Project Venv
+
+- Created per project during `base setup <project>` or `base setup` when scanning
+  all projects
+- Lives inside the project directory (e.g., `.venv/`)
+- Activated automatically when `base activate <project>` spawns the project subshell
+- Deactivated automatically when the subshell exits
+
+### Key Distinction
+
+Only one Python venv can be active at a time. Base venv runs quietly in the background
+for Base's own tools. Project venv is what the user interacts with. The two never
+conflict because Base venv is not surfaced in the interactive shell.
+
+---
+
+## Project Manifest
+
+Each Base-managed project declares its dependencies in a YAML manifest file at the
+project root. Base reads this manifest to know what to install and configure.
+
+File: `base.yaml` (name TBD)
+
+Conceptual structure:
+
+```yaml
+project:
+  name: myproject
+  description: A short description
+
+dependencies:
+  system:
+    - kubernetes
+    - terraform
+    - docker
+  python:
+    - version: "3.12"
+      packages:
+        - requests
+        - rich
+  go:
+    - version: "1.22"
+
+shell:
+  env:
+    MY_PROJECT_ENV: production
+  path:
+    - ./bin
+```
+
+The Python layer interprets this declarative manifest and translates each item into
+concrete installation actions. Base knows how to install system tools via Homebrew,
+manage Python versions and packages, and handle language-specific package managers.
+
+Version conflicts across projects are a known complexity — addressed in a later
+iteration, not in the initial build.
+
+---
+
+## Mac Bootstrap Sequence
+
+When `base setup` runs on a fresh Mac:
+
+1. Check for Homebrew — install if missing
+2. Check for Xcode CLI tools — install if missing
+3. Install Python (target version) via Homebrew
+4. Create Base's own virtual environment at `~/.base.d/.venv`
+5. Install Base's Python dependencies into `~/.base.d/.venv`
+6. Prepare the managed shell startup model (currently via Base-managed startup files and shell adoption helpers)
+7. Scan the parent directory for peer repos with base manifests
+8. For each discovered project, run project-level setup (install declared dependencies,
+   create project venv)
+
+---
+
+## GitHub and Repository Conventions
+
+- Base is a public GitHub repository
+- Issues are the official communication channel for bug reports and feedback
+- The README contains a clear "Issues and Feedback" section pointing users to GitHub
+  Issues
+- A stable release tag (e.g. `v0.9.0`) marks the last version of the old Base design
+  before the current rewrite begins
+- The README includes a notice that active development is happening on master and the
+  API is changing significantly
+- Users who want stability should pin to the stable release tag
+
+---
+
+## Utility Scripts and Extras
+
+Base ships with a small collection of utility scripts useful for day-to-day Mac
+development:
+
+- Shell helper functions for common operations
+- Python library utilities for unified CLI development (shared across Base-managed
+  projects)
+- Git convenience helpers (branch management, PR workflows)
+- Potentially: a base-provided Python CLI framework so that projects built within the
+  Base ecosystem share a consistent CLI style
+
+These extras emerge organically from real needs — they are not designed upfront.
+
+---
+
+## What Base Is Not
+
+- Not a replacement for Docker or dev containers — those solve a different problem
+  (containerization). Base is Mac-native and lightweight.
+- Not cross-platform — Windows is explicitly out of scope.
+- Not a universal package manager — Homebrew handles that. Base orchestrates on top
+  of Homebrew.
+- Not trying to solve every edge case — version conflict handling across projects,
+  language runtimes beyond Python, and container integration are future considerations.
+
+---
+
+## Open Questions (To Resolve Through Use)
+
+- Exact manifest file name (`base.yaml`, `.base.yaml`, `base_manifest.yaml`)
+- Version conflict resolution strategy across projects with different dependency versions
+- Docker/dev container integration path for banyanlabs
+- How Base handles projects that don't use Python at all
+- Fish shell support — revisit if real demand emerges
+
+---
+
+## Relationship to Banyanlabs
+
+Base is the prerequisite for banyanlabs. Banyanlabs (a multi-cloud, polyglot DevOps
+learning environment) will be a Base-managed project — it will have a base manifest
+declaring all its infrastructure tool dependencies. Base handles the bootstrapping.
+Banyanlabs handles the learning environment. Base must ship first.
+
+---
+
+*This document reflects design decisions made in May 2026. It is a living document —
+update it as the design evolves through real implementation experience.*


### PR DESCRIPTION
## Summary

This PR tightens the `base` command surface and aligns the docs with the direction we have actually chosen.

It removes a set of leftover commands inherited from the older `base.sh` behavior, keeps only the relevant shell-management commands, and updates the design docs to reflect the decision that `base` is the single public command for now.

## Why

After the earlier refactors, the `base` umbrella CLI still carried several commands that no longer fit the new Base model:

- `update`
- `status`
- `run`
- `set-team`
- `set-shared-teams`
- `man`

Those commands were tied to older assumptions about Base as a repo-local shell helper and team-specific wrapper surface.

At the same time, the design note still described a `basectl` / `base` split that no longer matches the implementation direction or the product decision we want to keep.

This PR cleans both of those up.

## What changed

### CLI cleanup

Removed these legacy commands from `base`:

- `update`
- `status`
- `run`
- `set-team`
- `set-shared-teams`
- `man`

Kept these relevant commands in place:

- `setup`
- `check`
- `update-profile`
- `install`
- `embrace`
- `shell`
- `version`
- `help`

### Option cleanup

Removed obsolete global option handling tied to the deleted team-related commands:

- `-t`
- `-s`

### Install behavior

Simplified `base install` so it now only persists:

- `BASE_HOME`

It no longer writes team-related state into `~/.baserc`.

### Docs updates

Updated:

- `cli/bash/commands/base/README.md`
- `README.md`

The main README now points readers to:

- `docs/design.md`

for the evolving architecture and product-direction notes.

### Design doc reconciliation

Updated:

- `docs/design.md`

to align with the current Base direction:

- `base` is the single canonical public command
- `basectl` is not introduced for now
- a future shell function is optional, not foundational
- project activation can still be modeled as `base activate <project>` launching a subshell
- shell setup is described in terms of the current `lib/shell/` + `~/.baserc` + `base embrace` model
- Base’s own virtualenv path now matches current reality: `~/.base.d/.venv`

## Validation

Passed:

```bash
bash -n cli/bash/commands/base/base.sh
bats cli/bash/commands/tests/base.bats
bats cli/bash/commands/tests/setup.bats
bats cli/bash/bin/tests/base-wrapper.bats
bats cli/env/tests/baseenv.bats
```