### PR TITLE
Add shared Base shell defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,9 @@ by plain `basectl update-profile`.
 
 Current default-setting scripts are:
 
-- `lib/shell/bash_defaults.sh` for Bash
-- `lib/shell/zsh_defaults.sh` for Zsh
+- `lib/shell/base_defaults.sh` for shell-neutral defaults shared by Bash and Zsh
+- `lib/shell/bash_defaults.sh` for Bash-specific defaults
+- `lib/shell/zsh_defaults.sh` for Zsh-specific defaults
 
 Users can opt in during profile updates with:
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -206,8 +206,10 @@ Base-managed shell startup files follow this separation of concerns:
 - `bashrc` / `zshrc`
   - interactive shell guards and dotfile-only behavior
   - Base `bin/` PATH availability for interactive shells
+- `base_defaults.sh`
+  - optional shell-neutral interactive defaults shared by Bash and Zsh
 - `bash_defaults.sh` / `zsh_defaults.sh`
-  - optional shared interactive defaults
+  - optional shell-specific interactive defaults
 
 Startup files should stay thin and predictable. They must not source
 `base_init.sh`; Base runtime setup belongs to the `basectl` command path.

--- a/cli/bash/commands/tests/setup.bats
+++ b/cli/bash/commands/tests/setup.bats
@@ -498,13 +498,16 @@ run_base_command() {
     [[ "$(cat "$TEST_HOME/.bashrc")" != *"defaults.sh"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" != *"defaults.sh"* ]]
 
-    run env -u BASE_HOME -u BASE_HOST -u BASE_OS \
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u EDITOR -u VISUAL -u EXINIT \
         HOME="$TEST_HOME" \
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'alias cp; printf "BASE_HOME=%s\n" "$BASE_HOME"'
+        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'alias cp; printf "EDITOR=%s\n" "$EDITOR"; printf "VISUAL=%s\n" "$VISUAL"; printf "EXINIT=%s\n" "$EXINIT"; printf "BASE_HOME=%s\n" "$BASE_HOME"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"alias cp='cp -i'"* ]]
+    [[ "$output" == *"EDITOR=vi"* ]]
+    [[ "$output" == *"VISUAL=vi"* ]]
+    [[ "$output" == *"EXINIT=set ts=4 sw=4 ai nows nosm expandtab"* ]]
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
 }
 

--- a/lib/shell/base_defaults.sh
+++ b/lib/shell/base_defaults.sh
@@ -1,0 +1,36 @@
+#
+# base_defaults.sh
+#     Optional shell-neutral interactive defaults shared by Bash and Zsh.
+#
+# Purpose:
+#     - define conservative defaults that mean the same thing in Bash and Zsh
+#     - keep duplicated alias/editor setup out of shell-specific defaults files
+#
+# How it is loaded:
+#     - sourced by bash_defaults.sh and zsh_defaults.sh
+#     - only when the user runs `basectl update-profile --defaults`
+#     - only for interactive shells
+#
+# What belongs here:
+#     - shell-neutral aliases
+#     - editor environment defaults
+#     - other simple defaults that are valid in both Bash and Zsh
+#
+# What does not belong here:
+#     - BASE_HOME discovery
+#     - sourcing of base_init.sh
+#     - shell-specific options such as shopt, setopt, bindkey, or PROMPT/PS1
+#     - machine-specific overrides
+#
+[[ $- != *i* ]] && return 0
+
+[[ -n "${__base_defaults_sourced__:-}" ]] && return 0
+readonly __base_defaults_sourced__=1
+
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
+export EDITOR="${EDITOR:-vi}"
+export VISUAL="${VISUAL:-$EDITOR}"
+export EXINIT="${EXINIT:-set ts=4 sw=4 ai nows nosm expandtab}"

--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -4,8 +4,9 @@
 #     provide a standard shell experience.
 #
 # Purpose:
-#     - define a conservative shared set of aliases, editor defaults, prompt
-#       settings, and history behavior for interactive Bash shells
+#     - load Base's shared shell defaults
+#     - define conservative Bash-specific command-line editing, prompt, and
+#       history behavior for interactive Bash shells
 #
 # How it is loaded:
 #     - sourced from the Base-managed ~/.bashrc section
@@ -13,12 +14,12 @@
 #     - only for interactive Bash shells
 #
 # What belongs here:
-#     - aliases such as rm -i / cp -i / mv -i
-#     - editor and command-line editing defaults
-#     - prompt defaults
-#     - history-related shell options
+#     - Bash command-line editing defaults
+#     - Bash prompt defaults
+#     - Bash history-related shell options
 #
 # What does not belong here:
+#     - aliases and editor defaults shared with Zsh; use base_defaults.sh
 #     - BASE_HOME discovery
 #     - sourcing of base_init.sh
 #     - login-shell orchestration
@@ -26,15 +27,20 @@
 #
 [[ $- != *i* ]] && return 0
 
-alias rm='rm -i'
-alias cp='cp -i'
-alias mv='mv -i'
+base_bash_defaults_file="${BASE_HOME:-}/lib/shell/base_defaults.sh"
+[[ -f "$base_bash_defaults_file" ]] || {
+    printf "ERROR: Base shared defaults file '%s' was not found.\n" "$base_bash_defaults_file" >&2
+    unset base_bash_defaults_file
+    return 1
+}
+# shellcheck source=/dev/null
+source "$base_bash_defaults_file" || {
+    unset base_bash_defaults_file
+    return 1
+}
+unset base_bash_defaults_file
 
 set -o vi
-export EDITOR="${EDITOR:-vi}"
-export VISUAL="${VISUAL:-$EDITOR}"
-
-export EXINIT="set ts=4 sw=4 ai nows nosm expandtab"
 
 export PS1='\[\033[0;35m\]\T \h\[\033[0;33m\] \w\[\033[00m\]: '
 

--- a/lib/shell/zsh_defaults.sh
+++ b/lib/shell/zsh_defaults.sh
@@ -4,9 +4,9 @@
 #     provide a standard Zsh experience.
 #
 # Purpose:
-#     - define a conservative shared set of aliases, editor defaults,
-#       keybindings, prompt settings, and history behavior for interactive Zsh
-#       shells
+#     - load Base's shared shell defaults
+#     - define conservative Zsh-specific keybindings, prompt, and history
+#       behavior for interactive Zsh shells
 #
 # How it is loaded:
 #     - sourced from the Base-managed ~/.zshrc section
@@ -14,12 +14,12 @@
 #     - only for interactive Zsh shells
 #
 # What belongs here:
-#     - aliases such as rm -i / cp -i / mv -i
-#     - bindkey/editor preferences
-#     - prompt defaults
-#     - history-related zsh options
+#     - Zsh bindkey/editor behavior
+#     - Zsh prompt defaults
+#     - Zsh history-related shell options
 #
 # What does not belong here:
+#     - aliases and editor defaults shared with Bash; use base_defaults.sh
 #     - BASE_HOME discovery
 #     - sourcing of base_init.sh
 #     - login-shell orchestration
@@ -27,13 +27,20 @@
 #
 [[ ! -o interactive ]] && return 0
 
-alias rm='rm -i'
-alias cp='cp -i'
-alias mv='mv -i'
+base_zsh_defaults_file="${BASE_HOME:-}/lib/shell/base_defaults.sh"
+[[ -f "$base_zsh_defaults_file" ]] || {
+    printf "ERROR: Base shared defaults file '%s' was not found.\n" "$base_zsh_defaults_file" >&2
+    unset base_zsh_defaults_file
+    return 1
+}
+# shellcheck source=/dev/null
+source "$base_zsh_defaults_file" || {
+    unset base_zsh_defaults_file
+    return 1
+}
+unset base_zsh_defaults_file
 
 bindkey -v
-export EDITOR="${EDITOR:-vi}"
-export VISUAL="${VISUAL:-$EDITOR}"
 
 export HISTSIZE="${HISTSIZE:-5000}"
 export SAVEHIST="${SAVEHIST:-5000}"


### PR DESCRIPTION
## Summary

This PR introduces `lib/shell/base_defaults.sh` as the shared defaults layer for
Base-managed interactive shells.

The goal is to keep common shell behavior in one place while preserving separate
Bash and Zsh files for shell-specific behavior.

## Changes

- Add `lib/shell/base_defaults.sh`
  - shared `rm -i`, `cp -i`, `mv -i` aliases
  - shared `EDITOR`, `VISUAL`, and `EXINIT` defaults
- Update `lib/shell/bash_defaults.sh`
  - source `base_defaults.sh`
  - keep Bash-specific vi mode, prompt, and history behavior
- Update `lib/shell/zsh_defaults.sh`
  - source `base_defaults.sh`
  - keep Zsh-specific keybindings, prompt, and history behavior
- Update `README.md` and `STANDARDS.md`
  - document the shared vs shell-specific defaults split
- Extend setup tests to verify shared editor defaults are applied

## Verification

- `bash -n lib/shell/base_defaults.sh lib/shell/bash_defaults.sh lib/shell/zsh_defaults.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/zprofile lib/shell/zshrc`
- `zsh -n lib/shell/base_defaults.sh lib/shell/zsh_defaults.sh lib/shell/zprofile lib/shell/zshrc`
- `git diff --check`
- Zsh smoke check for shared defaults
- `bats cli/bash/commands/tests/base.bats cli/bash/commands/tests/setup.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/std/tests/lib_std.bats`

Result: `103` tests passing, with the existing expected tty-related skip.