### PR TITLE
Share Bash baserc guard across startup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ The managed sections source matching snippets under `lib/shell/`:
 The names intentionally mirror the dotfiles they support, without leading dots
 inside the repository.
 
+Bash snippets and the Bash runtime rcfile share `lib/shell/baserc_guard.bash` for
+safe `~/.baserc` loading. Zsh snippets keep their own guard logic for now.
+
 ### Login Profiles
 
 `bash_profile` and `zprofile` stay thin.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -73,7 +73,7 @@ basectl_verify_home() {
         return 1
     fi
 
-    for file in base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/bash/runtime/bashrc bin/basectl cli/bash/commands/basectl/basectl.sh; do
+    for file in base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/baserc_guard.bash lib/bash/runtime/bashrc bin/basectl cli/bash/commands/basectl/basectl.sh; do
         if [[ ! -f "$base_home/$file" ]]; then
             missing+=("$file")
         fi

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -87,6 +87,7 @@ run_basectl() {
         "$base_home/base_init.sh" \
         "$base_home/lib/shell/bash_profile" \
         "$base_home/lib/shell/bashrc" \
+        "$base_home/lib/shell/baserc_guard.bash" \
         "$base_home/lib/bash/runtime/bashrc" \
         "$base_home/bin/basectl" \
         "$base_home/cli/bash/commands/basectl/basectl.sh"

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -482,6 +482,27 @@ run_base_command() {
     [[ "$output" == *"BASE_DEBUG bashrc: complete"* ]]
 }
 
+@test "Bash profile bridge shares the baserc guard with bashrc" {
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    printf '%s
+' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u BASE_DEBUG \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash --norc -i -c 'source "$HOME/.bash_profile"; command -v basectl; printf "BASE_HOME=%s
+" "${BASE_HOME-unset}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG bash_profile: sourced '$TEST_HOME/.baserc'"* ]]
+    [[ "$output" == *"BASE_DEBUG bash_profile: sourcing '$TEST_HOME/.bashrc'"* ]]
+    [[ "$output" == *"BASE_DEBUG bashrc: loading"* ]]
+    [[ "$output" != *"BASE_DEBUG bashrc: sourced '$TEST_HOME/.baserc'"* ]]
+    [[ "$output" == *"$BASE_REPO_ROOT/bin/basectl"* ]]
+    [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
+}
+
 @test "baserc cannot override BASE_HOME for Base-managed Bash startup" {
     run_base_command update-profile
     [ "$status" -eq 0 ]

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -186,6 +186,9 @@ normal interactive Bash behavior while also making Base stdlib functions such as
 `import_base_lib` available during user Bash startup. Base still owns the final
 runtime prompt.
 
+Bash startup paths share `lib/shell/baserc_guard.bash` for safe `~/.baserc`
+loading and Base-owned variable protection.
+
 ## Dotfile Boundary
 
 The normal shell-startup snippets under `lib/shell/` do not source

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -28,71 +28,17 @@ _base_runtime_debug() {
     esac
 }
 
-_base_runtime_reject_baserc_owned_var() {
-    local var_name="$1"
-    local before_set="$2"
-    local before_value="$3"
-    local after_set
-    local after_value
+_base_runtime_source_baserc_guard() {
+    local guard_path="$BASE_HOME/lib/shell/baserc_guard.bash"
 
-    eval "after_set=\"\${$var_name+x}\""
-    eval "after_value=\"\${$var_name-}\""
-
-    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
-        return 0
-    fi
-
-    if [[ -n "$before_set" ]]; then
-        printf -v "$var_name" '%s' "$before_value"
-    else
-        unset "$var_name"
-    fi
-
-    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
-    return 1
-}
-
-_base_runtime_source_baserc() {
-    local baserc="$HOME/.baserc"
-    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
-    local var_name
-    local snapshot_name
-    local before_set
-    local before_value
-    local baserc_status=0
-
-    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
-    [[ -f "$baserc" && -r "$baserc" ]] || return 0
-
-    for var_name in $base_owned_vars; do
-        snapshot_name="_base_runtime_before_$var_name"
-        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
-        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
-    done
-
-    __base_baserc_sourced__=1
-    # shellcheck source=/dev/null
-    source "$baserc" || {
-        unset __base_baserc_sourced__
-        _base_runtime_error "Failed to source Base user config '$baserc'."
+    [[ -f "$guard_path" ]] || {
+        _base_runtime_error "Base baserc guard '$guard_path' was not found."
         return 1
     }
 
-    for var_name in $base_owned_vars; do
-        snapshot_name="_base_runtime_before_$var_name"
-        eval "before_set=\"\${${snapshot_name}_set}\""
-        eval "before_value=\"\${${snapshot_name}_value}\""
-        _base_runtime_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
-    done
-
-    if [[ "$baserc_status" -ne 0 ]]; then
-        unset __base_baserc_sourced__
-        return "$baserc_status"
-    fi
-
-    _base_runtime_debug "sourced '$baserc'"
+    # shellcheck source=/dev/null
+    source "$guard_path"
 }
-
 
 _base_runtime_source_user_bashrc() {
     local user_bashrc="$HOME/.bashrc"
@@ -178,7 +124,8 @@ _base_runtime_main() {
     }
 
     export BASE_SHELL=1
-    _base_runtime_source_baserc || return $?
+    _base_runtime_source_baserc_guard || return $?
+    base_baserc_guard_source _base_runtime_debug || return $?
     _base_runtime_debug "loading"
 
     _base_runtime_debug "sourcing '$BASE_HOME/base_init.sh'"

--- a/lib/shell/baserc_guard.bash
+++ b/lib/shell/baserc_guard.bash
@@ -1,0 +1,102 @@
+# shellcheck shell=bash
+
+#
+# baserc_guard.bash
+#     Shared Bash helper for safely loading user-managed ~/.baserc.
+#
+# Purpose:
+#     - source ~/.baserc at most once per shell
+#     - allow simple user-managed Base preferences such as BASE_DEBUG=1
+#     - reject and restore Base-owned variables when ~/.baserc tries to set them
+#     - keep Bash dotfile snippets and runtime rcfile from duplicating this logic
+#
+# Callers should define their own debug function, then call:
+#
+#     base_baserc_guard_source caller_debug_function
+#
+# This helper is Bash-only. Zsh startup snippets keep their own implementation
+# until Base has stronger Zsh-specific coverage.
+#
+
+[[ -n "${__base_baserc_guard_sourced__:-}" ]] && return 0
+readonly __base_baserc_guard_sourced__=1
+
+base_baserc_guard_debug() {
+    local debug_function="${1:-}"
+    [[ $# -gt 0 ]] && shift
+
+    [[ -n "$debug_function" ]] || return 0
+    declare -F "$debug_function" >/dev/null 2>&1 || return 0
+    "$debug_function" "$*"
+}
+
+base_baserc_guard_owned_vars() {
+    printf '%s\n' "BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
+}
+
+base_baserc_guard_reject_owned_var() {
+    local var_name="$1"
+    local before_set="$2"
+    local before_value="$3"
+    local after_set
+    local after_value
+
+    eval "after_set=\"\${$var_name+x}\""
+    eval "after_value=\"\${$var_name-}\""
+
+    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
+        return 0
+    fi
+
+    if [[ -n "$before_set" ]]; then
+        printf -v "$var_name" '%s' "$before_value"
+    else
+        unset "$var_name"
+    fi
+
+    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
+    return 1
+}
+
+base_baserc_guard_source() {
+    local debug_function="${1:-}"
+    local baserc="${2:-$HOME/.baserc}"
+    local base_owned_vars
+    local var_name
+    local snapshot_name
+    local before_set
+    local before_value
+    local baserc_status=0
+
+    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
+    [[ -f "$baserc" && -r "$baserc" ]] || return 0
+
+    base_owned_vars="$(base_baserc_guard_owned_vars)"
+    for var_name in $base_owned_vars; do
+        snapshot_name="base_baserc_guard_before_$var_name"
+        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
+        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
+    done
+
+    __base_baserc_sourced__=1
+    # shellcheck source=/dev/null
+    source "$baserc" || {
+        unset __base_baserc_sourced__
+        printf "ERROR: Failed to source Base user config '%s'.\n" "$baserc" >&2
+        return 1
+    }
+
+    for var_name in $base_owned_vars; do
+        snapshot_name="base_baserc_guard_before_$var_name"
+        eval "before_set=\"\${${snapshot_name}_set}\""
+        eval "before_value=\"\${${snapshot_name}_value}\""
+        base_baserc_guard_reject_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
+    done
+
+    if [[ "$baserc_status" -ne 0 ]]; then
+        unset __base_baserc_sourced__
+        return "$baserc_status"
+    fi
+
+    base_baserc_guard_debug "$debug_function" "sourced '$baserc'"
+}

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -22,77 +22,49 @@ base_bash_profile_debug() {
     esac
 }
 
-base_bash_profile_reject_baserc_owned_var() {
-    local var_name="$1"
-    local before_set="$2"
-    local before_value="$3"
-    local after_set
-    local after_value
+base_bash_profile_source_path() {
+    local source_path="${BASH_SOURCE[0]}"
+    local link_dir
+    local target
 
-    eval "after_set=\"\${$var_name+x}\""
-    eval "after_value=\"\${$var_name-}\""
-
-    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
-        return 0
-    fi
-
-    if [[ -n "$before_set" ]]; then
-        printf -v "$var_name" '%s' "$before_value"
-    else
-        unset "$var_name"
-    fi
-
-    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
-    return 1
-}
-
-base_bash_profile_source_baserc() {
-    local baserc="$HOME/.baserc"
-    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
-    local var_name
-    local snapshot_name
-    local before_set
-    local before_value
-    local baserc_status=0
-
-    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
-    [[ -f "$baserc" && -r "$baserc" ]] || return 0
-
-    for var_name in $base_owned_vars; do
-        snapshot_name="base_bash_profile_before_$var_name"
-        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
-        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
+    while [[ -L "$source_path" ]]; do
+        link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+        target="$(readlink "$source_path")" || return 1
+        if [[ "$target" == /* ]]; then
+            source_path="$target"
+        else
+            source_path="$link_dir/$target"
+        fi
     done
 
-    __base_baserc_sourced__=1
-    # shellcheck source=/dev/null
-    source "$baserc" || {
-        unset __base_baserc_sourced__
-        printf "ERROR: Failed to source Base user config '%s'.\n" "$baserc" >&2
+    link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    printf '%s/%s\n' "$link_dir" "$(basename -- "$source_path")"
+}
+
+base_bash_profile_source_baserc_guard() {
+    local source_path
+    local snippet_dir
+    local guard_path
+
+    source_path="$(base_bash_profile_source_path)" || return 1
+    snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    guard_path="$snippet_dir/baserc_guard.bash"
+
+    [[ -f "$guard_path" ]] || {
+        printf "ERROR: Base baserc guard '%s' was not found.\n" "$guard_path" >&2
         return 1
     }
 
-    for var_name in $base_owned_vars; do
-        snapshot_name="base_bash_profile_before_$var_name"
-        eval "before_set=\"\${${snapshot_name}_set}\""
-        eval "before_value=\"\${${snapshot_name}_value}\""
-        base_bash_profile_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
-    done
-
-    if [[ "$baserc_status" -ne 0 ]]; then
-        unset __base_baserc_sourced__
-        return "$baserc_status"
-    fi
-
-    base_bash_profile_debug "sourced '$baserc'"
+    # shellcheck source=/dev/null
+    source "$guard_path"
 }
 
-
-base_bash_profile_source_baserc || return $?
+base_bash_profile_source_baserc_guard || return $?
+base_baserc_guard_source base_bash_profile_debug || return $?
 
 if [[ -n "${__base_bash_profile_sourced__:-}" ]]; then
     base_bash_profile_debug "already sourced; skipping"
-    unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc
+    unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard
     return 0
 fi
 readonly __base_bash_profile_sourced__=1
@@ -100,13 +72,13 @@ base_bash_profile_debug "loading"
 
 if [[ -n "${__base_sourcing_bashrc_from_profile__:-}" ]]; then
     base_bash_profile_debug "bashrc bridge guard is active; skipping"
-    unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc
+    unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard
     return 0
 fi
 
 if [[ ! -f "$HOME/.bashrc" ]]; then
     base_bash_profile_debug "'$HOME/.bashrc' not found; skipping"
-    unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc
+    unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard
     return 0
 fi
 
@@ -116,4 +88,4 @@ __base_sourcing_bashrc_from_profile__=1
 source "$HOME/.bashrc"
 unset __base_sourcing_bashrc_from_profile__
 base_bash_profile_debug "complete"
-unset -f base_bash_profile_debug base_bash_profile_reject_baserc_owned_var base_bash_profile_source_baserc
+unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -21,88 +21,6 @@ base_bashrc_debug() {
     esac
 }
 
-base_bashrc_reject_baserc_owned_var() {
-    local var_name="$1"
-    local before_set="$2"
-    local before_value="$3"
-    local after_set
-    local after_value
-
-    eval "after_set=\"\${$var_name+x}\""
-    eval "after_value=\"\${$var_name-}\""
-
-    if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
-        return 0
-    fi
-
-    if [[ -n "$before_set" ]]; then
-        printf -v "$var_name" '%s' "$before_value"
-    else
-        unset "$var_name"
-    fi
-
-    printf "ERROR: ~/.baserc must not set Base-owned variable '%s'.\n" "$var_name" >&2
-    return 1
-}
-
-base_bashrc_source_baserc() {
-    local baserc="$HOME/.baserc"
-    local base_owned_vars="BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_ARCH BASE_HOST BASE_SHELL BASE_PROFILE_VERSION BASE_ENABLE_BASH_DEFAULTS BASE_ENABLE_ZSH_DEFAULTS"
-    local var_name
-    local snapshot_name
-    local before_set
-    local before_value
-    local baserc_status=0
-
-    [[ -n "${__base_baserc_sourced__:-}" ]] && return 0
-    [[ -f "$baserc" && -r "$baserc" ]] || return 0
-
-    for var_name in $base_owned_vars; do
-        snapshot_name="base_bashrc_before_$var_name"
-        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
-        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
-    done
-
-    __base_baserc_sourced__=1
-    # shellcheck source=/dev/null
-    source "$baserc" || {
-        unset __base_baserc_sourced__
-        printf "ERROR: Failed to source Base user config '%s'.\n" "$baserc" >&2
-        return 1
-    }
-
-    for var_name in $base_owned_vars; do
-        snapshot_name="base_bashrc_before_$var_name"
-        eval "before_set=\"\${${snapshot_name}_set}\""
-        eval "before_value=\"\${${snapshot_name}_value}\""
-        base_bashrc_reject_baserc_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
-    done
-
-    if [[ "$baserc_status" -ne 0 ]]; then
-        unset __base_baserc_sourced__
-        return "$baserc_status"
-    fi
-
-    base_bashrc_debug "sourced '$baserc'"
-}
-
-
-base_bashrc_source_baserc || return $?
-
-if [[ $- != *i* ]]; then
-    base_bashrc_debug "non-interactive shell; skipping"
-    unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc
-    return 0
-fi
-
-if [[ -n "${__base_bashrc_sourced__:-}" ]]; then
-    base_bashrc_debug "already sourced; skipping"
-    unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc
-    return 0
-fi
-readonly __base_bashrc_sourced__=1
-base_bashrc_debug "loading"
-
 base_bashrc_source_path() {
     local source_path="${BASH_SOURCE[0]}"
     local link_dir
@@ -121,6 +39,41 @@ base_bashrc_source_path() {
     link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
     printf '%s/%s\n' "$link_dir" "$(basename -- "$source_path")"
 }
+
+base_bashrc_source_baserc_guard() {
+    local source_path
+    local snippet_dir
+    local guard_path
+
+    source_path="$(base_bashrc_source_path)" || return 1
+    snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    guard_path="$snippet_dir/baserc_guard.bash"
+
+    [[ -f "$guard_path" ]] || {
+        printf "ERROR: Base baserc guard '%s' was not found.\n" "$guard_path" >&2
+        return 1
+    }
+
+    # shellcheck source=/dev/null
+    source "$guard_path"
+}
+
+base_bashrc_source_baserc_guard || return $?
+base_baserc_guard_source base_bashrc_debug || return $?
+
+if [[ $- != *i* ]]; then
+    base_bashrc_debug "non-interactive shell; skipping"
+    unset -f base_bashrc_debug base_bashrc_source_path base_bashrc_source_baserc_guard
+    return 0
+fi
+
+if [[ -n "${__base_bashrc_sourced__:-}" ]]; then
+    base_bashrc_debug "already sourced; skipping"
+    unset -f base_bashrc_debug base_bashrc_source_path base_bashrc_source_baserc_guard
+    return 0
+fi
+readonly __base_bashrc_sourced__=1
+base_bashrc_debug "loading"
 
 base_bashrc_set_base_home() {
     local source_path
@@ -188,7 +141,7 @@ base_bashrc_source_defaults() {
 
 base_bashrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
-    unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc
+    unset -f base_bashrc_debug base_bashrc_source_path base_bashrc_source_baserc_guard
     return 1
 }
 base_bashrc_prepend_path
@@ -197,4 +150,4 @@ base_bashrc_debug "complete"
 
 unset -f base_bashrc_source_path base_bashrc_set_base_home
 unset -f base_bashrc_prepend_path base_bashrc_source_defaults
-unset -f base_bashrc_debug base_bashrc_reject_baserc_owned_var base_bashrc_source_baserc
+unset -f base_bashrc_source_baserc_guard base_bashrc_debug


### PR DESCRIPTION
## Summary

This PR extracts the duplicated Bash `~/.baserc` loading and Base-owned variable protection logic into a shared helper.

## Why

`lib/shell/bashrc`, `lib/shell/bash_profile`, and `lib/bash/runtime/bashrc` all carried similar logic for:

- sourcing `~/.baserc`
- preventing `~/.baserc` from overriding Base-owned variables
- restoring protected values after invalid user config
- emitting caller-specific debug output

Keeping that logic duplicated made drift likely as the dotfile/runtime model evolves.

## Changes

- Adds `lib/shell/baserc_guard.bash` as a Bash-only shared helper.
- Updates Bash startup snippets to source and call the shared guard:
  - `lib/shell/bashrc`
  - `lib/shell/bash_profile`
  - `lib/bash/runtime/bashrc`
- Leaves Zsh guard logic unchanged for now.
- Updates `basectl` Base-home verification to require the new helper file.
- Adds a regression test for the Bash profile bridge to confirm:
  - `~/.baserc` is loaded once
  - `bash_profile` and `bashrc` share the same guard state
  - `basectl` remains available through the profile bridge
- Documents the shared Bash guard in README and execution model docs.

## Verification

- `bash -n lib/shell/baserc_guard.bash lib/shell/bashrc lib/shell/bash_profile lib/bash/runtime/bashrc cli/bash/commands/basectl/basectl.sh`
- `bats cli/bash/commands/basectl/tests`
- `bats lib/bash/file/tests lib/bash/git/tests lib/bash/std/tests`
- `git diff --check`