### PR TITLE
Fix shell standards issues in Base runtime helpers

### DIFF
--- a/base_init.sh
+++ b/base_init.sh
@@ -92,20 +92,38 @@ base_init_resolve_home() {
 }
 
 base_init_export_contract() {
-    local base_home
+    local base_home base_os base_host
 
     base_home="$(base_init_resolve_home)" || return 1
+    base_os="$(uname -s)" || {
+        base_init_error "Unable to determine BASE_OS with uname."
+        return 1
+    }
+    [[ -n "$base_os" ]] || {
+        base_init_error "Unable to determine BASE_OS with uname."
+        return 1
+    }
+    base_host="$(hostname -s)" || {
+        base_init_error "Unable to determine BASE_HOST with hostname."
+        return 1
+    }
+    [[ -n "$base_host" ]] || {
+        base_init_error "Unable to determine BASE_HOST with hostname."
+        return 1
+    }
 
-    export BASE_HOME="$base_home"
-    export BASE_BIN_DIR="$BASE_HOME/bin"
-    export BASE_CLI_DIR="$BASE_HOME/cli"
-    export BASE_BASH_DIR="$BASE_CLI_DIR/bash"
-    export BASE_BASH_COMMANDS_DIR="$BASE_BASH_DIR/commands"
-    export BASE_LIB_DIR="$BASE_HOME/lib"
-    export BASE_BASH_LIB_DIR="$BASE_LIB_DIR/bash"
-    export BASE_SHELL_DIR="$BASE_LIB_DIR/shell"
-    export BASE_OS="$(uname -s)"
-    export BASE_HOST="$(hostname -s)"
+    BASE_HOME="$base_home"
+    BASE_BIN_DIR="$BASE_HOME/bin"
+    BASE_CLI_DIR="$BASE_HOME/cli"
+    BASE_BASH_DIR="$BASE_CLI_DIR/bash"
+    BASE_BASH_COMMANDS_DIR="$BASE_BASH_DIR/commands"
+    BASE_LIB_DIR="$BASE_HOME/lib"
+    BASE_BASH_LIB_DIR="$BASE_LIB_DIR/bash"
+    BASE_SHELL_DIR="$BASE_LIB_DIR/shell"
+    BASE_OS="$base_os"
+    BASE_HOST="$base_host"
+    export BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_BASH_DIR BASE_BASH_COMMANDS_DIR
+    export BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_HOST
 }
 
 base_init_source_stdlib() {

--- a/bin/basectl
+++ b/bin/basectl
@@ -90,10 +90,11 @@ basectl_filter_runtime_args() {
 
     while (($#)); do
         case "$1" in
-            --debug-wrapper)
-                export LOG_DEBUG=1
-                ;;
-            --verbose-wrapper)
+            --debug-wrapper|--verbose-wrapper)
+                # base_init.sh receives the original arguments, so lib_std.sh still
+                # applies DEBUG vs VERBOSE precisely after it is sourced. Before
+                # stdlib exists, both modes only have the LOG_DEBUG environment
+                # contract available for downstream tools.
                 export LOG_DEBUG=1
                 ;;
             --utc-wrapper)

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -150,6 +150,10 @@ basectl_do_shell() {
     exec "${BASH:-bash}" --rcfile "$shell_rc"
 }
 
+basectl_should_start_shell() {
+    [[ -t 0 && -t 1 ]]
+}
+
 
 basectl_main() {
     local base_debug=0 command=""
@@ -208,7 +212,7 @@ basectl_main() {
         shell)            basectl_do_shell ;;
         update-profile)   basectl_do_update_profile "$@" ;;
         "")
