### PR TITLE
Hpr/fix claude findings2

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -6,7 +6,8 @@ This file is the shared working memory for future AI-assisted development in thi
 
 - Branch: `hpr/fix-claude-findings2`.
 - Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
-- Most recent uncommitted change adds the supported `--version` flag to `basectl --help`.
+- Most recent uncommitted change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
+- The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.
 - The previous change consolidated Base version reading in `lib/bash/version/lib_version.sh`, shared by early `basectl --version` handling and the runtime `basectl version` command.
 - `lib/bash/version` and `lib/bash/runtime` now have local README files and colocated BATS coverage, in addition to existing basectl integration coverage.
@@ -43,7 +44,7 @@ This file is the shared working memory for future AI-assisted development in thi
 ## Current TODO Progress
 
 - Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, wrapper runtime flag documentation, simplified shell snippet path discovery, and shared version reading.
-- Current uncommitted TODO item: add `--version` to `basectl` help.
+- Current uncommitted TODO item: decide how `basectl shell` handles arguments; current decision is to reject them because `basectl shell` is an interactive shell entrypoint, not a `bash` argument passthrough.
 - Next likely TODO item after that commit: remove interactive Bash upgrade behavior from `lib_std.sh`.
 
 ## Testing Notes
@@ -59,4 +60,4 @@ bats cli/bash/commands/basectl/tests/setup.bats
 bats cli/bash/commands/basectl/tests/basectl.bats
 ```
 
-- Latest verification in this session: full BATS suite passed, 134 tests with the existing pseudo-tty `wait_for_enter` case skipped.
+- Latest verification in this session: full BATS suite passed, 135 tests with the existing pseudo-tty `wait_for_enter` case skipped.

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -6,7 +6,8 @@ This file is the shared working memory for future AI-assisted development in thi
 
 - Branch: `hpr/fix-claude-findings2`.
 - Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
-- Most recent uncommitted change consolidates `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.
+- Most recent uncommitted change adds the supported `--version` flag to `basectl --help`.
+- The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.
 - The previous change consolidated Base version reading in `lib/bash/version/lib_version.sh`, shared by early `basectl --version` handling and the runtime `basectl version` command.
 - `lib/bash/version` and `lib/bash/runtime` now have local README files and colocated BATS coverage, in addition to existing basectl integration coverage.
 - Confirmed there are no symlinked snippets in the repo; `basectl update-profile` writes direct `source $BASE_HOME/lib/shell/<snippet>` lines into managed dotfile sections.
@@ -42,7 +43,7 @@ This file is the shared working memory for future AI-assisted development in thi
 ## Current TODO Progress
 
 - Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, wrapper runtime flag documentation, simplified shell snippet path discovery, and shared version reading.
-- Current uncommitted TODO item: consolidate setup dry-run state on `DRY_RUN`.
+- Current uncommitted TODO item: add `--version` to `basectl` help.
 - Next likely TODO item after that commit: remove interactive Bash upgrade behavior from `lib_std.sh`.
 
 ## Testing Notes

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -6,7 +6,8 @@ This file is the shared working memory for future AI-assisted development in thi
 
 - Branch: `hpr/fix-claude-findings2`.
 - Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
-- Most recent uncommitted change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
+- Most recent uncommitted change adds `basectl update-profile --no-defaults`, including conflict handling with `--defaults`, docs, and BATS coverage.
+- The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.
 - The previous change consolidated Base version reading in `lib/bash/version/lib_version.sh`, shared by early `basectl --version` handling and the runtime `basectl version` command.
@@ -44,7 +45,7 @@ This file is the shared working memory for future AI-assisted development in thi
 ## Current TODO Progress
 
 - Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, wrapper runtime flag documentation, simplified shell snippet path discovery, and shared version reading.
-- Current uncommitted TODO item: decide how `basectl shell` handles arguments; current decision is to reject them because `basectl shell` is an interactive shell entrypoint, not a `bash` argument passthrough.
+- Current uncommitted TODO item: add a CLI path to disable profile defaults.
 - Next likely TODO item after that commit: remove interactive Bash upgrade behavior from `lib_std.sh`.
 
 ## Testing Notes
