### PR TITLE
Hpr/fix claude findings

### DIFF
--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,47 @@
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Python cache
+pycache/
+*.pyc
+.pytest_cache/
+
+# Virtual environments
+venv/
+.venv/
+env/
+
+# Node modules
+node_modules/
+
+# Logs
+*.log
+logs/
+
+# Generated files
+generated/
+tmp/
+temp/
+
+# Git
+.git/
+
+# IDE
+.idea/
+.vscode/
+
+# Coverage
+htmlcov/
+.coverage
+
+# Large binaries
+*.zip
+*.tar.gz
+*.bin
+
+# Secrets
+.env
+.env.local
+secrets/

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -6,7 +6,8 @@ This file is the shared working memory for future AI-assisted development in thi
 
 - Branch: `hpr/fix-claude-findings`.
 - Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
-- Most recent uncommitted change simplifies managed shell snippet path discovery by removing stale symlink-resolving loops from `lib/shell/bashrc`, `lib/shell/bash_profile`, and `lib/shell/zshrc`.
+- Most recent uncommitted change consolidates Base version reading in `lib/bash/version/lib_version.sh`, shared by early `basectl --version` handling and the runtime `basectl version` command.
+- `lib/bash/version` and `lib/bash/runtime` now have local README files and colocated BATS coverage, in addition to existing basectl integration coverage.
 - Confirmed there are no symlinked snippets in the repo; `basectl update-profile` writes direct `source $BASE_HOME/lib/shell/<snippet>` lines into managed dotfile sections.
 - The recent extension cleanup is considered complete.
 - The broader development thread remains improving focused tests and startup/public utility coverage while closing TODO items in small commits.
@@ -39,9 +40,9 @@ This file is the shared working memory for future AI-assisted development in thi
 
 ## Current TODO Progress
 
-- Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, and wrapper runtime flag documentation.
-- Current uncommitted TODO item: simplify duplicated shell snippet path discovery for the direct-source startup model.
-- Next likely TODO item after that commit: decide whether to remove or consolidate duplicate `basectl_read_version`.
+- Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, wrapper runtime flag documentation, and simplified shell snippet path discovery.
+- Current uncommitted TODO item: remove duplicate `basectl_read_version` bodies by sharing `base_read_version`.
+- Next likely TODO item after that commit: consolidate setup dry-run state on `DRY_RUN`.
 
 ## Testing Notes
 
@@ -56,4 +57,4 @@ bats cli/bash/commands/basectl/tests/setup.bats
 bats cli/bash/commands/basectl/tests/basectl.bats
 ```
 
-- Latest verification in this session: full BATS suite passed, 128 tests with the existing pseudo-tty `wait_for_enter` case skipped.
+- Latest verification in this session: full BATS suite passed, 134 tests with the existing pseudo-tty `wait_for_enter` case skipped.

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -5,10 +5,11 @@ This file is the shared working memory for future AI-assisted development in thi
 ## Current State
 
 - Branch: `hpr/fix-claude-findings`.
-- Working tree was clean before the current prompt-defaults fix.
-- Current uncommitted work adds this context file and fixes normal Bash defaults so git branches appear in the prompt after `exec bash`.
+- Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
+- Most recent uncommitted change simplifies managed shell snippet path discovery by removing stale symlink-resolving loops from `lib/shell/bashrc`, `lib/shell/bash_profile`, and `lib/shell/zshrc`.
+- Confirmed there are no symlinked snippets in the repo; `basectl update-profile` writes direct `source $BASE_HOME/lib/shell/<snippet>` lines into managed dotfile sections.
 - The recent extension cleanup is considered complete.
-- The next broader development thread is the coverage PR: add or confirm focused tests for public utility commands and startup snippets.
+- The broader development thread remains improving focused tests and startup/public utility coverage while closing TODO items in small commits.
 
 ## Project Shape
 
@@ -31,10 +32,16 @@ This file is the shared working memory for future AI-assisted development in thi
 
 ## Recent Bug Context
 
-- Observed bug: after `basectl update-profile` and `exec bash`, the prompt inside `/Users/rameshhp/work/base` did not show the git branch.
+- Previously observed bug: after `basectl update-profile` and `exec bash`, the prompt inside `/Users/rameshhp/work/base` did not show the git branch.
 - `basectl shell` did show the branch because it uses `lib/bash/runtime/bashrc`, whose prompt calls `_base_runtime_git_prompt`.
 - Root cause: normal Bash shells with optional Base defaults use `lib/shell/bash_defaults.sh`, whose prompt only showed time, host, and cwd.
 - Fix: keep ordinary shell startup separate from runtime bootstrap, but make `bash_defaults.sh` include a small dynamic git prompt helper so normal interactive Bash defaults show the active repo branch.
+
+## Current TODO Progress
+
+- Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, and wrapper runtime flag documentation.
+- Current uncommitted TODO item: simplify duplicated shell snippet path discovery for the direct-source startup model.
+- Next likely TODO item after that commit: decide whether to remove or consolidate duplicate `basectl_read_version`.
 
 ## Testing Notes
 
@@ -49,4 +56,4 @@ bats cli/bash/commands/basectl/tests/setup.bats
 bats cli/bash/commands/basectl/tests/basectl.bats
 ```
 
