### PR TITLE
Define user-managed baserc contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ Base snippets.
 `BASE_PROFILE_VERSION` records the schema version of this Base-managed file. It
 is reserved for future migrations and is not intended to be edited by users.
 
+Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
+is user-managed and may be hand-edited. It is intended for simple,
+shell-startup-safe Base preferences such as `BASE_DEBUG=1`; it should not become
+a second `.bashrc` with arbitrary setup logic.
+
+`~/.baserc` must not set Base-owned runtime or profile variables such as
+`BASE_HOME`, `BASE_BIN_DIR`, `BASE_LIB_DIR`, `BASE_OS`, `BASE_SHELL`,
+`BASE_PROFILE_VERSION`, `BASE_ENABLE_BASH_DEFAULTS`, or
+`BASE_ENABLE_ZSH_DEFAULTS`. Base startup snippets reject and restore those
+variables if `~/.baserc` tries to change them.
+
 Base-managed sections use explicit markers such as:
 
 ```bash
@@ -221,26 +232,26 @@ environment and final prompt.
 
 Set `BASE_DEBUG=1` to make Base-managed shell startup snippets print diagnostic
 messages while they run. This is intentionally independent of `base_init.sh` and
-stdlib logging, because dotfile debugging happens before the Base runtime is
+stdlib logging, because dotfile debugging can happen before the Base runtime is
 loaded.
 
-Examples:
+For normal terminal startup, put this in `~/.baserc`:
+
+```bash
+BASE_DEBUG=1
+```
+
+For one-off checks, use an environment variable:
 
 ```bash
 BASE_DEBUG=1 bash --rcfile ~/.bashrc -i
 BASE_DEBUG=1 zsh -i
