### PR TITLE
Load Base runtime before user bashrc in basectl shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ Base-enabled Bash shell.
 
 When `basectl` starts an interactive Bash runtime shell, it uses Base's runtime
 rcfile rather than making Bash read `~/.bashrc` directly. That runtime rcfile
-sources the user's `~/.bashrc` once with guardrails, then loads `base_init.sh`,
-and finally sets the Base runtime prompt. This keeps user aliases and normal
-interactive Bash behavior available while still letting Base own the runtime
-environment and final prompt.
+loads `base_init.sh`, sources the user's `~/.bashrc` once with guardrails, and
+finally sets the Base runtime prompt. This keeps user aliases and normal
+interactive Bash behavior available while making Base stdlib functions such as
+`import_base_lib` available during user Bash startup.
 
 ### Debugging Shell Startup
 

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -176,10 +176,13 @@ EOF
 }
 
 
-@test "Base runtime shell sources user bashrc before setting prompt" {
+@test "Base runtime shell loads base_init before user bashrc and owns final prompt" {
     cat > "$TEST_HOME/.bashrc" <<'EOF'
 alias user_bashrc_alias='printf user-bashrc'
 export USER_BASHRC_LOADED=1
+if declare -F import_base_lib >/dev/null 2>&1; then
+    export USER_BASHRC_HAS_BASE_IMPORT=1
+fi
 PS1='user prompt: '
 EOF
 
@@ -190,11 +193,13 @@ EOF
         "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
             alias user_bashrc_alias; \
             printf "USER_BASHRC_LOADED=%s\n" "${USER_BASHRC_LOADED:-}"; \
+            printf "USER_BASHRC_HAS_BASE_IMPORT=%s\n" "${USER_BASHRC_HAS_BASE_IMPORT:-}"; \
             printf "PS1=%s\n" "$PS1"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"alias user_bashrc_alias='printf user-bashrc'"* ]]
     [[ "$output" == *"USER_BASHRC_LOADED=1"* ]]
+    [[ "$output" == *"USER_BASHRC_HAS_BASE_IMPORT=1"* ]]
     [[ "$output" == *'PS1=\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 
@@ -212,8 +217,8 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_DEBUG runtime: loading"* ]]
-    [[ "$output" == *"BASE_DEBUG runtime: sourcing '$TEST_HOME/.bashrc'"* ]]
     [[ "$output" == *"BASE_DEBUG runtime: sourcing '$BASE_REPO_ROOT/base_init.sh'"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: sourcing '$TEST_HOME/.bashrc'"* ]]
     [[ "$output" == *"BASE_DEBUG runtime: complete"* ]]
 }
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -180,10 +180,11 @@ That shell uses Base's runtime rcfile:
 $BASE_HOME/lib/bash/runtime/bashrc
 ```
 
-The runtime rcfile sources the user's `~/.bashrc` once with guardrails, sources
-`base_init.sh`, and then sets the Base runtime prompt. This gives the user their
-normal interactive Bash behavior while still letting Base own the final runtime
-contract.
+The runtime rcfile sources `base_init.sh`, sources the user's `~/.bashrc` once
+with guardrails, and then sets the Base runtime prompt. This gives the user their
+normal interactive Bash behavior while also making Base stdlib functions such as
+`import_base_lib` available during user Bash startup. Base still owns the final
+runtime prompt.
 
 ## Dotfile Boundary
 

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -8,6 +8,7 @@
 #     - start an interactive Bash shell with the Base runtime already loaded
 #     - keep runtime shell initialization separate from user dotfile integration
 #     - source user-managed ~/.baserc preferences when present
+#     - source base_init.sh before user ~/.bashrc so Base functions are available
 #     - source the user's ~/.bashrc with guardrails
 #     - provide a Base runtime prompt with time, host, venv, git branch, and cwd
 #
@@ -179,12 +180,12 @@ _base_runtime_main() {
     export BASE_SHELL=1
     _base_runtime_source_baserc || return $?
     _base_runtime_debug "loading"
-    _base_runtime_source_user_bashrc || return $?
 
     _base_runtime_debug "sourcing '$BASE_HOME/base_init.sh'"
     # shellcheck source=/dev/null
     source "$BASE_HOME/base_init.sh" || return $?
 
+    _base_runtime_source_user_bashrc || return $?
     _base_runtime_set_prompt
     _base_runtime_debug "complete"
 }


### PR DESCRIPTION
## Summary

This PR changes the `basectl` interactive runtime shell so Base runtime initialization happens before the user's `~/.bashrc` is sourced.

## Why

Previously, the runtime rcfile sourced the user's `~/.bashrc` first and loaded `base_init.sh` afterward. That meant Base stdlib helpers such as `import_base_lib` were not available during user Bash startup inside a `basectl` shell.

## Changes

- Loads `base_init.sh` before sourcing the user's `~/.bashrc` in `lib/bash/runtime/bashrc`.
- Keeps the final runtime prompt owned by Base after user `.bashrc` runs.
- Updates basectl tests to assert that `import_base_lib` is available from user `.bashrc`.
- Updates README and execution model docs to describe the new runtime shell order.

## Verification

- `bats cli/bash/commands/basectl/tests`
- `bats lib/bash/file/tests lib/bash/git/tests lib/bash/std/tests`
- `git diff --check`