-- Latest verification in this session: full BATS suite passed, 125 tests with the existing pseudo-tty `wait_for_enter` case skipped.
+- Latest verification in this session: full BATS suite passed, 128 tests with the existing pseudo-tty `wait_for_enter` case skipped.

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -1,0 +1,52 @@
+# AI Context
+
+This file is the shared working memory for future AI-assisted development in this repository. Keep it current when project direction, recent fixes, or useful debugging context changes.
+
+## Current State
+
+- Branch: `hpr/fix-claude-findings`.
+- Working tree was clean before the current prompt-defaults fix.
+- Current uncommitted work adds this context file and fixes normal Bash defaults so git branches appear in the prompt after `exec bash`.
+- The recent extension cleanup is considered complete.
+- The next broader development thread is the coverage PR: add or confirm focused tests for public utility commands and startup snippets.
+
+## Project Shape
+
+- Base is a macOS-first developer tooling foundation for a multi-repo workspace.
+- Public commands live in `bin/`; `bin/basectl` is the control-plane command.
+- Command implementations live under `cli/bash/commands/<command>/`.
+- Shared Bash libraries live under `lib/bash/`.
+- Shell startup snippets live under `lib/shell/`.
+- `basectl update-profile` manages marked sections in `~/.bash_profile`, `~/.bashrc`, `~/.zprofile`, and `~/.zshrc`.
+- `~/.base.d/profile.conf` records whether optional Bash/Zsh defaults are enabled.
+- `~/.baserc` is user-managed and may set startup-safe preferences such as `BASE_DEBUG=1`, but must not set Base-owned variables like `BASE_HOME` or `BASE_ENABLE_BASH_DEFAULTS`.
+
+## Shell Startup Model
+
+- Managed login/interactive snippets must not source `base_init.sh`.
+- `lib/shell/bash_profile` only bridges Bash login shells into `~/.bashrc`.
+- `lib/shell/bashrc` derives `BASE_HOME`, prepends `$BASE_HOME/bin` to `PATH`, reads optional defaults from `profile.conf`, and sources `lib/shell/bash_defaults.sh` only when defaults are enabled.
+- `lib/shell/zshrc` mirrors the same integration model for Zsh.
+- `lib/bash/runtime/bashrc` is separate from managed dotfiles and is used by `basectl shell`; it sources `base_init.sh`, then user `~/.bashrc`, then owns the final runtime prompt.
+
+## Recent Bug Context
+
+- Observed bug: after `basectl update-profile` and `exec bash`, the prompt inside `/Users/rameshhp/work/base` did not show the git branch.
+- `basectl shell` did show the branch because it uses `lib/bash/runtime/bashrc`, whose prompt calls `_base_runtime_git_prompt`.
+- Root cause: normal Bash shells with optional Base defaults use `lib/shell/bash_defaults.sh`, whose prompt only showed time, host, and cwd.
+- Fix: keep ordinary shell startup separate from runtime bootstrap, but make `bash_defaults.sh` include a small dynamic git prompt helper so normal interactive Bash defaults show the active repo branch.
+
+## Testing Notes
+
+- Tests are BATS-based.
+- Shared BATS helper: `lib/bash/tests/test_helper.sh`.
+- Main basectl startup/profile coverage: `cli/bash/commands/basectl/tests/setup.bats`.
+- Runtime shell prompt coverage: `cli/bash/commands/basectl/tests/basectl.bats`.
+- Good focused verification after startup changes:
+
+```bash
+bats cli/bash/commands/basectl/tests/setup.bats
+bats cli/bash/commands/basectl/tests/basectl.bats
+```
+
+- Latest verification in this session: full BATS suite passed, 125 tests with the existing pseudo-tty `wait_for_enter` case skipped.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,19 @@ Diagnostics are printed to stderr and show which Base snippet loaded, how
 `BASE_HOME` was derived, whether `$BASE_HOME/bin` was added to `PATH`, whether
 optional shell defaults were enabled, and how the Base runtime shell was layered.
 
+For command debugging, `basectl -v <command>` enables DEBUG logs after the Base
+runtime is loaded and the selected command is dispatched. For earlier startup
+debugging, use wrapper options that are consumed by `bin/basectl` before
+`base_init.sh` is sourced:
+
+- `--debug-wrapper` and `--verbose-wrapper` enable `LOG_DEBUG=1` before runtime
+  initialization.
+- `--utc-wrapper` enables UTC log timestamps before runtime initialization.
+- `--color` preserves color-aware wrapper argument handling while keeping the flag
+  out of command arguments.
+
+Prefer `-v` unless the problem happens before the command implementation starts.
+
 ### Standard Shell Defaults
 
 Base can provide optional, opinionated shell defaults, but they are not enabled

--- a/TODO.md
+++ b/TODO.md
@@ -25,14 +25,15 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: in the markers-not-found path, failures after creating the temp file can leave an orphan temp file.
   - Expected fix: centralize cleanup for copy, newline append, content write, and move failures.
   - Add focused failure-path coverage in `lib/bash/file/tests/lib_file.bats` if practical.
-  - Done locally; pending commit.
+  - Done.
 
 ## Design Issues
 
-- [ ] Document wrapper runtime flags.
+- [x] Document wrapper runtime flags.
   - Files: `bin/basectl`, `cli/bash/commands/basectl/basectl.sh`, possibly `README.md`
   - Problem: `--debug-wrapper`, `--verbose-wrapper`, `--utc-wrapper`, and `--color` are consumed by the launcher but not documented.
   - Expected fix: document what each flag does and clarify the difference between `-v` and `--debug-wrapper`.
+  - Done locally; pending commit.
 
 - [ ] Reduce duplicated source-path resolution logic.
   - Files: `bin/basectl`, `base_init.sh`, `lib/shell/bashrc`, `lib/shell/bash_profile`, `lib/shell/zshrc`

--- a/TODO.md
+++ b/TODO.md
@@ -6,11 +6,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
 
 ## Bugs
 
-- [ ] Fix `_git_only_path_dirty` directory matching.
+- [x] Fix `_git_only_path_dirty` directory matching.
   - File: `lib/bash/git/lib_git.sh`
   - Problem: dirty files under an allowed directory such as `shared/foo.txt` are compared to `shared` exactly, so allowed dirty directories are rejected.
   - Expected fix: accept either the exact allowed path or paths prefixed by `allowed_path/`.
   - Add or update BATS coverage in `lib/bash/git/tests/lib_git.bats`.
+  - Done locally; pending commit.
 
 - [ ] Quote or array-encode `sort-in-place` flags.
   - File: `cli/bash/commands/sort-in-place/sort-in-place.sh`

--- a/TODO.md
+++ b/TODO.md
@@ -18,13 +18,14 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: `sort $unique_flag "$file"` violates the quoting standard and ShellCheck expectations.
   - Expected fix: use a flag array or `${unique_flag:+"$unique_flag"}`.
   - Verify existing `sort-in-place` BATS coverage still passes.
-  - Done locally; pending commit.
+  - Done.
 
-- [ ] Ensure `update_file_section` cleans temp files on all write failures.
+- [x] Ensure `update_file_section` cleans temp files on all write failures.
   - File: `lib/bash/file/lib_file.sh`
   - Problem: in the markers-not-found path, failures after creating the temp file can leave an orphan temp file.
   - Expected fix: centralize cleanup for copy, newline append, content write, and move failures.
   - Add focused failure-path coverage in `lib/bash/file/tests/lib_file.bats` if practical.