-```
-
-For normal terminal startup, temporarily add this before the Base-managed section
-in the relevant dotfile:
-
-```bash
-export BASE_DEBUG=1
+BASE_DEBUG=1 basectl
 ```
 
 Diagnostics are printed to stderr and show which Base snippet loaded, how
-`BASE_HOME` was derived, whether `$BASE_HOME/bin` was added to `PATH`, and
-whether optional shell defaults were enabled.
+`BASE_HOME` was derived, whether `$BASE_HOME/bin` was added to `PATH`, whether
+optional shell defaults were enabled, and how the Base runtime shell was layered.
 
 ### Standard Shell Defaults
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -211,3 +211,10 @@ Base-managed shell startup files follow this separation of concerns:
 
 Startup files should stay thin and predictable. They must not source
 `base_init.sh`; Base runtime setup belongs to the `basectl` command path.
+
+`~/.baserc` is user-managed input for simple Base preferences such as
+`BASE_DEBUG=1`. It must not set Base-owned runtime or profile state such as
+`BASE_HOME`, `BASE_BIN_DIR`, `BASE_LIB_DIR`, `BASE_OS`, `BASE_SHELL`,
+`BASE_PROFILE_VERSION`, `BASE_ENABLE_BASH_DEFAULTS`, or
+`BASE_ENABLE_ZSH_DEFAULTS`. Shell startup code that sources `~/.baserc` should
+reject attempts to change those variables and restore the previous values.

--- a/cli/bash/commands/tests/base.bats
+++ b/cli/bash/commands/tests/base.bats
@@ -177,3 +177,34 @@ EOF
     [[ "$output" == *"BASE_DEBUG runtime: sourcing '$BASE_REPO_ROOT/base_init.sh'"* ]]
     [[ "$output" == *"BASE_DEBUG runtime: complete"* ]]
 }
+
+
+@test "baserc can enable BASE_DEBUG for Base runtime shells" {
+    printf '%s\n' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
+
+    run env -u BASE_DEBUG \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c 'printf "ok\n"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG runtime: sourced '$TEST_HOME/.baserc'"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: loading"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: complete"* ]]
+}
+
+@test "baserc cannot override BASE_HOME for Base runtime shells" {
+    printf '%s\n' 'BASE_HOME=/tmp/not-base' > "$TEST_HOME/.baserc"
+
+    run env -u BASE_DEBUG \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c 'printf "BASE_HOME=%s\n" "$BASE_HOME"; printf "BASE_BIN_DIR=%s\n" "${BASE_BIN_DIR-unset}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ERROR: ~/.baserc must not set Base-owned variable 'BASE_HOME'."* ]]
+    [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
+    [[ "$output" == *"BASE_BIN_DIR=unset"* ]]
+}

--- a/cli/bash/commands/tests/setup.bats
+++ b/cli/bash/commands/tests/setup.bats
@@ -444,6 +444,37 @@ run_base_command() {
     [[ "$output" == *"BASE_DEBUG bashrc: complete"* ]]
 }
 
+@test "baserc can enable BASE_DEBUG for Base-managed Bash startup" {
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    printf '%s\n' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u BASE_DEBUG \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'command -v basectl >/dev/null'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG bashrc: sourced '$TEST_HOME/.baserc'"* ]]
+    [[ "$output" == *"BASE_DEBUG bashrc: loading"* ]]
+    [[ "$output" == *"BASE_DEBUG bashrc: complete"* ]]
+}
+
+@test "baserc cannot override BASE_HOME for Base-managed Bash startup" {
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    printf '%s\n' 'BASE_HOME=/tmp/not-base' > "$TEST_HOME/.baserc"
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u BASE_DEBUG \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'printf "BASE_HOME=%s\n" "${BASE_HOME-unset}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ERROR: ~/.baserc must not set Base-owned variable 'BASE_HOME'."* ]]
+    [[ "$output" == *"BASE_HOME=unset"* ]]
+}
+
 @test "basectl update-profile --dry-run does not create dotfiles" {
     run_base_command update-profile --dry-run
 

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -205,9 +205,8 @@ What Base should not do:
 How Base should coexist:
 
 - Base-managed startup files can be installed through `chezmoi`
-- Base's current profile state lives in `~/.base.d/profile.conf`
-- broader machine-local override files are deferred until the core profile
-  contract is stable
+- Base-managed profile state lives in `~/.base.d/profile.conf`
+- user-managed Base preferences live in `~/.baserc`
 - users who already use `chezmoi` should be able to adopt Base cleanly
 
 Current stance: light coexistence, distinct responsibilities.

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -7,6 +7,7 @@
 # Purpose:
 #     - start an interactive Bash shell with the Base runtime already loaded
 #     - keep runtime shell initialization separate from user dotfile integration
+#     - source user-managed ~/.baserc preferences when present
 #     - source the user's ~/.bashrc with guardrails
 #     - provide a Base runtime prompt with time, host, venv, git branch, and cwd
 #
@@ -25,6 +26,72 @@ _base_runtime_debug() {
             ;;
     esac
 }
+
+_base_runtime_reject_baserc_owned_var() {
+    local var_name="$1"
+    local before_set="$2"
+    local before_value="$3"
+    local after_set
+    local after_value
+
+    eval "after_set=\"\${$var_name+x}\""
+    eval "after_value=\"\${$var_name-}\""
+
+    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
+        return 0
+    fi
+
+    if [[ -n "$before_set" ]]; then
+        printf -v "$var_name" '%s' "$before_value"
+    else
+        unset "$var_name"
+    fi
+
+    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
+    return 1
+}
+
+_base_runtime_source_baserc() {
+    local baserc="$HOME/.baserc"
+    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
+    local var_name
+    local snapshot_name
+    local before_set
+    local before_value
+    local baserc_status=0
+
+    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
+    [[ -f "$baserc" && -r "$baserc" ]] || return 0
+
+    for var_name in $base_owned_vars; do
+        snapshot_name="_base_runtime_before_$var_name"
+        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
+        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
+    done
+
+    __base_baserc_sourced__=1
+    # shellcheck source=/dev/null
+    source "$baserc" || {
+        unset __base_baserc_sourced__
+        _base_runtime_error "Failed to source Base user config '$baserc'."
+        return 1
+    }
+
+    for var_name in $base_owned_vars; do
+        snapshot_name="_base_runtime_before_$var_name"
+        eval "before_set=\"\${${snapshot_name}_set}\""
+        eval "before_value=\"\${${snapshot_name}_value}\""
+        _base_runtime_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
+    done
+
+    if [[ "$baserc_status" -ne 0 ]]; then
+        unset __base_baserc_sourced__
+        return "$baserc_status"
+    fi
+
+    _base_runtime_debug "sourced '$baserc'"
+}
+
 
 _base_runtime_source_user_bashrc() {
     local user_bashrc="$HOME/.bashrc"
@@ -110,6 +177,7 @@ _base_runtime_main() {
     }
 
     export BASE_SHELL=1
+    _base_runtime_source_baserc || return $?
     _base_runtime_debug "loading"
     _base_runtime_source_user_bashrc || return $?
 

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -4,6 +4,7 @@
 #
 # Purpose:
 #     - sourced from the Base-managed section in ~/.bash_profile
+#     - source user-managed ~/.baserc preferences when present
 #     - keep Bash login startup thin
 #     - bridge interactive login Bash shells into ~/.bashrc with a guardrail
 #     - print startup diagnostics when BASE_DEBUG=1 is set
@@ -21,9 +22,77 @@ base_bash_profile_debug() {
     esac
 }
 
+base_bash_profile_reject_baserc_owned_var() {
+    local var_name="$1"
+    local before_set="$2"
+    local before_value="$3"
+    local after_set
+    local after_value
+
+    eval "after_set=\"\${$var_name+x}\""
+    eval "after_value=\"\${$var_name-}\""
+
+    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
+        return 0
+    fi
+
+    if [[ -n "$before_set" ]]; then
+        printf -v "$var_name" '%s' "$before_value"
+    else
+        unset "$var_name"
+    fi
+
+    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
+    return 1
+}
+
+base_bash_profile_source_baserc() {
+    local baserc="$HOME/.baserc"
+    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
+    local var_name
+    local snapshot_name
+    local before_set
+    local before_value
+    local baserc_status=0
+
+    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
+    [[ -f "$baserc" && -r "$baserc" ]] || return 0
+
+    for var_name in $base_owned_vars; do
+        snapshot_name="base_bash_profile_before_$var_name"
+        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
+        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
+    done
+
+    __base_baserc_sourced__=1
+    # shellcheck source=/dev/null
+    source "$baserc" || {
+        unset __base_baserc_sourced__
+        printf "ERROR: Failed to source Base user config '%s'.\n" "$baserc" >&2
+        return 1
+    }
+
+    for var_name in $base_owned_vars; do
+        snapshot_name="base_bash_profile_before_$var_name"
+        eval "before_set=\"\${${snapshot_name}_set}\""
+        eval "before_value=\"\${${snapshot_name}_value}\""
+        base_bash_profile_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
+    done
+
+    if [[ "$baserc_status" -ne 0 ]]; then
+        unset __base_baserc_sourced__
+        return "$baserc_status"
+    fi
+
+    base_bash_profile_debug "sourced '$baserc'"
+}
+
+
+base_bash_profile_source_baserc || return $?
+
 if [[ -n "${__base_bash_profile_sourced__:-}" ]]; then
     base_bash_profile_debug "already sourced; skipping"
-    unset -f base_bash_profile_debug
+    unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc
     return 0
 fi
 readonly __base_bash_profile_sourced__=1
@@ -31,13 +100,13 @@ base_bash_profile_debug "loading"
 
 if [[ -n "${__base_sourcing_bashrc_from_profile__:-}" ]]; then
     base_bash_profile_debug "bashrc bridge guard is active; skipping"
-    unset -f base_bash_profile_debug
+    unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc
     return 0
 fi
 
 if [[ ! -f "$HOME/.bashrc" ]]; then
     base_bash_profile_debug "'$HOME/.bashrc' not found; skipping"
-    unset -f base_bash_profile_debug
+    unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc
     return 0
 fi
 
@@ -47,4 +116,4 @@ __base_sourcing_bashrc_from_profile__=1
 source "$HOME/.bashrc"
 unset __base_sourcing_bashrc_from_profile__
 base_bash_profile_debug "complete"
-unset -f base_bash_profile_debug
+unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -3,6 +3,7 @@
 #     Base-managed interactive-shell integration for Bash dotfiles.
 #
 # Purpose:
+#     - source user-managed ~/.baserc preferences when present
 #     - derive and export BASE_HOME from this snippet's location
 #     - make basectl available on PATH
 #     - source optional Bash defaults when enabled in ~/.base.d/profile.conf
@@ -20,15 +21,83 @@ base_bashrc_debug() {
     esac
 }
 
+base_bashrc_reject_baserc_owned_var() {
+    local var_name="$1"
+    local before_set="$2"
+    local before_value="$3"
+    local after_set
+    local after_value
+
+    eval "after_set=\"\${$var_name+x}\""
+    eval "after_value=\"\${$var_name-}\""
+
+    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
+        return 0
+    fi
+
+    if [[ -n "$before_set" ]]; then
+        printf -v "$var_name" '%s' "$before_value"
+    else
+        unset "$var_name"
+    fi
+
+    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
+    return 1
+}
+
+base_bashrc_source_baserc() {
+    local baserc="$HOME/.baserc"
+    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
+    local var_name
+    local snapshot_name
+    local before_set
+    local before_value
+    local baserc_status=0
+
+    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
+    [[ -f "$baserc" && -r "$baserc" ]] || return 0
+
+    for var_name in $base_owned_vars; do
+        snapshot_name="base_bashrc_before_$var_name"
+        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
+        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
+    done
+
+    __base_baserc_sourced__=1
+    # shellcheck source=/dev/null
+    source "$baserc" || {
+        unset __base_baserc_sourced__
+        printf "ERROR: Failed to source Base user config '%s'.\n" "$baserc" >&2
+        return 1
+    }
+
+    for var_name in $base_owned_vars; do
+        snapshot_name="base_bashrc_before_$var_name"
+        eval "before_set=\"\${${snapshot_name}_set}\""
+        eval "before_value=\"\${${snapshot_name}_value}\""
+        base_bashrc_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
+    done
+
+    if [[ "$baserc_status" -ne 0 ]]; then
+        unset __base_baserc_sourced__
+        return "$baserc_status"
+    fi
+
+    base_bashrc_debug "sourced '$baserc'"
+}
+
+
+base_bashrc_source_baserc || return $?
+
 if [[ $- != *i* ]]; then
     base_bashrc_debug "non-interactive shell; skipping"
-    unset -f base_bashrc_debug
+    unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc
     return 0
 fi
 
 if [[ -n "${__base_bashrc_sourced__:-}" ]]; then
     base_bashrc_debug "already sourced; skipping"
-    unset -f base_bashrc_debug
+    unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc
     return 0
 fi
 readonly __base_bashrc_sourced__=1
@@ -119,7 +188,7 @@ base_bashrc_source_defaults() {
 
 base_bashrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
-    unset -f base_bashrc_debug
+    unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc
     return 1
 }
 base_bashrc_prepend_path
@@ -128,4 +197,4 @@ base_bashrc_debug "complete"
 
 unset -f base_bashrc_source_path base_bashrc_set_base_home
 unset -f base_bashrc_prepend_path base_bashrc_source_defaults
-unset -f base_bashrc_debug
+unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc

--- a/lib/shell/zprofile
+++ b/lib/shell/zprofile
@@ -4,6 +4,7 @@
 #
 # Purpose:
 #     - sourced from the Base-managed section in ~/.zprofile
+#     - source user-managed ~/.baserc preferences when present
 #     - keep Zsh login startup thin
 #     - print startup diagnostics when BASE_DEBUG=1 is set
 #
@@ -19,12 +20,84 @@ base_zprofile_debug() {
     esac
 }
 
+base_zprofile_reject_baserc_owned_var() {
+    local var_name="$1"
+    local before_set="$2"
+    local before_value="$3"
+    local after_set
+    local after_value
+
+    eval "after_set=\"\${+$var_name}\""
+    eval "after_value=\"\${(P)var_name}\""
+
+    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
+        return 0
+    fi
+
+    if [[ "$before_set" == 1 ]]; then
+        typeset -g -- "$var_name=$before_value"
+    else
+        unset "$var_name"
+    fi
+
+    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
+    return 1
+}
+
+base_zprofile_source_baserc() {
+    local baserc="$HOME/.baserc"
+    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
+    local var_name
+    local snapshot_name
+    local snapshot_set_name
+    local snapshot_value_name
+    local before_set
+    local before_value
+    local baserc_status=0
+
+    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
+    [[ -f "$baserc" && -r "$baserc" ]] || return 0
+
+    for var_name in ${=base_owned_vars}; do
+        snapshot_name="base_zprofile_before_$var_name"
+        eval "local ${snapshot_name}_set=\"\${+$var_name}\""
+        eval "local ${snapshot_name}_value=\"\${(P)var_name}\""
+    done
+
+    __base_baserc_sourced__=1
+    # shellcheck source=/dev/null
+    source "$baserc" || {
+        unset __base_baserc_sourced__
+        printf "ERROR: Failed to source Base user config '%s'.\n" "$baserc" >&2
+        return 1
+    }
+
+    for var_name in ${=base_owned_vars}; do
+        snapshot_name="base_zprofile_before_$var_name"
+        snapshot_set_name="${snapshot_name}_set"
+        snapshot_value_name="${snapshot_name}_value"
+        before_set="${(P)snapshot_set_name}"
+        before_value="${(P)snapshot_value_name}"
+        base_zprofile_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
+    done
+
+    if [[ "$baserc_status" -ne 0 ]]; then
+        unset __base_baserc_sourced__
+        return "$baserc_status"
+    fi
+
+    base_zprofile_debug "sourced '$baserc'"
+}
+
+
+base_zprofile_source_baserc || return $?
+
 if [[ -n "${__base_zprofile_sourced__:-}" ]]; then
     base_zprofile_debug "already sourced; skipping"
-    unset -f base_zprofile_debug
+    unset -f base_zprofile_debug base_zprofile_reject_baserc_owned_var base_zprofile_source_baserc
     return 0
 fi
 readonly __base_zprofile_sourced__=1
 base_zprofile_debug "loading"
 base_zprofile_debug "complete"
-unset -f base_zprofile_debug
+unset -f base_zprofile_debug base_zprofile_reject_baserc_owned_var base_zprofile_source_baserc

--- a/lib/shell/zshrc
+++ b/lib/shell/zshrc
@@ -3,6 +3,7 @@
 #     Base-managed interactive-shell integration for Zsh dotfiles.
 #
 # Purpose:
+#     - source user-managed ~/.baserc preferences when present
 #     - derive and export BASE_HOME from this snippet's location
 #     - make basectl available on PATH
 #     - source optional Zsh defaults when enabled in ~/.base.d/profile.conf
@@ -20,15 +21,87 @@ base_zshrc_debug() {
     esac
 }
 
+base_zshrc_reject_baserc_owned_var() {
+    local var_name="$1"
+    local before_set="$2"
+    local before_value="$3"
+    local after_set
+    local after_value
+
+    eval "after_set=\"\${+$var_name}\""
+    eval "after_value=\"\${(P)var_name}\""
+
+    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
+        return 0
+    fi
+
+    if [[ "$before_set" == 1 ]]; then
+        typeset -g -- "$var_name=$before_value"
+    else
+        unset "$var_name"
+    fi
+
+    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
+    return 1
+}
+
+base_zshrc_source_baserc() {
+    local baserc="$HOME/.baserc"
+    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
+    local var_name
+    local snapshot_name
+    local snapshot_set_name
+    local snapshot_value_name
+    local before_set
+    local before_value
+    local baserc_status=0
+
+    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
+    [[ -f "$baserc" && -r "$baserc" ]] || return 0
+
+    for var_name in ${=base_owned_vars}; do
+        snapshot_name="base_zshrc_before_$var_name"
+        eval "local ${snapshot_name}_set=\"\${+$var_name}\""
+        eval "local ${snapshot_name}_value=\"\${(P)var_name}\""
+    done
+
+    __base_baserc_sourced__=1
+    # shellcheck source=/dev/null
+    source "$baserc" || {
+        unset __base_baserc_sourced__
+        printf "ERROR: Failed to source Base user config '%s'.\n" "$baserc" >&2
+        return 1
+    }
+
+    for var_name in ${=base_owned_vars}; do
+        snapshot_name="base_zshrc_before_$var_name"
+        snapshot_set_name="${snapshot_name}_set"
+        snapshot_value_name="${snapshot_name}_value"
+        before_set="${(P)snapshot_set_name}"
+        before_value="${(P)snapshot_value_name}"
+        base_zshrc_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
+    done
+
+    if [[ "$baserc_status" -ne 0 ]]; then
+        unset __base_baserc_sourced__
+        return "$baserc_status"
+    fi
+
+    base_zshrc_debug "sourced '$baserc'"
+}
+
+
+base_zshrc_source_baserc || return $?
+
 if [[ ! -o interactive ]]; then
     base_zshrc_debug "non-interactive shell; skipping"
-    unset -f base_zshrc_debug
+    unset -f base_zshrc_debug base_zshrc_reject_baserc_owned_var base_zshrc_source_baserc
     return 0
 fi
 
 if [[ -n "${__base_zshrc_sourced__:-}" ]]; then
     base_zshrc_debug "already sourced; skipping"
-    unset -f base_zshrc_debug
+    unset -f base_zshrc_debug base_zshrc_reject_baserc_owned_var base_zshrc_source_baserc
     return 0
 fi
 readonly __base_zshrc_sourced__=1
@@ -122,7 +195,7 @@ base_zshrc_source_defaults() {
 
 base_zshrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base zshrc snippet. Run basectl update-profile.\n' >&2
-    unset -f base_zshrc_debug
+    unset -f base_zshrc_debug base_zshrc_reject_baserc_owned_var base_zshrc_source_baserc
     return 1
 }
 base_zshrc_prepend_path
@@ -131,4 +204,4 @@ base_zshrc_debug "complete"
 
 unset -f base_zshrc_source_path base_zshrc_set_base_home
 unset -f base_zshrc_prepend_path base_zshrc_source_defaults
-unset -f base_zshrc_debug
+unset -f base_zshrc_debug base_zshrc_reject_baserc_owned_var base_zshrc_source_baserc


### PR DESCRIPTION
## Summary

This PR defines the initial `~/.baserc` contract for Base shell startup.

`~/.baserc` is now treated as user-managed input for simple Base preferences,
while `~/.base.d/profile.conf` remains Base-managed state written by
`basectl update-profile`.

## Changes

- Source `~/.baserc` from:
  - Base-managed Bash login/interactive snippets
  - Base-managed Zsh login/interactive snippets
  - Base runtime Bash shells started by `basectl`
- Support `BASE_DEBUG=1` from `~/.baserc`
- Guard against `~/.baserc` overriding Base-owned variables such as:
  - `BASE_HOME`
  - `BASE_BIN_DIR`
  - `BASE_LIB_DIR`
  - `BASE_OS`
  - `BASE_SHELL`
  - `BASE_PROFILE_VERSION`
  - `BASE_ENABLE_BASH_DEFAULTS`
  - `BASE_ENABLE_ZSH_DEFAULTS`
- Restore protected variable values and print a clear error when such overrides are attempted
- Document the `~/.baserc` vs `~/.base.d/profile.conf` ownership split
- Update standards for shell startup and Base-owned variables

## Verification

- `bash -n lib/shell/bash_profile lib/shell/bashrc lib/shell/zprofile lib/shell/zshrc lib/bash/runtime/bashrc`
- `zsh -n lib/shell/zprofile lib/shell/zshrc`
- `git diff --check`
- Zsh smoke checks for accepted/rejected `~/.baserc` values
- `bats cli/bash/commands/tests/base.bats cli/bash/commands/tests/setup.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/std/tests/lib_std.bats`

Result: `103` tests passing, with the existing expected tty-related skip.