-            if is_interactive; then
+            if basectl_should_start_shell; then
                 basectl_do_shell
             else
                 basectl_show_help

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -18,7 +18,7 @@ _base_setup_common_sourced=1
 readonly _base_setup_common_sourced
 
 setup_clear_run_state() {
-    unset dry_run
+    unset dry_run DRY_RUN
 }
 
 setup_enable_dry_run() {
@@ -155,13 +155,13 @@ setup_install_xcode_tools() {
         fatal_error "Xcode Command Line Tools installation requires an interactive terminal."
     fi
 
-    log_info "Installing Xcode Command Line Tools."
-    run --no-exit xcode-select --install
-
     if setup_is_dry_run; then
-        log_info "[DRY-RUN] Would wait for Xcode Command Line Tools installation to complete."
+        log_info "[DRY-RUN] Would install Xcode Command Line Tools and wait for installation to complete."
         return 0
     fi
+
+    log_info "Installing Xcode Command Line Tools."
+    run --no-exit xcode-select --install
 
     timeout="$(setup_xcode_wait_timeout_seconds)"
     interval="$(setup_xcode_wait_interval_seconds)"

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -307,12 +307,34 @@ run_base_command() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would install Homebrew using the official installer."* ]]
-    [[ "$output" == *"[DRY-RUN] Would wait for Xcode Command Line Tools installation to complete."* ]]
+    [[ "$output" == *"[DRY-RUN] Would install Xcode Command Line Tools and wait for installation to complete."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python formula 'python@3.13' via Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would install BATS formula 'bats-core' via Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/.venv'."* ]]
     [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
     [ ! -e "$TEST_HOME/.base.d/.venv" ]
+}
+
+@test "basectl setup ignores inherited DRY_RUN without --dry-run" {
+    local installer
+    local venv_dir="$TEST_HOME/.base.d/.venv"
+
+    create_xcode_stubs
+    installer="$(create_homebrew_installer_stub)"
+
+    run_base_command \
+        DRY_RUN=true \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
+        setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"[DRY-RUN]"* ]]
+    [[ "$output" == *"Installing Homebrew."* ]]
+    [[ "$output" == *"Installing Xcode Command Line Tools."* ]]
+    [[ "$output" == *"Creating Python virtual environment at '$venv_dir'."* ]]
+    [ -f "$TEST_STATE_DIR/homebrew-install-ran" ]
+    [ -f "$venv_dir/pyvenv.cfg" ]
 }
 
 @test "basectl check passes when all required components are present" {

--- a/cli/bash/commands/caff/caff.sh
+++ b/cli/bash/commands/caff/caff.sh
@@ -43,7 +43,7 @@ main() {
             ;;
     esac
 
-    if ! type -ft caffeinate >/dev/null; then
+    if ! command -v caffeinate >/dev/null 2>&1; then
         print_error "There is no caffeinate command on your system."
         return 1
     fi

--- a/lib/bash/file/lib_file.sh
+++ b/lib/bash/file/lib_file.sh
@@ -3,6 +3,9 @@
 # lib_file.sh - Bash library of generic file manipulation functions.
 #
 
+[[ -n "${__lib_file_sourced__:-}" ]] && return 0
+readonly __lib_file_sourced__=1
+
 #
 # update_file_section - Idempotently manages a block of text within a file,
 #                       demarcated by start and end markers.
@@ -140,13 +143,13 @@ update_file_section() {
             cp "$target_file" "$temp_file"
 
             if [[ $(tail -c 1 "$temp_file" 2>/dev/null | wc -l) -eq 0 ]]; then
-                 echo "" >> "$temp_file"
+                printf '\n' >> "$temp_file"
             fi
 
             if {
-                echo "$beginning_marker"
-                printf "%s" "$new_content_string"
-                echo "$end_marker"
+                printf '%s\n' "$beginning_marker"
+                printf '%s' "$new_content_string"
+                printf '%s\n' "$end_marker"
             } >> "$temp_file" && mv -f "$temp_file" "$target_file"; then
                 return 0
             fi

--- a/lib/bash/file/tests/lib_file.bats
+++ b/lib/bash/file/tests/lib_file.bats
@@ -17,6 +17,21 @@ setup() {
     [ "$(cat "$target")" = $'line-one\n# BEGIN\nfirst\nsecond\n# END' ]
 }
 
+@test "lib_file can be sourced more than once" {
+    source "$BASE_BASH_DIR/file/lib_file.sh"
+
+    [ "$(type -t update_file_section)" = "function" ]
+}
+
+@test "update_file_section writes option-like markers literally" {
+    local target="$TEST_TMPDIR/config.txt"
+    printf 'line-one' > "$target"
+
+    update_file_section "$target" "-n" "-e" "value"
+
+    [ "$(cat "$target")" = $'line-one\n-n\nvalue\n-e' ]
+}
+
 @test "update_file_section replaces the first matching section" {
     local target="$TEST_TMPDIR/config.txt"
     cat <<'EOF' > "$target"

--- a/lib/bash/git/lib_git.sh
+++ b/lib/bash/git/lib_git.sh
@@ -3,6 +3,9 @@
 # lib_git.sh: Git operations
 #
 
+[[ -n "${__lib_git_sourced__:-}" ]] && return 0
+readonly __lib_git_sourced__=1
+
 #
 # Returns success when tracked changes are limited to one repo-relative path.
 #
@@ -29,20 +32,66 @@ _git_only_path_dirty() {
     return 0
 }
 
+_git_expected_update_branch() {
+    local configured_branch="${1:-}"
+    local default_branch
+
+    if [[ -n "$configured_branch" ]]; then
+        printf '%s\n' "$configured_branch"
+        return 0
+    fi
+
+    if default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+        default_branch="${default_branch#origin/}"
+        if [[ -n "$default_branch" ]]; then
+            printf '%s\n' "$default_branch"
+            return 0
+        fi
+    fi
+
+    if git show-ref --verify --quiet refs/heads/main; then
+        printf '%s\n' main
+        return 0
+    fi
+
+    if git show-ref --verify --quiet refs/heads/master; then
+        printf '%s\n' master
+        return 0
+    fi
+
+    printf '%s\n' master
+}
+
+_git_update_repo_finish() {
+    local git_log="${1:-}"
+    local should_popd="${2:-false}"
+    local status="${3:-0}"
+
+    if [[ "$should_popd" == true ]]; then
+        popd >/dev/null || status=1
+    fi
+
+    [[ -n "$git_log" ]] && rm -f "$git_log"
+    return "$status"
+}
+
 #
-# Safely updates a Git repository and its submodules after checking if the current branch is 'master'.
+# Safely updates a Git repository and its submodules after checking that the
+# current branch is the repo default branch or an explicit expected branch.
 #
 # @param $1 git_repo           The path to the local git repository.
 # @param $2 allowed_dirty_path Optional repo-relative path that may be dirty.
+# @param $3 expected_branch    Optional branch name to require instead of auto-detecting.
 #
 git_update_repo() {
     local git_repo="$1"
     local allowed_dirty_path="${2:-}"
+    local expected_branch="${3:-}"
     local git_log
 
     if [[ -z "$git_repo" ]]; then
         log_error "No git repository path provided."
-        log_info "Usage: update_repo /path/to/repo [allowed_dirty_path]"
+        log_info "Usage: update_repo /path/to/repo [allowed_dirty_path] [expected_branch]"
         return 1
     fi
 
@@ -51,26 +100,31 @@ git_update_repo() {
         return 1
     fi
 
-    git_log=$(mktemp -p /tmp)
+    git_log="$(mktemp "${TMPDIR:-/tmp}/git_log.XXXXXX")" || {
+        log_error "Unable to create temporary git log file."
+        return 1
+    }
     if ! pushd "$git_repo" > /dev/null; then
         # If cd fails, we can't proceed.
-        return 1
+        _git_update_repo_finish "$git_log" false 1
+        return $?
     fi
 
     # Check if it's a valid git repo
     if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
         log_error "'$git_repo' is not a Git repository."
-        popd >/dev/null || return 1
-        return 1
+        _git_update_repo_finish "$git_log" true 1
+        return $?
     fi
 
-    # Make sure the current branch is master
+    # Make sure the current branch is the expected update branch.
     local current_branch
+    expected_branch="$(_git_expected_update_branch "$expected_branch")"
     current_branch=$(git rev-parse --abbrev-ref HEAD)
-    if [[ "$current_branch" != "master" ]]; then
-        log_debug "Current branch of '$git_repo' is '${current_branch}', not 'master'. Skipping update."
-        popd >/dev/null || return 1
-        return 1
+    if [[ "$current_branch" != "$expected_branch" ]]; then
+        log_debug "Current branch of '$git_repo' is '${current_branch}', not '$expected_branch'. Skipping update."
+        _git_update_repo_finish "$git_log" true 1
+        return $?
     fi
 
     local dirty=false
@@ -85,8 +139,8 @@ git_update_repo() {
             log_debug "Repo '$git_repo' only has tracked changes in '$allowed_dirty_path'; attempting git pull."
         else
             log_debug "Repo '$git_repo' has local changes; skipping auto-update. Commit or stash to enable git pull."
-            popd >/dev/null || return 1
-            return 0
+            _git_update_repo_finish "$git_log" true 0
+            return $?
         fi
     fi
 
@@ -94,21 +148,21 @@ git_update_repo() {
     if ! { git pull || git pull; } >"$git_log" 2>&1; then
         log_error "git pull failed on repo '$git_repo'"
         [[ -s "$git_log" ]] && log_info_file "$git_log"
-        popd >/dev/null || return 1
-        return 1
+        _git_update_repo_finish "$git_log" true 1
+        return $?
     fi
 
     # it is safe to run submodule commands even if the repo has no submodules
     if ! { git submodule init && git submodule sync && git submodule update; } >/dev/null; then
         log_error "git submodule update failed on repo '$git_repo'"
         [[ -s "$git_log" ]] && log_info_file "$git_log"
-        popd >/dev/null || return 1
-        return 1
+        _git_update_repo_finish "$git_log" true 1
+        return $?
     fi
 
-    log_debug "Git repo '$git_repo' updated to latest master"
-    popd >/dev/null || return 1
-    return 0
+    log_debug "Git repo '$git_repo' updated to latest '$expected_branch'"
+    _git_update_repo_finish "$git_log" true 0
+    return $?
 }
 
 #

--- a/lib/bash/git/tests/lib_git.bats
+++ b/lib/bash/git/tests/lib_git.bats
@@ -47,6 +47,44 @@ setup() {
     [[ "$output" == *"has local changes; skipping auto-update"* ]]
 }
 
+@test "git_update_repo accepts main as the detected update branch" {
+    local repo="$TEST_TMPDIR/repo"
+
+    init_git_repo "$repo"
+    git -C "$repo" checkout -B main >/dev/null 2>&1
+    printf 'base\n' > "$repo/data.txt"
+    commit_all "$repo" "Initial commit"
+    printf 'local change\n' > "$repo/data.txt"
+    set_log_level DEBUG
+
+    bats_run git_update_repo "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"has local changes; skipping auto-update"* ]]
+    [[ "$output" != *"not 'master'"* ]]
+}
+
+@test "git_update_repo cleans up temp log without changing RETURN trap" {
+    local repo="$TEST_TMPDIR/repo"
+    local temp_dir="$TEST_TMPDIR/git-temp"
+    local return_trap
+
+    mkdir -p "$temp_dir"
+    init_git_repo "$repo"
+    printf 'base\n' > "$repo/data.txt"
+    commit_all "$repo" "Initial commit"
+    printf 'local change\n' > "$repo/data.txt"
+
+    trap 'printf "outer return trap\n"' RETURN
+    TMPDIR="$temp_dir" bats_run git_update_repo "$repo"
+    return_trap="$(trap -p RETURN)"
+    trap - RETURN
+
+    [ "$status" -eq 0 ]
+    [[ "$return_trap" == *"outer return trap"* ]]
+    ! compgen -G "$temp_dir/git_log.*" >/dev/null
+}
+
 @test "check_script_up_to_date reports success for an up-to-date tracked script" {
     local repo="$TEST_TMPDIR/repo"
     local remote="$TEST_TMPDIR/remote.git"


### PR DESCRIPTION
## Summary

This PR fixes a set of shell standards and runtime correctness issues found in
Base’s Bash layer.

Changes include:

- avoid `export VAR="$(cmd)"` in `base_init.sh`
  - command substitution failures are now checked explicitly
  - `BASE_OS` and `BASE_HOST` must resolve to non-empty values
- add idempotency guards to:
  - `lib/bash/file/lib_file.sh`
  - `lib/bash/git/lib_git.sh`
- replace `echo` with `printf` for managed file section markers
- update `git_update_repo` so it no longer hardcodes `master`
  - accepts an optional expected branch as arg 3
  - otherwise detects `origin/HEAD`
  - falls back to local `main`, then local `master`
- keep Git temp-log cleanup without using a `RETURN` trap that can clobber caller trap state
- make `caff` use `command -v caffeinate` instead of `type -ft`
- make `basectl` start an interactive runtime shell only when both stdin and stdout are TTYs
- prevent inherited exported `DRY_RUN=true` from leaking into `basectl setup`
- clarify why `--debug-wrapper` and `--verbose-wrapper` both set `LOG_DEBUG=1` before stdlib loads

## Testing

Added regression coverage for:

- sourcing `lib_file.sh` more than once
- option-like file section markers such as `-n` / `-e`
- `git_update_repo` accepting `main`
- `git_update_repo` preserving existing `RETURN` traps while cleaning temp logs
- inherited `DRY_RUN=true` not forcing `basectl setup` into dry-run mode

Validated with:

```bash
bash -n base_init.sh bin/basectl cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/caff/caff.sh lib/bash/file/lib_file.sh lib/bash/git/lib_git.sh
bats cli/bash/commands/basectl/tests/basectl.bats cli/bash/commands/basectl/tests/setup.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/std/tests/lib_std.bats
git diff --check