+  - Done locally; pending commit.
 
 ## Design Issues
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,20 +33,21 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Files: `bin/basectl`, `cli/bash/commands/basectl/basectl.sh`, possibly `README.md`
   - Problem: `--debug-wrapper`, `--verbose-wrapper`, `--utc-wrapper`, and `--color` are consumed by the launcher but not documented.
   - Expected fix: document what each flag does and clarify the difference between `-v` and `--debug-wrapper`.
-  - Done locally; pending commit.
+  - Done.
 
 - [x] Reduce duplicated source-path resolution logic.
   - Files: `bin/basectl`, `base_init.sh`, `lib/shell/bashrc`, `lib/shell/bash_profile`, `lib/shell/zshrc`
   - Problem: symlink-resolving path normalization is copied in multiple places.
   - Expected fix: keep the launcher and runtime bootstrap self-contained, but simplify shell snippets for the current direct-source startup model.
   - Confirmed there are no symlinked snippets; `basectl update-profile` writes direct `source` lines to Base files.
-  - Done locally; pending commit.
+  - Done.
 
-- [ ] Remove or consolidate duplicate `basectl_read_version`.
+- [x] Remove or consolidate duplicate `basectl_read_version`.
   - Files: `bin/basectl`, `cli/bash/commands/basectl/basectl.sh`
   - Problem: the version-reading function body exists in two layers.
   - Expected fix: decide whether duplication is required by startup ordering; if not, consolidate or rename responsibilities so the duplication is intentional and documented.
   - Verify both `basectl --version` and `basectl version`.
+  - Done locally; pending commit.
 
 - [ ] Consolidate setup dry-run state on `DRY_RUN`.
   - File: `cli/bash/commands/basectl/subcommands/setup_common.sh`

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,105 @@
+# TODO
+
+Action items from Claude's Base code analysis for version `0.1.0-dev`.
+
+Use this as a commit-by-commit work queue. When an item is fixed, update the checkbox and add the commit hash or a short note.
+
+## Bugs
+
+- [ ] Fix `_git_only_path_dirty` directory matching.
+  - File: `lib/bash/git/lib_git.sh`
+  - Problem: dirty files under an allowed directory such as `shared/foo.txt` are compared to `shared` exactly, so allowed dirty directories are rejected.
+  - Expected fix: accept either the exact allowed path or paths prefixed by `allowed_path/`.
+  - Add or update BATS coverage in `lib/bash/git/tests/lib_git.bats`.
+
+- [ ] Quote or array-encode `sort-in-place` flags.
+  - File: `cli/bash/commands/sort-in-place/sort-in-place.sh`
+  - Problem: `sort $unique_flag "$file"` violates the quoting standard and ShellCheck expectations.
+  - Expected fix: use a flag array or `${unique_flag:+"$unique_flag"}`.
+  - Verify existing `sort-in-place` BATS coverage still passes.
+
+- [ ] Ensure `update_file_section` cleans temp files on all write failures.
+  - File: `lib/bash/file/lib_file.sh`
+  - Problem: in the markers-not-found path, failures after creating the temp file can leave an orphan temp file.
+  - Expected fix: centralize cleanup for copy, newline append, content write, and move failures.
+  - Add focused failure-path coverage in `lib/bash/file/tests/lib_file.bats` if practical.
+
+## Design Issues
+
+- [ ] Document wrapper runtime flags.
+  - Files: `bin/basectl`, `cli/bash/commands/basectl/basectl.sh`, possibly `README.md`
+  - Problem: `--debug-wrapper`, `--verbose-wrapper`, `--utc-wrapper`, and `--color` are consumed by the launcher but not documented.
+  - Expected fix: document what each flag does and clarify the difference between `-v` and `--debug-wrapper`.
+
+- [ ] Reduce duplicated source-path resolution logic.
+  - Files: `bin/basectl`, `base_init.sh`, `lib/shell/bashrc`, `lib/shell/bash_profile`, `lib/shell/zshrc`
+  - Problem: symlink-resolving path normalization is copied in multiple places.
+  - Expected fix: keep the launcher self-contained, but consider sharing helper logic among shell snippets where startup ordering permits.
+  - Preserve behavior for symlinked snippets and direct sourcing.
+
+- [ ] Remove or consolidate duplicate `basectl_read_version`.
+  - Files: `bin/basectl`, `cli/bash/commands/basectl/basectl.sh`
+  - Problem: the version-reading function body exists in two layers.
+  - Expected fix: decide whether duplication is required by startup ordering; if not, consolidate or rename responsibilities so the duplication is intentional and documented.
+  - Verify both `basectl --version` and `basectl version`.
+
+- [ ] Consolidate setup dry-run state on `DRY_RUN`.
+  - File: `cli/bash/commands/basectl/subcommands/setup_common.sh`
+  - Problem: both local `dry_run` and exported `DRY_RUN` are maintained.
+  - Expected fix: use exported `DRY_RUN` as the canonical state because `lib_std.sh` already consumes it.
+  - Verify dry-run setup/check tests and inherited `DRY_RUN` behavior.
+
+- [ ] Remove interactive Bash upgrade behavior from `lib_std.sh`.
+  - File: `lib/bash/std/lib_std.sh`
+  - Problem: `__stdlib_init__` calls `check_bash_version_and_upgrade`, which can trigger interactive Homebrew/Bash installation from a library source path.
+  - Expected fix: keep Bash version enforcement in the entrypoint layer; make the library non-interactive when sourced.
+  - Review tests that cover `check_bash_version_and_upgrade` and adjust the public contract.
+
+- [ ] Avoid exporting multi-line `AWK_NEW_TEXT`.
+  - File: `lib/bash/file/lib_file.sh`
+  - Problem: `update_file_section` passes replacement content through an exported environment variable.
+  - Expected fix: pass multi-line content through a temp file, stdin, or another scoped mechanism that does not leak into subprocess environments.
+  - Preserve support for multi-line replacement sections.
+
+- [ ] Investigate and replace double `git pull` retry.
+  - File: `lib/bash/git/lib_git.sh`
+  - Problem: `git pull || git pull` hides the underlying failure or warning mode.
+  - Expected fix: identify the root cause and use explicit git configuration or clearer failure handling.
+  - Add tests around the intended retry or non-retry behavior.
+
+## Usability Issues
+
+- [ ] Make `basectl check` more automation-friendly.
+  - Files: `cli/bash/commands/basectl/subcommands/check.sh`, `lib/bash/std/lib_std.sh`
+  - Problem: all log output goes to stderr, so `basectl check > result.txt` captures nothing and scripting requires `2>&1`.
+  - Expected fix: consider `--format json`, `--quiet`, or a documented stdout/stderr contract.
+  - Add tests for any new output mode.
+
+- [ ] Add a CLI path to disable profile defaults.
+  - File: `cli/bash/commands/basectl/subcommands/update_profile.sh`
+  - Problem: after `basectl update-profile --defaults`, later runs preserve defaults; disabling requires manual `profile.conf` edits.
+  - Expected fix: add `--no-defaults` or an equivalent explicit disable flag, and document the behavior.
+  - Cover default enable, preserve, and disable flows.
+
+- [ ] Decide whether BATS is a required or dev-only dependency.
+  - File: `cli/bash/commands/basectl/subcommands/setup_common.sh`
+  - Problem: setup installs BATS unconditionally and check treats missing BATS as a failure.
+  - Expected fix: either document BATS as a first-class dependency or make it optional via `--dev` or project metadata.
+  - Update setup/check tests and README accordingly.
+
+- [ ] Make `caff` PID detection more robust.
+  - File: `cli/bash/commands/caff/caff.sh`
+  - Problem: parsing `ps -o args` assumes a fixed `caffeinate -iw <pid>` argument position, and `pgrep | head -1` hides non-not-found errors.
+  - Expected fix: use a more reliable relationship check, or parse arguments defensively with error handling.
+  - Add tests for alternate caffeinate argument shapes and pgrep failures if feasible.
+
+- [ ] Add `--version` to `basectl` help.
+  - File: `cli/bash/commands/basectl/basectl.sh`
+  - Problem: `version` is listed as a command, but the supported `--version` flag is omitted.
+  - Expected fix: include `--version` in the help output and verify with existing help tests.
+
+- [ ] Decide how `basectl shell` handles arguments.
+  - File: `cli/bash/commands/basectl/basectl.sh`
+  - Problem: `basectl shell -c 'echo hello'` silently ignores arguments.
+  - Expected fix: either reject unexpected args with usage, document that no args are accepted, or pass args through to the spawned shell.
+  - Add tests for the chosen behavior.