@@ -60,4 +61,4 @@ bats cli/bash/commands/basectl/tests/setup.bats
 bats cli/bash/commands/basectl/tests/basectl.bats
 ```
 
-- Latest verification in this session: full BATS suite passed, 135 tests with the existing pseudo-tty `wait_for_enter` case skipped.
+- Latest verification in this session: full BATS suite passed, 137 tests with the existing pseudo-tty `wait_for_enter` case skipped.

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -4,9 +4,10 @@ This file is the shared working memory for future AI-assisted development in thi
 
 ## Current State
 
-- Branch: `hpr/fix-claude-findings`.
+- Branch: `hpr/fix-claude-findings2`.
 - Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
-- Most recent uncommitted change consolidates Base version reading in `lib/bash/version/lib_version.sh`, shared by early `basectl --version` handling and the runtime `basectl version` command.
+- Most recent uncommitted change consolidates `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.
+- The previous change consolidated Base version reading in `lib/bash/version/lib_version.sh`, shared by early `basectl --version` handling and the runtime `basectl version` command.
 - `lib/bash/version` and `lib/bash/runtime` now have local README files and colocated BATS coverage, in addition to existing basectl integration coverage.
 - Confirmed there are no symlinked snippets in the repo; `basectl update-profile` writes direct `source $BASE_HOME/lib/shell/<snippet>` lines into managed dotfile sections.
 - The recent extension cleanup is considered complete.
@@ -40,9 +41,9 @@ This file is the shared working memory for future AI-assisted development in thi
 
 ## Current TODO Progress
 
-- Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, wrapper runtime flag documentation, and simplified shell snippet path discovery.
-- Current uncommitted TODO item: remove duplicate `basectl_read_version` bodies by sharing `base_read_version`.
-- Next likely TODO item after that commit: consolidate setup dry-run state on `DRY_RUN`.
+- Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, wrapper runtime flag documentation, simplified shell snippet path discovery, and shared version reading.
+- Current uncommitted TODO item: consolidate setup dry-run state on `DRY_RUN`.
+- Next likely TODO item after that commit: remove interactive Bash upgrade behavior from `lib_std.sh`.
 
 ## Testing Notes
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ whether the user has opted into Base's optional shell defaults. The managed
 dotfile sections stay minimal and defer PATH/default handling to the sourced
 Base snippets.
 
+Run `basectl update-profile --defaults` to enable those optional defaults, and
+run `basectl update-profile --no-defaults` to disable them again. Plain
+`basectl update-profile` preserves the existing preference.
+
 `BASE_PROFILE_VERSION` records the schema version of this Base-managed file. It
 is reserved for future migrations and is not intended to be edited by users.
 
@@ -311,6 +315,12 @@ Users can opt in during profile updates with:
 
 ```bash
 basectl update-profile --defaults
+```
+
+Users can opt out again with:
+
+```bash
+basectl update-profile --no-defaults
 ```
 
 Those defaults are intended to stay conservative:

--- a/TODO.md
+++ b/TODO.md
@@ -100,10 +100,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: use a more reliable relationship check, or parse arguments defensively with error handling.
   - Add tests for alternate caffeinate argument shapes and pgrep failures if feasible.
 
-- [ ] Add `--version` to `basectl` help.
+- [x] Add `--version` to `basectl` help.
   - File: `cli/bash/commands/basectl/basectl.sh`
   - Problem: `version` is listed as a command, but the supported `--version` flag is omitted.
   - Expected fix: include `--version` in the help output and verify with existing help tests.
+  - Done locally; pending commit.
 
 - [ ] Decide how `basectl shell` handles arguments.
   - File: `cli/bash/commands/basectl/basectl.sh`

--- a/TODO.md
+++ b/TODO.md
@@ -47,13 +47,14 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: the version-reading function body exists in two layers.
   - Expected fix: decide whether duplication is required by startup ordering; if not, consolidate or rename responsibilities so the duplication is intentional and documented.
   - Verify both `basectl --version` and `basectl version`.
-  - Done locally; pending commit.
+  - Done.
 
-- [ ] Consolidate setup dry-run state on `DRY_RUN`.
+- [x] Consolidate setup dry-run state on `DRY_RUN`.
   - File: `cli/bash/commands/basectl/subcommands/setup_common.sh`
   - Problem: both local `dry_run` and exported `DRY_RUN` are maintained.
   - Expected fix: use exported `DRY_RUN` as the canonical state because `lib_std.sh` already consumes it.
   - Verify dry-run setup/check tests and inherited `DRY_RUN` behavior.
+  - Done locally; pending commit.
 
 - [ ] Remove interactive Bash upgrade behavior from `lib_std.sh`.
   - File: `lib/bash/std/lib_std.sh`

--- a/TODO.md
+++ b/TODO.md
@@ -104,10 +104,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - File: `cli/bash/commands/basectl/basectl.sh`
   - Problem: `version` is listed as a command, but the supported `--version` flag is omitted.
   - Expected fix: include `--version` in the help output and verify with existing help tests.
