### PR TITLE
Add manifest-driven project artifact setup layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Ignore macOS DS_Store files
 .DS_Store
+
+# Ignore Python interpreter caches
+__pycache__/
+*.py[cod]

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -6,6 +6,15 @@ This file is the shared working memory for future AI-assisted development in thi
 
 - Branch: `hpr/fix-claude-findings2`.
 - Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
+- New in-progress feature work adds the first artifact setup layer: root
+  `base_manifest.yaml`, a Python `base_setup` package under `cli/python/`, and
+  a Bash setup handoff after Base bootstrap.
+- The Python layer now reads manifests with PyYAML. PyYAML is a Base bootstrap
+  dependency installed by the Bash setup layer into `~/.base.d/.venv`, not a
+  project artifact.
+- Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
+  and `version`; users do not specify managers. The Python registry maps known
+  `(type, name)` pairs to managers and errors on unknown artifacts.
 - Most recent uncommitted change adds `basectl update-profile --no-defaults`, including conflict handling with `--defaults`, docs, and BATS coverage.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ next to it under a shared parent directory, for example:
 Over time, each project repo can declare how Base should interact with it,
 likely through a small project manifest or well-defined conventions.
 
+The first version of that manifest is `base_manifest.yaml` at a project repo
+root. It declares the project name and the project artifacts Base should manage:
+
+```yaml
+project:
+  name: example
+
+artifacts:
+  - type: tool
+    name: terraform
+    version: "1.8.5"
+```
+
+The manifest intentionally describes what the project needs, not how to install
+it. Base owns the artifact registry and chooses the manager for each supported
+`type` and `name` pair. Unknown artifacts fail setup clearly instead of running
+arbitrary user-provided install commands.
+
 ### 2. Shell Environment Management
 
 Base should manage shell environments at two levels:
@@ -124,6 +142,9 @@ exec "$(dirname "$0")/basectl" caff "$@"
 `basectl setup` deliberately pins its default Homebrew Python formula so setup is
 reproducible across machines. The current default is `python@3.13`. Override it
 with `BASE_SETUP_PYTHON_FORMULA` when a workspace needs a different formula.
+After this Bash bootstrap layer creates Base's own Python environment, setup
+installs `PyYAML` into that environment and invokes the Python project setup
+layer to read `base_manifest.yaml` and reconcile project artifacts.
 
 ## Quick Start
 

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -1,0 +1,4 @@
+project:
+  name: base
+
+artifacts: []

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -33,6 +33,9 @@ that delegate to `basectl`.
 ## Notes
 
 - `basectl setup` is the default local bootstrap path.
+- `basectl setup [project]` runs the Bash bootstrap layer first, then invokes the
+  Python project setup layer for `base_manifest.yaml` artifacts. The optional
+  project argument validates `project.name`.
 - `basectl check` verifies the same local requirements without making changes.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -11,12 +11,13 @@ source "$_base_setup_common_path"
 base_setup_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl setup [options]
+  basectl setup [options] [project]
 
 Options:
-  --dry-run   Log what would happen without making changes.
-  -v          Enable DEBUG logging for this subcommand.
-  -h, --help  Show this help text.
+  --dry-run          Log what would happen without making changes.
+  --manifest <path>  Use a specific base_manifest.yaml path.
+  -v                 Enable DEBUG logging for this subcommand.
+  -h, --help         Show this help text.
 
 Purpose:
   Prepare the local Base CLI environment on macOS.
@@ -27,14 +28,19 @@ Setup does:
   3. Install Python 3.13 via Homebrew if needed.
   4. Install BATS via Homebrew if needed.
   5. Create ~/.base.d/.venv if it does not already exist.
+  6. Install PyYAML into the Base virtual environment if needed.
+  7. Invoke the Python project setup layer for base_manifest.yaml artifacts.
 
 Notes:
   - This command is intentionally idempotent.
+  - The optional project argument validates project.name in base_manifest.yaml.
   - Use `basectl check` to verify the same requirements without making changes.
 EOF
 }
 
 base_setup_subcommand_main() {
+    local project_name=""
+
     setup_clear_run_state
 
     while (($#)); do
@@ -46,18 +52,38 @@ base_setup_subcommand_main() {
             --dry-run)
                 setup_enable_dry_run
                 ;;
+            --manifest)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    print_error "Option '--manifest' requires an argument."
+                    base_setup_subcommand_usage >&2
+                    return 1
+                fi
+                BASE_SETUP_MANIFEST="$1"
+                export BASE_SETUP_MANIFEST
+                ;;
             -v)
                 setup_enable_debug_logging
                 ;;
-            *)
+            --*)
                 print_error "Unknown option '$1'."
                 base_setup_subcommand_usage >&2
                 return 1
+                ;;
+            *)
+                if [[ -n "$project_name" ]]; then
+                    print_error "Only one project argument is supported."
+                    base_setup_subcommand_usage >&2
+                    return 1
+                fi
+                project_name="$1"
                 ;;
         esac
         shift
     done
 
