### PR TITLE
Add base_cli v1 foundation

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -12,6 +12,9 @@ This file is the shared working memory for future AI-assisted development in thi
 - The Python layer now reads manifests with PyYAML. PyYAML is a Base bootstrap
   dependency installed by the Bash setup layer into `~/.base.d/.venv`, not a
   project artifact.
+- Current in-progress work rewrites `docs/base-cli-design.md` around explicit
+  `base_cli.App`/`Context` initialization and starts v1 under `cli/python/base_cli/`.
+  Click is a Base Python bootstrap dependency installed into `~/.base.d/.venv`.
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.

--- a/TODO.md
+++ b/TODO.md
@@ -113,3 +113,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: either reject unexpected args with usage, document that no args are accepted, or pass args through to the spawned shell.
   - Add tests for the chosen behavior.
   - Done locally; pending commit.
+
+## Base CLI Python Layer
+
+- [ ] Implement `base_cli` v1 for Python CLIs.
+  - Files: `cli/python/base_cli/`, `docs/base-cli-design.md`, `cli/bash/commands/basectl/subcommands/setup_common.sh`
+  - Goal: provide explicit `App`/decorator-driven initialization for Base and Base-supported project CLIs.
+  - V1 scope: `Context`, Click wrapper decorators, standard options, `~/.base.d/cli/<name>` paths, user/file logging, temp/cache directories, sensitive option redaction for invocation logging, project manifest discovery, and a test helper.
+  - Bootstrap: install Click into Base's Python virtual environment alongside PyYAML.
+  - Add focused Python tests and keep existing setup tests passing.

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -28,7 +28,7 @@ Setup does:
   3. Install Python 3.13 via Homebrew if needed.
   4. Install BATS via Homebrew if needed.
   5. Create ~/.base.d/.venv if it does not already exist.