-  - Done locally; pending commit.
+  - Done.
 
-- [ ] Decide how `basectl shell` handles arguments.
+- [x] Decide how `basectl shell` handles arguments.
   - File: `cli/bash/commands/basectl/basectl.sh`
   - Problem: `basectl shell -c 'echo hello'` silently ignores arguments.
   - Expected fix: either reject unexpected args with usage, document that no args are accepted, or pass args through to the spawned shell.
   - Add tests for the chosen behavior.
+  - Done locally; pending commit.

--- a/TODO.md
+++ b/TODO.md
@@ -82,11 +82,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: consider `--format json`, `--quiet`, or a documented stdout/stderr contract.
   - Add tests for any new output mode.
 
-- [ ] Add a CLI path to disable profile defaults.
+- [x] Add a CLI path to disable profile defaults.
   - File: `cli/bash/commands/basectl/subcommands/update_profile.sh`
   - Problem: after `basectl update-profile --defaults`, later runs preserve defaults; disabling requires manual `profile.conf` edits.
   - Expected fix: add `--no-defaults` or an equivalent explicit disable flag, and document the behavior.
   - Cover default enable, preserve, and disable flows.
+  - Done locally; pending commit.
 
 - [ ] Decide whether BATS is a required or dev-only dependency.
   - File: `cli/bash/commands/basectl/subcommands/setup_common.sh`

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -152,6 +152,11 @@ basectl_do_update_profile() {
 basectl_do_shell() {
     local shell_rc
 
+    if (($# > 0)); then
+        basectl_usage_error "The 'shell' command does not accept arguments."
+        return $?
+    fi
+
     shell_rc="$(basectl_shell_rc_path)" || {
         basectl_error "$BASE_CLI_ERROR_MESSAGE"
         return 1
@@ -244,7 +249,7 @@ basectl_main() {
         check)            basectl_do_check "$@" ;;
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
-        shell)            basectl_do_shell ;;
+        shell)            basectl_do_shell "$@" ;;
         update-profile)   basectl_do_update_profile "$@" ;;
         version)          basectl_do_version ;;
         "")

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -26,6 +26,8 @@ Options:
   -v       Enable DEBUG logging for the selected command.
   -x       Enable Bash xtrace before running the command.
   -h       Show this help text.
+  --version
+           Show the installed Base version.
 
 Wrapper options:
   --debug-wrapper    Enable DEBUG logging before the Base runtime is loaded.

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -58,6 +58,6 @@ base_setup_subcommand_main() {
         shift
     done
 
-    log_debug "Running 'basectl setup' (dry_run=${dry_run:-false})."
+    log_debug "Running 'basectl setup' (DRY_RUN=$(setup_is_dry_run && printf true || printf false))."
     setup_run_install
 }

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -18,11 +18,12 @@ _base_setup_common_sourced=1
 readonly _base_setup_common_sourced
 
 setup_clear_run_state() {
+    # Clear legacy lowercase state too so inherited environments cannot trigger
+    # lib_std.sh dry-run behavior unless this command explicitly enables it.
     unset dry_run DRY_RUN
 }
 
 setup_enable_dry_run() {
-    dry_run=true
     export DRY_RUN=true
 }
 
