### PR TITLE
Implement managed shell profile updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,26 +99,47 @@ invoke it from whatever shell state they already had.
 
 ## Shell Startup Files
 
-Base now ships managed startup files under `lib/shell/` for both Bash and Zsh:
+Base integrates with Bash and Zsh through small managed sections in the user's
+real dotfiles. Base does not take over whole dotfiles.
 
-- `lib/shell/bash_profile`
-- `lib/shell/bashrc`
-- `lib/shell/zprofile`
-- `lib/shell/zshrc`
+The command that installs or refreshes those sections is:
 
-The division of responsibility is intentional.
+```bash
+base update-profile
+```
+
+By default it updates all four startup files:
+
+- `~/.bash_profile`
+- `~/.bashrc`
+- `~/.zprofile`
+- `~/.zshrc`
+
+Missing files are created. Existing files keep their non-Base content; Base only
+adds or replaces its marked section.
+
+### Base Snippets
+
+The managed sections source matching snippets under `lib/shell/`:
+
+- `lib/shell/bash_profile` for `~/.bash_profile`
+- `lib/shell/bashrc` for `~/.bashrc`
+- `lib/shell/zprofile` for `~/.zprofile`
+- `lib/shell/zshrc` for `~/.zshrc`
+
+The names intentionally mirror the dotfiles they support, without leading dots
+inside the repository.
 
 ### Login Profiles
 
-`bash_profile` and `zprofile` should stay thin.
+`bash_profile` and `zprofile` stay thin.
 
-They are responsible for:
+For Bash, Base makes the login-shell bridge explicit: the Bash profile snippet
+sources `~/.bashrc` with a guardrail. Bash needs this because login Bash shells
+do not automatically read `~/.bashrc`.
 
-- one-time setup for a login shell
-- handing off to the interactive rc file
-
-They should not be the main place for aliases, prompt settings, shell editing
-mode, completion, or project activation logic.
+For Zsh, Base does not source `~/.zshrc` from `zprofile`. Zsh already reads
+`~/.zshrc` for interactive shells.
 
 ### Interactive RC Files
 
@@ -128,65 +149,33 @@ They are responsible for:
 
 - guarding against non-interactive execution
 - guarding against repeated sourcing
-- locating `BASE_HOME`
-- sourcing `~/.baserc` for machine-local overrides
-- sourcing `base_init.sh`
+- validating or inferring `BASE_HOME`
+- sourcing `base_init.sh` through the shared startup helper
 - optionally enabling shared shell defaults
-
-This is where Base becomes active for day-to-day terminal use.
 
 ### Standard Shell Defaults
 
-Reusable, opinionated shell defaults should live outside the profile files
-themselves.
+Base can provide optional, opinionated shell defaults, but they are not enabled
+by plain `base update-profile`.
 
 Current default-setting scripts are:
 
-- `lib/shell/base_defaults.sh` for Bash
+- `lib/shell/bash_defaults.sh` for Bash
 - `lib/shell/zsh_defaults.sh` for Zsh
 
-These are intentionally optional. Users can opt in by setting:
+Users can opt in during profile updates with:
 
 ```bash
-BASE_ENABLE_SHELL_DEFAULTS=true
+base update-profile --defaults
 ```
 
-in `~/.baserc`.
-
-That keeps the startup files focused on shell bootstrap while letting Base also
-house standard interactive settings such as:
+Those defaults are intended to stay conservative:
 
 - aliases like `rm -i`, `cp -i`, `mv -i`
 - vi-style command editing
 - editor defaults
 - prompt defaults
 - history behavior
-
-### Machine-Local Overrides
-
-`~/.baserc` is the right place for machine-local settings that should not be
-hard-coded into the shared startup files, such as:
-
-- `BASE_HOME`
-- `BASE_ENABLE_SHELL_DEFAULTS`
-- host-specific overrides
-- local experimental toggles
-
-### Adoption
-
-The expected setup is to symlink your shell startup files to the Base-managed
-versions:
-
-```bash
-ln -sf /path/to/base/lib/shell/bash_profile ~/.bash_profile
-ln -sf /path/to/base/lib/shell/bashrc ~/.bashrc
-ln -sf /path/to/base/lib/shell/zprofile ~/.zprofile
-ln -sf /path/to/base/lib/shell/zshrc ~/.zshrc
-```
-
-When the files are symlinked, the rc files can infer `BASE_HOME` from their own
-resolved path. When they are copied instead of symlinked, `~/.baserc` should
-set `BASE_HOME` explicitly.
 
 ## What Base Is Responsible For
 