+    BASE_SETUP_PROJECT_NAME="$project_name"
+    export BASE_SETUP_PROJECT_NAME
     log_debug "Running 'basectl setup' (DRY_RUN=$(setup_is_dry_run && printf true || printf false))."
     setup_run_install
 }

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -20,7 +20,7 @@ readonly _base_setup_common_sourced
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset dry_run DRY_RUN
+    unset dry_run DRY_RUN BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_PYYAML_READY
 }
 
 setup_enable_dry_run() {
@@ -53,6 +53,10 @@ setup_python_formula() {
 
 setup_bats_formula() {
     printf '%s\n' "${BASE_SETUP_BATS_FORMULA:-bats-core}"
+}
+
+setup_pyyaml_package() {
+    printf '%s\n' "${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 }
 
 setup_xcode_tools_dir() {
@@ -293,6 +297,108 @@ setup_create_virtualenv() {
     run "$python_bin" -m venv "$venv_dir"
 }
 
+setup_base_venv_python_bin() {
+    local venv_dir="$1"
+    local python_bin="$venv_dir/bin/python"
+
+    [[ -x "$python_bin" ]] || return 1
+    printf '%s\n' "$python_bin"
+}
+
+setup_pyyaml_installed() {
+    local venv_dir python_bin package
+
+    venv_dir="$(setup_venv_dir)"
+    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1
+    package="$(setup_pyyaml_package)"
+    "$python_bin" -m pip show "$package" >/dev/null 2>&1
+}
+
+setup_install_pyyaml() {
+    local venv_dir python_bin package
+
+    venv_dir="$(setup_venv_dir)"
+    package="$(setup_pyyaml_package)"
+
+    if setup_pyyaml_installed; then
+        BASE_SETUP_PYYAML_READY=true
+        export BASE_SETUP_PYYAML_READY
+        log_info "Python package '$package' is already installed in the Base virtual environment."
+        return 0
+    fi
+
+    if setup_is_dry_run; then
+        BASE_SETUP_PYYAML_READY=false
+        export BASE_SETUP_PYYAML_READY
+        log_info "[DRY-RUN] Would install Python package '$package' in the Base virtual environment."
+        return 0
+    fi
+
+    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'."
+
+    log_info "Installing Python package '$package' in the Base virtual environment."
+    run "$python_bin" -m pip install "$package"
+    BASE_SETUP_PYYAML_READY=true
+    export BASE_SETUP_PYYAML_READY
+}
+
+setup_project_setup_python_bin() {
+    local venv_dir python_bin
+
+    venv_dir="$(setup_venv_dir)"
+    python_bin="$venv_dir/bin/python"
+    if [[ -x "$python_bin" ]]; then
+        printf '%s\n' "$python_bin"
+        return 0
+    fi
+
+    setup_find_python_bin
+}
+
+setup_run_project_artifact_setup() {
+    local python_bin old_pythonpath
+    local exit_code
+    local args=()
+
+    if setup_is_dry_run && [[ "${BASE_SETUP_PYYAML_READY:-}" != true ]]; then
+        log_info "[DRY-RUN] Would run Python project setup layer after PyYAML is installed."
+        return 0
+    fi
+
+    python_bin="$(setup_project_setup_python_bin)" || fatal_error "Unable to locate a python3 executable for project artifact setup."
+
+    if setup_is_dry_run; then
+        args+=(--dry-run)
+    fi
+    if [[ -n "${BASE_SETUP_MANIFEST:-}" ]]; then
+        args+=(--manifest "$BASE_SETUP_MANIFEST")
+    fi
+    if [[ -n "${BASE_SETUP_PROJECT_NAME:-}" ]]; then
+        args+=("$BASE_SETUP_PROJECT_NAME")
+    fi
+
+    old_pythonpath="${PYTHONPATH-}"
+    if [[ -n "$old_pythonpath" ]]; then
+        PYTHONPATH="$BASE_HOME/cli/python:$old_pythonpath"
+    else
+        PYTHONPATH="$BASE_HOME/cli/python"
+    fi
+    export PYTHONPATH
+
+    log_info "Running Python project setup layer."
+    "$python_bin" -m base_setup "${args[@]}"
+    exit_code=$?
+
+    if [[ -n "$old_pythonpath" ]]; then
+        PYTHONPATH="$old_pythonpath"
+        export PYTHONPATH
+    else
+        unset PYTHONPATH
+    fi
+
+    exit_if_error "$exit_code" "Python project setup layer failed."
+}
+
 setup_run_check() {
     local brew_bin="" venv_dir missing=0
 
@@ -352,6 +458,8 @@ setup_run_install() {
     setup_install_python
     setup_install_bats
     setup_create_virtualenv
+    setup_install_pyyaml
+    setup_run_project_artifact_setup
 
     if setup_is_dry_run; then
         log_info "[DRY-RUN] Base CLI setup check is complete."

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -63,6 +63,7 @@ state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
 python_prefix="${BASE_SETUP_TEST_PYTHON_PREFIX:?}"
 python_formula="${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
 bats_formula="${BASE_SETUP_BATS_FORMULA:-bats-core}"
+pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 
 case "${1:-}" in
     list)
@@ -89,6 +90,30 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     mkdir -p "$3/bin"
     printf 'python-home = test\n' > "$3/pyvenv.cfg"
     printf '#!/usr/bin/env bash\n' > "$3/bin/activate"
+    cat > "$3/bin/python" <<'VENVEOF'
+#!/usr/bin/env bash
+pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$pyyaml_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed"
+    exit 0
+fi
+printf 'unexpected venv python args: %s\n' "$*" >&2
+exit 1
+VENVEOF
+    chmod +x "$3/bin/python"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
 printf 'unexpected python3 args: %s\n' "$*" >&2
@@ -133,6 +158,7 @@ state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
 python_prefix="${BASE_SETUP_TEST_PYTHON_PREFIX:?}"
 python_formula="${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
 bats_formula="${BASE_SETUP_BATS_FORMULA:-bats-core}"
+pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 
 case "${1:-}" in
     list)
@@ -159,6 +185,30 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     mkdir -p "$3/bin"
     printf 'python-home = test\n' > "$3/pyvenv.cfg"
     printf '#!/usr/bin/env bash\n' > "$3/bin/activate"
+    cat > "$3/bin/python" <<'VENVEOF'
+#!/usr/bin/env bash
+pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$pyyaml_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed"
+    exit 0
+fi
+printf 'unexpected venv python args: %s\n' "$*" >&2
+exit 1
+VENVEOF
+    chmod +x "$3/bin/python"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
 printf 'unexpected python3 args: %s\n' "$*" >&2
@@ -261,8 +311,29 @@ run_base_command() {
     mkdir -p "$TEST_TMPDIR/CommandLineTools"
     touch "$TEST_STATE_DIR/python-installed"
     touch "$TEST_STATE_DIR/bats-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
     mkdir -p "$venv_dir/bin"
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+    cat > "$venv_dir/bin/python" <<'EOF'
+#!/usr/bin/env bash
+pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$pyyaml_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed"
+    exit 0
+fi
+printf 'unexpected venv python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$venv_dir/bin/python"
 
     run_base_command setup
 
@@ -272,8 +343,12 @@ run_base_command() {
     [[ "$output" == *"Python formula 'python@3.13' is already installed via Homebrew."* ]]
     [[ "$output" == *"BATS formula 'bats-core' is already installed via Homebrew."* ]]
     [[ "$output" == *"Virtual environment already exists at '$venv_dir'."* ]]
+    [[ "$output" == *"Python package 'PyYAML' is already installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Running Python project setup layer."* ]]
     [ ! -f "$TEST_STATE_DIR/python-install-ran" ]
     [ ! -f "$TEST_STATE_DIR/bats-install-ran" ]
+    [ ! -f "$TEST_STATE_DIR/pyyaml-install-ran" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
 @test "basectl setup installs missing dependencies and creates the Base virtual environment" {
@@ -295,10 +370,14 @@ run_base_command() {
     [[ "$output" == *"Installing Python formula 'python@3.13' via Homebrew."* ]]
     [[ "$output" == *"Installing BATS formula 'bats-core' via Homebrew."* ]]
     [[ "$output" == *"Creating Python virtual environment at '$venv_dir'."* ]]
+    [[ "$output" == *"Installing Python package 'PyYAML' in the Base virtual environment."* ]]
+    [[ "$output" == *"Running Python project setup layer."* ]]
     [[ "$output" == *"Base CLI setup is complete."* ]]
     [ -f "$TEST_STATE_DIR/homebrew-install-ran" ]
     [ -f "$TEST_STATE_DIR/python-install-ran" ]
     [ -f "$TEST_STATE_DIR/bats-install-ran" ]
+    [ -f "$TEST_STATE_DIR/pyyaml-install-ran" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ -f "$venv_dir/pyvenv.cfg" ]
 }
 
@@ -311,6 +390,8 @@ run_base_command() {
     [[ "$output" == *"[DRY-RUN] Would install Python formula 'python@3.13' via Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would install BATS formula 'bats-core' via Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/.venv'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would install Python package 'PyYAML' in the Base virtual environment."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run Python project setup layer after PyYAML is installed."* ]]
     [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
     [ ! -e "$TEST_HOME/.base.d/.venv" ]
 }

--- a/cli/python/base_setup/__init__.py
+++ b/cli/python/base_setup/__init__.py
@@ -1,0 +1,2 @@
+"""Base project setup engine."""
+

--- a/cli/python/base_setup/__main__.py
+++ b/cli/python/base_setup/__main__.py
@@ -1,0 +1,6 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+from .manifest import BaseManifest, ManifestError, discover_manifest, read_manifest
+from .registry import ArtifactDefinition, get_artifact_definition
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Base project artifact setup.")
+    parser.add_argument("project", nargs="?", help="Expected project name from base_manifest.yaml.")
+    parser.add_argument("--manifest", help="Path to base_manifest.yaml.")
+    parser.add_argument("--start-dir", default=os.getcwd(), help="Directory where manifest discovery should start.")
+    parser.add_argument("--dry-run", action="store_true", help="Log planned changes without making them.")
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest).resolve() if args.manifest else discover_manifest(Path(args.start_dir))
+    if manifest_path is None:
+        if args.project:
+            error(f"No base_manifest.yaml found while setting up project '{args.project}'.")
+            return 1
+        info("No base_manifest.yaml found; skipping project artifact setup.")
+        return 0
+
+    try:
+        manifest = read_manifest(manifest_path)
+        validate_project_name(manifest, args.project)
+        reconcile_manifest(manifest, dry_run=args.dry_run)
+    except ManifestError as exc:
+        error(str(exc))
+        return 1
+    except ArtifactError as exc:
+        error(str(exc))
+        return 1
+
+    return 0
+
+
+class ArtifactError(RuntimeError):
+    pass
+
+
+def validate_project_name(manifest: BaseManifest, expected_project: str | None) -> None:
+    if expected_project and manifest.project_name != expected_project:
+        raise ManifestError(
+            f"{manifest.path}: project.name is '{manifest.project_name}', expected '{expected_project}'."
+        )
+
+
+def reconcile_manifest(manifest: BaseManifest, dry_run: bool) -> None:
+    info(f"Reading Base manifest at '{manifest.path}'.")
+    info(f"Setting up project '{manifest.project_name}'.")
+
+    project_root = manifest.path.parent
+    if not manifest.artifacts:
+        info(f"Project '{manifest.project_name}' declares no artifacts.")
+        info(f"Project '{manifest.project_name}' artifact setup is complete.")
+        return
+
+    for artifact in manifest.artifacts:
+        definition = get_artifact_definition(artifact.artifact_type, artifact.name)
+        if definition is None:
+            raise ArtifactError(
+                "Unsupported artifact "
+                f"'{artifact.name}' of type '{artifact.artifact_type}'. "
+                "Base does not know how to manage this artifact yet."
+            )
+        reconcile_artifact(project_root, definition, artifact.version, dry_run=dry_run)
+
+    info(f"Project '{manifest.project_name}' artifact setup is complete.")
+
+
+def reconcile_artifact(project_root: Path, definition: ArtifactDefinition, version: str, dry_run: bool) -> None:
+    if definition.manager == "homebrew":
+        reconcile_homebrew_artifact(definition, version, dry_run=dry_run)
+        return
+    if definition.manager == "pip":
+        reconcile_python_artifact(project_root, definition, version, dry_run=dry_run)
+        return
+    raise ArtifactError(f"Artifact manager '{definition.manager}' is not implemented.")
+
+
+def reconcile_homebrew_artifact(definition: ArtifactDefinition, version: str, dry_run: bool) -> None:
+    command = ["brew", "install", definition.package]
+    if dry_run:
+        dry_run_command(command)
+        return
+
+    if not command_exists("brew"):
+        raise ArtifactError(f"Homebrew is required to install artifact '{definition.name}'.")
+
+    if run_check(["brew", "list", definition.package]):
+        info(f"Artifact '{definition.name}' is already installed via Homebrew package '{definition.package}'.")
+        return
+
+    info(f"Installing artifact '{definition.name}' via Homebrew package '{definition.package}' ({version}).")
+    run_command(command)
+
+
+def reconcile_python_artifact(project_root: Path, definition: ArtifactDefinition, version: str, dry_run: bool) -> None:
+    venv_dir = project_root / ".base" / ".venv"
+    python_bin = venv_dir / "bin" / "python"
+    requirement = f"{definition.package}=={version}" if version != "latest" else definition.package
+
+    if dry_run:
+        if not python_bin.exists():
+            info(f"[DRY-RUN] Would create project virtual environment at '{venv_dir}'.")
+        dry_run_command([str(python_bin), "-m", "pip", "install", requirement])
+        return
+
+    if not python_bin.exists():
+        info(f"Creating project virtual environment at '{venv_dir}'.")
+        venv.create(venv_dir, with_pip=True)
+
+    info(f"Installing Python artifact '{definition.name}' into project virtual environment.")
+    run_command([str(python_bin), "-m", "pip", "install", requirement])
+
+
+def command_exists(name: str) -> bool:
+    return any((Path(directory) / name).is_file() and os.access(Path(directory) / name, os.X_OK) for directory in os.environ.get("PATH", "").split(os.pathsep))
+
+
+def run_check(command: list[str]) -> bool:
+    return subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False).returncode == 0
+
+
+def run_command(command: list[str]) -> None:
+    completed = subprocess.run(command, check=False)
+    if completed.returncode:
+        raise ArtifactError(f"Command failed with exit {completed.returncode}: {format_command(command)}")
+
+
+def dry_run_command(command: list[str]) -> None:
+    info(f"[DRY-RUN] Would run: {format_command(command)}")
+
+
+def format_command(command: list[str]) -> str:
+    return " ".join(_quote_arg(arg) for arg in command)
+
+
+def _quote_arg(arg: str) -> str:
+    if arg and all(char.isalnum() or char in "/._=:@+-" for char in arg):
+        return arg
+    return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+
+def info(message: str) -> None:
+    print(f"INFO: {message}")
+
+
+def error(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:
+    yaml = None
+    _yaml_import_error = exc
+else:
+    _yaml_import_error = None
+
+
+class ManifestError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ArtifactRequest:
+    artifact_type: str
+    name: str
+    version: str
+
+
+@dataclass(frozen=True)
+class BaseManifest:
+    path: Path
+    project_name: str
+    artifacts: tuple[ArtifactRequest, ...]
+
+
+def discover_manifest(start: Path) -> Path | None:
+    current = start.resolve()
+    if current.is_file():
+        current = current.parent
+
+    while True:
+        candidate = current / "base_manifest.yaml"
+        if candidate.is_file():
+            return candidate
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def read_manifest(path: Path) -> BaseManifest:
+    if yaml is None:
+        raise ManifestError(
+            "PyYAML is required to read base_manifest.yaml. "
+            "Run 'basectl setup' to install Base Python bootstrap dependencies."
+        ) from _yaml_import_error
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"{path}: invalid YAML: {exc}") from exc
+
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ManifestError(f"{path}: manifest must be a YAML mapping.")
+
+    allowed_top_level = {"project", "artifacts"}
+    unknown_top_level = sorted(set(data) - allowed_top_level)
+    if unknown_top_level:
+        raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
+
+    project_name = _read_project_name(path, data.get("project"))
+    artifacts = _read_artifacts(path, data.get("artifacts", []))
+
+    return BaseManifest(path=path, project_name=project_name, artifacts=tuple(artifacts))
+
+
+def _read_project_name(path: Path, project_data: Any) -> str:
+    if not isinstance(project_data, dict):
+        raise ManifestError(f"{path}: project must be a mapping.")
+
+    allowed_project_keys = {"name"}
+    unknown_project_keys = sorted(set(project_data) - allowed_project_keys)
+    if unknown_project_keys:
+        raise ManifestError(f"{path}: unsupported project keys: {', '.join(unknown_project_keys)}.")
+
+    project_name = project_data.get("name")
+    if not isinstance(project_name, str) or not project_name:
+        raise ManifestError(f"{path}: project.name is required.")
+    return project_name
+
+
+def _read_artifacts(path: Path, artifacts_data: Any) -> list[ArtifactRequest]:
+    if artifacts_data is None:
+        return []
+    if not isinstance(artifacts_data, list):
+        raise ManifestError(f"{path}: artifacts must be a list.")
+
+    artifacts: list[ArtifactRequest] = []
+    for index, artifact_data in enumerate(artifacts_data, start=1):
+        artifacts.append(_read_artifact(path, artifact_data, index))
+    return artifacts
+
+
+def _read_artifact(path: Path, artifact_data: Any, index: int) -> ArtifactRequest:
+    if not isinstance(artifact_data, dict):
+        raise ManifestError(f"{path}: artifacts[{index}] must be a mapping.")
+
+    allowed_artifact_keys = {"type", "name", "version"}
+    unknown_artifact_keys = sorted(set(artifact_data) - allowed_artifact_keys)
+    if unknown_artifact_keys:
+        raise ManifestError(
+            f"{path}: artifacts[{index}] has unsupported keys: {', '.join(unknown_artifact_keys)}."
+        )
+
+    missing = sorted(key for key in allowed_artifact_keys if not artifact_data.get(key))
+    if missing:
+        raise ManifestError(f"{path}: artifacts[{index}] is missing required keys: {', '.join(missing)}.")
+
+    artifact_type = artifact_data["type"]
+    name = artifact_data["name"]
+    version = artifact_data["version"]
+    if not all(isinstance(value, str) for value in (artifact_type, name, version)):
+        raise ManifestError(f"{path}: artifacts[{index}] type, name, and version must be strings.")
+
+    return ArtifactRequest(
+        artifact_type=artifact_type,
+        name=name,
+        version=version,
+    )

--- a/cli/python/base_setup/registry.py
+++ b/cli/python/base_setup/registry.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ArtifactDefinition:
+    name: str
+    artifact_type: str
+    manager: str
+    package: str
+    target: str
+
+
+_ARTIFACTS = {
+    ("tool", "terraform"): ArtifactDefinition(
+        name="terraform",
+        artifact_type="tool",
+        manager="homebrew",
+        package="terraform",
+        target="system",
+    ),
+    ("tool", "kubectl"): ArtifactDefinition(
+        name="kubectl",
+        artifact_type="tool",
+        manager="homebrew",
+        package="kubernetes-cli",
+        target="system",
+    ),
+    ("tool", "node"): ArtifactDefinition(
+        name="node",
+        artifact_type="tool",
+        manager="homebrew",
+        package="node",
+        target="system",
+    ),
+    ("tool", "nodejs"): ArtifactDefinition(
+        name="nodejs",
+        artifact_type="tool",
+        manager="homebrew",
+        package="node",
+        target="system",
+    ),
+    ("python-package", "requests"): ArtifactDefinition(
+        name="requests",
+        artifact_type="python-package",
+        manager="pip",
+        package="requests",
+        target="project-venv",
+    ),
+}
+
+
+def get_artifact_definition(artifact_type: str, name: str) -> ArtifactDefinition | None:
+    return _ARTIFACTS.get((artifact_type, name))

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from base_setup.engine import main
+from base_setup.manifest import read_manifest
+
+
+class ManifestTests(unittest.TestCase):
+    def test_reads_basic_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: tool",
+                        "    name: terraform",
+                        "    version: \"1.8.5\"",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.project_name, "demo")
+        self.assertEqual(manifest.artifacts[0].artifact_type, "tool")
+        self.assertEqual(manifest.artifacts[0].name, "terraform")
+        self.assertEqual(manifest.artifacts[0].version, "1.8.5")
+
+    def test_unknown_artifact_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: tool",
+                        "    name: not-a-real-artifact",
+                        "    version: \"1.0\"",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            stderr = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(stderr):
+                status = main(["--manifest", str(manifest_path)])
+
+        self.assertEqual(status, 1)
+        self.assertIn("Unsupported artifact 'not-a-real-artifact' of type 'tool'", stderr.getvalue())
+
+    def test_known_homebrew_artifact_dry_run_does_not_require_brew(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: tool",
+                        "    name: terraform",
+                        "    version: \"1.8.5\"",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                status = main(["--dry-run", "--manifest", str(manifest_path)])
+
+        self.assertEqual(status, 0)
+        self.assertIn("[DRY-RUN] Would run: brew install terraform", stdout.getvalue())
+
+    def test_project_argument_validates_manifest_project_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            stderr = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(stderr):
+                status = main(["--manifest", str(manifest_path), "other"])
+
+        self.assertEqual(status, 1)
+        self.assertIn("project.name is 'demo', expected 'other'", stderr.getvalue())
+
+    def test_empty_artifact_list_is_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.project_name, "demo")
+        self.assertEqual(manifest.artifacts, ())
+
+    def test_empty_artifact_list_logs_that_no_artifacts_are_declared(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                status = main(["--manifest", str(manifest_path)])
+
+        self.assertEqual(status, 0)
+        self.assertIn("Project 'demo' declares no artifacts.", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/base-cli-design.md
+++ b/docs/base-cli-design.md
@@ -1,0 +1,386 @@
+# base_cli — Design Specification
+
+> The Python standardization layer for all CLIs in the Base ecosystem.
+
+---
+
+## 1. Overview
+
+`base_cli` is a Python package that sits on top of [Click](https://click.palletsprojects.com/) and provides a unified, opinionated framework for building CLIs within the Base ecosystem. It eliminates boilerplate, enforces consistency, and transparently handles cross-cutting concerns — logging, temp files, cache, configuration, interrupt handling, and cloud telemetry — so CLI authors focus entirely on business logic.
+
+### Design Philosophy
+
+- **Transparency first**: Infrastructure initializes automatically on import. CLI authors do not configure it.
+- **Opinionated by default**: Sensible defaults for all behaviors; overrides are explicit and layered.
+- **Simplicity is the ultimate sophistication**: Every decision prioritizes clarity over clever abstraction.
+- **Cross-platform**: Works on macOS (Apple Silicon and Intel) and Linux without platform-specific code from CLI authors.
+- **Supports both interactive and headless modes**: User-facing CLIs and background daemons (systemd, launchd) are first-class citizens.
+
+---
+
+## 2. Package Name and Import
+
+```python
+import base_cli
+```
+
+A single import is all that is required. All infrastructure initializes automatically.
+
+```python
+# CLI author's main.py — complete boilerplate-free example
+import base_cli
+
+@base_cli.command()
+@base_cli.option("--name", help="Your name")
+def greet(name):
+    base_cli.log_info(f"Hello, {name}")
+```
+
+---
+
+## 3. Initialization on Import
+
+When `base_cli` is imported, the following happens automatically — in order, silently, and quickly:
+
+1. Detect runtime mode: interactive TTY vs. headless daemon
+2. Resolve the CLI name from `sys.argv[0]`
+3. Create the standard directory structure under `~/.based/` (see Section 4)
+4. Initialize the dual logging streams (see Section 5)
+5. Log the full invocation — CLI name + all arguments — at DEBUG level
+6. Create a temporary directory for this run (see Section 7)
+7. Register signal handlers for interrupt and termination (see Section 9)
+
+No network calls are made on import. Initialization is fast and side-effect-free from the CLI author's perspective.
+
+---
+
+## 4. Standard Directory Structure
+
+All Base-managed state lives under `~/.based/` in the user's home directory.
+
+```
+~/.based/
+  cli/
+    <cli-name>/
+      logs/
+        2025-04-15T10-30-00_abc123.log   # one file per run
+        2025-04-14T09-00-00_xyz789.log
+      cache/
+        ...                               # persistent across runs
+      tmp/
+        2025-04-15T10-30-00_abc123/       # ephemeral, per-run
+```
+
+The CLI name is derived from the invoked script name (the basename of `sys.argv[0]`, without extension).
+
+### Directory Lifecycle
+
+| Directory | Created | Destroyed |
+|---|---|---|
+| `logs/` | On first run | Never (retention policy applies) |
+| `cache/` | On first run | Never (explicit clear or CLI logic) |
+| `tmp/<run>/` | On import | On exit (unless `BASE_CLI_KEEP_TEMP=true`) |
+
+---
+
+## 5. Logging
+
+### Dual-Stream Architecture
+
+Every CLI run produces two independent logging streams:
+
+| Stream | Destination | Level | Format |
+|---|---|---|---|
+| User stream | stdout / stderr | User-configured (default: INFO) | Human-readable, optionally colorized |
+| Persistent stream | `~/.based/cli/<name>/logs/<timestamp>.log` | Always DEBUG | Structured, with timestamps |
+
+The persistent stream is always DEBUG regardless of the user's chosen level. This ensures full diagnostic context is available after a failure — even if the user did not request verbose output at runtime.
+
+### Log Levels
+
+`base_cli` uses Python's standard `logging` module with its five built-in levels. No custom levels are added.
+
+| Level | User stream | Persistent stream |
+|---|---|---|
+| DEBUG | Only if `--debug` flag set | Always |
+| INFO | Yes (default) | Always |
+| WARNING | Yes | Always |
+| ERROR | Yes | Always |
+| CRITICAL | Yes | Always |
+
+### Logging API
+
+```python
+base_cli.log_debug("message")
+base_cli.log_info("message")
+base_cli.log_warning("message")
+base_cli.log_error("message")
+base_cli.log_critical("message")
+
+# Sensitive data — shown to user but redacted from file and cloud upload
+base_cli.log_info("Token accepted", redact=True)
+```
+
+The `redact=True` parameter is available on all five logging functions. When set, the message is shown on the user-facing stream but replaced with `[REDACTED]` in the persistent log and excluded from cloud uploads.
+
+### Automatic Invocation Logging
+
+On every run, `base_cli` automatically logs at DEBUG level:
+
+- Full command invocation (`sys.argv`)
+- Timestamp and run ID
+- Platform (OS, architecture)
+- Python version
+- Environment name (if set)
+
+CLI authors do not write any of this.
+
+### Headless / Daemon Mode
+
+When no TTY is detected (e.g., running under systemd or launchd), the user-facing stream is automatically redirected to syslog or a structured JSON log format suitable for log aggregation. The persistent file stream continues as normal.
+
+---
+
+## 6. Configuration
+
+### Layered Override Model
+
+Configuration is resolved in this priority order (highest to lowest):
+
+| Priority | Source | Example |
+|---|---|---|
+| 1 (highest) | Code hooks — explicit API calls | `base_cli.set_log_level("debug")` |
+| 2 | Config file | `~/.based/config.yaml` or project-level |
+| 3 | Command line arguments | `--debug`, `--environment prod` |
+| 4 (lowest) | Environment variables | `BASE_CLI_LOG_LEVEL=debug` |
+
+### Config File
+
+Config files are always YAML. They are discovered in this order:
+
+1. Current working directory: `.based.yaml`
+2. User home directory: `~/.based/config.yaml`
+3. System-wide: `/etc/based/config.yaml`
+
+Project-level config (CWD) takes precedence over user-level, which takes precedence over system-level.
+
+### Environment-Specific Config
+
+When an environment is set (via `--environment` or `BASE_CLI_ENVIRONMENT`), `base_cli` additionally loads:
+
+```
+~/.based/config.<environment>.yaml
+```
+
+For example, `BASE_CLI_ENVIRONMENT=prod` loads `~/.based/config.prod.yaml`. Environment configs merge with the base config; the environment-specific values override.
+
+Supported environments are open-ended (e.g., `dev`, `staging`, `prod`). `base_cli` does not hard-code environment names.
+
+### Key Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BASE_CLI_LOG_LEVEL` | User-facing log level | `info` |
+| `BASE_CLI_ENVIRONMENT` | Active environment | `dev` |
+| `BASE_CLI_KEEP_TEMP` | Preserve temp dir after run | `false` |
+| `BASE_CLI_TEMP_RETENTION_DAYS` | Days to keep old temp dirs | `7` |
+| `BASE_CLI_NO_CLOUD_UPLOAD` | Disable cloud log upload | `false` |
+| `BASE_CLI_CLOUD_BUCKET` | Cloud bucket for log upload | _(unset)_ |
+
+---
+
+## 7. Temporary File Handling
+
+### Automatic Lifecycle
+
+On import, `base_cli` creates a run-scoped temp directory using Python's `tempfile` module, which handles platform differences (macOS, Linux) automatically.
+
+```python
+# Accessible to CLI authors as:
+base_cli.temp_dir   # Path object pointing to the run's temp directory
+```
+
+The temp directory is automatically deleted on clean exit and on interrupt (see Section 9), unless `BASE_CLI_KEEP_TEMP=true`.
+
+### Retention Policy
+
+When `BASE_CLI_KEEP_TEMP=true`, temp directories from previous runs are preserved. To prevent unbounded growth, `base_cli` prunes temp directories older than `BASE_CLI_TEMP_RETENTION_DAYS` (default: 7 days) at the start of each run.
+
+### No Output File Management
+
+Output files produced by a CLI are the CLI author's responsibility. `base_cli` does not manage output paths. The user specifies output locations through CLI arguments or config.
+
+---
+
+## 8. Cache Management
+
+### Persistent Cache Directory
+
+```python
+base_cli.cache_dir   # Path object pointing to ~/.based/cli/<name>/cache/
+```
+
+The cache directory persists across runs. `base_cli` provides the directory; individual CLIs decide what to store and when to invalidate.
+
+Cache management is intentionally minimal at the base_cli level — it is a convention and location standard, not a full caching framework.
+
+---
+
+## 9. Interrupt Handling
+
+### Default Behavior
+
+`base_cli` registers signal handlers for `SIGINT` (Ctrl+C) and `SIGTERM` on import. On interrupt:
+
+1. Flush and close all log file handles
+2. Write a final log entry noting the interruption
+3. Clean up the temp directory (unless `BASE_CLI_KEEP_TEMP=true`)
+4. Call any registered user cleanup hooks (in registration order)
+5. Exit cleanly
+
+### User Cleanup Hooks
+
+CLI authors can register optional cleanup functions:
+
+```python
+def my_cleanup():
+    # close connections, finalize output, etc.
+    pass
+
+base_cli.on_interrupt(my_cleanup)
+```
+
+Multiple hooks can be registered. They are called in the order registered, after base_cli's own cleanup.
+
+---
+
+## 10. Command Line Argument Handling
+
+### Click as the Foundation
+
+`base_cli` wraps [Click](https://click.palletsprojects.com/) — the standard Python CLI framework — to enforce uniformity while preserving Click's full power. CLI authors use `base_cli` decorators, which delegate to Click under the hood.
+
+```python
+# Instead of @click.command(), use:
+@base_cli.command()
+
+# Instead of @click.option(), use:
+@base_cli.option()
+```
+
+### Why a Wrapper?
+
+Without the wrapper layer, there is no mechanism to:
+- Automatically redact sensitive arguments before logging or cloud upload
+- Inject standard arguments across all CLIs uniformly
+- Integrate argument parsing with the logging and config systems
+- Enforce consistent error handling and exit codes
+
+### Sensitive Argument Redaction
+
+CLI authors annotate sensitive arguments at definition time:
+
+```python
+@base_cli.option("--api-key", sensitive=True, help="API key")
+```
+
+When `sensitive=True`, the argument value is:
+- Never written to the persistent log file
+- Never included in cloud uploads
+- Replaced with `[REDACTED]` in all log output
+
+### Standard Arguments — Provided by base_cli for All CLIs
+
+The following arguments are automatically available in every CLI without the author declaring them:
+
+| Argument | Purpose |
+|---|---|
+| `--debug` | Enable DEBUG level on user-facing stream |
+| `--environment` | Set the active environment (dev/staging/prod) |
+| `--config` | Path to a custom config file |
+| `--no-cloud-upload` | Disable cloud log upload for this run |
+| `--log-file` | Override the default log file location |
+| `--version` | Show CLI version (auto-populated) |
+| `--help` | Show help (provided by Click) |
+
+---
+
+## 11. Cloud Log Telemetry
+
+### Purpose
+
+When CLIs run across many engineers' laptops, `base_cli` can aggregate logs to a central cloud bucket. This enables:
+
+- Usage analytics: which CLIs are most used, which subcommands are popular
+- Error pattern detection: what failures occur most frequently
+- Remote debugging: support staff can retrieve logs without user involvement
+
+### Upload Behavior
+
+Log upload happens asynchronously on CLI exit. `base_cli` uploads logs accumulated since the last successful upload (delta upload, not full history). Logs are scrubbed of sensitive data before upload.
+
+Upload is a no-op if `BASE_CLI_CLOUD_BUCKET` is not configured or `BASE_CLI_NO_CLOUD_UPLOAD=true`.
+
+### Multi-Cloud Design
+
+The upload mechanism is abstracted behind a provider interface. AWS S3 is the initial implementation. Additional providers (Azure Blob Storage, Google Cloud Storage) can be added as plugins.
+
+```yaml
+# ~/.based/config.yaml
+cloud:
+  provider: aws
+  bucket: my-org-cli-logs
+  region: us-west-2
+  retention_days: 90
+```
+
+### Privacy and Consent
+
+- Sensitive arguments (marked `sensitive=True`) are never uploaded
+- Log messages marked `redact=True` are excluded from uploads
+- Upload can be disabled globally via environment variable or per-run via `--no-cloud-upload`
+- Future: explicit opt-in model with clear documentation of what is uploaded
+
+---
+
+## 12. Platform Support
+
+| Platform | Status |
+|---|---|
+| macOS (Apple Silicon) | Primary |
+| macOS (Intel) | Supported via Python/Homebrew abstraction |
+| Linux | Supported |
+
+Platform-specific differences (temp directory locations, signal handling, syslog integration) are handled internally by `base_cli` using Python's standard library. CLI authors write platform-agnostic code.
+
+---
+
+## 13. Future Considerations
+
+- **Go equivalent**: `base_cli_go` — a Go package implementing the same philosophy for Go-based CLIs. Separate namespace, same conventions.
+- **Config file per CLI**: In addition to the project-level config, individual CLIs may support their own config file in a future iteration.
+- **Plugin system**: Extend cloud upload providers and other behaviors via a plugin registry.
+- **Usage dashboard**: A companion CLI (`based stats`) to visualize local and cloud-aggregated usage.
+
+---
+
+## 14. Summary — What CLI Authors Get for Free
+
+By adding `import base_cli` to their `main.py`, every CLI author automatically receives:
+
+- Dual-stream logging (user-facing + always-debug file)
+- Automatic invocation logging (args, platform, timestamp)
+- Standard directory structure under `~/.based/`
+- Temp directory created and cleaned up per run
+- Cache directory provisioned and accessible
+- Interrupt handling with cleanup
+- Standard CLI arguments (`--debug`, `--environment`, `--config`, etc.)
+- Sensitive argument and log redaction framework
+- Cloud log upload (when configured)
+- Cross-platform compatibility (macOS + Linux)
+
+All of this with **zero configuration code** in the CLI itself.
+
+---
+
+*base_cli — Infrastructure that gets out of the way.*


### PR DESCRIPTION
## Summary

- Add the first `base_manifest.yaml` for Base with no project artifacts yet
- Add a Python `base_setup` package for reading and validating Base manifests
- Add a basic artifact registry keyed by `(type, name)`
- Wire `basectl setup` to run Bash bootstrap first, then invoke the Python project setup layer
- Install `PyYAML` into Base's own venv as a bootstrap dependency
- Keep artifact managers out of project manifests and fail on unknown artifacts
- Update docs, AI context, setup BATS coverage, and Python unit tests

## Notes

Base's own manifest intentionally starts with `artifacts: []`. Python, BATS, PyYAML, and Base's runtime venv remain Bash/bootstrap-layer concerns, not project artifacts.

## Verification

- `bin/basectl setup --dry-run`
- `env PYTHONPATH=cli/python python3 -m unittest discover -s cli/python/base_setup/tests`
- Full BATS suite: 137 tests passing, with the existing pseudo-tty skip