@@ -32,7 +33,7 @@ setup_enable_debug_logging() {
 }
 
 setup_is_dry_run() {
-    [[ "${DRY_RUN-}" == true || "${dry_run-}" == true ]]
+    [[ "${DRY_RUN-}" == true ]]
 }
 
 setup_virtualenv_exists() {
@@ -358,4 +359,3 @@ setup_run_install() {
         log_info "Base CLI setup is complete."
     fi
 }
-

--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -15,6 +15,8 @@ Usage:
 
 Options:
   --defaults  Enable Base's optional Bash/Zsh shell defaults.
+  --no-defaults
+              Disable Base's optional Bash/Zsh shell defaults.
   --dry-run   Show what would be updated without changing files.
   -v          Enable DEBUG logging for this subcommand.
   -h, --help  Show this help text.
@@ -119,7 +121,8 @@ base_update_profile_defaults_previously_enabled() {
 
 base_update_profile_write_profile_conf() {
     local enable_defaults="$1"
-    local dry_run="$2"
+    local disable_defaults="$2"
+    local dry_run="$3"
     local state_dir
     local profile_conf
     local temp_file
@@ -128,7 +131,9 @@ base_update_profile_write_profile_conf() {
     state_dir="$(base_update_profile_state_dir)" || return 1
     profile_conf="$(base_update_profile_profile_conf)" || return 1
 
-    if ((enable_defaults)) || base_update_profile_defaults_previously_enabled; then
+    if ((disable_defaults)); then
+        enable_value=false
+    elif ((enable_defaults)) || base_update_profile_defaults_previously_enabled; then
         enable_value=true
     fi
 
@@ -155,6 +160,7 @@ base_update_profile_write_profile_conf() {
 
 base_update_profile_subcommand_main() {
     local enable_defaults=0
+    local disable_defaults=0
     local dry_run=0
     local base_home
 
@@ -162,6 +168,9 @@ base_update_profile_subcommand_main() {
         case "$1" in
             --defaults)
                 enable_defaults=1
+                ;;
+            --no-defaults)
+                disable_defaults=1
                 ;;
             --dry-run)
                 dry_run=1
@@ -182,6 +191,12 @@ base_update_profile_subcommand_main() {
         shift
     done
 
+    if ((enable_defaults && disable_defaults)); then
+        print_error "Options '--defaults' and '--no-defaults' cannot be used together."
+        base_update_profile_subcommand_usage >&2
+        return 1
+    fi
+
     log_debug "Running 'basectl update-profile'."
 
     base_home="$(basectl_runtime_base_home)" || {
@@ -192,7 +207,7 @@ base_update_profile_subcommand_main() {
     export BASE_HOME
 
     base_update_profile_source_file_library || return 1
-    base_update_profile_write_profile_conf "$enable_defaults" "$dry_run" || return 1
+    base_update_profile_write_profile_conf "$enable_defaults" "$disable_defaults" "$dry_run" || return 1
 
     base_update_profile_update_file "$HOME/.bash_profile" bash_profile "$dry_run" || return 1
     base_update_profile_update_file "$HOME/.bashrc" bashrc "$dry_run" || return 1

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -22,6 +22,7 @@ run_basectl() {
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [options]"* ]]
+    [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
     [[ "$output" == *"--debug-wrapper"* ]]
     [[ "$output" == *"--verbose-wrapper"* ]]

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -88,6 +88,14 @@ run_basectl() {
     done
 }
 
+@test "basectl shell rejects arguments" {
+    run_basectl shell -c 'echo ignored'
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"The 'shell' command does not accept arguments."* ]]
+    [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
+}
+
 @test "Base home verification does not require a git repository" {
     local base_home="$TEST_TMPDIR/embedded/base"
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -597,3 +597,23 @@ run_base_command() {
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_BASH_DEFAULTS=true"* ]]
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_ZSH_DEFAULTS=true"* ]]
 }
+
+@test "basectl update-profile --no-defaults disables existing defaults preference" {
+    run_base_command update-profile --defaults
+    [ "$status" -eq 0 ]
+
+    run_base_command update-profile --no-defaults
+    [ "$status" -eq 0 ]
+
+    [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_BASH_DEFAULTS=false"* ]]
+    [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_ZSH_DEFAULTS=false"* ]]
+}
+
+@test "basectl update-profile rejects conflicting defaults options" {
+    run_base_command update-profile --defaults --no-defaults
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Options '--defaults' and '--no-defaults' cannot be used together."* ]]
+    [[ "$output" == *"Usage:"* ]]
+    [ ! -e "$TEST_HOME/.base.d/profile.conf" ]
+}


### PR DESCRIPTION
## Summary

- Consolidate `basectl setup` dry-run state on exported `DRY_RUN` while clearing legacy inherited `dry_run`.
- Document `basectl --version` in help output.
- Make `basectl shell` reject unexpected arguments instead of silently ignoring them.
- Add `basectl update-profile --no-defaults` so users can disable optional shell defaults through the CLI.
- Update `README.md`, `TODO.md`, and `AI_CONTEXT.md` for the new behavior.

## Tests

```bash
bats cli/bash/commands/basectl/tests/setup.bats
bats cli/bash/commands/basectl/tests/basectl.bats
bats cli/bash/commands/caff/tests/caff.bats
bats cli/bash/commands/sort-in-place/tests/sort-in-place.bats
bats lib/bash/file/tests/lib_file.bats
bats lib/bash/git/tests/lib_git.bats
bats lib/bash/runtime/tests/runtime_bashrc.bats
bats lib/bash/std/tests/lib_std.bats
bats lib/bash/version/tests/lib_version.bats
Result: 137 tests passed, with the existing pseudo-tty wait_for_enter skip.
```