### PR TITLE
Add coverage for utility commands and Zsh startup

### DIFF
--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -486,13 +486,11 @@ run_base_command() {
     run_base_command update-profile
     [ "$status" -eq 0 ]
 
-    printf '%s
-' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
+    printf '%s\n' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
     run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u BASE_DEBUG \
         HOME="$TEST_HOME" \
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash --norc -i -c 'source "$HOME/.bash_profile"; command -v basectl; printf "BASE_HOME=%s
-" "${BASE_HOME-unset}"'
+        bash --norc -i -c 'source "$HOME/.bash_profile"; command -v basectl; printf "BASE_HOME=%s\n" "${BASE_HOME-unset}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_DEBUG bash_profile: sourced '$TEST_HOME/.baserc'"* ]]
@@ -512,6 +510,39 @@ run_base_command() {
         HOME="$TEST_HOME" \
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
         bash --rcfile "$TEST_HOME/.bashrc" -i -c 'printf "BASE_HOME=%s\n" "${BASE_HOME-unset}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ERROR: ~/.baserc must not set Base-owned variable 'BASE_HOME'."* ]]
+    [[ "$output" == *"BASE_HOME=unset"* ]]
+}
+
+@test "basectl update-profile makes basectl available in interactive Zsh without runtime bootstrap" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        zsh -f -i -c 'source "$HOME/.zshrc"; command -v basectl; printf "BASE_HOME=%s\n" "${BASE_HOME-unset}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$BASE_REPO_ROOT/bin/basectl"* ]]
+    [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
+}
+
+@test "baserc cannot override BASE_HOME for Base-managed Zsh startup" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    printf '%s\n' 'BASE_HOME=/tmp/not-base' > "$TEST_HOME/.baserc"
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u BASE_DEBUG \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        zsh -f -i -c 'source "$HOME/.zshrc"; printf "BASE_HOME=%s\n" "${BASE_HOME-unset}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"ERROR: ~/.baserc must not set Base-owned variable 'BASE_HOME'."* ]]

--- a/cli/bash/commands/caff/tests/caff.bats
+++ b/cli/bash/commands/caff/tests/caff.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+load ../../../../../lib/bash/tests/test_helper.bash
+
+setup() {
+    setup_test_tmpdir
+    TEST_HOME="$TEST_TMPDIR/home"
+    TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
+    TEST_STATE_DIR="$TEST_TMPDIR/state"
+    mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
+}
+
+run_caff() {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" caff "$@"
+}
+
+create_caffeinate_stub() {
+    cat > "$TEST_MOCKBIN/caffeinate" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${CAFF_TEST_RECORD:-}" ]]; then
+    printf '%s\n' "$*" > "$CAFF_TEST_RECORD"
+fi
+sleep 0.2
+EOF
+    chmod +x "$TEST_MOCKBIN/caffeinate"
+}
+
+create_pgrep_stub() {
+    cat > "$TEST_MOCKBIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    caffeinate)
+        [[ -n "${CAFF_TEST_CAFFEINATE_PID:-}" ]] && printf '%s\n' "$CAFF_TEST_CAFFEINATE_PID"
+        ;;
+    "${CAFF_TEST_PROCESS_NAME:-}")
+        [[ -n "${CAFF_TEST_TARGET_PID:-}" ]] && printf '%s\n' "$CAFF_TEST_TARGET_PID"
+        ;;
+esac
+EOF
+    chmod +x "$TEST_MOCKBIN/pgrep"
+}
+
+create_ps_stub() {
+    cat > "$TEST_MOCKBIN/ps" <<'EOF'
+#!/usr/bin/env bash
+printf 'ARGS\n'
+if [[ -n "${CAFF_TEST_CAFFEINATED_PID:-}" ]]; then
+    printf 'caffeinate -iw %s\n' "$CAFF_TEST_CAFFEINATED_PID"
+fi
+EOF
+    chmod +x "$TEST_MOCKBIN/ps"
+}
+
+create_core_tool_links_without_caffeinate() {
+    local tool
+    local tool_path
+
+    for tool in uname dirname readlink basename; do
+        tool_path="$(command -v "$tool")"
+        ln -s "$tool_path" "$TEST_MOCKBIN/$tool"
+    done
+}
+
+wait_for_record() {
+    local record_file="$1"
+    local attempt
+
+    for attempt in 1 2 3 4 5; do
+        [[ -f "$record_file" ]] && return 0
+        sleep 0.1
+    done
+
+    return 1
+}
+
+@test "caff prints help" {
+    run_caff --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"caff [-s] <process-name>"* ]]
+}
+
+@test "caff fails when caffeinate is unavailable" {
+    create_core_tool_links_without_caffeinate
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" caff worker
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"There is no caffeinate command on your system."* ]]
+}
+
+@test "caff requires exactly one process name" {
+    create_caffeinate_stub
+
+    run_caff
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"A process name is required."* ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "caff warns when the target process is not running" {
+    create_caffeinate_stub
+    create_pgrep_stub
+
+    run_caff worker
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"'worker' process is not running."* ]]
+}
+
+@test "caff starts caffeinate for the first matching process" {
+    local record_file="$TEST_STATE_DIR/caffeinate.args"
+
+    create_caffeinate_stub
+    create_pgrep_stub
+    create_ps_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        CAFF_TEST_PROCESS_NAME=worker \
+        CAFF_TEST_TARGET_PID=1234 \
+        CAFF_TEST_RECORD="$record_file" \
+        "$BASE_REPO_ROOT/bin/basectl" caff worker
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Caffeinating PID 1234"* ]]
+    wait_for_record "$record_file"
+    [ "$(cat "$record_file")" = "-iw 1234" ]
+}
+
+@test "caff does not start another caffeinate for an already caffeinated process" {
+    local record_file="$TEST_STATE_DIR/caffeinate.args"
+
+    create_caffeinate_stub
+    create_pgrep_stub
+    create_ps_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        CAFF_TEST_PROCESS_NAME=worker \
+        CAFF_TEST_TARGET_PID=1234 \
+        CAFF_TEST_CAFFEINATE_PID=9999 \
+        CAFF_TEST_CAFFEINATED_PID=1234 \
+        CAFF_TEST_RECORD="$record_file" \
+        "$BASE_REPO_ROOT/bin/basectl" caff worker
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Already caffeinating: worker pid=1234, caffeinate pid=9999"* ]]
+    [ ! -e "$record_file" ]
+}