--- a/TODO.md
+++ b/TODO.md
@@ -11,13 +11,14 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: dirty files under an allowed directory such as `shared/foo.txt` are compared to `shared` exactly, so allowed dirty directories are rejected.
   - Expected fix: accept either the exact allowed path or paths prefixed by `allowed_path/`.
   - Add or update BATS coverage in `lib/bash/git/tests/lib_git.bats`.
-  - Done locally; pending commit.
+  - Done.
 
-- [ ] Quote or array-encode `sort-in-place` flags.
+- [x] Quote or array-encode `sort-in-place` flags.
   - File: `cli/bash/commands/sort-in-place/sort-in-place.sh`
   - Problem: `sort $unique_flag "$file"` violates the quoting standard and ShellCheck expectations.
   - Expected fix: use a flag array or `${unique_flag:+"$unique_flag"}`.
   - Verify existing `sort-in-place` BATS coverage still passes.
+  - Done locally; pending commit.
 
 - [ ] Ensure `update_file_section` cleans temp files on all write failures.
   - File: `lib/bash/file/lib_file.sh`

--- a/TODO.md
+++ b/TODO.md
@@ -35,11 +35,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: document what each flag does and clarify the difference between `-v` and `--debug-wrapper`.
   - Done locally; pending commit.
 
-- [ ] Reduce duplicated source-path resolution logic.
+- [x] Reduce duplicated source-path resolution logic.
   - Files: `bin/basectl`, `base_init.sh`, `lib/shell/bashrc`, `lib/shell/bash_profile`, `lib/shell/zshrc`
   - Problem: symlink-resolving path normalization is copied in multiple places.
-  - Expected fix: keep the launcher self-contained, but consider sharing helper logic among shell snippets where startup ordering permits.
-  - Preserve behavior for symlinked snippets and direct sourcing.
+  - Expected fix: keep the launcher and runtime bootstrap self-contained, but simplify shell snippets for the current direct-source startup model.
+  - Confirmed there are no symlinked snippets; `basectl update-profile` writes direct `source` lines to Base files.
+  - Done locally; pending commit.
 
 - [ ] Remove or consolidate duplicate `basectl_read_version`.
   - Files: `bin/basectl`, `cli/bash/commands/basectl/basectl.sh`

--- a/bin/basectl
+++ b/bin/basectl
@@ -54,22 +54,21 @@ basectl_base_home() {
     cd -- "$bin_dir/.." && pwd -P
 }
 
