### PR TITLE
Improve Base runtime shell startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ Example launcher:
 exec "$(dirname "$0")/basectl" caff "$@"
 ```
 
+## Compatibility
+
+Base is currently macOS-first.
+
+Intended supported platforms are:
+
+- macOS on Apple Silicon
+- macOS on Intel Macs
+- at least one Linux variant, with the first target still to be decided
+
+The supported macOS version floor is still TBD. The current implementation
+assumes a modern macOS environment with Homebrew, Xcode Command Line Tools, a
+Homebrew-managed Bash, Git, and Python installed through Base setup.
+
+Linux support is a design target, but not yet an implemented or tested support
+contract. OS-specific behavior should stay isolated behind small helpers instead
+of being scattered through command code. For example, the Base runtime prompt can
+prefer macOS `scutil` names while still falling back to generic `hostname`.
+
 ## Shell Startup Files
 
 Base integrates with Bash and Zsh through small managed sections in the user's
@@ -139,6 +158,9 @@ adds or replaces its marked section.
 whether the user has opted into Base's optional shell defaults. The managed
 dotfile sections stay minimal and defer PATH/default handling to the sourced
 Base snippets.
+
+`BASE_PROFILE_VERSION` records the schema version of this Base-managed file. It
+is reserved for future migrations and is not intended to be edited by users.
 
 Base-managed sections use explicit markers such as:
 
@@ -187,6 +209,38 @@ They are responsible for:
 They do not source `base_init.sh`. Base runtime setup happens only when the
 `basectl` command runs a Base command, runs an explicit script path, or starts a
 Base-enabled Bash shell.
+
+When `basectl` starts an interactive Bash runtime shell, it uses Base's runtime
+rcfile rather than making Bash read `~/.bashrc` directly. That runtime rcfile
+sources the user's `~/.bashrc` once with guardrails, then loads `base_init.sh`,
+and finally sets the Base runtime prompt. This keeps user aliases and normal
+interactive Bash behavior available while still letting Base own the runtime
+environment and final prompt.
+
+### Debugging Shell Startup
+
+Set `BASE_DEBUG=1` to make Base-managed shell startup snippets print diagnostic
+messages while they run. This is intentionally independent of `base_init.sh` and
+stdlib logging, because dotfile debugging happens before the Base runtime is
+loaded.
+
+Examples:
+
+```bash
+BASE_DEBUG=1 bash --rcfile ~/.bashrc -i
+BASE_DEBUG=1 zsh -i
+```
+
+For normal terminal startup, temporarily add this before the Base-managed section
+in the relevant dotfile:
+
+```bash
+export BASE_DEBUG=1
+```
+
+Diagnostics are printed to stderr and show which Base snippet loaded, how
+`BASE_HOME` was derived, whether `$BASE_HOME/bin` was added to `PATH`, and
+whether optional shell defaults were enabled.
 
 ### Standard Shell Defaults
 

--- a/cli/bash/commands/tests/base.bats
+++ b/cli/bash/commands/tests/base.bats
@@ -94,3 +94,86 @@ run_basectl() {
     [ "$status" -eq 0 ]
     [ "$(cat "$input_file")" = $'a\nb' ]
 }
+
+
+@test "Base runtime shell prompt includes host, venv, and git segments" {
+    local venv_dir="$TEST_TMPDIR/.venv"
+    local mockbin="$TEST_TMPDIR/mockbin"
+
+    mkdir -p "$venv_dir" "$mockbin"
+    cat > "$mockbin/scutil" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--get" && "${2:-}" == "ComputerName" ]]; then
+    printf '%s\n' "aadhara"
+    exit 0
+fi
+if [[ "${1:-}" == "--get" && "${2:-}" == "LocalHostName" ]]; then
+    printf '%s\n' "aadhara-local"
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "$mockbin/scutil"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        VIRTUAL_ENV="$venv_dir" \
+        PATH="$mockbin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            printf "PS1=%s\n" "$PS1"; \
+            printf "host=%s\n" "$(_base_runtime_host_prompt)"; \
+            printf "venv=%s\n" "$(_base_runtime_venv_prompt)"; \
+            cd "$BASE_HOME"; \
+            printf "git=%s\n" "$(_base_runtime_git_prompt)"; \
+            printf "disable=%s\n" "${VIRTUAL_ENV_DISABLE_PROMPT:-}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'PS1=\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+    [[ "$output" == *"host=aadhara"* ]]
+    [[ "$output" == *"venv=[.venv] "* ]]
+    [[ "$output" == *"git=("* ]]
+    [[ "$output" == *"disable=1"* ]]
+}
+
+
+@test "Base runtime shell sources user bashrc before setting prompt" {
+    cat > "$TEST_HOME/.bashrc" <<'EOF'
+alias user_bashrc_alias='printf user-bashrc'
+export USER_BASHRC_LOADED=1
+PS1='user prompt: '
+EOF
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            alias user_bashrc_alias; \
+            printf "USER_BASHRC_LOADED=%s\n" "${USER_BASHRC_LOADED:-}"; \
+            printf "PS1=%s\n" "$PS1"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"alias user_bashrc_alias='printf user-bashrc'"* ]]
+    [[ "$output" == *"USER_BASHRC_LOADED=1"* ]]
+    [[ "$output" == *'PS1=\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+}
+
+@test "BASE_DEBUG traces Base runtime shell startup" {
+    cat > "$TEST_HOME/.bashrc" <<'EOF'
+export USER_BASHRC_LOADED=1
+EOF
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_DEBUG=1 \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c 'printf "ok\n"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG runtime: loading"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: sourcing '$TEST_HOME/.bashrc'"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: sourcing '$BASE_REPO_ROOT/base_init.sh'"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: complete"* ]]
+}

--- a/cli/bash/commands/tests/setup.bats
+++ b/cli/bash/commands/tests/setup.bats
@@ -427,6 +427,23 @@ run_base_command() {
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
 }
 
+@test "BASE_DEBUG traces Base-managed Bash startup" {
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS \
+        HOME="$TEST_HOME" \
+        BASE_DEBUG=1 \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'command -v basectl >/dev/null'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG bashrc: loading"* ]]
+    [[ "$output" == *"BASE_DEBUG bashrc: BASE_HOME=$BASE_REPO_ROOT"* ]]
+    [[ "$output" == *"BASE_DEBUG bashrc: prepended '$BASE_REPO_ROOT/bin' to PATH"* ]]
+    [[ "$output" == *"BASE_DEBUG bashrc: complete"* ]]
+}
+
 @test "basectl update-profile --dry-run does not create dotfiles" {
     run_base_command update-profile --dry-run
 

--- a/lib/bash/README.md
+++ b/lib/bash/README.md
@@ -13,8 +13,9 @@ Reusable Bash libraries for Base-owned command wrappers and other Bash tooling.
   File-editing helpers built on top of the stdlib.
 - `runtime/`
   Bash runtime startup files used only by `basectl` when it starts an
-  interactive Base shell. These are passed with `bash --rcfile` and are not
-  installed into user dotfiles.
+  interactive Base shell. These are passed with `bash --rcfile`, source the
+  user's `~/.bashrc` with guardrails, load the Base runtime, and define the
+  Base runtime prompt.
 - `tests/`
   Common BATS helpers for Bash library test suites.
 

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -7,21 +7,118 @@
 # Purpose:
 #     - start an interactive Bash shell with the Base runtime already loaded
 #     - keep runtime shell initialization separate from user dotfile integration
+#     - source the user's ~/.bashrc with guardrails
+#     - provide a Base runtime prompt with time, host, venv, git branch, and cwd
 #
 # This file is not installed into user dotfiles. It is passed to Bash with
 # `bash --rcfile` by the Base CLI.
 #
 
-[[ -n "${BASE_HOME:-}" ]] || {
-    printf 'ERROR: BASE_HOME is not set.\n' >&2
-    return 1
+_base_runtime_error() {
+    printf 'ERROR: %s\n' "$*" >&2
 }
 
-[[ -f "$BASE_HOME/base_init.sh" ]] || {
-    printf "ERROR: Base init script '%s/base_init.sh' was not found.\n" "$BASE_HOME" >&2
-    return 1
+_base_runtime_debug() {
+    case "${BASE_DEBUG:-}" in
+        1|true|TRUE|yes|YES|on|ON)
+            printf 'BASE_DEBUG runtime: %s\n' "$*" >&2
+            ;;
+    esac
 }
 
-export BASE_SHELL=1
-# shellcheck source=/dev/null
-source "$BASE_HOME/base_init.sh" || return $?
+_base_runtime_source_user_bashrc() {
+    local user_bashrc="$HOME/.bashrc"
+
+    if [[ -n "${__base_runtime_sourcing_user_bashrc__:-}" ]]; then
+        _base_runtime_debug "user bashrc guard is active; skipping"
+        return 0
+    fi
+
+    if [[ ! -f "$user_bashrc" ]]; then
+        _base_runtime_debug "'$user_bashrc' not found; skipping"
+        return 0
+    fi
+
+    _base_runtime_debug "sourcing '$user_bashrc'"
+    __base_runtime_sourcing_user_bashrc__=1
+    # shellcheck source=/dev/null
+    source "$user_bashrc" || return $?
+    unset __base_runtime_sourcing_user_bashrc__
+}
+
+_base_runtime_host_prompt() {
+    local host_name=""
+
+    if command -v scutil >/dev/null 2>&1; then
+        host_name="$(scutil --get ComputerName 2>/dev/null)" || host_name=""
+        if [[ -z "$host_name" ]]; then
+            host_name="$(scutil --get LocalHostName 2>/dev/null)" || host_name=""
+        fi
+    fi
+
+    if [[ -z "$host_name" ]]; then
+        host_name="$(hostname -s 2>/dev/null)" || host_name=""
+    fi
+
+    if [[ -z "$host_name" ]]; then
+        host_name="$(hostname 2>/dev/null)" || host_name=""
+    fi
+
+    printf '%s' "${host_name:-unknown}"
+}
+
+_base_runtime_venv_prompt() {
+    local venv_path="${VIRTUAL_ENV:-}"
+    local venv_name
+
+    [[ -n "$venv_path" ]] || return 0
+    venv_name="${venv_path##*/}"
+    [[ -n "$venv_name" ]] || return 0
+
+    printf '[%s] ' "$venv_name"
+}
+
+_base_runtime_git_prompt() {
+    local branch
+
+    command -v git >/dev/null 2>&1 || return 0
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+    branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)" || \
+        branch="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
+    [[ -n "$branch" ]] || return 0
+
+    printf '(%s) ' "$branch"
+}
+
+_base_runtime_set_prompt() {
+    # Base owns this runtime shell prompt, so disable prompt mutation by Python
+    # virtualenv activation and render the active venv dynamically instead.
+    export VIRTUAL_ENV_DISABLE_PROMPT=1
+    PS1='\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '
+}
+
+_base_runtime_main() {
+    [[ -n "${BASE_HOME:-}" ]] || {
+        _base_runtime_error "BASE_HOME is not set."
+        return 1
+    }
+
+    [[ -f "$BASE_HOME/base_init.sh" ]] || {
+        _base_runtime_error "Base init script '$BASE_HOME/base_init.sh' was not found."
+        return 1
+    }
+
+    export BASE_SHELL=1
+    _base_runtime_debug "loading"
+    _base_runtime_source_user_bashrc || return $?
+
+    _base_runtime_debug "sourcing '$BASE_HOME/base_init.sh'"
+    # shellcheck source=/dev/null
+    source "$BASE_HOME/base_init.sh" || return $?
+
+    _base_runtime_set_prompt
+    _base_runtime_debug "complete"
+}
+
+_base_runtime_main || return $?

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -6,19 +6,45 @@
 #     - sourced from the Base-managed section in ~/.bash_profile
 #     - keep Bash login startup thin
 #     - bridge interactive login Bash shells into ~/.bashrc with a guardrail
+#     - print startup diagnostics when BASE_DEBUG=1 is set
 #
 # Design note:
 #     Bash does not automatically source ~/.bashrc for login shells. Base makes
 #     that bridge explicit here. The flow is one-way: bash_profile may source
 #     bashrc, but bashrc must never source bash_profile.
 #
-[[ -n "${__base_bash_profile_sourced__:-}" ]] && return 0
+base_bash_profile_debug() {
+    case "${BASE_DEBUG:-}" in
+        1|true|TRUE|yes|YES|on|ON)
+            printf 'BASE_DEBUG bash_profile: %s\n' "$*" >&2
+            ;;
+    esac
+}
+
+if [[ -n "${__base_bash_profile_sourced__:-}" ]]; then
+    base_bash_profile_debug "already sourced; skipping"
+    unset -f base_bash_profile_debug
+    return 0
+fi
 readonly __base_bash_profile_sourced__=1
+base_bash_profile_debug "loading"
 
-[[ -n "${__base_sourcing_bashrc_from_profile__:-}" ]] && return 0
-[[ -f "$HOME/.bashrc" ]] || return 0
+if [[ -n "${__base_sourcing_bashrc_from_profile__:-}" ]]; then
+    base_bash_profile_debug "bashrc bridge guard is active; skipping"
+    unset -f base_bash_profile_debug
+    return 0
+fi
 
+if [[ ! -f "$HOME/.bashrc" ]]; then
+    base_bash_profile_debug "'$HOME/.bashrc' not found; skipping"
+    unset -f base_bash_profile_debug
+    return 0
+fi
+
+base_bash_profile_debug "sourcing '$HOME/.bashrc'"
 __base_sourcing_bashrc_from_profile__=1
 # shellcheck source=/dev/null
 source "$HOME/.bashrc"
 unset __base_sourcing_bashrc_from_profile__
+base_bash_profile_debug "complete"
+unset -f base_bash_profile_debug

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -6,14 +6,33 @@
 #     - derive and export BASE_HOME from this snippet's location
 #     - make basectl available on PATH
 #     - source optional Bash defaults when enabled in ~/.base.d/profile.conf
+#     - print startup diagnostics when BASE_DEBUG=1 is set
 #
 # Important:
 #     This file must not source base_init.sh. Base runtime setup belongs to the
 #     basectl command path, not ordinary shell startup.
 #
-[[ $- != *i* ]] && return 0
-[[ -n "${__base_bashrc_sourced__:-}" ]] && return 0
+base_bashrc_debug() {
+    case "${BASE_DEBUG:-}" in
+        1|true|TRUE|yes|YES|on|ON)
+            printf 'BASE_DEBUG bashrc: %s\n' "$*" >&2
+            ;;
+    esac
+}
+
+if [[ $- != *i* ]]; then
+    base_bashrc_debug "non-interactive shell; skipping"
+    unset -f base_bashrc_debug
+    return 0
+fi
+
+if [[ -n "${__base_bashrc_sourced__:-}" ]]; then
+    base_bashrc_debug "already sourced; skipping"
+    unset -f base_bashrc_debug
+    return 0
+fi
 readonly __base_bashrc_sourced__=1
+base_bashrc_debug "loading"
 
 base_bashrc_source_path() {
     local source_path="${BASH_SOURCE[0]}"
@@ -45,15 +64,26 @@ base_bashrc_set_base_home() {
 
     [[ -f "$base_home/base_init.sh" ]] || return 1
     export BASE_HOME="$base_home"
+    base_bashrc_debug "BASE_HOME=$BASE_HOME"
 }
 
 base_bashrc_prepend_path() {
     local bin_dir="$BASE_HOME/bin"
 
-    [[ -d "$bin_dir" ]] || return 0
+    [[ -d "$bin_dir" ]] || {
+        base_bashrc_debug "bin dir '$bin_dir' does not exist; PATH unchanged"
+        return 0
+    }
+
     case ":$PATH:" in
-        *:"$bin_dir":*) ;;
-        *) PATH="$bin_dir${PATH:+:$PATH}"; export PATH ;;
+        *:"$bin_dir":*)
+            base_bashrc_debug "PATH already contains '$bin_dir'"
+            ;;
+        *)
+            PATH="$bin_dir${PATH:+:$PATH}"
+            export PATH
+            base_bashrc_debug "prepended '$bin_dir' to PATH"
+            ;;
     esac
 }
 
@@ -61,25 +91,41 @@ base_bashrc_source_defaults() {
     local profile_conf="$HOME/.base.d/profile.conf"
     local enable_defaults=false
 
-    [[ -f "$profile_conf" ]] || return 0
+    if [[ ! -f "$profile_conf" ]]; then
+        base_bashrc_debug "profile config '$profile_conf' not found; defaults disabled"
+        return 0
+    fi
+
+    base_bashrc_debug "sourcing profile config '$profile_conf'"
     # shellcheck source=/dev/null
     source "$profile_conf"
     enable_defaults="${BASE_ENABLE_BASH_DEFAULTS:-false}"
     unset BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS
 
-    [[ "$enable_defaults" == true ]] || return 0
-    [[ -f "$BASE_HOME/lib/shell/bash_defaults.sh" ]] || return 0
+    if [[ "$enable_defaults" != true ]]; then
+        base_bashrc_debug "Bash defaults disabled"
+        return 0
+    fi
 
+    if [[ ! -f "$BASE_HOME/lib/shell/bash_defaults.sh" ]]; then
+        base_bashrc_debug "Bash defaults file not found; skipping"
+        return 0
+    fi
+
+    base_bashrc_debug "sourcing Bash defaults"
     # shellcheck source=/dev/null
     source "$BASE_HOME/lib/shell/bash_defaults.sh"
 }
 
 base_bashrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
+    unset -f base_bashrc_debug
     return 1
 }
 base_bashrc_prepend_path
 base_bashrc_source_defaults || return 1
+base_bashrc_debug "complete"
 
 unset -f base_bashrc_source_path base_bashrc_set_base_home
 unset -f base_bashrc_prepend_path base_bashrc_source_defaults
+unset -f base_bashrc_debug

--- a/lib/shell/zprofile
+++ b/lib/shell/zprofile
@@ -5,10 +5,26 @@
 # Purpose:
 #     - sourced from the Base-managed section in ~/.zprofile
 #     - keep Zsh login startup thin
+#     - print startup diagnostics when BASE_DEBUG=1 is set
 #
 # Design note:
 #     Zsh already reads ~/.zshrc for interactive shells. Base does not source
 #     ~/.zshrc from this file.
 #
-[[ -n "${__base_zprofile_sourced__:-}" ]] && return 0
+base_zprofile_debug() {
+    case "${BASE_DEBUG:-}" in
+        1|true|TRUE|yes|YES|on|ON)
+            printf 'BASE_DEBUG zprofile: %s\n' "$*" >&2
+            ;;
+    esac
+}
+
+if [[ -n "${__base_zprofile_sourced__:-}" ]]; then
+    base_zprofile_debug "already sourced; skipping"
+    unset -f base_zprofile_debug
+    return 0
+fi
 readonly __base_zprofile_sourced__=1
+base_zprofile_debug "loading"
+base_zprofile_debug "complete"
+unset -f base_zprofile_debug

--- a/lib/shell/zshrc
+++ b/lib/shell/zshrc
@@ -6,14 +6,33 @@
 #     - derive and export BASE_HOME from this snippet's location
 #     - make basectl available on PATH
 #     - source optional Zsh defaults when enabled in ~/.base.d/profile.conf
+#     - print startup diagnostics when BASE_DEBUG=1 is set
 #
 # Important:
 #     This file must not source base_init.sh. Base runtime setup belongs to the
 #     Bash-based basectl command path, not ordinary Zsh startup.
 #
-[[ ! -o interactive ]] && return 0
-[[ -n "${__base_zshrc_sourced__:-}" ]] && return 0
+base_zshrc_debug() {
+    case "${BASE_DEBUG:-}" in
+        1|true|TRUE|yes|YES|on|ON)
+            printf 'BASE_DEBUG zshrc: %s\n' "$*" >&2
+            ;;
+    esac
+}
+
+if [[ ! -o interactive ]]; then
+    base_zshrc_debug "non-interactive shell; skipping"
+    unset -f base_zshrc_debug
+    return 0
+fi
+
+if [[ -n "${__base_zshrc_sourced__:-}" ]]; then
+    base_zshrc_debug "already sourced; skipping"
+    unset -f base_zshrc_debug
+    return 0
+fi
 readonly __base_zshrc_sourced__=1
+base_zshrc_debug "loading"
 
 base_zshrc_source_path() {
     local source_path
@@ -48,15 +67,26 @@ base_zshrc_set_base_home() {
 
     [[ -f "$base_home/base_init.sh" ]] || return 1
     export BASE_HOME="$base_home"
+    base_zshrc_debug "BASE_HOME=$BASE_HOME"
 }
 
 base_zshrc_prepend_path() {
     local bin_dir="$BASE_HOME/bin"
 
-    [[ -d "$bin_dir" ]] || return 0
+    [[ -d "$bin_dir" ]] || {
+        base_zshrc_debug "bin dir '$bin_dir' does not exist; PATH unchanged"
+        return 0
+    }
+
     case ":$PATH:" in
-        *:"$bin_dir":*) ;;
-        *) PATH="$bin_dir${PATH:+:$PATH}"; export PATH ;;
+        *:"$bin_dir":*)
+            base_zshrc_debug "PATH already contains '$bin_dir'"
+            ;;
+        *)
+            PATH="$bin_dir${PATH:+:$PATH}"
+            export PATH
+            base_zshrc_debug "prepended '$bin_dir' to PATH"
+            ;;
     esac
 }
 
@@ -64,25 +94,41 @@ base_zshrc_source_defaults() {
     local profile_conf="$HOME/.base.d/profile.conf"
     local enable_defaults=false
 
-    [[ -f "$profile_conf" ]] || return 0
+    if [[ ! -f "$profile_conf" ]]; then
+        base_zshrc_debug "profile config '$profile_conf' not found; defaults disabled"
+        return 0
+    fi
+
+    base_zshrc_debug "sourcing profile config '$profile_conf'"
     # shellcheck source=/dev/null
     source "$profile_conf"
     enable_defaults="${BASE_ENABLE_ZSH_DEFAULTS:-false}"
     unset BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS
 
-    [[ "$enable_defaults" == true ]] || return 0
-    [[ -f "$BASE_HOME/lib/shell/zsh_defaults.sh" ]] || return 0
+    if [[ "$enable_defaults" != true ]]; then
+        base_zshrc_debug "Zsh defaults disabled"
+        return 0
+    fi
 
+    if [[ ! -f "$BASE_HOME/lib/shell/zsh_defaults.sh" ]]; then
+        base_zshrc_debug "Zsh defaults file not found; skipping"
+        return 0
+    fi
+
+    base_zshrc_debug "sourcing Zsh defaults"
     # shellcheck source=/dev/null
     source "$BASE_HOME/lib/shell/zsh_defaults.sh"
 }
 
 base_zshrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base zshrc snippet. Run basectl update-profile.\n' >&2
+    unset -f base_zshrc_debug
     return 1
 }
 base_zshrc_prepend_path
 base_zshrc_source_defaults || return 1
+base_zshrc_debug "complete"
 
 unset -f base_zshrc_source_path base_zshrc_set_base_home
 unset -f base_zshrc_prepend_path base_zshrc_source_defaults
+unset -f base_zshrc_debug


### PR DESCRIPTION
## Summary

This PR tightens the interactive shell experience created by `basectl`.

The Base runtime shell now behaves more like a normal interactive Bash shell while still preserving Base's runtime contract: it sources the user's `~/.bashrc`, loads `base_init.sh`, and then sets the Base runtime prompt last.

## What Changed

- Added a Base runtime prompt in `lib/bash/runtime/bashrc`
- Prompt includes:
  - time
  - host
  - active Python virtualenv name
  - current Git branch
  - current working directory
- Host prompt now prefers macOS `scutil --get ComputerName`, then falls back to `LocalHostName`, `hostname -s`, and `hostname`
- `basectl` runtime shells now source the user's `~/.bashrc` with guardrails before loading `base_init.sh`
- Base runtime prompt is applied after user Bash startup so Base remains authoritative for runtime shell prompt behavior
- Added `BASE_DEBUG=1` diagnostics for:
  - Base-managed Bash/Zsh startup snippets
  - Base runtime shell startup
- Documented shell startup debugging in the README
- Added a compatibility note describing the current macOS-first support stance
- Updated `lib/bash/README.md` to clarify runtime shell behavior
- Added BATS coverage for:
  - runtime prompt segments
  - user `~/.bashrc` layering
  - runtime `BASE_DEBUG`
  - dotfile `BASE_DEBUG`

## Design Notes

`BASE_DEBUG` is intentionally lightweight and independent of `base_init.sh`/stdlib logging. Dotfile debugging happens before the Base runtime exists, so the shell startup snippets print directly to stderr.

This PR does not introduce `~/.baserc`. Current stance:

- `~/.base.d/profile.conf` remains Base-managed state
- `~/.baserc` should be designed separately as a possible user-authored override file

## Verification

- `bash -n` passed
- `zsh -n` passed
- `git diff --check` passed
- BATS suite passed: 99 tests
- Manually verified `BASE_DEBUG=1 basectl`
- Manually verified user aliases from `~/.bashrc` are available in the `basectl` shell