### PR TITLE
Simplify basectl command dispatch and Base home validation

### DIFF
--- a/bin/basectl
+++ b/bin/basectl
@@ -45,7 +45,7 @@ basectl_resolve_path() {
     printf '%s/%s\n' "$link_dir" "$(basename -- "$source_path")"
 }
 
-basectl_repo_root() {
+basectl_base_home() {
     local source_path
     local bin_dir
 
@@ -110,7 +110,7 @@ basectl_filter_runtime_args() {
 }
 
 basectl_run_bash_script() {
-    local repo_root="$1"
+    local base_home="$1"
     local script_path="$2"
     local command_name="$3"
     local command_dir
@@ -121,14 +121,14 @@ basectl_run_bash_script() {
 
     basectl_filter_runtime_args "$@"
 
-    export BASE_HOME="$repo_root"
+    export BASE_HOME="$base_home"
     export BASE_BASH_COMMAND_NAME="$command_name"
     export BASE_BASH_COMMAND_DIR="$command_dir"
     export BASE_BASH_COMMAND_SCRIPT="$script_path"
 
     BASE_BASH_BOOTSTRAP_SOURCE="$script_path"
     # shellcheck source=/dev/null
-    source "$repo_root/base_init.sh" "$@" || exit $?
+    source "$base_home/base_init.sh" "$@" || exit $?
     unset BASE_BASH_BOOTSTRAP_SOURCE
 
     unset -f main
@@ -144,18 +144,18 @@ basectl_run_bash_script() {
 }
 
 basectl_start_shell() {
-    local repo_root="$1"
-    local shell_rc="$repo_root/lib/bash/runtime/bashrc"
+    local base_home="$1"
+    local shell_rc="$base_home/lib/bash/runtime/bashrc"
 
     [[ -f "$shell_rc" ]] || basectl_die "Base runtime Bash rcfile '$shell_rc' was not found."
 
-    export BASE_HOME="$repo_root"
+    export BASE_HOME="$base_home"
     export BASE_SHELL=1
     exec "${BASH:-bash}" --rcfile "$shell_rc"
 }
 
 basectl_command_script() {
-    local repo_root="$1"
+    local base_home="$1"
     local command_name="${2:-}"
     local script_path
 
@@ -167,39 +167,39 @@ basectl_command_script() {
             ;;
     esac
 
-    script_path="$repo_root/cli/bash/commands/$command_name/$command_name.sh"
+    script_path="$base_home/cli/bash/commands/$command_name/$command_name.sh"
     [[ -f "$script_path" ]] || return 1
     printf '%s\n' "$script_path"
 }
 
 basectl_run_command_name() {
-    local repo_root="$1"
+    local base_home="$1"
     local command_name="$2"
     local script_path
     shift 2
 
-    script_path="$(basectl_command_script "$repo_root" "$command_name")" || return 1
-    basectl_run_bash_script "$repo_root" "$script_path" "$command_name" "$@"
+    script_path="$(basectl_command_script "$base_home" "$command_name")" || return 1
+    basectl_run_bash_script "$base_home" "$script_path" "$command_name" "$@"
 }
 
 basectl_run_control_command() {
-    local repo_root="$1"
-    local script_path="$repo_root/cli/bash/commands/base/base.sh"
+    local base_home="$1"
+    local script_path="$base_home/cli/bash/commands/base/base.sh"
     shift
 
-    basectl_run_bash_script "$repo_root" "$script_path" basectl "$@"
+    basectl_run_bash_script "$base_home" "$script_path" basectl "$@"
 }
 
 main() {
-    local repo_root
+    local base_home
     local script_path
     local command_name
 
     basectl_ensure_supported_bash "$@"
-    repo_root="$(basectl_repo_root)" || basectl_die "Unable to resolve the Base repository root."
+    base_home="$(basectl_base_home)" || basectl_die "Unable to resolve Base home."
 
     if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
-        basectl_start_shell "$repo_root"
+        basectl_start_shell "$base_home"
         return $?
     fi
 
@@ -207,18 +207,18 @@ main() {
         script_path="$(basectl_resolve_path "$1")" || basectl_die "Script '$1' was not found."
         command_name="$(basectl_normalize_script_name "$(basename -- "$script_path")")"
         shift
-        basectl_run_bash_script "$repo_root" "$script_path" "$command_name" "$@"
+        basectl_run_bash_script "$base_home" "$script_path" "$command_name" "$@"
         return $?
     fi
 
-    if [[ -n "${1:-}" ]] && basectl_command_script "$repo_root" "$1" >/dev/null; then
+    if [[ -n "${1:-}" ]] && basectl_command_script "$base_home" "$1" >/dev/null; then
         command_name="$1"
         shift
-        basectl_run_command_name "$repo_root" "$command_name" "$@"
+        basectl_run_command_name "$base_home" "$command_name" "$@"
         return $?
     fi
 
-    basectl_run_control_command "$repo_root" "$@"
+    basectl_run_control_command "$base_home" "$@"
 }
 
 main "$@"

--- a/cli/bash/commands/base/README.md
+++ b/cli/bash/commands/base/README.md
@@ -12,8 +12,9 @@ It is invoked through:
 basectl <subcommand> [args...]
 ```
 
-The public entrypoint lives at `bin/basectl`. It sources `base_init.sh` to establish
-the Base runtime, then sources this command implementation and calls `main`.
+The public entrypoint lives at `bin/basectl`. It establishes the Base runtime
+for command implementations, then sources this command implementation and calls
+`main`.
 
 `basectl` also dispatches direct command names by convention. For example,
 `basectl caff` loads `cli/bash/commands/caff/caff.sh`. Public convenience
@@ -25,9 +26,7 @@ that delegate to `basectl`.
 - `setup`
 - `check`
 - `update-profile`
-- `install`
 - `shell`
-- `version`
 - `help`
 
 ## Notes

--- a/cli/bash/commands/base/base.sh
+++ b/cli/bash/commands/base/base.sh
@@ -15,20 +15,13 @@ Commands:
     Verify the local Base CLI environment without making changes.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
-  install
-    Install Base into BASE_HOME.
   shell
     Start an interactive Bash shell with the Base runtime loaded.
-  version
-    Show the Base CLI version.
   help
     Show this help text.
 
 Options:
-  -b DIR   Use DIR as BASE_HOME.
-  -f       Force install by moving aside an existing BASE_HOME directory.
   -v       Enable DEBUG logging for the selected command.
-  -V       Show the CLI version.
   -x       Enable Bash xtrace before running the command.
   -h       Show this help text.
 
@@ -71,36 +64,31 @@ base_cli_get_base_home() {
     export BASE_HOME
 }
 
-base_cli_verify_repo() {
-    local repo_root="$1"
+base_cli_verify_home() {
+    local base_home="$1"
     local file missing=()
 
-    if [[ ! -d "$repo_root" ]]; then
-        BASE_CLI_ERROR_MESSAGE="Base is not installed at '$repo_root'"
+    if [[ ! -d "$base_home" ]]; then
+        BASE_CLI_ERROR_MESSAGE="Base home '$base_home' is not a directory."
         return 1
     fi
 
-    if ! git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1; then
-        BASE_CLI_ERROR_MESSAGE="Directory '$repo_root' is not a git repo; check if Base is installed."
-        return 1
-    fi
-
-    for file in base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/bash/runtime/bashrc bin/basectl; do
-        if [[ ! -f "$repo_root/$file" ]]; then
+    for file in base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/bash/runtime/bashrc bin/basectl cli/bash/commands/base/base.sh; do
+        if [[ ! -f "$base_home/$file" ]]; then
             missing+=("$file")
         fi
     done
 
     if (( ${#missing[@]} > 0 )); then
-        BASE_CLI_ERROR_MESSAGE="Files missing in Base repo: ${missing[*]}"
+        BASE_CLI_ERROR_MESSAGE="Files missing in Base home '$base_home': ${missing[*]}"
         return 1
     fi
 
     return 0
 }
 
-base_cli_runtime_repo_root() {
-    if base_cli_verify_repo "$BASE_HOME"; then
+base_cli_runtime_base_home() {
+    if base_cli_verify_home "$BASE_HOME"; then
         printf '%s\n' "$BASE_HOME"
         return 0
     fi
@@ -109,30 +97,12 @@ base_cli_runtime_repo_root() {
 }
 
 base_cli_shell_rc_path() {
-    local repo_root
+    local base_home
 
-    repo_root="$(base_cli_runtime_repo_root)" || return 1
-    printf '%s\n' "$repo_root/lib/bash/runtime/bashrc"
+    base_home="$(base_cli_runtime_base_home)" || return 1
+    printf '%s\n' "$base_home/lib/bash/runtime/bashrc"
 }
 
-
-base_cli_version_value() {
-    if [[ -n "${BASE_VERSION:-}" ]]; then
-        printf '%s\n' "$BASE_VERSION"
-        return 0
-    fi
-
-    if git -C "$BASE_HOME" rev-parse --short HEAD >/dev/null 2>&1; then
-        git -C "$BASE_HOME" rev-parse --short HEAD
-        return 0
-    fi
-
-    printf '%s\n' "dev"
-}
-
-base_cli_do_version() {
-    printf 'basectl version %s\n' "$(base_cli_version_value)"
-}
 
 base_cli_enable_debug_logging() {
     set_log_level DEBUG
@@ -167,34 +137,6 @@ base_cli_do_update_profile() {
     base_update_profile_subcommand_main "$@"
 }
 
-base_cli_do_install() {
-    local repo_url="ssh://git@github.com:codeforester/base.git"
-    local base_home_backup=""
-
-    if [[ -d "$BASE_HOME" ]]; then
-        if (( force_install )); then
-            base_home_backup="$BASE_HOME.$current_time"
-            mv -- "$BASE_HOME" "$base_home_backup" || {
-                base_cli_error "Couldn't move current Base home directory '$BASE_HOME' to '$base_home_backup'."
-                return 1
-            }
-            printf "Moved current Base home directory '%s' to '%s'\n" "$BASE_HOME" "$base_home_backup"
-        else
-            printf "Base is already installed at '%s'\n" "$BASE_HOME"
-            return 0
-        fi
-    fi
-
-    git clone "$repo_url" "$BASE_HOME" || {
-        base_cli_error "Couldn't install Base."
-        return 1
-    }
-    printf "Installed Base at '%s'\n" "$BASE_HOME"
-    printf "Run '%s/bin/basectl update-profile' to update shell startup files.\n" "$BASE_HOME"
-
-    return 0
-}
-
 base_cli_do_shell() {
     local shell_rc
 
@@ -210,16 +152,11 @@ base_cli_do_shell() {
 
 
 base_cli_main() {
-    local base_debug=0 bash_version current_time_fmt command=""
+    local base_debug=0 command=""
     local opt
 
     if [[ "${1:-}" =~ ^(-h|--help|-help|help)$ ]]; then
         base_cli_show_help
-        return 0
-    fi
-
-    if [[ "${1:-}" =~ ^(--version|-version|-V)$ ]]; then
-        base_cli_do_version
         return 0
     fi
 
@@ -228,33 +165,30 @@ base_cli_main() {
         return 0
     fi
 
-    force_install=0
-    bash_version="${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}"
-    current_time_fmt="%Y-%m-%d:%H:%M:%S"
-    if (( bash_version >= 42 )); then
-        printf -v current_time "%($current_time_fmt)T" -1
-    else
-        current_time="$(date +"$current_time_fmt")"
-    fi
+    case "${1:-}" in
+        --*)
+            base_cli_usage_error "Unknown option '$1'"
+            return $?
+            ;;
+    esac
 
     OPTIND=1
-    while getopts "fhb:vVx" opt; do
+    OPTERR=0
+    while getopts ":hvx" opt; do
         case "$opt" in
-            b) export BASE_HOME="$OPTARG" ;;
-            f) force_install=1 ;;
             v) base_debug=1 ;;
-            V)
-                base_cli_do_version
-                return 0
-                ;;
             x) set -x ;;
             h)
                 base_cli_show_help
                 return 0
                 ;;
-            *)
-                base_cli_show_help >&2
-                return 2
+            \?)
+                base_cli_usage_error "Unknown option '-$OPTARG'"
+                return $?
+                ;;
+            :)
+                base_cli_usage_error "Option '-$OPTARG' requires an argument."
+                return $?
                 ;;
         esac
     done
@@ -271,10 +205,8 @@ base_cli_main() {
         check)            base_cli_do_check "$@" ;;
         setup)            base_cli_do_setup "$@" ;;
         help)             base_cli_show_help ;;
-        install)          base_cli_do_install ;;
         shell)            base_cli_do_shell ;;
         update-profile)   base_cli_do_update_profile "$@" ;;
-        version)          base_cli_do_version ;;
         "")
             if is_interactive; then
                 base_cli_do_shell

--- a/cli/bash/commands/base/subcommands/update_profile.sh
+++ b/cli/bash/commands/base/subcommands/update_profile.sh
@@ -156,7 +156,7 @@ base_update_profile_write_profile_conf() {
 base_update_profile_subcommand_main() {
     local enable_defaults=0
     local dry_run=0
-    local repo_root
+    local base_home
 
     while (($#)); do
         case "$1" in
@@ -184,11 +184,11 @@ base_update_profile_subcommand_main() {
 
     log_debug "Running 'basectl update-profile'."
 
-    repo_root="$(base_cli_runtime_repo_root)" || {
-        print_error "${BASE_CLI_ERROR_MESSAGE:-Unable to find the Base repository root.}"
+    base_home="$(base_cli_runtime_base_home)" || {
+        print_error "${BASE_CLI_ERROR_MESSAGE:-Unable to find Base home.}"
         return 1
     }
-    BASE_HOME="$repo_root"
+    BASE_HOME="$base_home"
     export BASE_HOME
 
     base_update_profile_source_file_library || return 1

--- a/cli/bash/commands/tests/base.bats
+++ b/cli/bash/commands/tests/base.bats
@@ -35,6 +35,11 @@ run_basectl() {
     ! grep -Fqx '  set-shared-teams TEAM...' <<<"$output"
     ! grep -Fqx '  man' <<<"$output"
     ! grep -Fqx '  embrace' <<<"$output"
+    ! grep -Fqx '  install' <<<"$output"
+    ! grep -Fqx '  version' <<<"$output"
+    [[ "$output" != *"-b DIR"* ]]
+    [[ "$output" != *"Force install"* ]]
+    [[ "$output" != *"-V"* ]]
 }
 
 @test "basectl prints help when no command is given in a non-interactive shell" {
@@ -44,15 +49,11 @@ run_basectl() {
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
 }
 
-@test "basectl --version uses BASE_VERSION when provided" {
-    run env \
-        HOME="$TEST_HOME" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        BASE_VERSION="test-version" \
-        "$BASE_REPO_ROOT/bin/basectl" --version
+@test "basectl rejects removed version option" {
+    run_basectl --version
 
-    [ "$status" -eq 0 ]
-    [[ "$output" == "basectl version test-version" ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown option '--version'"* ]]
 }
 
 @test "basectl setup prints setup-specific help" {
@@ -67,11 +68,34 @@ run_basectl() {
 @test "basectl rejects removed legacy commands" {
     local legacy_command
 
-    for legacy_command in status update run set-team set-shared-teams man embrace; do
+    for legacy_command in status update run set-team set-shared-teams man embrace install version; do
         run_basectl "$legacy_command"
         [ "$status" -eq 2 ]
         [[ "$output" == *"Unrecognized command: $legacy_command"* ]]
     done
+}
+
+@test "Base home verification does not require a git repository" {
+    local base_home="$TEST_TMPDIR/embedded/base"
+
+    mkdir -p \
+        "$base_home/bin" \
+        "$base_home/lib/shell" \
+        "$base_home/lib/bash/runtime" \
+        "$base_home/cli/bash/commands/base"
+    touch \
+        "$base_home/base_init.sh" \
+        "$base_home/lib/shell/bash_profile" \
+        "$base_home/lib/shell/bashrc" \
+        "$base_home/lib/bash/runtime/bashrc" \
+        "$base_home/bin/basectl" \
+        "$base_home/cli/bash/commands/base/base.sh"
+
+    run bash -c 'source "$1"; base_cli_verify_home "$2"' _ \
+        "$BASE_REPO_ROOT/cli/bash/commands/base/base.sh" \
+        "$base_home"
+
+    [ "$status" -eq 0 ]
 }
 
 
@@ -80,6 +104,21 @@ run_basectl() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Sort text files in place."* ]]
+}
+
+@test "basectl treats path-like arguments as scripts before command names" {
+    local script_path="$TEST_TMPDIR/sort-in-place"
+
+    cat > "$script_path" <<'EOF'
+main() {
+    printf 'script path wins: %s\n' "$1"
+}
+EOF
+
+    run_basectl "$script_path" arg1
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"script path wins: arg1"* ]]
 }
 
 @test "sort-in-place launcher delegates through basectl" {

--- a/docs/design.md
+++ b/docs/design.md
@@ -72,7 +72,6 @@ layers. This keeps the product name and the control-plane action separate:
 
 - `basectl setup`
 - `basectl check`
-- `basectl install`
 - `basectl update-profile`
 - `basectl shell`
 - future commands such as `basectl projects list`, `basectl test`, and


### PR DESCRIPTION
## Summary

This PR cleans up the current `basectl` command surface and removes a few
classic Base assumptions that no longer fit the new design.

Changes include:

- remove the legacy `install` command from `basectl`
- remove `version`, `--version`, and `-V` until Base has a clear versioning model
- rename internal `repo_root` variables to `base_home`
- stop requiring Base to live inside a Git repository
- validate Base home by checking for required Base files instead
- clarify command dispatch behavior in tests:
  - path-like or existing-file arguments are treated as scripts
  - known command names dispatch through `cli/bash/commands/<name>/<name>.sh`
  - everything else falls through to the umbrella Base command dispatcher

## Why

Base should work both as its own repository and as an embedded component inside
a larger monorepo. Requiring `.git` at `BASE_HOME` made that unnecessarily
fragile.

The command surface is also simpler now: `setup` owns bootstrap/install behavior,
and versioning can return later once the release/version contract is designed.

## Testing

- `bash -n bin/basectl cli/bash/commands/base/base.sh cli/bash/commands/base/subcommands/update_profile.sh`
- `git diff --check`
- `bats cli/bash/commands/tests/base.bats cli/bash/commands/tests/setup.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/std/tests/lib_std.bats`

Result: 105 tests passing.