-  6. Install PyYAML into the Base virtual environment if needed.
+  6. Install Base Python bootstrap packages into the Base virtual environment.
   7. Invoke the Python project setup layer for base_manifest.yaml artifacts.
 
 Notes:

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -59,6 +59,10 @@ setup_pyyaml_package() {
     printf '%s\n' "${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 }
 
+setup_click_package() {
+    printf '%s\n' "${BASE_SETUP_CLICK_PACKAGE:-click}"
+}
+
 setup_xcode_tools_dir() {
     printf '%s\n' "${BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR:-/Library/Developer/CommandLineTools}"
 }
@@ -305,31 +309,27 @@ setup_base_venv_python_bin() {
     printf '%s\n' "$python_bin"
 }
 
-setup_pyyaml_installed() {
-    local venv_dir python_bin package
+setup_base_python_package_installed() {
+    local package="$1"
+    local venv_dir python_bin
 
     venv_dir="$(setup_venv_dir)"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1
-    package="$(setup_pyyaml_package)"
     "$python_bin" -m pip show "$package" >/dev/null 2>&1
 }
 
-setup_install_pyyaml() {
-    local venv_dir python_bin package
+setup_install_base_python_package() {
+    local package="$1"
+    local venv_dir python_bin
 
     venv_dir="$(setup_venv_dir)"
-    package="$(setup_pyyaml_package)"
 
-    if setup_pyyaml_installed; then
-        BASE_SETUP_PYYAML_READY=true
-        export BASE_SETUP_PYYAML_READY
+    if setup_base_python_package_installed "$package"; then
         log_info "Python package '$package' is already installed in the Base virtual environment."
         return 0
     fi
 
     if setup_is_dry_run; then
-        BASE_SETUP_PYYAML_READY=false
-        export BASE_SETUP_PYYAML_READY
         log_info "[DRY-RUN] Would install Python package '$package' in the Base virtual environment."
         return 0
     fi
@@ -338,8 +338,28 @@ setup_install_pyyaml() {
 
     log_info "Installing Python package '$package' in the Base virtual environment."
     run "$python_bin" -m pip install "$package"
-    BASE_SETUP_PYYAML_READY=true
+}
+
+setup_install_pyyaml() {
+    local package
+
+    package="$(setup_pyyaml_package)"
+    if setup_base_python_package_installed "$package"; then
+        BASE_SETUP_PYYAML_READY=true
+    else
+        BASE_SETUP_PYYAML_READY=false
+    fi
     export BASE_SETUP_PYYAML_READY
+
+    setup_install_base_python_package "$package"
+    if ! setup_is_dry_run; then
+        BASE_SETUP_PYYAML_READY=true
+    fi
+    export BASE_SETUP_PYYAML_READY
+}
+
+setup_install_click() {
+    setup_install_base_python_package "$(setup_click_package)"
 }
 
 setup_project_setup_python_bin() {
@@ -459,6 +479,7 @@ setup_run_install() {
     setup_install_bats
     setup_create_virtualenv
     setup_install_pyyaml
+    setup_install_click
     setup_run_project_artifact_setup
 
     if setup_is_dry_run; then

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -64,6 +64,7 @@ python_prefix="${BASE_SETUP_TEST_PYTHON_PREFIX:?}"
 python_formula="${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
 bats_formula="${BASE_SETUP_BATS_FORMULA:-bats-core}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 
 case "${1:-}" in
     list)
@@ -93,6 +94,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     cat > "$3/bin/python" <<'VENVEOF'
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
@@ -104,6 +106,15 @@ fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$pyyaml_package" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-install-ran"
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$click_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$click_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed"
     exit 0
 fi
 printf 'unexpected venv python args: %s\n' "$*" >&2
@@ -159,6 +170,7 @@ python_prefix="${BASE_SETUP_TEST_PYTHON_PREFIX:?}"
 python_formula="${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
 bats_formula="${BASE_SETUP_BATS_FORMULA:-bats-core}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 
 case "${1:-}" in
     list)
@@ -188,6 +200,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     cat > "$3/bin/python" <<'VENVEOF'
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
@@ -199,6 +212,15 @@ fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$pyyaml_package" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-install-ran"
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$click_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$click_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed"
     exit 0
 fi
 printf 'unexpected venv python args: %s\n' "$*" >&2
@@ -312,11 +334,13 @@ run_base_command() {
     touch "$TEST_STATE_DIR/python-installed"
     touch "$TEST_STATE_DIR/bats-installed"
     touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
     mkdir -p "$venv_dir/bin"
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
@@ -328,6 +352,15 @@ fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$pyyaml_package" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-install-ran"
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$click_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$click_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed"
     exit 0
 fi
 printf 'unexpected venv python args: %s\n' "$*" >&2
@@ -344,10 +377,12 @@ EOF
     [[ "$output" == *"BATS formula 'bats-core' is already installed via Homebrew."* ]]
     [[ "$output" == *"Virtual environment already exists at '$venv_dir'."* ]]
     [[ "$output" == *"Python package 'PyYAML' is already installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Python package 'click' is already installed in the Base virtual environment."* ]]
     [[ "$output" == *"Running Python project setup layer."* ]]
     [ ! -f "$TEST_STATE_DIR/python-install-ran" ]
     [ ! -f "$TEST_STATE_DIR/bats-install-ran" ]
     [ ! -f "$TEST_STATE_DIR/pyyaml-install-ran" ]
+    [ ! -f "$TEST_STATE_DIR/click-install-ran" ]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
@@ -371,12 +406,14 @@ EOF
     [[ "$output" == *"Installing BATS formula 'bats-core' via Homebrew."* ]]
     [[ "$output" == *"Creating Python virtual environment at '$venv_dir'."* ]]
     [[ "$output" == *"Installing Python package 'PyYAML' in the Base virtual environment."* ]]
+    [[ "$output" == *"Installing Python package 'click' in the Base virtual environment."* ]]
     [[ "$output" == *"Running Python project setup layer."* ]]
     [[ "$output" == *"Base CLI setup is complete."* ]]
     [ -f "$TEST_STATE_DIR/homebrew-install-ran" ]
     [ -f "$TEST_STATE_DIR/python-install-ran" ]
     [ -f "$TEST_STATE_DIR/bats-install-ran" ]
     [ -f "$TEST_STATE_DIR/pyyaml-install-ran" ]
+    [ -f "$TEST_STATE_DIR/click-install-ran" ]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ -f "$venv_dir/pyvenv.cfg" ]
 }
@@ -391,6 +428,7 @@ EOF
     [[ "$output" == *"[DRY-RUN] Would install BATS formula 'bats-core' via Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/.venv'."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python package 'PyYAML' in the Base virtual environment."* ]]
+    [[ "$output" == *"[DRY-RUN] Would install Python package 'click' in the Base virtual environment."* ]]
     [[ "$output" == *"[DRY-RUN] Would run Python project setup layer after PyYAML is installed."* ]]
     [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
     [ ! -e "$TEST_HOME/.base.d/.venv" ]

--- a/cli/python/base_cli/__init__.py
+++ b/cli/python/base_cli/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .app import App, command, option
+from .context import Context, get_current_context
+from .logging import log_critical, log_debug, log_error, log_info, log_warning
+
+__all__ = [
+    "App",
+    "Context",
+    "command",
+    "get_current_context",
+    "log_critical",
+    "log_debug",
+    "log_error",
+    "log_info",
+    "log_warning",
+    "option",
+]
+

--- a/cli/python/base_cli/app.py
+++ b/cli/python/base_cli/app.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import functools
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from .config import load_config
+from .context import Context, reset_current_context, set_current_context
+from .logging import configure_logger, log_invocation
+from .paths import base_state_root, discover_manifest, make_run_id, normalize_cli_name, resolve_base_home
+from .redaction import parameter_name_from_decls
+
+
+def _require_click():
+    try:
+        import click
+    except ImportError as exc:
+        raise RuntimeError("Click is required for base_cli. Run 'basectl setup' to install it.") from exc
+    return click
+
+
+class App:
+    def __init__(self, name: str | None = None, version: str | None = None) -> None:
+        self.name = normalize_cli_name(name or sys.argv[0])
+        self.version = version
+        self._click_command = None
+
+    def command(self, *command_args: Any, **command_kwargs: Any):
+        click = _require_click()
+
+        def decorator(func: Callable[..., Any]):
+            sensitive_options = set(getattr(func, "__base_cli_sensitive_options__", set()))
+
+            @functools.wraps(func)
+            def wrapper(**kwargs: Any):
+                standard = _pop_standard_options(kwargs)
+                context = self._create_context(standard, sensitive_options)
+                token = set_current_context(context)
+                try:
+                    log_invocation(context.log, sys.argv, sensitive_options)
+                    if context.project_root is not None:
+                        context.log.debug("project_root=%s", context.project_root)
+                    if context.manifest_path is not None:
+                        context.log.debug("manifest_path=%s", context.manifest_path)
+                    return func(context, **kwargs)
+                finally:
+                    reset_current_context(token)
+                    context.cleanup()
+
+            wrapper.__click_params__ = list(getattr(func, "__click_params__", []))
+            wrapper = _decorate_standard_options(click, wrapper, self.version)
+            self._click_command = click.command(*command_args, **command_kwargs)(wrapper)
+            return self._click_command
+
+        return decorator
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if self._click_command is None:
+            raise RuntimeError("No command has been registered on this base_cli.App.")
+        return self._click_command(*args, **kwargs)
+
+    def _create_context(self, standard: dict[str, Any], sensitive_options: set[str]) -> Context:
+        del sensitive_options
+        run_id = make_run_id()
+        manifest_path = discover_manifest(Path.cwd())
+        project_root = manifest_path.parent if manifest_path is not None else None
+        explicit_config = Path(standard["config"]).expanduser() if standard.get("config") else None
+        config = load_config(project_root, explicit_config)
+
+        environment = standard.get("environment") or config.get("environment") or "dev"
+        debug = bool(standard.get("debug") or str(config.get("log_level", "")).lower() == "debug")
+        keep_temp = bool(standard.get("keep_temp") or config.get("keep_temp"))
+
+        state_dir = base_state_root() / "cli" / self.name
+        log_dir = state_dir / "logs"
+        cache_dir = state_dir / "cache"
+        temp_dir = state_dir / "tmp" / run_id
+        for directory in (log_dir, cache_dir, temp_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        log_file = Path(standard["log_file"]).expanduser() if standard.get("log_file") else log_dir / f"{run_id}.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        logger = configure_logger(self.name, log_file, debug)
+        logger.debug("cli=%s run_id=%s environment=%s", self.name, run_id, environment)
+
+        return Context(
+            cli_name=self.name,
+            run_id=run_id,
+            base_home=resolve_base_home(),
+            project_root=project_root,
+            manifest_path=manifest_path,
+            state_dir=state_dir,
+            log_dir=log_dir,
+            cache_dir=cache_dir,
+            temp_dir=temp_dir,
+            log_file=log_file,
+            config=config,
+            environment=environment,
+            debug=debug,
+            keep_temp=keep_temp,
+            log=logger,
+        )
+
+
+def command(*args: Any, **kwargs: Any):
+    return App().command(*args, **kwargs)
+
+
+def option(*param_decls: str, sensitive: bool = False, **attrs: Any):
+    click = _require_click()
+
+    def decorator(func: Callable[..., Any]):
+        decorated = click.option(*param_decls, **attrs)(func)
+        if sensitive:
+            options = set(getattr(decorated, "__base_cli_sensitive_options__", set()))
+            options.add(parameter_name_from_decls(param_decls))
+            decorated.__base_cli_sensitive_options__ = options
+        return decorated
+
+    return decorator
+
+
+def _decorate_standard_options(click: Any, func: Callable[..., Any], version: str | None):
+    func = click.option("--log-file", type=click.Path(dir_okay=False), help="Override the persistent log file.")(func)
+    func = click.option("--keep-temp", is_flag=True, help="Preserve this run's temp directory.")(func)
+    func = click.option("--config", type=click.Path(dir_okay=False), help="Load an additional config file.")(func)
+    func = click.option("--environment", help="Set the Base CLI environment.")(func)
+    func = click.option("--debug", is_flag=True, help="Enable DEBUG logging on the user-facing stream.")(func)
+    if version is not None:
+        func = click.version_option(version)(func)
+    return func
+
+
+def _pop_standard_options(kwargs: dict[str, Any]) -> dict[str, Any]:
+    standard = {}
+    for key in ("debug", "environment", "config", "keep_temp", "log_file"):
+        standard[key] = kwargs.pop(key, None)
+    return standard
+

--- a/cli/python/base_cli/config.py
+++ b/cli/python/base_cli/config.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def load_yaml_file(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to load base_cli configuration.") from exc
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Config file '{path}' must contain a YAML mapping.")
+    return data
+
+
+def merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = merge_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_config(
+    project_root: Path | None,
+    explicit_config: Path | None,
+    home: Path | None = None,
+) -> dict[str, Any]:
+    root = home or Path.home()
+    config: dict[str, Any] = {}
+    config = merge_dicts(config, load_yaml_file(Path("/etc/base.d/config.yaml")))
+    config = merge_dicts(config, load_yaml_file(root / ".base.d" / "config.yaml"))
+    if project_root is not None:
+        config = merge_dicts(config, load_yaml_file(project_root / ".base" / "config.yaml"))
+    if explicit_config is not None:
+        config = merge_dicts(config, load_yaml_file(explicit_config))
+
+    env_config: dict[str, Any] = {}
+    if "BASE_CLI_ENVIRONMENT" in os.environ:
+        env_config["environment"] = os.environ["BASE_CLI_ENVIRONMENT"]
+    if "BASE_CLI_LOG_LEVEL" in os.environ:
+        env_config["log_level"] = os.environ["BASE_CLI_LOG_LEVEL"]
+    if "BASE_CLI_KEEP_TEMP" in os.environ:
+        env_config["keep_temp"] = os.environ["BASE_CLI_KEEP_TEMP"].lower() == "true"
+    return merge_dicts(config, env_config)
+

--- a/cli/python/base_cli/context.py
+++ b/cli/python/base_cli/context.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import contextvars
+import logging
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+
+_current_context: contextvars.ContextVar[Context | None] = contextvars.ContextVar(
+    "base_cli_current_context",
+    default=None,
+)
+
+
+@dataclass
+class Context:
+    cli_name: str
+    run_id: str
+    state_dir: Path
+    log_dir: Path
+    cache_dir: Path
+    temp_dir: Path
+    log_file: Path
+    config: dict
+    environment: str
+    debug: bool
+    keep_temp: bool
+    log: logging.Logger
+    base_home: Path | None = None
+    project_root: Path | None = None
+    manifest_path: Path | None = None
+    cleanup_hooks: list[Callable[[], None]] = field(default_factory=list)
+
+    def on_cleanup(self, hook: Callable[[], None]) -> None:
+        self.cleanup_hooks.append(hook)
+
+    def cleanup(self) -> None:
+        for hook in self.cleanup_hooks:
+            hook()
+        for handler in list(self.log.handlers):
+            handler.flush()
+            handler.close()
+            self.log.removeHandler(handler)
+        if not self.keep_temp and self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+
+
+def set_current_context(context: Context | None) -> contextvars.Token[Context | None]:
+    return _current_context.set(context)
+
+
+def reset_current_context(token: contextvars.Token[Context | None]) -> None:
+    _current_context.reset(token)
+
+
+def get_current_context() -> Context:
+    context = _current_context.get()
+    if context is None:
+        raise RuntimeError("base_cli context is not active. Run inside a base_cli.App command.")
+    return context
+

--- a/cli/python/base_cli/logging.py
+++ b/cli/python/base_cli/logging.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+import platform
+import sys
+from pathlib import Path
+
+from .context import get_current_context
+from .redaction import redact_argv
+
+
+def configure_logger(
+    cli_name: str,
+    log_file: Path,
+    debug: bool,
+) -> logging.Logger:
+    logger = logging.getLogger(f"base_cli.{cli_name}")
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    for handler in list(logger.handlers):
+        handler.close()
+        logger.removeHandler(handler)
+
+    user_handler = logging.StreamHandler()
+    user_handler.setLevel(logging.DEBUG if debug else logging.INFO)
+    user_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logger.addHandler(user_handler)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logger.addHandler(file_handler)
+    return logger
+
+
+def log_invocation(logger: logging.Logger, argv: list[str], sensitive_options: set[str]) -> None:
+    logger.debug("argv=%s", redact_argv(argv, sensitive_options))
+    logger.debug("platform=%s %s", platform.system(), platform.machine())
+    logger.debug("python=%s", sys.version.replace("\n", " "))
+
+
+def log_debug(message: str, *args: object) -> None:
+    get_current_context().log.debug(message, *args)
+
+
+def log_info(message: str, *args: object) -> None:
+    get_current_context().log.info(message, *args)
+
+
+def log_warning(message: str, *args: object) -> None:
+    get_current_context().log.warning(message, *args)
+
+
+def log_error(message: str, *args: object) -> None:
+    get_current_context().log.error(message, *args)
+
+
+def log_critical(message: str, *args: object) -> None:
+    get_current_context().log.critical(message, *args)
+

--- a/cli/python/base_cli/paths.py
+++ b/cli/python/base_cli/paths.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from pathlib import Path
+
+
+def base_state_root(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".base.d"
+
+
+def make_run_id() -> str:
+    timestamp = time.strftime("%Y%m%dT%H%M%S")
+    return f"{timestamp}_{uuid.uuid4().hex[:8]}"
+
+
+def normalize_cli_name(name: str) -> str:
+    stem = Path(name).name
+    if "." in stem:
+        stem = stem.rsplit(".", 1)[0]
+    return stem.replace(" ", "-")
+
+
+def discover_manifest(start: Path) -> Path | None:
+    current = start.resolve()
+    if current.is_file():
+        current = current.parent
+
+    while True:
+        candidate = current / "base_manifest.yaml"
+        if candidate.is_file():
+            return candidate
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def resolve_base_home() -> Path | None:
+    value = os.environ.get("BASE_HOME")
+    if not value:
+        return None
+    return Path(value).expanduser().resolve()
+

--- a/cli/python/base_cli/redaction.py
+++ b/cli/python/base_cli/redaction.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+
+REDACTED = "[REDACTED]"
+
+
+def option_name_to_parameter(param_decl: str) -> str:
+    name = param_decl.lstrip("-")
+    return name.replace("-", "_")
+
+
+def parameter_name_from_decls(param_decls: tuple[str, ...]) -> str:
+    options = [decl for decl in param_decls if decl.startswith("--")]
+    if options:
+        return option_name_to_parameter(options[0])
+    return option_name_to_parameter(param_decls[0])
+
+
+def redact_argv(argv: list[str], sensitive_options: set[str]) -> list[str]:
+    redacted: list[str] = []
+    skip_next = False
+    for arg in argv:
+        if skip_next:
+            redacted.append(REDACTED)
+            skip_next = False
+            continue
+
+        option, separator, value = arg.partition("=")
+        normalized = option_name_to_parameter(option) if option.startswith("--") else option
+        if option.startswith("--") and normalized in sensitive_options:
+            if separator:
+                redacted.append(f"{option}={REDACTED}")
+            else:
+                redacted.append(option)
+                skip_next = True
+            continue
+
+        redacted.append(arg)
+    return redacted
+

--- a/cli/python/base_cli/testing.py
+++ b/cli/python/base_cli/testing.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def invoke(app: Any, args: list[str] | None = None, home: Path | None = None):
+    try:
+        from click.testing import CliRunner
+    except ImportError as exc:
+        raise RuntimeError("Click is required for base_cli.testing. Run 'basectl setup' to install it.") from exc
+
+    env = {}
+    if home is not None:
+        env["HOME"] = str(home)
+    runner = CliRunner()
+    return runner.invoke(app._click_command, args or [], env=env)
+

--- a/cli/python/base_cli/tests/test_base_cli.py
+++ b/cli/python/base_cli/tests/test_base_cli.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+import base_cli
+from base_cli.paths import base_state_root, discover_manifest, normalize_cli_name
+from base_cli.redaction import redact_argv
+
+
+class BaseCliTests(unittest.TestCase):
+    def test_import_has_no_state_directory_side_effect(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+                self.assertFalse((home / ".base.d").exists())
+
+    def test_path_helpers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            nested = root / "a" / "b"
+            nested.mkdir(parents=True)
+            (root / "base_manifest.yaml").write_text("project:\n  name: demo\n", encoding="utf-8")
+
+            self.assertEqual(base_state_root(root), root / ".base.d")
+            self.assertEqual(normalize_cli_name("/tmp/demo.py"), "demo")
+            self.assertEqual(discover_manifest(nested), (root / "base_manifest.yaml").resolve())
+
+    def test_redacts_sensitive_option_values(self) -> None:
+        argv = ["tool", "--api-key", "secret", "--token=hidden", "--name", "visible"]
+
+        self.assertEqual(
+            redact_argv(argv, {"api_key", "token"}),
+            ["tool", "--api-key", "[REDACTED]", "--token=[REDACTED]", "--name", "visible"],
+        )
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_runs_with_context_and_cleans_temp_dir(self) -> None:
+        app = base_cli.App(name="demo", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        @base_cli.option("--name", required=True)
+        def main(ctx: base_cli.Context, name: str) -> None:
+            seen["name"] = name
+            seen["temp_dir"] = ctx.temp_dir
+            seen["cache_dir"] = ctx.cache_dir
+            ctx.log.info("hello %s", name)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+                from base_cli.testing import invoke
+
+                stderr = io.StringIO()
+                with redirect_stderr(stderr):
+                    result = invoke(app, ["--name", "Ada"], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(seen["name"], "Ada")
+            self.assertFalse(seen["temp_dir"].exists())
+            self.assertTrue(seen["cache_dir"].is_dir())
+            self.assertTrue((home / ".base.d" / "cli" / "demo" / "logs").is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/base-cli-design.md
+++ b/docs/base-cli-design.md
@@ -1,114 +1,141 @@
-# base_cli — Design Specification
+# base_cli Design
 
-> The Python standardization layer for all CLIs in the Base ecosystem.
+`base_cli` is the Python CLI foundation for Base and Base-supported projects.
+It wraps Click with Base conventions for runtime context, logging, run-scoped
+temporary files, cache directories, configuration, and manifest-aware project
+execution.
 
----
+The goal is **minimal boilerplate**, not magic. Importing `base_cli` must be
+cheap and side-effect free. Runtime infrastructure is initialized explicitly
+when a `base_cli.App` command is invoked.
 
-## 1. Overview
+## Goals
 
-`base_cli` is a Python package that sits on top of [Click](https://click.palletsprojects.com/) and provides a unified, opinionated framework for building CLIs within the Base ecosystem. It eliminates boilerplate, enforces consistency, and transparently handles cross-cutting concerns — logging, temp files, cache, configuration, interrupt handling, and cloud telemetry — so CLI authors focus entirely on business logic.
+- Make Base Python CLIs consistent without hiding Click.
+- Provide a single context object with Base, project, logging, temp, and cache
+  information.
+- Keep CLI code readable and close to ordinary Python functions.
+- Support Base itself and project CLIs that live in repositories managed by
+  Base.
+- Use `~/.base.d` for Base-owned user state.
+- Keep v1 local-only. Cloud telemetry is intentionally out of scope.
 
-### Design Philosophy
+## Non-Goals For V1
 
-- **Transparency first**: Infrastructure initializes automatically on import. CLI authors do not configure it.
-- **Opinionated by default**: Sensible defaults for all behaviors; overrides are explicit and layered.
-- **Simplicity is the ultimate sophistication**: Every decision prioritizes clarity over clever abstraction.
-- **Cross-platform**: Works on macOS (Apple Silicon and Intel) and Linux without platform-specific code from CLI authors.
-- **Supports both interactive and headless modes**: User-facing CLIs and background daemons (systemd, launchd) are first-class citizens.
+- No cloud log upload.
+- No plugin system.
+- No daemon/syslog integration beyond clean non-interactive behavior.
+- No full caching framework.
+- No automatic initialization on import.
 
----
-
-## 2. Package Name and Import
+## Author Experience
 
 ```python
 import base_cli
+
+app = base_cli.App(name="greet", version="0.1.0")
+
+
+@app.command()
+@base_cli.option("--name", required=True, help="Name to greet.")
+def main(ctx: base_cli.Context, name: str) -> None:
+    ctx.log.info("Hello, %s", name)
+
+
+if __name__ == "__main__":
+    app()
 ```
 
-A single import is all that is required. All infrastructure initializes automatically.
+The command function receives `ctx` as its first argument. Infrastructure is
+created immediately before command execution and cleaned up afterward.
+
+## Package Layout
+
+```text
+cli/python/base_cli/
+  __init__.py
+  app.py
+  config.py
+  context.py
+  logging.py
+  paths.py
+  redaction.py
+  testing.py
+```
+
+## Context
+
+`Context` is the center of the API:
 
 ```python
-# CLI author's main.py — complete boilerplate-free example
-import base_cli
-
-@base_cli.command()
-@base_cli.option("--name", help="Your name")
-def greet(name):
-    base_cli.log_info(f"Hello, {name}")
+ctx.cli_name       # str
+ctx.run_id         # str
+ctx.base_home      # Path | None
+ctx.project_root   # Path | None
+ctx.manifest_path  # Path | None
+ctx.state_dir      # ~/.base.d/cli/<cli-name>
+ctx.log_dir        # state_dir/logs
+ctx.cache_dir      # state_dir/cache
+ctx.temp_dir       # state_dir/tmp/<run-id>
+ctx.log_file       # log_dir/<run-id>.log
+ctx.config         # dict
+ctx.environment    # str
+ctx.debug          # bool
+ctx.keep_temp      # bool
+ctx.log            # logging.Logger
 ```
 
----
+Project discovery walks upward from the invocation directory looking for
+`base_manifest.yaml`. If found, `project_root` is the manifest's parent and
+`manifest_path` points to the manifest. The context does not need to fully parse
+the manifest in v1; deeper manifest interpretation belongs to project setup and
+artifact management.
 
-## 3. Initialization on Import
+`base_home` is read from `BASE_HOME` when available and otherwise remains
+`None`. Python CLIs invoked through Base wrappers should have `BASE_HOME` set.
 
-When `base_cli` is imported, the following happens automatically — in order, silently, and quickly:
+## State Directories
 
-1. Detect runtime mode: interactive TTY vs. headless daemon
-2. Resolve the CLI name from `sys.argv[0]`
-3. Create the standard directory structure under `~/.based/` (see Section 4)
-4. Initialize the dual logging streams (see Section 5)
-5. Log the full invocation — CLI name + all arguments — at DEBUG level
-6. Create a temporary directory for this run (see Section 7)
-7. Register signal handlers for interrupt and termination (see Section 9)
+All Base-owned user state remains under `~/.base.d`.
 
-No network calls are made on import. Initialization is fast and side-effect-free from the CLI author's perspective.
-
----
-
-## 4. Standard Directory Structure
-
-All Base-managed state lives under `~/.based/` in the user's home directory.
-
-```
-~/.based/
+```text
+~/.base.d/
   cli/
     <cli-name>/
       logs/
-        2025-04-15T10-30-00_abc123.log   # one file per run
-        2025-04-14T09-00-00_xyz789.log
+        <run-id>.log
       cache/
-        ...                               # persistent across runs
       tmp/
-        2025-04-15T10-30-00_abc123/       # ephemeral, per-run
+        <run-id>/
 ```
 
-The CLI name is derived from the invoked script name (the basename of `sys.argv[0]`, without extension).
+Directory lifecycle:
 
-### Directory Lifecycle
-
-| Directory | Created | Destroyed |
+| Directory | Created | Removed |
 |---|---|---|
-| `logs/` | On first run | Never (retention policy applies) |
-| `cache/` | On first run | Never (explicit clear or CLI logic) |
-| `tmp/<run>/` | On import | On exit (unless `BASE_CLI_KEEP_TEMP=true`) |
+| `logs/` | before command execution | never by default |
+| `cache/` | before command execution | explicit CLI logic only |
+| `tmp/<run-id>/` | before command execution | after command execution unless kept |
 
----
+## Logging
 
-## 5. Logging
-
-### Dual-Stream Architecture
-
-Every CLI run produces two independent logging streams:
+Every run gets two streams:
 
 | Stream | Destination | Level | Format |
 |---|---|---|---|
-| User stream | stdout / stderr | User-configured (default: INFO) | Human-readable, optionally colorized |
-| Persistent stream | `~/.based/cli/<name>/logs/<timestamp>.log` | Always DEBUG | Structured, with timestamps |
+| user | stderr | INFO by default, DEBUG with `--debug` | concise text |
+| persistent | `ctx.log_file` | DEBUG | timestamped text |
 
-The persistent stream is always DEBUG regardless of the user's chosen level. This ensures full diagnostic context is available after a failure — even if the user did not request verbose output at runtime.
+`base_cli` logs invocation metadata at DEBUG level:
 
-### Log Levels
+- CLI name
+- run ID
+- argv with sensitive values redacted
+- platform
+- Python version
+- project root and manifest path when discovered
 
-`base_cli` uses Python's standard `logging` module with its five built-in levels. No custom levels are added.
-
-| Level | User stream | Persistent stream |
-|---|---|---|
-| DEBUG | Only if `--debug` flag set | Always |
-| INFO | Yes (default) | Always |
-| WARNING | Yes | Always |
-| ERROR | Yes | Always |
-| CRITICAL | Yes | Always |
-
-### Logging API
+The public convenience API mirrors the logger:
 
 ```python
 base_cli.log_debug("message")
@@ -116,271 +143,126 @@ base_cli.log_info("message")
 base_cli.log_warning("message")
 base_cli.log_error("message")
 base_cli.log_critical("message")
-
-# Sensitive data — shown to user but redacted from file and cloud upload
-base_cli.log_info("Token accepted", redact=True)
 ```
 
-The `redact=True` parameter is available on all five logging functions. When set, the message is shown on the user-facing stream but replaced with `[REDACTED]` in the persistent log and excluded from cloud uploads.
+These functions log to the current active context. CLI code should prefer
+`ctx.log` when it already has a context.
 
-### Automatic Invocation Logging
+## Redaction
 
-On every run, `base_cli` automatically logs at DEBUG level:
+Options may be marked sensitive:
 
-- Full command invocation (`sys.argv`)
-- Timestamp and run ID
-- Platform (OS, architecture)
-- Python version
-- Environment name (if set)
-
-CLI authors do not write any of this.
-
-### Headless / Daemon Mode
-
-When no TTY is detected (e.g., running under systemd or launchd), the user-facing stream is automatically redirected to syslog or a structured JSON log format suitable for log aggregation. The persistent file stream continues as normal.
-
----
-
-## 6. Configuration
-
-### Layered Override Model
-
-Configuration is resolved in this priority order (highest to lowest):
-
-| Priority | Source | Example |
-|---|---|---|
-| 1 (highest) | Code hooks — explicit API calls | `base_cli.set_log_level("debug")` |
-| 2 | Config file | `~/.based/config.yaml` or project-level |
-| 3 | Command line arguments | `--debug`, `--environment prod` |
-| 4 (lowest) | Environment variables | `BASE_CLI_LOG_LEVEL=debug` |
-
-### Config File
-
-Config files are always YAML. They are discovered in this order:
-
-1. Current working directory: `.based.yaml`
-2. User home directory: `~/.based/config.yaml`
-3. System-wide: `/etc/based/config.yaml`
-
-Project-level config (CWD) takes precedence over user-level, which takes precedence over system-level.
-
-### Environment-Specific Config
-
-When an environment is set (via `--environment` or `BASE_CLI_ENVIRONMENT`), `base_cli` additionally loads:
-
-```
-~/.based/config.<environment>.yaml
+```python
+@base_cli.option("--api-key", sensitive=True)
 ```
 
-For example, `BASE_CLI_ENVIRONMENT=prod` loads `~/.based/config.prod.yaml`. Environment configs merge with the base config; the environment-specific values override.
+For v1, sensitive values are redacted from automatic invocation logging. More
+advanced redaction of arbitrary log messages can follow after the basic CLI
+shape is stable.
 
-Supported environments are open-ended (e.g., `dev`, `staging`, `prod`). `base_cli` does not hard-code environment names.
+## Configuration
 
-### Key Environment Variables
+Configuration is resolved from lowest to highest precedence:
+
+1. Code defaults
+2. System config: `/etc/base.d/config.yaml`
+3. User config: `~/.base.d/config.yaml`
+4. Project config: `<project-root>/.base/config.yaml`
+5. Environment variables
+6. Command line options
+7. Explicit runtime API overrides
+
+V1 implements the shape and context fields, but only needs a minimal config
+loader: YAML files are merged when present, environment is read from
+`BASE_CLI_ENVIRONMENT`, and CLI options can override `--environment`, `--debug`,
+`--keep-temp`, and `--log-file`.
+
+Standard environment variables:
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `BASE_CLI_LOG_LEVEL` | User-facing log level | `info` |
-| `BASE_CLI_ENVIRONMENT` | Active environment | `dev` |
-| `BASE_CLI_KEEP_TEMP` | Preserve temp dir after run | `false` |
-| `BASE_CLI_TEMP_RETENTION_DAYS` | Days to keep old temp dirs | `7` |
-| `BASE_CLI_NO_CLOUD_UPLOAD` | Disable cloud log upload | `false` |
-| `BASE_CLI_CLOUD_BUCKET` | Cloud bucket for log upload | _(unset)_ |
+| `BASE_CLI_ENVIRONMENT` | active environment | `dev` |
+| `BASE_CLI_LOG_LEVEL` | user stream log level | `info` |
+| `BASE_CLI_KEEP_TEMP` | keep run temp directory | `false` |
+| `BASE_CLI_TEMP_RETENTION_DAYS` | prune retained temp dirs older than N days | `7` |
 
----
+## Standard Options
 
-## 7. Temporary File Handling
+Every `base_cli.App` command gets:
 
-### Automatic Lifecycle
-
-On import, `base_cli` creates a run-scoped temp directory using Python's `tempfile` module, which handles platform differences (macOS, Linux) automatically.
-
-```python
-# Accessible to CLI authors as:
-base_cli.temp_dir   # Path object pointing to the run's temp directory
-```
-
-The temp directory is automatically deleted on clean exit and on interrupt (see Section 9), unless `BASE_CLI_KEEP_TEMP=true`.
-
-### Retention Policy
-
-When `BASE_CLI_KEEP_TEMP=true`, temp directories from previous runs are preserved. To prevent unbounded growth, `base_cli` prunes temp directories older than `BASE_CLI_TEMP_RETENTION_DAYS` (default: 7 days) at the start of each run.
-
-### No Output File Management
-
-Output files produced by a CLI are the CLI author's responsibility. `base_cli` does not manage output paths. The user specifies output locations through CLI arguments or config.
-
----
-
-## 8. Cache Management
-
-### Persistent Cache Directory
-
-```python
-base_cli.cache_dir   # Path object pointing to ~/.based/cli/<name>/cache/
-```
-
-The cache directory persists across runs. `base_cli` provides the directory; individual CLIs decide what to store and when to invalidate.
-
-Cache management is intentionally minimal at the base_cli level — it is a convention and location standard, not a full caching framework.
-
----
-
-## 9. Interrupt Handling
-
-### Default Behavior
-
-`base_cli` registers signal handlers for `SIGINT` (Ctrl+C) and `SIGTERM` on import. On interrupt:
-
-1. Flush and close all log file handles
-2. Write a final log entry noting the interruption
-3. Clean up the temp directory (unless `BASE_CLI_KEEP_TEMP=true`)
-4. Call any registered user cleanup hooks (in registration order)
-5. Exit cleanly
-
-### User Cleanup Hooks
-
-CLI authors can register optional cleanup functions:
-
-```python
-def my_cleanup():
-    # close connections, finalize output, etc.
-    pass
-
-base_cli.on_interrupt(my_cleanup)
-```
-
-Multiple hooks can be registered. They are called in the order registered, after base_cli's own cleanup.
-
----
-
-## 10. Command Line Argument Handling
-
-### Click as the Foundation
-
-`base_cli` wraps [Click](https://click.palletsprojects.com/) — the standard Python CLI framework — to enforce uniformity while preserving Click's full power. CLI authors use `base_cli` decorators, which delegate to Click under the hood.
-
-```python
-# Instead of @click.command(), use:
-@base_cli.command()
-
-# Instead of @click.option(), use:
-@base_cli.option()
-```
-
-### Why a Wrapper?
-
-Without the wrapper layer, there is no mechanism to:
-- Automatically redact sensitive arguments before logging or cloud upload
-- Inject standard arguments across all CLIs uniformly
-- Integrate argument parsing with the logging and config systems
-- Enforce consistent error handling and exit codes
-
-### Sensitive Argument Redaction
-
-CLI authors annotate sensitive arguments at definition time:
-
-```python
-@base_cli.option("--api-key", sensitive=True, help="API key")
-```
-
-When `sensitive=True`, the argument value is:
-- Never written to the persistent log file
-- Never included in cloud uploads
-- Replaced with `[REDACTED]` in all log output
-
-### Standard Arguments — Provided by base_cli for All CLIs
-
-The following arguments are automatically available in every CLI without the author declaring them:
-
-| Argument | Purpose |
+| Option | Purpose |
 |---|---|
-| `--debug` | Enable DEBUG level on user-facing stream |
-| `--environment` | Set the active environment (dev/staging/prod) |
-| `--config` | Path to a custom config file |
-| `--no-cloud-upload` | Disable cloud log upload for this run |
-| `--log-file` | Override the default log file location |
-| `--version` | Show CLI version (auto-populated) |
-| `--help` | Show help (provided by Click) |
+| `--debug` | enable DEBUG on the user-facing stream |
+| `--environment <name>` | set the active environment |
+| `--config <path>` | load an additional config file |
+| `--keep-temp` | preserve this run's temp directory |
+| `--log-file <path>` | override the persistent log file |
+| `--version` | show the CLI version when configured |
+| `--help` | Click help |
 
----
+## Interrupt And Cleanup
 
-## 11. Cloud Log Telemetry
+`base_cli` may register signal handlers while a command is running. It must not
+register them on import. Cleanup should:
 
-### Purpose
+1. call user cleanup hooks
+2. flush and close log handlers
+3. remove `ctx.temp_dir` unless `keep_temp` is true
 
-When CLIs run across many engineers' laptops, `base_cli` can aggregate logs to a central cloud bucket. This enables:
+CLI authors can register hooks:
 
-- Usage analytics: which CLIs are most used, which subcommands are popular
-- Error pattern detection: what failures occur most frequently
-- Remote debugging: support staff can retrieve logs without user involvement
-
-### Upload Behavior
-
-Log upload happens asynchronously on CLI exit. `base_cli` uploads logs accumulated since the last successful upload (delta upload, not full history). Logs are scrubbed of sensitive data before upload.
-
-Upload is a no-op if `BASE_CLI_CLOUD_BUCKET` is not configured or `BASE_CLI_NO_CLOUD_UPLOAD=true`.
-
-### Multi-Cloud Design
-
-The upload mechanism is abstracted behind a provider interface. AWS S3 is the initial implementation. Additional providers (Azure Blob Storage, Google Cloud Storage) can be added as plugins.
-
-```yaml
-# ~/.based/config.yaml
-cloud:
-  provider: aws
-  bucket: my-org-cli-logs
-  region: us-west-2
-  retention_days: 90
+```python
+ctx.on_cleanup(close_connection)
 ```
 
-### Privacy and Consent
+## Testing
 
-- Sensitive arguments (marked `sensitive=True`) are never uploaded
-- Log messages marked `redact=True` are excluded from uploads
-- Upload can be disabled globally via environment variable or per-run via `--no-cloud-upload`
-- Future: explicit opt-in model with clear documentation of what is uploaded
+The package should include a small test helper:
 
----
+```python
+result = base_cli.testing.invoke(app, ["--debug"])
+```
 
-## 12. Platform Support
+This wraps Click's test runner and gives tests access to isolated `HOME`,
+captured output, and generated Base state.
 
-| Platform | Status |
-|---|---|
-| macOS (Apple Silicon) | Primary |
-| macOS (Intel) | Supported via Python/Homebrew abstraction |
-| Linux | Supported |
+## Phases
 
-Platform-specific differences (temp directory locations, signal handling, syslog integration) are handled internally by `base_cli` using Python's standard library. CLI authors write platform-agnostic code.
+### V1
 
----
+- `App`
+- `Context`
+- Click wrapper decorators
+- standard options
+- state directories under `~/.base.d`
+- user and file logging
+- run-scoped temp directory cleanup
+- cache directory provisioning
+- sensitive option redaction for invocation logging
+- manifest/project discovery
+- testing helper
 
-## 13. Future Considerations
+### V2
 
-- **Go equivalent**: `base_cli_go` — a Go package implementing the same philosophy for Go-based CLIs. Separate namespace, same conventions.
-- **Config file per CLI**: In addition to the project-level config, individual CLIs may support their own config file in a future iteration.
-- **Plugin system**: Extend cloud upload providers and other behaviors via a plugin registry.
-- **Usage dashboard**: A companion CLI (`based stats`) to visualize local and cloud-aggregated usage.
+- richer YAML config merging
+- project manifest loading helpers
+- version discovery conventions
+- subcommand groups
+- better error formatting and exit code conventions
 
----
+### V3
 
-## 14. Summary — What CLI Authors Get for Free
+- headless/syslog behavior
+- retained-temp pruning
+- structured persistent logs
 
-By adding `import base_cli` to their `main.py`, every CLI author automatically receives:
+### V4
 
-- Dual-stream logging (user-facing + always-debug file)
-- Automatic invocation logging (args, platform, timestamp)
-- Standard directory structure under `~/.based/`
-- Temp directory created and cleaned up per run
-- Cache directory provisioned and accessible
-- Interrupt handling with cleanup
-- Standard CLI arguments (`--debug`, `--environment`, `--config`, etc.)
-- Sensitive argument and log redaction framework
-- Cloud log upload (when configured)
-- Cross-platform compatibility (macOS + Linux)
+- optional cloud telemetry, with explicit opt-in, documented payloads, and
+  organization-level policy controls.
 
-All of this with **zero configuration code** in the CLI itself.
+## Summary
 
----
-
-*base_cli — Infrastructure that gets out of the way.*
+`base_cli` should feel like Click with Base batteries included. It should make
+the common path short, make runtime state visible through `Context`, and avoid
+surprising import-time side effects.


### PR DESCRIPTION
## Summary

- Rewrite `docs/base-cli-design.md` around the updated v1 design:
  - explicit `base_cli.App` / `Context` initialization
  - no import-time side effects
  - `~/.base.d` state layout
  - corrected config precedence
  - no cloud telemetry in v1
  - Base project and manifest awareness
- Add initial `cli/python/base_cli/` implementation:
  - `App`
  - `Context`
  - Click-backed `command` and `option` decorators
  - standard option wiring
  - user/file logging setup
  - run-scoped temp directories
  - cache/log directory provisioning
  - sensitive option redaction for invocation logging
  - project manifest discovery
  - testing helper
- Update `basectl setup` to install Click into Base's venv alongside PyYAML
- Add TODO tracking for the Base Python CLI layer
- Extend setup tests for the new Python bootstrap dependency

## Notes

`base_cli` imports without creating state. Runtime initialization happens when a registered `App` command executes.

The Click-dependent execution test is skipped when Click is not installed in the current Python. After `basectl setup` installs Click into Base's venv, that test will run in environments using the Base venv.

## Verification

- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/setup.sh`
- `env PYTHONPATH=cli/python python3 -m unittest discover -s cli/python/base_setup/tests`
- `env PYTHONPATH=cli/python python3 -m unittest discover -s cli/python/base_cli/tests`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- Full BATS suite: 137 passing, with the existing pseudo-tty skip