--- a/cli/bash/commands/base/README.md
+++ b/cli/bash/commands/base/README.md
@@ -22,7 +22,6 @@ Bash stdlib loading path as other wrapped commands.
 - `check`
 - `update-profile`
 - `install`
-- `embrace`
 - `shell`
 - `version`
 - `help`
@@ -31,6 +30,6 @@ Bash stdlib loading path as other wrapped commands.
 
 - `base setup` is the default local bootstrap path.
 - `base check` verifies the same local requirements without making changes.
-- `embrace` and `shell` are the remaining shell-management entrypoints.
+- `base update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - Base-specific bootstrap subcommands live under `cli/bash/commands/base/subcommands/`.
 - Shared tests for Base subcommands live under `cli/bash/commands/tests/`.

--- a/cli/bash/commands/base/base.sh
+++ b/cli/bash/commands/base/base.sh
@@ -14,11 +14,9 @@ Commands:
   check [options]
     Verify the local Base CLI environment without making changes.
   update-profile [options]
-    Reserved for future shell profile updates.
+    Create or update Base-managed sections in Bash and Zsh startup files.
   install
     Install Base into BASE_HOME.
-  embrace
-    Symlink shell startup files from Base into the user's home directory.
   shell
     Start an interactive Bash shell using Base's managed startup files.
   version
@@ -118,11 +116,11 @@ base_cli_runtime_repo_root() {
     return 1
 }
 
-base_cli_shell_profile_path() {
+base_cli_shell_rc_path() {
     local repo_root
 
     repo_root="$(base_cli_runtime_repo_root)" || return 1
-    printf '%s\n' "$repo_root/lib/shell/bash_profile"
+    printf '%s\n' "$repo_root/lib/shell/bashrc"
 }
 
 base_cli_patch_baserc() {
@@ -253,81 +251,18 @@ base_cli_do_install() {
     return 0
 }
 
-base_cli_do_embrace() {
-    local base_bash_profile base_bashrc
-    local bash_profile bashrc
-    local bash_profile_link="" bashrc_link=""
-    local bash_profile_backup="" bashrc_backup=""
-
-    if ! base_cli_verify_repo "$BASE_HOME"; then
-        if base_cli_verify_repo "$BASE_REPO_ROOT"; then
-            BASE_HOME="$BASE_REPO_ROOT"
-            export BASE_HOME
-        else
-            base_cli_error "$BASE_CLI_ERROR_MESSAGE"
-            return 1
-        fi
-    fi
-
-    base_bash_profile="$BASE_HOME/lib/shell/bash_profile"
-    base_bashrc="$BASE_HOME/lib/shell/bashrc"
-    bash_profile="$HOME/.bash_profile"
-    bashrc="$HOME/.bashrc"
-
-    [[ -L "$bash_profile" ]] && bash_profile_link="$(readlink "$bash_profile")"
-    [[ -L "$bashrc" ]] && bashrc_link="$(readlink "$bashrc")"
-
-    if [[ "$bash_profile_link" == "$base_bash_profile" ]]; then
-        printf '%s\n' "$bash_profile is already symlinked to $base_bash_profile"
-    else
-        if [[ -f "$bash_profile" ]]; then
-            bash_profile_backup="$HOME/.bash_profile.$current_time"
-            printf "Backing up %s to %s and overriding it with %s\n" "$bash_profile" "$bash_profile_backup" "$base_bash_profile"
-            cp -- "$bash_profile" "$bash_profile_backup" || {
-                base_cli_error "Can't create a backup of $bash_profile."
-                return 1
-            }
-        fi
-        ln -sf -- "$base_bash_profile" "$bash_profile" || {
-            base_cli_error "Couldn't symlink '$bash_profile' to '$base_bash_profile'."
-            return 1
-        }
-        printf "Symlinked '%s' to '%s'\n" "$bash_profile" "$base_bash_profile"
-    fi
-
-    if [[ "$bashrc_link" == "$base_bashrc" ]]; then
-        printf '%s\n' "$bashrc is already symlinked to $base_bashrc"
-    else
-        if [[ -f "$bashrc" ]]; then
-            bashrc_backup="$HOME/.bashrc.$current_time"
-            printf "Backing up %s to %s and overriding it with %s\n" "$bashrc" "$bashrc_backup" "$base_bashrc"
-            cp -- "$bashrc" "$bashrc_backup" || {
-                base_cli_error "Can't create a backup of $bashrc."
-                return 1
-            }
-        fi
-        ln -sf -- "$base_bashrc" "$bashrc" || {
-            base_cli_error "Couldn't symlink '$bashrc' to '$base_bashrc'."
-            return 1
-        }
-        printf "Symlinked '%s' to '%s'\n" "$bashrc" "$base_bashrc"
-    fi
-
-    return 0
-}
-
 base_cli_do_shell() {
-    local shell_profile
+    local shell_rc
 
-    shell_profile="$(base_cli_shell_profile_path)" || {
+    shell_rc="$(base_cli_shell_rc_path)" || {
         base_cli_error "$BASE_CLI_ERROR_MESSAGE"
         return 1
     }
 
-    BASE_HOME="$(cd -- "$(dirname -- "$shell_profile")/../.." && pwd -P)"
+    BASE_HOME="$(cd -- "$(dirname -- "$shell_rc")/../.." && pwd -P)"
     export BASE_HOME
     export BASE_SHELL=1
-    exec bash --rcfile "$shell_profile"
+    exec bash --rcfile "$shell_rc"
 }
 
 
@@ -392,7 +327,6 @@ base_cli_main() {
     case "$command" in
         check)            base_cli_do_check "$@" ;;
         setup)            base_cli_do_setup "$@" ;;
-        embrace)          base_cli_do_embrace ;;
         help)             base_cli_show_help ;;
         install)          base_cli_do_install ;;
         shell)            base_cli_do_shell ;;

--- a/cli/bash/commands/base/subcommands/setup_common.sh
+++ b/cli/bash/commands/base/subcommands/setup_common.sh
@@ -359,7 +359,3 @@ setup_run_install() {
     fi
 }
 
-setup_run_update_profile() {
-    print_warn "The 'base update-profile' subcommand is not implemented yet."
-    return 1
-}

--- a/cli/bash/commands/base/subcommands/update_profile.sh
+++ b/cli/bash/commands/base/subcommands/update_profile.sh
@@ -14,17 +14,81 @@ Usage:
   base update-profile [options]
 
 Options:
+  --defaults  Enable Base's optional Bash/Zsh shell defaults in managed rc sections.
   -v          Enable DEBUG logging for this subcommand.
   -h, --help  Show this help text.
 
 Purpose:
-  Reserved for future shell profile updates managed by Base.
+  Create or update Base-managed sections in Bash and Zsh startup files.
+
+Updated files:
+  ~/.bash_profile
+  ~/.bashrc
+  ~/.zprofile
+  ~/.zshrc
 EOF
 }
 
+base_update_profile_source_file_library() {
+    local file_lib="${BASE_BASH_LIB_DIR:-$BASE_REPO_ROOT/lib/bash}/file/lib_file.sh"
+
+    [[ -f "$file_lib" ]] || {
+        print_error "File library '$file_lib' was not found."
+        return 1
+    }
+
+    # shellcheck source=/dev/null
+    source "$file_lib"
+}
+
+base_update_profile_quote() {
+    local value="$1"
+    printf '%q\n' "$value"
+}
+
+base_update_profile_section_lines() {
+    local snippet_name="$1"
+    local enable_defaults="$2"
+    local quoted_base_home
+
+    quoted_base_home="$(base_update_profile_quote "$BASE_HOME")" || return 1
+
+    printf '%s\n' "# Managed by Base. Run 'base update-profile' to refresh this section."
+    printf 'export BASE_HOME=%s\n' "$quoted_base_home"
+
+    case "$snippet_name:$enable_defaults" in
+        bashrc:1|zshrc:1)
+            printf '%s\n' 'export BASE_ENABLE_SHELL_DEFAULTS=true'
+            ;;
+    esac
+
+    printf '%s\n' '# shellcheck source=/dev/null'
+    printf 'source "$BASE_HOME/lib/shell/%s"\n' "$snippet_name"
+}
+
+base_update_profile_update_file() {
+    local target_file="$1"
+    local snippet_name="$2"
+    local enable_defaults="$3"
+    local start_marker="# >>> base ${snippet_name} >>>"
+    local end_marker="# <<< base ${snippet_name} <<<"
+    local lines=()
+
+    safe_touch "$target_file"
+
+    mapfile -t lines < <(base_update_profile_section_lines "$snippet_name" "$enable_defaults") || return 1
+    update_file_section "$target_file" "$start_marker" "$end_marker" "${lines[@]}"
+}
+
 base_update_profile_subcommand_main() {
+    local enable_defaults=0
+    local repo_root
+
     while (($#)); do
         case "$1" in
+            --defaults)
+                enable_defaults=1
+                ;;
             -h|--help|help)
                 base_update_profile_subcommand_usage
                 return 0
@@ -42,5 +106,20 @@ base_update_profile_subcommand_main() {
     done
 
     log_debug "Running 'base update-profile'."
-    setup_run_update_profile
+
+    repo_root="$(base_cli_runtime_repo_root)" || {
+        print_error "${BASE_CLI_ERROR_MESSAGE:-Unable to find the Base repository root.}"
+        return 1
+    }
+    BASE_HOME="$repo_root"
+    export BASE_HOME
+
+    base_update_profile_source_file_library || return 1
+
+    base_update_profile_update_file "$HOME/.bash_profile" bash_profile 0 || return 1
+    base_update_profile_update_file "$HOME/.bashrc" bashrc "$enable_defaults" || return 1
+    base_update_profile_update_file "$HOME/.zprofile" zprofile 0 || return 1
+    base_update_profile_update_file "$HOME/.zshrc" zshrc "$enable_defaults" || return 1
+
+    print_success "Updated Base-managed shell startup sections."
 }

--- a/cli/bash/commands/tests/base.bats
+++ b/cli/bash/commands/tests/base.bats
@@ -31,6 +31,7 @@ run_base() {
     ! grep -Fqx '  set-team TEAM' <<<"$output"
     ! grep -Fqx '  set-shared-teams TEAM...' <<<"$output"
     ! grep -Fqx '  man' <<<"$output"
+    ! grep -Fqx '  embrace' <<<"$output"
 }
 
 @test "base prints help when no command is given in a non-interactive shell" {
@@ -59,7 +60,7 @@ run_base() {
 @test "base rejects removed legacy commands" {
     local legacy_command
 
-    for legacy_command in status update run set-team set-shared-teams man; do
+    for legacy_command in status update run set-team set-shared-teams man embrace; do
         run_base "$legacy_command"
         [ "$status" -eq 2 ]
         [[ "$output" == *"Unrecognized command: $legacy_command"* ]]

--- a/cli/bash/commands/tests/setup.bats
+++ b/cli/bash/commands/tests/setup.bats
@@ -367,10 +367,48 @@ run_base_command() {
     [[ "$output" == *"Running 'base setup'"* ]]
 }
 
-@test "base update-profile is reserved for later work" {
+@test "base update-profile creates Base-managed sections in all shell dotfiles" {
     run_base_command update-profile
 
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"update-profile"* ]]
-    [[ "$output" == *"not implemented yet"* ]]
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Updated Base-managed shell startup sections."* ]]
+
+    for dotfile in .bash_profile .bashrc .zprofile .zshrc; do
+        [ -f "$TEST_HOME/$dotfile" ]
+        [[ "$(cat "$TEST_HOME/$dotfile")" == *"export BASE_HOME=$BASE_REPO_ROOT"* ]]
+    done
+
+    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"# >>> base bash_profile >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.bash_profile")" == *'source "$BASE_HOME/lib/shell/bash_profile"'* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"# >>> base bashrc >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *'source "$BASE_HOME/lib/shell/bashrc"'* ]]
+    [[ "$(cat "$TEST_HOME/.zprofile")" == *"# >>> base zprofile >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.zprofile")" == *'source "$BASE_HOME/lib/shell/zprofile"'* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" == *"# >>> base zshrc >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" == *'source "$BASE_HOME/lib/shell/zshrc"'* ]]
+}
+
+@test "base update-profile preserves non-Base dotfile content and is idempotent" {
+    printf '%s
+' 'user line before' > "$TEST_HOME/.bashrc"
+
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    [ "$(grep -c '# >>> base bashrc >>>' "$TEST_HOME/.bashrc")" -eq 1 ]
+    [ "$(grep -c '# <<< base bashrc <<<' "$TEST_HOME/.bashrc")" -eq 1 ]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"user line before"* ]]
+}
+
+@test "base update-profile --defaults enables defaults only in interactive rc files" {
+    run_base_command update-profile --defaults
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"export BASE_ENABLE_SHELL_DEFAULTS=true"* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" == *"export BASE_ENABLE_SHELL_DEFAULTS=true"* ]]
+    [[ "$(cat "$TEST_HOME/.bash_profile")" != *"BASE_ENABLE_SHELL_DEFAULTS"* ]]
+    [[ "$(cat "$TEST_HOME/.zprofile")" != *"BASE_ENABLE_SHELL_DEFAULTS"* ]]
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -73,7 +73,7 @@ Base wrapper/bootstrap path. This keeps the product surface simple:
 - `base setup`
 - `base check`
 - `base install`
-- `base embrace`
+- `base update-profile`
 - `base shell`
 - future commands such as `base projects list`, `base test`, and `base activate`
 
@@ -161,7 +161,7 @@ Contains:
 - `BASE_PROJECT` set to `"base"` by default
 - `BASE_HOME` pointing to the base project root
 
-This layer is currently installed by adopting the Base-managed startup files under `lib/shell/`, typically through symlinks or a helper such as `base embrace`. Machine-local overrides belong in `~/.baserc`.
+This layer is currently installed by running `base update-profile`, which creates or updates Base-managed sections in the user's Bash and Zsh dotfiles. Base owns only its marked sections, not the whole dotfile.
 
 ### Layer 2 — Project-Specific Environment
 
@@ -179,16 +179,22 @@ the project layer disappears naturally — no explicit deactivation needed.
 
 ### Dotfile Management
 
-Base currently ships managed shell startup files instead of injecting a large managed block into user dotfiles. The preferred adoption model is:
+Base updates the user's real dotfiles by managing small marked sections. The preferred adoption model is:
 
-| File | Purpose |
-|---|---|
-| `lib/shell/bashrc` | Interactive bash shell settings |
-| `lib/shell/bash_profile` | Login bash shell settings |
-| `lib/shell/zshrc` | Interactive zsh shell settings |
-| `lib/shell/zprofile` | Login zsh shell settings |
+```bash
+base update-profile
+```
 
-Users can symlink these into place, and Base can provide helper commands such as `base embrace` to make that easier. `~/.baserc` remains the machine-local override file for settings such as `BASE_HOME`.
+By default, Base updates all four files:
+
+| Dotfile | Base snippet | Purpose |
+|---|---|---|
+| `~/.bash_profile` | `lib/shell/bash_profile` | Login Bash bridge into `~/.bashrc` |
+| `~/.bashrc` | `lib/shell/bashrc` | Interactive Bash startup |
+| `~/.zprofile` | `lib/shell/zprofile` | Thin Zsh login startup |
+| `~/.zshrc` | `lib/shell/zshrc` | Interactive Zsh startup |
+
+Base does not symlink over the user's dotfiles and does not own content outside its marked sections. Optional Base shell defaults are enabled explicitly with `base update-profile --defaults`.
 
 ---
 
@@ -336,7 +342,7 @@ When `base setup` runs on a fresh Mac:
 3. Install Python (target version) via Homebrew
 4. Create Base's own virtual environment at `~/.base.d/.venv`
 5. Install Base's Python dependencies into `~/.base.d/.venv`
-6. Prepare the managed shell startup model (currently via Base-managed startup files and shell adoption helpers)
+6. Prepare the managed shell startup model with `base update-profile`
 7. Scan the parent directory for peer repos with base manifests
 8. For each discovered project, run project-level setup (install declared dependencies,
    create project venv)

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -229,7 +229,7 @@ How Base should coexist:
 
 - users may use `dotbot` to install or link Base-managed shell startup files
 - Base does not need native `dotbot` integration beyond staying compatible with
-  symlink-based installation
+  ordinary dotfile management and marked sections
 
 Current stance: light coexistence, otherwise not a major design influence.
 

--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -1,5 +1,5 @@
 #
-# base_defaults.sh
+# bash_defaults.sh
 #     Optional Bash-specific interactive defaults for users who want Base to
 #     provide a standard shell experience in addition to the core bootstrap.
 #

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -1,7 +1,24 @@
+#
+# bash_profile
+#     Base-managed login-shell snippet for Bash.
+#
+# Purpose:
+#     - sourced from the Base-managed section in ~/.bash_profile
+#     - keep Bash login startup thin
+#     - bridge interactive login Bash shells into ~/.bashrc with a guardrail
+#
+# Design note:
+#     Bash does not automatically source ~/.bashrc for login shells. Base makes
+#     that bridge explicit here. The flow is one-way: bash_profile may source
+#     bashrc, but bashrc must never source bash_profile.
+#
 [[ -n "${__base_bash_profile_sourced__:-}" ]] && return 0
 readonly __base_bash_profile_sourced__=1
 
+[[ -n "${__base_sourcing_bashrc_from_profile__:-}" ]] && return 0
 [[ -f "$HOME/.bashrc" ]] || return 0
 
+__base_sourcing_bashrc_from_profile__=1
 # shellcheck source=/dev/null
 source "$HOME/.bashrc"
+unset __base_sourcing_bashrc_from_profile__

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -1,3 +1,24 @@
+#
+# bashrc
+#     Base-managed interactive-shell snippet for Bash.
+#
+# Purpose:
+#     - sourced from the Base-managed section in ~/.bashrc
+#     - run only for interactive Bash shells
+#     - determine BASE_HOME from the managed dotfile section, with a fallback
+#       to this file's resolved location
+#     - hand off to lib/shell/shell_startup.sh
+#
+# What belongs here:
+#     - interactive-shell guards
+#     - BASE_HOME validation/fallback
+#     - loading the shared Base shell bootstrap
+#
+# What does not belong here:
+#     - login-shell bridging (that belongs in lib/shell/bash_profile)
+#     - sourcing ~/.bash_profile
+#     - machine-local configuration policy
+#
 [[ $- != *i* ]] && return 0
 [[ -n "${__base_bashrc_sourced__:-}" ]] && return 0
 readonly __base_bashrc_sourced__=1
@@ -16,46 +37,42 @@ base_bashrc_source_path() {
     done
 
     link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    printf '%s/%s\n' "$link_dir" "$(basename "$source_path")"
+    printf '%s/%s
+' "$link_dir" "$(basename "$source_path")"
 }
 
 base_bashrc_set_base_home() {
     local source_path lib_dir candidate
-
-    source_path="$(base_bashrc_source_path)" || return 1
-    lib_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    candidate="$(cd -- "$lib_dir/../.." && pwd -P)" || return 1
-
-    if [[ -f "$HOME/.baserc" && -z "${__base_user_baserc_sourced__:-}" ]]; then
-        # shellcheck source=/dev/null
-        source "$HOME/.baserc"
-        _baserc_sourced=1
-        readonly __base_user_baserc_sourced__=1
-    fi
 
     if [[ -n "${BASE_HOME:-}" && -f "$BASE_HOME/base_init.sh" ]]; then
         export BASE_HOME
         return 0
     fi
 
+    source_path="$(base_bashrc_source_path)" || return 1
+    lib_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    candidate="$(cd -- "$lib_dir/../.." && pwd -P)" || return 1
+
     if [[ -f "$candidate/base_init.sh" ]]; then
         BASE_HOME="$candidate"
-    else
-        BASE_HOME="$HOME/base"
+        export BASE_HOME
+        return 0
     fi
 
-    export BASE_HOME
+    return 1
 }
 
 [[ -f /etc/bashrc ]] && source /etc/bashrc
 
 base_bashrc_set_base_home || {
-    printf 'ERROR: Unable to determine BASE_HOME.\n' >&2
+    printf 'ERROR: Unable to determine BASE_HOME. Run base update-profile to refresh shell startup files.
+' >&2
     return 1
 }
 
 [[ -f "$BASE_HOME/lib/shell/shell_startup.sh" ]] || {
-    printf "ERROR: Base shell startup helper '%s/lib/shell/shell_startup.sh' was not found.\n" "$BASE_HOME" >&2
+    printf "ERROR: Base shell startup helper '%s/lib/shell/shell_startup.sh' was not found.
+" "$BASE_HOME" >&2
     return 1
 }
 

--- a/lib/shell/shell_startup.sh
+++ b/lib/shell/shell_startup.sh
@@ -12,7 +12,7 @@ base_shell_source_defaults() {
     [[ "${BASE_ENABLE_SHELL_DEFAULTS:-false}" == true ]] || return 0
 
     case "$shell_name" in
-        bash) defaults_script="$BASE_HOME/lib/shell/base_defaults.sh" ;;
+        bash) defaults_script="$BASE_HOME/lib/shell/bash_defaults.sh" ;;
         zsh)  defaults_script="$BASE_HOME/lib/shell/zsh_defaults.sh" ;;
         *)
             base_shell_error "Unknown shell '$shell_name' for default settings."

--- a/lib/shell/zprofile
+++ b/lib/shell/zprofile
@@ -1,34 +1,14 @@
 #
-# .zprofile
-#     Base-managed login startup file for Zsh.
+# zprofile
+#     Base-managed login-shell snippet for Zsh.
 #
 # Purpose:
-#     - stay intentionally thin
-#     - run in login Zsh shells
-#     - hand off to ~/.zshrc so that interactive setup happens in one place
-#
-# Expected usage:
-#     symlink ~/.zprofile -> /path/to/base/lib/shell/zprofile
-#
-# What belongs here:
-#     - login-shell bridging into ~/.zshrc
-#
-# What does not belong here:
-#     - aliases, prompts, keybindings, completion setup, or Base activation
-#       logic beyond the handoff to ~/.zshrc
+#     - sourced from the Base-managed section in ~/.zprofile
+#     - keep Zsh login startup thin
 #
 # Design note:
-#     Keeping zprofile small makes the startup chain easier to reason about and
-#     keeps interactive behavior centralized in lib/shell/zshrc.
-#
-# See also:
-#     lib/shell/zshrc
-#     README.md section "Shell Startup Files"
+#     Zsh already reads ~/.zshrc for interactive shells. Base does not source
+#     ~/.zshrc from this file.
 #
 [[ -n "${__base_zprofile_sourced__:-}" ]] && return 0
 readonly __base_zprofile_sourced__=1
-
-[[ -f "$HOME/.zshrc" ]] || return 0
-
-# shellcheck source=/dev/null
-source "$HOME/.zshrc"

--- a/lib/shell/zshrc
+++ b/lib/shell/zshrc
@@ -1,33 +1,23 @@
 #
-# .zshrc
-#     Base-managed interactive Zsh startup file.
+# zshrc
+#     Base-managed interactive-shell snippet for Zsh.
 #
 # Purpose:
+#     - sourced from the Base-managed section in ~/.zshrc
 #     - run only for interactive Zsh shells
-#     - guard against repeated sourcing
-#     - determine BASE_HOME from ~/.baserc or from the resolved path of this
-#       file when it is symlinked from the user's home directory
-#     - hand off to lib/shell/shell_startup.sh, which applies optional shell defaults
-#       and then sources base_init.sh
-#
-# Expected usage:
-#     symlink ~/.zshrc -> /path/to/base/lib/shell/zshrc
+#     - determine BASE_HOME from the managed dotfile section, with a fallback
+#       to this file's resolved location
+#     - hand off to lib/shell/shell_startup.sh
 #
 # What belongs here:
 #     - interactive-shell guards
-#     - BASE_HOME discovery for Zsh
+#     - BASE_HOME validation/fallback
 #     - loading the shared Base shell bootstrap
 #
 # What does not belong here:
-#     - login-only behavior (that belongs in lib/shell/zprofile)
-#     - large sets of aliases or prompt customizations
-#       (those belong in zsh_defaults.sh or user-specific files)
-#
-# See also:
-#     lib/shell/zprofile
-#     lib/shell/shell_startup.sh
-#     base_init.sh
-#     README.md section "Shell Startup Files"
+#     - login-shell behavior (that belongs in lib/shell/zprofile)
+#     - sourcing ~/.zprofile
+#     - machine-local configuration policy
 #
 [[ ! -o interactive ]] && return 0
 [[ -n "${__base_zshrc_sourced__:-}" ]] && return 0
@@ -50,44 +40,40 @@ base_zshrc_source_path() {
     done
 
     link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    printf '%s/%s\n' "$link_dir" "$(basename "$source_path")"
+    printf '%s/%s
+' "$link_dir" "$(basename "$source_path")"
 }
 
 base_zshrc_set_base_home() {
     local source_path lib_dir candidate
-
-    source_path="$(base_zshrc_source_path)" || return 1
-    lib_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    candidate="$(cd -- "$lib_dir/../.." && pwd -P)" || return 1
-
-    if [[ -f "$HOME/.baserc" && -z "${__base_user_baserc_sourced__:-}" ]]; then
-        # shellcheck source=/dev/null
-        source "$HOME/.baserc"
-        _baserc_sourced=1
-        readonly __base_user_baserc_sourced__=1
-    fi
 
     if [[ -n "${BASE_HOME:-}" && -f "$BASE_HOME/base_init.sh" ]]; then
         export BASE_HOME
         return 0
     fi
 
+    source_path="$(base_zshrc_source_path)" || return 1
+    lib_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    candidate="$(cd -- "$lib_dir/../.." && pwd -P)" || return 1
+
     if [[ -f "$candidate/base_init.sh" ]]; then
         BASE_HOME="$candidate"
-    else
-        BASE_HOME="$HOME/base"
+        export BASE_HOME
+        return 0
     fi
 
-    export BASE_HOME
+    return 1
 }
 
 base_zshrc_set_base_home || {
-    printf 'ERROR: Unable to determine BASE_HOME.\n' >&2
+    printf 'ERROR: Unable to determine BASE_HOME. Run base update-profile to refresh shell startup files.
+' >&2
     return 1
 }
 
 [[ -f "$BASE_HOME/lib/shell/shell_startup.sh" ]] || {
-    printf "ERROR: Base shell startup helper '%s/lib/shell/shell_startup.sh' was not found.\n" "$BASE_HOME" >&2
+    printf "ERROR: Base shell startup helper '%s/lib/shell/shell_startup.sh' was not found.
+" "$BASE_HOME" >&2
     return 1
 }
 


### PR DESCRIPTION
## Summary

This PR implements the first real `base update-profile` flow.

Base now integrates with Bash and Zsh by managing small marked sections inside the user's existing dotfiles, instead of symlinking over whole startup files.

## Why

We decided that Base should not own user dotfiles wholesale.

The safer and clearer contract is:

- Base owns only its marked sections
- existing user dotfile content is preserved
- missing dotfiles are created
- profile updates are idempotent
- shell defaults are explicit opt-in behavior

This replaces the older `embrace`/symlink model.

## What Changed

- Implemented `base update-profile`
- Updates all four shell startup files by default:
  - `~/.bash_profile`
  - `~/.bashrc`
  - `~/.zprofile`
  - `~/.zshrc`
- Uses `update_file_section` for managed sections
- Added `base update-profile --defaults`
- Removed the legacy `embrace` command
- Renamed `lib/shell/base_defaults.sh` to `lib/shell/bash_defaults.sh`
- Updated Bash/Zsh startup snippets for the new model
- Updated README, design docs, and tool-boundary docs
- Added BATS coverage for profile creation, idempotence, and defaults opt-in

## Design Notes

`base update-profile` now owns the dotfile interface.

Bash profile behavior:
- `~/.bash_profile` sources Base's `bash_profile` snippet
- the snippet bridges to `~/.bashrc` with a guardrail

Zsh profile behavior:
- `~/.zprofile` sources Base's `zprofile` snippet
- it does not source `~/.zshrc`, since Zsh handles interactive rc loading itself

Shell defaults are not enabled by plain `base update-profile`.
Users must explicitly run:

```bash
base update-profile --defaults
```