-basectl_read_version() {
+basectl_source_version_library() {
     local base_home="$1"
-    local version_file="$base_home/VERSION"
+    local version_lib="$base_home/lib/bash/version/lib_version.sh"
 
-    [[ -f "$version_file" ]] || {
-        printf '%s\n' "unknown"
-        return 0
-    }
+    [[ -f "$version_lib" ]] || basectl_die "Base version library '$version_lib' was not found."
 
-    IFS= read -r version < "$version_file" || version=""
-    printf '%s\n' "${version:-unknown}"
+    # shellcheck source=/dev/null
+    source "$version_lib"
 }
 
 basectl_print_version() {
     local base_home="$1"
-    printf 'basectl %s\n' "$(basectl_read_version "$base_home")"
+
+    basectl_source_version_library "$base_home"
+    printf 'basectl %s\n' "$(base_read_version "$base_home")"
 }
 
 basectl_ensure_supported_bash() {

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -27,11 +27,19 @@ Options:
   -x       Enable Bash xtrace before running the command.
   -h       Show this help text.
 
+Wrapper options:
+  --debug-wrapper    Enable DEBUG logging before the Base runtime is loaded.
+  --verbose-wrapper  Enable verbose runtime argument handling before dispatch.
+  --utc-wrapper      Print wrapper/runtime log timestamps in UTC.
+  --color            Preserve color-aware wrapper argument handling.
+
 Notes:
   - `basectl setup` is the preferred entrypoint for machine bootstrap.
   - `basectl check` verifies the same local requirements without making changes.
   - Invoking `basectl` with no command opens an interactive shell when attached to
     a terminal; otherwise it prints this help text.
+  - Use `-v` for command-level debug logs. Use `--debug-wrapper` when debugging
+    startup before command dispatch or Base runtime initialization.
 EOF
 }
 

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -83,7 +83,7 @@ basectl_verify_home() {
         return 1
     fi
 
-    for file in VERSION base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/baserc_guard.sh lib/bash/runtime/bashrc bin/basectl cli/bash/commands/basectl/basectl.sh; do
+    for file in VERSION base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/baserc_guard.sh lib/bash/runtime/bashrc lib/bash/version/lib_version.sh bin/basectl cli/bash/commands/basectl/basectl.sh; do
         if [[ ! -f "$base_home/$file" ]]; then
             missing+=("$file")
         fi
@@ -160,21 +160,21 @@ basectl_do_shell() {
     exec "${BASH:-bash}" --rcfile "$shell_rc"
 }
 
-basectl_read_version() {
-    local version_file="$BASE_HOME/VERSION"
-    local version
+basectl_source_version_library() {
+    local version_lib="$BASE_HOME/lib/bash/version/lib_version.sh"
 
-    [[ -f "$version_file" ]] || {
-        printf '%s\n' "unknown"
-        return 0
+    [[ -f "$version_lib" ]] || {
+        basectl_error "Base version library '$version_lib' was not found."
+        return 1
     }
 
-    IFS= read -r version < "$version_file" || version=""
-    printf '%s\n' "${version:-unknown}"
+    # shellcheck source=/dev/null
+    source "$version_lib"
 }
 
 basectl_do_version() {
-    printf 'basectl %s\n' "$(basectl_read_version)"
+    basectl_source_version_library || return 1
+    printf 'basectl %s\n' "$(base_read_version "$BASE_HOME")"
 }
 
 basectl_should_start_shell() {

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -22,6 +22,11 @@ run_basectl() {
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [options]"* ]]
+    [[ "$output" == *"Wrapper options:"* ]]
+    [[ "$output" == *"--debug-wrapper"* ]]
+    [[ "$output" == *"--verbose-wrapper"* ]]
+    [[ "$output" == *"--utc-wrapper"* ]]
+    [[ "$output" == *"--color"* ]]
 }
 
 @test "basectl help omits legacy leftover commands" {

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -94,6 +94,7 @@ run_basectl() {
         "$base_home/bin" \
         "$base_home/lib/shell" \
         "$base_home/lib/bash/runtime" \
+        "$base_home/lib/bash/version" \
         "$base_home/cli/bash/commands/basectl"
     touch \
         "$base_home/VERSION" \
@@ -102,6 +103,7 @@ run_basectl() {
         "$base_home/lib/shell/bashrc" \
         "$base_home/lib/shell/baserc_guard.sh" \
         "$base_home/lib/bash/runtime/bashrc" \
+        "$base_home/lib/bash/version/lib_version.sh" \
         "$base_home/bin/basectl" \
         "$base_home/cli/bash/commands/basectl/basectl.sh"
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -575,7 +575,7 @@ run_base_command() {
     run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u EDITOR -u VISUAL -u EXINIT \
         HOME="$TEST_HOME" \
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'alias cp; printf "EDITOR=%s\n" "$EDITOR"; printf "VISUAL=%s\n" "$VISUAL"; printf "EXINIT=%s\n" "$EXINIT"; printf "BASE_HOME=%s\n" "$BASE_HOME"'
+        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'alias cp; printf "EDITOR=%s\n" "$EDITOR"; printf "VISUAL=%s\n" "$VISUAL"; printf "EXINIT=%s\n" "$EXINIT"; printf "BASE_HOME=%s\n" "$BASE_HOME"; cd "$BASE_HOME"; printf "git=%s\n" "$(_base_bash_defaults_git_prompt)"; printf "PS1=%s\n" "$PS1"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"alias cp='cp -i'"* ]]
@@ -583,6 +583,8 @@ run_base_command() {
     [[ "$output" == *"VISUAL=vi"* ]]
     [[ "$output" == *"EXINIT=set ts=4 sw=4 ai nows nosm expandtab"* ]]
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
+    [[ "$output" == *"git=("* ]]
+    [[ "$output" == *'PS1=\[\033[0;35m\]\T \h\[\033[0;33m\] $(_base_bash_defaults_git_prompt)\w\[\033[00m\]: '* ]]
 }
 
 @test "basectl update-profile preserves an existing defaults preference" {

--- a/cli/bash/commands/sort-in-place/sort-in-place.sh
+++ b/cli/bash/commands/sort-in-place/sort-in-place.sh
@@ -22,7 +22,7 @@ sort_in_place_describe() {
 }
 
 main() {
-    local unique_flag=""
+    local sort_args=()
     local file
     local temp_file
     local rc=0
@@ -37,7 +37,7 @@ main() {
             return 0
             ;;
         -u)
-            unique_flag="-u"
+            sort_args=(-u)
             shift
             ;;
     esac
@@ -60,7 +60,7 @@ main() {
             continue
         fi
 
-        if ! sort $unique_flag "$file" > "$temp_file"; then
+        if ! sort "${sort_args[@]}" "$file" > "$temp_file"; then
             print_error "Can't write to '$temp_file'."
             rc=1
             continue

--- a/lib/bash/README.md
+++ b/lib/bash/README.md
@@ -11,6 +11,8 @@ Reusable Bash libraries for Base-owned command wrappers and other Bash tooling.
   Git-related helpers built on top of the stdlib.
 - `file/`
   File-editing helpers built on top of the stdlib.
+- `version/`
+  Base version helpers that can be sourced before the full runtime is loaded.
 - `runtime/`
   Bash runtime startup files used only by `basectl` when it starts an
   interactive Base shell. These are passed with `bash --rcfile`, source the

--- a/lib/bash/file/lib_file.sh
+++ b/lib/bash/file/lib_file.sh
@@ -140,23 +140,37 @@ update_file_section() {
             rm -f "$temp_file"
             return 0
         else
-            cp "$target_file" "$temp_file"
-
-            if [[ $(tail -c 1 "$temp_file" 2>/dev/null | wc -l) -eq 0 ]]; then
-                printf '\n' >> "$temp_file"
+            if ! cp "$target_file" "$temp_file"; then
+                log_error "Failed to copy '$target_file' to '$temp_file'."
+                rm -f "$temp_file"
+                return 1
             fi
 
-            if {
+            if [[ $(tail -c 1 "$temp_file" 2>/dev/null | wc -l) -eq 0 ]]; then
+                if ! printf '\n' >> "$temp_file"; then
+                    log_error "Failed to add trailing newline to '$temp_file'."
+                    rm -f "$temp_file"
+                    return 1
+                fi
+            fi
+
+            if ! {
                 printf '%s\n' "$beginning_marker"
                 printf '%s' "$new_content_string"
                 printf '%s\n' "$end_marker"
-            } >> "$temp_file" && mv -f "$temp_file" "$target_file"; then
-                return 0
+            } >> "$temp_file"; then
+                log_error "Failed to add new section to '$target_file'."
+                rm -f "$temp_file"
+                return 1
             fi
 
-            log_error "Failed to add new section to '$target_file'."
-            rm -f "$temp_file"
-            return 1
+            if ! mv -f "$temp_file" "$target_file"; then
+                log_error "Failed to replace '$target_file' with '$temp_file'."
+                rm -f "$temp_file"
+                return 1
+            fi
+
+            return 0
         fi
     fi
 }

--- a/lib/bash/file/tests/lib_file.bats
+++ b/lib/bash/file/tests/lib_file.bats
@@ -80,3 +80,21 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"When -r flag is used"* ]]
 }
+
+@test "update_file_section cleans up temp file when initial copy fails" {
+    local target="$TEST_TMPDIR/config.txt"
+    printf 'line-one' > "$target"
+
+    cp() {
+        : > "$2"
+        return 1
+    }
+
+    bats_run update_file_section "$target" "# BEGIN" "# END" "value"
+    unset -f cp
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Failed to copy"* ]]
+    [ "$(cat "$target")" = "line-one" ]
+    ! compgen -G "$target".'*' >/dev/null
+}

--- a/lib/bash/git/lib_git.sh
+++ b/lib/bash/git/lib_git.sh
@@ -24,7 +24,7 @@ _git_only_path_dirty() {
         if [[ "$path" == *" -> "* ]]; then
             path="${path#* -> }"
         fi
-        if [[ "$path" != "$allowed_path" ]]; then
+        if [[ "$path" != "$allowed_path" && "$path" != "$allowed_path/"* ]]; then
             return 1
         fi
     done <<< "$status_output"

--- a/lib/bash/git/tests/lib_git.bats
+++ b/lib/bash/git/tests/lib_git.bats
@@ -64,6 +64,48 @@ setup() {
     [[ "$output" != *"not 'master'"* ]]
 }
 
+@test "_git_only_path_dirty accepts multiple dirty files under an allowed directory" {
+    local repo="$TEST_TMPDIR/repo"
+    local rc
+
+    init_git_repo "$repo"
+    mkdir -p "$repo/shared"
+    printf 'one\n' > "$repo/shared/one.txt"
+    printf 'two\n' > "$repo/shared/two.txt"
+    commit_all "$repo" "Initial commit"
+    printf 'local one\n' > "$repo/shared/one.txt"
+    printf 'local two\n' > "$repo/shared/two.txt"
+
+    pushd "$repo" >/dev/null
+    _git_only_path_dirty "shared"
+    rc=$?
+    popd >/dev/null
+
+    [ "$rc" -eq 0 ]
+}
+
+@test "_git_only_path_dirty does not treat sibling path prefixes as allowed" {
+    local repo="$TEST_TMPDIR/repo"
+    local rc
+
+    init_git_repo "$repo"
+    mkdir -p "$repo/shared"
+    printf 'one\n' > "$repo/shared/one.txt"
+    printf 'other\n' > "$repo/shared-other.txt"
+    commit_all "$repo" "Initial commit"
+    printf 'local one\n' > "$repo/shared/one.txt"
+    printf 'local other\n' > "$repo/shared-other.txt"
+
+    pushd "$repo" >/dev/null
+    set +e
+    _git_only_path_dirty "shared"
+    rc=$?
+    set -e
+    popd >/dev/null
+
+    [ "$rc" -eq 1 ]
+}
+
 @test "git_update_repo cleans up temp log without changing RETURN trap" {
     local repo="$TEST_TMPDIR/repo"
     local temp_dir="$TEST_TMPDIR/git-temp"

--- a/lib/bash/runtime/README.md
+++ b/lib/bash/runtime/README.md
@@ -1,0 +1,26 @@
+# Runtime Bash Rcfile
+
+`lib/bash/runtime/bashrc` is the rcfile used by `basectl` and `basectl shell`
+when they start a Base-enabled interactive Bash shell.
+
+## What It Does
+
+- validates `BASE_HOME`
+- sources `lib/shell/baserc_guard.sh`
+- sources user-managed `~/.baserc` when present
+- sources `base_init.sh`
+- sources the user's `~/.bashrc` with guardrails
+- owns the final runtime prompt
+
+## Behavior Notes
+
+- This file is passed to Bash with `bash --rcfile`.
+- It is not installed into user dotfiles by `basectl update-profile`.
+- It intentionally runs `base_init.sh`; normal shell startup snippets under
+  `lib/shell/` must not.
+
+## Tests
+
+BATS coverage lives in `tests/runtime_bashrc.bats`. Additional integration
+coverage for `basectl shell` and command startup lives in
+`cli/bash/commands/basectl/tests/basectl.bats`.

--- a/lib/bash/runtime/tests/runtime_bashrc.bats
+++ b/lib/bash/runtime/tests/runtime_bashrc.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load ../../tests/test_helper.sh
+
+setup() {
+    setup_test_tmpdir
+    TEST_HOME="$TEST_TMPDIR/home"
+    mkdir -p "$TEST_HOME"
+}
+
+@test "runtime bashrc sources base_init before user bashrc" {
+    cat > "$TEST_HOME/.bashrc" <<'EOF'
+if declare -F import_base_lib >/dev/null 2>&1; then
+    export USER_BASHRC_HAS_BASE_IMPORT=1
+fi
+PS1='user prompt: '
+EOF
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            printf "USER_BASHRC_HAS_BASE_IMPORT=%s\n" "${USER_BASHRC_HAS_BASE_IMPORT:-}"; \
+            printf "BASE_SHELL=%s\n" "${BASE_SHELL:-}"; \
+            printf "PS1=%s\n" "$PS1"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"USER_BASHRC_HAS_BASE_IMPORT=1"* ]]
+    [[ "$output" == *"BASE_SHELL=1"* ]]
+    [[ "$output" == *'PS1=\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+}
+
+@test "runtime bashrc sources baserc debug preferences" {
+    printf '%s\n' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
+
+    run env -u BASE_DEBUG \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c 'printf "ok\n"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG runtime: sourced '$TEST_HOME/.baserc'"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: complete"* ]]
+}

--- a/lib/bash/version/README.md
+++ b/lib/bash/version/README.md
@@ -1,0 +1,30 @@
+# `lib_version.sh`
+
+Base version helpers that are safe to source before the full Base runtime is
+loaded.
+
+## Public API
+
+- `base_read_version`
+  Read the first line of `$BASE_HOME/VERSION` for a caller-provided Base home,
+  returning `unknown` when the version file is missing or empty.
+
+## Usage
+
+```bash
+source "/absolute/path/to/lib/bash/version/lib_version.sh"
+
+printf 'basectl %s\n' "$(base_read_version "$BASE_HOME")"
+```
+
+## Behavior Notes
+
+- This library intentionally does not depend on `lib_std.sh`.
+- `bin/basectl` uses it before `base_init.sh` is sourced so `basectl --version`
+  stays available early in startup.
+- The runtime `basectl version` command uses the same helper after Base home has
+  been validated.
+
+## Tests
+
+BATS coverage lives in `tests/lib_version.bats`.

--- a/lib/bash/version/lib_version.sh
+++ b/lib/bash/version/lib_version.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+#
+# lib_version.sh: shared Base version helpers.
+#
+
+[[ -n "${__lib_version_sourced__:-}" ]] && return 0
+readonly __lib_version_sourced__=1
+
+base_read_version() {
+    local base_home="$1"
+    local version_file="$base_home/VERSION"
+    local version
+
+    [[ -f "$version_file" ]] || {
+        printf '%s\n' "unknown"
+        return 0
+    }
+
+    IFS= read -r version < "$version_file" || version=""
+    printf '%s\n' "${version:-unknown}"
+}

--- a/lib/bash/version/tests/lib_version.bats
+++ b/lib/bash/version/tests/lib_version.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load ../../tests/test_helper.sh
+
+setup() {
+    setup_test_tmpdir
+    source "$BASE_BASH_DIR/version/lib_version.sh"
+}
+
+@test "base_read_version returns the first version file line" {
+    local base_home="$TEST_TMPDIR/base"
+
+    mkdir -p "$base_home"
+    printf '1.2.3\nignored\n' > "$base_home/VERSION"
+
+    [ "$(base_read_version "$base_home")" = "1.2.3" ]
+}
+
+@test "base_read_version returns unknown when version file is missing" {
+    local base_home="$TEST_TMPDIR/base"
+
+    mkdir -p "$base_home"
+
+    [ "$(base_read_version "$base_home")" = "unknown" ]
+}
+
+@test "base_read_version returns unknown when version file is empty" {
+    local base_home="$TEST_TMPDIR/base"
+
+    mkdir -p "$base_home"
+    : > "$base_home/VERSION"
+
+    [ "$(base_read_version "$base_home")" = "unknown" ]
+}
+
+@test "lib_version can be sourced more than once" {
+    source "$BASE_BASH_DIR/version/lib_version.sh"
+
+    [ "$(type -t base_read_version)" = "function" ]
+}

--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -42,7 +42,20 @@ unset base_bash_defaults_file
 
 set -o vi
 
-export PS1='\[\033[0;35m\]\T \h\[\033[0;33m\] \w\[\033[00m\]: '
+_base_bash_defaults_git_prompt() {
+    local branch
+
+    command -v git >/dev/null 2>&1 || return 0
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+    branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)" || \
+        branch="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
+    [[ -n "$branch" ]] || return 0
+
+    printf '(%s) ' "$branch"
+}
+
+export PS1='\[\033[0;35m\]\T \h\[\033[0;33m\] $(_base_bash_defaults_git_prompt)\w\[\033[00m\]: '
 
 export HISTCONTROL=ignoredups:erasedups
 export HISTTIMEFORMAT="[%F %T] "

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -22,32 +22,15 @@ base_bash_profile_debug() {
     esac
 }
 
-base_bash_profile_source_path() {
-    local source_path="${BASH_SOURCE[0]}"
-    local link_dir
-    local target
-
-    while [[ -L "$source_path" ]]; do
-        link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-        target="$(readlink "$source_path")" || return 1
-        if [[ "$target" == /* ]]; then
-            source_path="$target"
-        else
-            source_path="$link_dir/$target"
-        fi
-    done
-
-    link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    printf '%s/%s\n' "$link_dir" "$(basename -- "$source_path")"
+base_bash_profile_snippet_dir() {
+    cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
 }
 
 base_bash_profile_source_baserc_guard() {
-    local source_path
     local snippet_dir
     local guard_path
 
-    source_path="$(base_bash_profile_source_path)" || return 1
-    snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    snippet_dir="$(base_bash_profile_snippet_dir)" || return 1
     guard_path="$snippet_dir/baserc_guard.sh"
 
     [[ -f "$guard_path" ]] || {
@@ -64,7 +47,7 @@ base_baserc_guard_source base_bash_profile_debug || return $?
 
 if [[ -n "${__base_bash_profile_sourced__:-}" ]]; then
     base_bash_profile_debug "already sourced; skipping"
-    unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard
+    unset -f base_bash_profile_debug base_bash_profile_snippet_dir base_bash_profile_source_baserc_guard
     return 0
 fi
 readonly __base_bash_profile_sourced__=1
@@ -72,13 +55,13 @@ base_bash_profile_debug "loading"
 
 if [[ -n "${__base_sourcing_bashrc_from_profile__:-}" ]]; then
     base_bash_profile_debug "bashrc bridge guard is active; skipping"
-    unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard
+    unset -f base_bash_profile_debug base_bash_profile_snippet_dir base_bash_profile_source_baserc_guard
     return 0
 fi
 
 if [[ ! -f "$HOME/.bashrc" ]]; then
     base_bash_profile_debug "'$HOME/.bashrc' not found; skipping"
-    unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard
+    unset -f base_bash_profile_debug base_bash_profile_snippet_dir base_bash_profile_source_baserc_guard
     return 0
 fi
 
@@ -88,4 +71,4 @@ __base_sourcing_bashrc_from_profile__=1
 source "$HOME/.bashrc"
 unset __base_sourcing_bashrc_from_profile__
 base_bash_profile_debug "complete"
-unset -f base_bash_profile_debug base_bash_profile_source_path base_bash_profile_source_baserc_guard
+unset -f base_bash_profile_debug base_bash_profile_snippet_dir base_bash_profile_source_baserc_guard

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -21,32 +21,15 @@ base_bashrc_debug() {
     esac
 }
 
-base_bashrc_source_path() {
-    local source_path="${BASH_SOURCE[0]}"
-    local link_dir
-    local target
-
-    while [[ -L "$source_path" ]]; do
-        link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-        target="$(readlink "$source_path")" || return 1
-        if [[ "$target" == /* ]]; then
-            source_path="$target"
-        else
-            source_path="$link_dir/$target"
-        fi
-    done
-
-    link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    printf '%s/%s\n' "$link_dir" "$(basename -- "$source_path")"
+base_bashrc_snippet_dir() {
+    cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
 }
 
 base_bashrc_source_baserc_guard() {
-    local source_path
     local snippet_dir
     local guard_path
 
-    source_path="$(base_bashrc_source_path)" || return 1
-    snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    snippet_dir="$(base_bashrc_snippet_dir)" || return 1
     guard_path="$snippet_dir/baserc_guard.sh"
 
     [[ -f "$guard_path" ]] || {
@@ -63,25 +46,23 @@ base_baserc_guard_source base_bashrc_debug || return $?
 
 if [[ $- != *i* ]]; then
     base_bashrc_debug "non-interactive shell; skipping"
-    unset -f base_bashrc_debug base_bashrc_source_path base_bashrc_source_baserc_guard
+    unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard
     return 0
 fi
 
 if [[ -n "${__base_bashrc_sourced__:-}" ]]; then
     base_bashrc_debug "already sourced; skipping"
-    unset -f base_bashrc_debug base_bashrc_source_path base_bashrc_source_baserc_guard
+    unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard
     return 0
 fi
 readonly __base_bashrc_sourced__=1
 base_bashrc_debug "loading"
 
 base_bashrc_set_base_home() {
-    local source_path
     local snippet_dir
     local base_home
 
-    source_path="$(base_bashrc_source_path)" || return 1
-    snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    snippet_dir="$(base_bashrc_snippet_dir)" || return 1
     base_home="$(cd -- "$snippet_dir/../.." && pwd -P)" || return 1
 
     [[ -f "$base_home/base_init.sh" ]] || return 1
@@ -141,13 +122,13 @@ base_bashrc_source_defaults() {
 
 base_bashrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
-    unset -f base_bashrc_debug base_bashrc_source_path base_bashrc_source_baserc_guard
+    unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard
     return 1
 }
 base_bashrc_prepend_path
 base_bashrc_source_defaults || return 1
 base_bashrc_debug "complete"
 
-unset -f base_bashrc_source_path base_bashrc_set_base_home
+unset -f base_bashrc_snippet_dir base_bashrc_set_base_home
 unset -f base_bashrc_prepend_path base_bashrc_source_defaults
 unset -f base_bashrc_source_baserc_guard base_bashrc_debug

--- a/lib/shell/zshrc
+++ b/lib/shell/zshrc
@@ -107,35 +107,20 @@ fi
 readonly __base_zshrc_sourced__=1
 base_zshrc_debug "loading"
 
-base_zshrc_source_path() {
+base_zshrc_snippet_dir() {
     local source_path
-    local link_dir
-    local target
 
     source_path="$(eval 'printf "%s\n" "${(%):-%x}"')" || return 1
     [[ -n "$source_path" ]] || return 1
 
-    while [[ -L "$source_path" ]]; do
-        link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-        target="$(readlink "$source_path")" || return 1
-        if [[ "$target" == /* ]]; then
-            source_path="$target"
-        else
-            source_path="$link_dir/$target"
-        fi
-    done
-
-    link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
-    printf '%s/%s\n' "$link_dir" "$(basename -- "$source_path")"
+    cd -- "$(dirname -- "$source_path")" && pwd -P
 }
 
 base_zshrc_set_base_home() {
-    local source_path
     local snippet_dir
     local base_home
 
-    source_path="$(base_zshrc_source_path)" || return 1
-    snippet_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    snippet_dir="$(base_zshrc_snippet_dir)" || return 1
     base_home="$(cd -- "$snippet_dir/../.." && pwd -P)" || return 1
 
     [[ -f "$base_home/base_init.sh" ]] || return 1
@@ -202,6 +187,6 @@ base_zshrc_prepend_path
 base_zshrc_source_defaults || return 1
 base_zshrc_debug "complete"
 
-unset -f base_zshrc_source_path base_zshrc_set_base_home
+unset -f base_zshrc_snippet_dir base_zshrc_set_base_home
 unset -f base_zshrc_prepend_path base_zshrc_source_defaults
 unset -f base_zshrc_debug base_zshrc_reject_baserc_owned_var base_zshrc_source_baserc


### PR DESCRIPTION
## Summary

- Add `AI_CONTEXT.md` and `TODO.md` to track project context and Claude finding follow-ups.
- Fix Bash default prompt behavior so normal interactive Bash shells show the active git branch.
- Address the first batch of Claude findings:
  - allow dirty files under an allowed git directory
  - use an array for `sort-in-place` flags
  - clean up `update_file_section` temp files on failure
  - document `basectl` wrapper runtime flags
  - simplify managed shell snippet path discovery
  - share Base version reading through `lib/bash/version/lib_version.sh`
- Add local docs and BATS coverage for `lib/bash/runtime` and `lib/bash/version`.

## Tests

```bash
bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/basectl.bats cli/bash/commands/caff/tests/caff.bats cli/bash/commands/sort-in-place/tests/sort-in-place.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/runtime/tests/runtime_bashrc.bats lib/bash/std/tests/lib_std.bats lib/bash/version/tests/lib_version.bats
Result: 134 tests passed, with the existing pseudo-tty wait_for_enter skip.
```