--- a/cli/bash/commands/sort-in-place/tests/sort-in-place.bats
+++ b/cli/bash/commands/sort-in-place/tests/sort-in-place.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+load ../../../../../lib/bash/tests/test_helper.bash
+
+setup() {
+    setup_test_tmpdir
+    TEST_HOME="$TEST_TMPDIR/home"
+    mkdir -p "$TEST_HOME"
+}
+
+run_sort_in_place() {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" sort-in-place "$@"
+}
+
+@test "sort-in-place prints help" {
+    run_sort_in_place --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"sort-in-place [-u] <file>..."* ]]
+}
+
+@test "sort-in-place requires at least one file" {
+    run_sort_in_place
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"At least one file is required."* ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "sort-in-place sorts a file in place" {
+    local input_file="$TEST_TMPDIR/input.txt"
+
+    printf 'b\na\nc\n' > "$input_file"
+
+    run_sort_in_place "$input_file"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$input_file")" = $'a\nb\nc' ]
+}
+
+@test "sort-in-place supports unique sorting" {
+    local input_file="$TEST_TMPDIR/input.txt"
+
+    printf 'b\na\nb\na\n' > "$input_file"
+
+    run_sort_in_place -u "$input_file"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$input_file")" = $'a\nb' ]
+}
+
+@test "sort-in-place skips non-regular files" {
+    local missing_file="$TEST_TMPDIR/missing.txt"
+
+    run_sort_in_place "$missing_file"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$missing_file is not a regular file; skipping."* ]]
+}
+
+@test "sort-in-place skips a file when its temp file already exists" {
+    local input_file="$TEST_TMPDIR/input.txt"
+    local temp_file="$input_file._tmp"
+
+    printf 'b\na\n' > "$input_file"
+    printf 'existing temp\n' > "$temp_file"
+
+    run_sort_in_place "$input_file"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$temp_file already exists; skipping $input_file."* ]]
+    [ "$(cat "$input_file")" = $'b\na' ]
+    [ "$(cat "$temp_file")" = "existing temp" ]
+}


### PR DESCRIPTION
## Summary

This PR adds focused test coverage for Base utility commands and Zsh shell startup behavior.

## Changes

- Adds colocated `caff` tests covering:
  - help output
  - missing `caffeinate`
  - missing process argument
  - target process not running
  - starting `caffeinate`
  - avoiding duplicate caffeination

- Adds colocated `sort-in-place` tests covering:
  - help output
  - missing file arguments
  - normal in-place sorting
  - unique sorting
  - missing/non-regular file skip behavior
  - temp-file collision skip behavior

- Adds Zsh startup coverage for:
  - making `basectl` available from Base-managed `.zshrc`
  - preventing `~/.baserc` from overriding `BASE_HOME`

- Cleans up newline escaping in the Bash profile bridge test.

## Verification

- `bats cli/bash/commands/caff/tests cli/bash/commands/sort-in-place/tests cli/bash/commands/basectl/tests lib/bash/file/tests lib/bash/git/tests lib/bash/std/tests`
- `git diff --check`