### PR TITLE
Standardize Bash helper filenames on .sh

### DIFF
--- a/lib/shell/baserc_guard.sh
+++ b/lib/shell/baserc_guard.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 #
-# baserc_guard.bash
+# baserc_guard.sh
 #     Shared Bash helper for safely loading user-managed ~/.baserc.
 #
 # Purpose:

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -48,7 +48,7 @@ base_bash_profile_source_baserc_guard() {
 
     source_path="$(base_bash_profile_source_path)" || return 1
     snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    guard_path="$snippet_dir/baserc_guard.bash"
+    guard_path="$snippet_dir/baserc_guard.sh"
 
     [[ -f "$guard_path" ]] || {
         printf "ERROR: Base baserc guard '%s' was not found.\n" "$guard_path" >&2

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -47,7 +47,7 @@ base_bashrc_source_baserc_guard() {
 
     source_path="$(base_bashrc_source_path)" || return 1
     snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    guard_path="$snippet_dir/baserc_guard.bash"
+    guard_path="$snippet_dir/baserc_guard.sh"
 
     [[ -f "$guard_path" ]] || {
         printf "ERROR: Base baserc guard '%s' was not found.\n" "$guard_path" >&2


### PR DESCRIPTION
## Summary

This PR standardizes Base's Bash helper filenames on the `.sh` extension.

Changes include:

- Rename `lib/shell/baserc_guard.bash` to `lib/shell/baserc_guard.sh`
- Rename `lib/bash/tests/test_helper.bash` to `lib/bash/tests/test_helper.sh`
- Update Bash startup snippets, runtime shell startup, and `basectl` home verification to reference the new filenames
- Update Bats tests and docs that referenced the old `.bash` names

## Why

Base already uses `.sh` for Bash commands and libraries almost everywhere. Keeping the remaining helper files on `.bash` created a small naming inconsistency without giving us much benefit.

This keeps the repo easier to scan and aligns helper scripts with the rest of the Bash codebase.

## Validation

- `bats cli/bash/commands/caff/tests cli/bash/commands/sort-in-place/tests cli/bash/commands/basectl/tests lib/bash/file/tests lib/bash/git/tests lib/bash/std/tests`
- `git diff --check`