### PR TITLE
Add base-wrapper and default artifact manifest

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -9,19 +9,26 @@ This file is the shared working memory for future AI-assisted development in thi
 - New in-progress feature work adds the first artifact setup layer: root
   `base_manifest.yaml`, a Python `base_setup` package under `cli/python/`, and
   a Bash setup handoff after Base bootstrap.
-- The Python layer now reads manifests with PyYAML. PyYAML is a Base bootstrap
-  dependency installed by the Bash setup layer into `~/.base.d/.venv`, not a
-  project artifact.
+- The Bash setup layer seeds Base's own project virtual environment at
+  `~/.base.d/base/.venv` with PyYAML and Click before invoking Python setup.
 - Current in-progress work rewrites `docs/base-cli-design.md` around explicit
   `base_cli.App`/`Context` initialization and starts v1 under `lib/python/base_cli/`.
-  Click is a Base Python bootstrap dependency installed into `~/.base.d/.venv`.
+  Click is a Base Python bootstrap dependency installed into `~/.base.d/base/.venv`.
 - Most recent local work dogfoods `base_cli` in `base_setup`: the Python setup
   engine now uses `base_cli.App`, `base_cli.argument`, `base_cli.option`, and
   `Context` logging while preserving the existing module CLI shape.
+- `bin/base-wrapper` is the single Python command wrapper, uses
+  `~/.base.d/<project>/.venv`, and invokes package commands such as
+  `base_setup`. Base itself uses project name `base`.
+- Default project artifacts are declared in `lib/base/default_manifest.yaml`
+  using the same manifest shape as project manifests; the Python setup layer
+  merges defaults with the project manifest before reconciling artifacts.
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change adds `basectl update-profile --no-defaults`, including conflict handling with `--defaults`, docs, and BATS coverage.
+- Most recent uncommitted change adds `base-wrapper`, moves Base's venv to
+  `~/.base.d/base/.venv`, and teaches the Python setup layer to merge default
+  artifacts from `lib/base/default_manifest.yaml`.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -129,3 +129,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Use `base_cli.Context` logging and path initialization, and keep Bash `basectl setup` behavior unchanged.
   - Verify with Base's real virtual environment after `basectl setup` installs Click.
   - Done locally; pending commit.
+
+- [x] Add `base-wrapper` as the Python command execution wrapper.
+  - Files: `bin/base-wrapper`, `cli/bash/commands/basectl/subcommands/setup_common.sh`, `lib/base/default_manifest.yaml`
+  - Goal: expose one internal Python package execution path that selects `~/.base.d/<project>/.venv`, sets `BASE_HOME`, `BASE_PROJECT`, and `PYTHONPATH`, and runs `python -m <package>`.
+  - Use `base` as the default project for now.
+  - Move Base's venv from `~/.base.d/.venv` to `~/.base.d/base/.venv`.
+  - Add default artifact manifest using the same manifest shape as project manifests.
+  - Done locally; pending commit.

--- a/bin/base-wrapper
+++ b/bin/base-wrapper
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+base_wrapper_die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+base_wrapper_resolve_path() {
+    local source_path="${1:-}"
+    local link_dir target
+
+    [[ -n "$source_path" ]] || return 1
+
+    if [[ "$source_path" != */* ]]; then
+        source_path="$(command -v -- "$source_path" 2>/dev/null || true)"
+        [[ -n "$source_path" ]] || return 1
+    fi
+
+    while [[ -L "$source_path" ]]; do
+        link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+        target="$(readlink "$source_path")" || return 1
+        if [[ "$target" == /* ]]; then
+            source_path="$target"
+        else
+            source_path="$link_dir/$target"
+        fi
+    done
+
+    link_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    printf '%s/%s\n' "$link_dir" "$(basename -- "$source_path")"
+}
+
+base_wrapper_base_home() {
+    local source_path bin_dir
+
+    source_path="$(base_wrapper_resolve_path "$0")" || return 1
+    bin_dir="$(cd -- "$(dirname -- "$source_path")" && pwd -P)" || return 1
+    cd -- "$bin_dir/.." && pwd -P
+}
+
+base_wrapper_usage() {
+    cat <<'EOF'
+Usage:
+  base-wrapper [--project <name>] <python-package> [args...]
+
+Options:
+  --project <name>  Run using ~/.base.d/<name>/.venv.
+  -h, --help        Show this help text.
+
+Purpose:
+  Run Base Python command packages through the selected project virtual
+  environment with Base's Python library and command roots on PYTHONPATH.
+EOF
+}
+
+main() {
+    local base_home project package python_bin old_pythonpath base_pythonpath
+
+    base_home="$(base_wrapper_base_home)" || base_wrapper_die "Unable to resolve Base home."
+    project="${BASE_PROJECT:-base}"
+
+    while (($#)); do
+        case "$1" in
+            -h|--help)
+                base_wrapper_usage
+                return 0
+                ;;
+            --project)
+                shift
+                [[ -n "${1:-}" ]] || base_wrapper_die "Option '--project' requires an argument."
+                project="$1"
+                ;;
+            --)
+                shift
+                break
+                ;;
+            --*)
+                base_wrapper_die "Unknown option '$1'."
+                ;;
+            *)
+                break
+                ;;
+        esac
+        shift
+    done
+
+    package="${1:-}"
+    [[ -n "$package" ]] || {
+        base_wrapper_usage >&2
+        return 2
+    }
+    shift
+
+    case "$project" in
+        ""|*/*|.*|*..*)
+            base_wrapper_die "Invalid BASE_PROJECT '$project'."
+            ;;
+    esac
+    case "$package" in
+        ""|*/*|.*|*..*)
+            base_wrapper_die "Expected a Python package name, got '$package'."
+            ;;
+    esac
+
+    BASE_HOME="$base_home"
+    BASE_PROJECT="$project"
+    export BASE_HOME BASE_PROJECT
+
+    python_bin="${BASE_PROJECT_VENV_DIR:-$HOME/.base.d/$project/.venv}/bin/python"
+    [[ -x "$python_bin" ]] || base_wrapper_die "Project virtual environment Python was not found at '$python_bin'. Run 'basectl setup'."
+
+    base_pythonpath="$BASE_HOME/lib/python:$BASE_HOME/cli/python"
+    old_pythonpath="${PYTHONPATH-}"
+    if [[ -n "$old_pythonpath" ]]; then
+        PYTHONPATH="$base_pythonpath:$old_pythonpath"
+    else
+        PYTHONPATH="$base_pythonpath"
+    fi
+    export PYTHONPATH
+
+    exec "$python_bin" -m "$package" "$@"
+}
+
+main "$@"

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -85,7 +85,7 @@ basectl_verify_home() {
         return 1
     fi
 
-    for file in VERSION base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/baserc_guard.sh lib/bash/runtime/bashrc lib/bash/version/lib_version.sh bin/basectl cli/bash/commands/basectl/basectl.sh; do
+    for file in VERSION base_init.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/baserc_guard.sh lib/bash/runtime/bashrc lib/bash/version/lib_version.sh bin/basectl bin/base-wrapper cli/bash/commands/basectl/basectl.sh; do
         if [[ ! -f "$base_home/$file" ]]; then
             missing+=("$file")
         fi

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -25,7 +25,7 @@ Check does:
   2. Verify Xcode Command Line Tools are installed.
   3. Verify Python 3.13 is installed via Homebrew.
   4. Verify BATS is installed via Homebrew.
-  5. Verify ~/.base.d/.venv exists.
+  5. Verify ~/.base.d/base/.venv exists.
 EOF
 }
 

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -27,7 +27,7 @@ Setup does:
   2. Install Xcode Command Line Tools if needed.
   3. Install Python 3.13 via Homebrew if needed.
   4. Install BATS via Homebrew if needed.
-  5. Create ~/.base.d/.venv if it does not already exist.
+  5. Create ~/.base.d/base/.venv if it does not already exist.
   6. Install Base Python bootstrap packages into the Base virtual environment.
   7. Invoke the Python project setup layer for base_manifest.yaml artifacts.
 

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -20,7 +20,7 @@ readonly _base_setup_common_sourced
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset dry_run DRY_RUN BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_PYYAML_READY
+    unset dry_run DRY_RUN BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_PYYAML_READY BASE_PROJECT
 }
 
 setup_enable_dry_run() {
@@ -44,7 +44,7 @@ setup_virtualenv_exists() {
 }
 
 setup_venv_dir() {
-    printf '%s\n' "${BASE_SETUP_VENV_DIR:-$HOME/.base.d/.venv}"
+    printf '%s\n' "${BASE_SETUP_VENV_DIR:-$HOME/.base.d/base/.venv}"
 }
 
 setup_python_formula() {
@@ -362,31 +362,18 @@ setup_install_click() {
     setup_install_base_python_package "$(setup_click_package)"
 }
 
-setup_project_setup_python_bin() {
-    local venv_dir python_bin
-
-    venv_dir="$(setup_venv_dir)"
-    python_bin="$venv_dir/bin/python"
-    if [[ -x "$python_bin" ]]; then
-        printf '%s\n' "$python_bin"
-        return 0
-    fi
-
-    setup_find_python_bin
-}
-
 setup_run_project_artifact_setup() {
-    local python_bin old_pythonpath
-    local exit_code
+    local exit_code project wrapper
     local args=()
-    local base_pythonpath="$BASE_HOME/lib/python:$BASE_HOME/cli/python"
 
     if setup_is_dry_run && [[ "${BASE_SETUP_PYYAML_READY:-}" != true ]]; then
         log_info "[DRY-RUN] Would run Python project setup layer after PyYAML is installed."
         return 0
     fi
 
-    python_bin="$(setup_project_setup_python_bin)" || fatal_error "Unable to locate a python3 executable for project artifact setup."
+    project="${BASE_SETUP_PROJECT_NAME:-base}"
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     if setup_is_dry_run; then
         args+=(--dry-run)
@@ -394,28 +381,11 @@ setup_run_project_artifact_setup() {
     if [[ -n "${BASE_SETUP_MANIFEST:-}" ]]; then
         args+=(--manifest "$BASE_SETUP_MANIFEST")
     fi
-    if [[ -n "${BASE_SETUP_PROJECT_NAME:-}" ]]; then
-        args+=("$BASE_SETUP_PROJECT_NAME")
-    fi
-
-    old_pythonpath="${PYTHONPATH-}"
-    if [[ -n "$old_pythonpath" ]]; then
-        PYTHONPATH="$base_pythonpath:$old_pythonpath"
-    else
-        PYTHONPATH="$base_pythonpath"
-    fi
-    export PYTHONPATH
+    args+=("$project")
 
     log_info "Running Python project setup layer."
-    "$python_bin" -m base_setup "${args[@]}"
+    "$wrapper" --project "$project" base_setup "${args[@]}"
     exit_code=$?
-
-    if [[ -n "$old_pythonpath" ]]; then
-        PYTHONPATH="$old_pythonpath"
-        export PYTHONPATH
-    else
-        unset PYTHONPATH
-    fi
 
     exit_if_error "$exit_code" "Python project setup layer failed."
 }

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -114,6 +114,7 @@ run_basectl() {
         "$base_home/lib/bash/runtime/bashrc" \
         "$base_home/lib/bash/version/lib_version.sh" \
         "$base_home/bin/basectl" \
+        "$base_home/bin/base-wrapper" \
         "$base_home/cli/bash/commands/basectl/basectl.sh"
 
     run bash -c 'source "$1"; basectl_verify_home "$2"' _ \
@@ -121,6 +122,32 @@ run_basectl() {
         "$base_home"
 
     [ "$status" -eq 0 ]
+}
+
+
+@test "base-wrapper runs package commands in the selected project venv" {
+    local python_bin="$TEST_HOME/.base.d/demo/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+printf 'BASE_HOME=%s\n' "$BASE_HOME"
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'PYTHONPATH=%s\n' "$PYTHONPATH"
+printf 'ARGS=%s\n' "$*"
+EOF
+    chmod +x "$python_bin"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PYTHONPATH="existing" \
+        "$BASE_REPO_ROOT/bin/base-wrapper" --project demo base_setup --dry-run demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"PYTHONPATH=$BASE_REPO_ROOT/lib/python:$BASE_REPO_ROOT/cli/python:existing"* ]]
+    [[ "$output" == *"ARGS=-m base_setup --dry-run demo"* ]]
 }
 
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -325,7 +325,7 @@ run_base_command() {
 }
 
 @test "basectl setup is idempotent when brew, xcode tools, python, and the venv already exist" {
-    local venv_dir="$TEST_HOME/.base.d/.venv"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_brew_stub
     create_xcode_stubs
@@ -388,7 +388,7 @@ EOF
 
 @test "basectl setup installs missing dependencies and creates the Base virtual environment" {
     local installer
-    local venv_dir="$TEST_HOME/.base.d/.venv"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_xcode_stubs
     installer="$(create_homebrew_installer_stub)"
@@ -426,17 +426,17 @@ EOF
     [[ "$output" == *"[DRY-RUN] Would install Xcode Command Line Tools and wait for installation to complete."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python formula 'python@3.13' via Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would install BATS formula 'bats-core' via Homebrew."* ]]
-    [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/.venv'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python package 'PyYAML' in the Base virtual environment."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python package 'click' in the Base virtual environment."* ]]
     [[ "$output" == *"[DRY-RUN] Would run Python project setup layer after PyYAML is installed."* ]]
     [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
-    [ ! -e "$TEST_HOME/.base.d/.venv" ]
+    [ ! -e "$TEST_HOME/.base.d/base/.venv" ]
 }
 
 @test "basectl setup ignores inherited DRY_RUN without --dry-run" {
     local installer
-    local venv_dir="$TEST_HOME/.base.d/.venv"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_xcode_stubs
     installer="$(create_homebrew_installer_stub)"
@@ -457,7 +457,7 @@ EOF
 }
 
 @test "basectl check passes when all required components are present" {
-    local venv_dir="$TEST_HOME/.base.d/.venv"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_brew_stub
     create_xcode_stubs
@@ -487,7 +487,7 @@ EOF
     [[ "$output" == *"Xcode Command Line Tools are not installed."* ]]
     [[ "$output" == *"Python formula 'python@3.13' is not installed via Homebrew."* ]]
     [[ "$output" == *"BATS formula 'bats-core' is not installed via Homebrew."* ]]
-    [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/.venv'."* ]]
+    [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [[ "$output" == *"Base CLI environment check found missing requirements."* ]]
 }
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import venv
 from pathlib import Path
 
 import base_cli
 
-from .manifest import BaseManifest, ManifestError, discover_manifest, read_manifest
+from .manifest import ArtifactRequest, BaseManifest, ManifestError, discover_manifest, read_manifest
 from .registry import ArtifactDefinition, get_artifact_definition
 
 
@@ -41,7 +42,8 @@ def run(
     try:
         base_manifest = read_manifest(manifest_path)
         validate_project_name(base_manifest, project)
-        reconcile_manifest(ctx, base_manifest, dry_run=dry_run)
+        default_manifest = read_default_manifest(ctx)
+        reconcile_manifest(ctx, default_manifest, base_manifest, dry_run=dry_run)
         return 0
     except ManifestError as exc:
         ctx.log.error(str(exc))
@@ -62,17 +64,36 @@ def validate_project_name(manifest: BaseManifest, expected_project: str | None) 
         )
 
 
-def reconcile_manifest(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
+def read_default_manifest(ctx: base_cli.Context) -> BaseManifest:
+    if ctx.base_home is None:
+        raise ManifestError("BASE_HOME is required to load Base's default artifact manifest.")
+    default_manifest_path = ctx.base_home / "lib" / "base" / "default_manifest.yaml"
+    return read_manifest(default_manifest_path)
+
+
+def reconcile_manifest(
+    ctx: base_cli.Context,
+    default_manifest: BaseManifest,
+    manifest: BaseManifest,
+    dry_run: bool,
+) -> None:
     ctx.log.info("Reading Base manifest at '%s'.", manifest.path)
     ctx.log.info("Setting up project '%s'.", manifest.project_name)
 
-    project_root = manifest.path.parent
+    artifacts = merge_artifacts(default_manifest.artifacts, manifest.artifacts)
+    definitions = resolve_artifact_definitions(artifacts)
     if not manifest.artifacts:
         ctx.log.info("Project '%s' declares no artifacts.", manifest.project_name)
-        ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
-        return
 
-    for artifact in manifest.artifacts:
+    for artifact, definition in zip(artifacts, definitions, strict=True):
+        reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
+
+    ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
+
+
+def resolve_artifact_definitions(artifacts: tuple[ArtifactRequest, ...]) -> tuple[ArtifactDefinition, ...]:
+    definitions: list[ArtifactDefinition] = []
+    for artifact in artifacts:
         definition = get_artifact_definition(artifact.artifact_type, artifact.name)
         if definition is None:
             raise ArtifactError(
@@ -80,14 +101,35 @@ def reconcile_manifest(ctx: base_cli.Context, manifest: BaseManifest, dry_run: b
                 f"'{artifact.name}' of type '{artifact.artifact_type}'. "
                 "Base does not know how to manage this artifact yet."
             )
-        reconcile_artifact(ctx, project_root, definition, artifact.version, dry_run=dry_run)
+        definitions.append(definition)
+    return tuple(definitions)
 
-    ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
+
+def merge_artifacts(
+    default_artifacts: tuple[ArtifactRequest, ...],
+    manifest_artifacts: tuple[ArtifactRequest, ...],
+) -> tuple[ArtifactRequest, ...]:
+    merged: dict[tuple[str, str], ArtifactRequest] = {}
+
+    for artifact in default_artifacts:
+        merged[(artifact.artifact_type, artifact.name)] = artifact
+
+    for artifact in manifest_artifacts:
+        key = (artifact.artifact_type, artifact.name)
+        existing = merged.get(key)
+        if existing is not None and existing.version != artifact.version:
+            raise ArtifactError(
+                "Artifact "
+                f"'{artifact.name}' of type '{artifact.artifact_type}' is declared by defaults "
+                f"as version '{existing.version}' and by the project manifest as version '{artifact.version}'."
+            )
+        merged[key] = artifact
+
+    return tuple(merged.values())
 
 
 def reconcile_artifact(
     ctx: base_cli.Context,
-    project_root: Path,
     definition: ArtifactDefinition,
     version: str,
     dry_run: bool,
@@ -96,7 +138,7 @@ def reconcile_artifact(
         reconcile_homebrew_artifact(ctx, definition, version, dry_run=dry_run)
         return
     if definition.manager == "pip":
-        reconcile_python_artifact(ctx, project_root, definition, version, dry_run=dry_run)
+        reconcile_python_artifact(ctx, definition, version, dry_run=dry_run)
         return
     raise ArtifactError(f"Artifact manager '{definition.manager}' is not implemented.")
 
@@ -134,14 +176,18 @@ def reconcile_homebrew_artifact(
 
 def reconcile_python_artifact(
     ctx: base_cli.Context,
-    project_root: Path,
     definition: ArtifactDefinition,
     version: str,
     dry_run: bool,
 ) -> None:
-    venv_dir = project_root / ".base" / ".venv"
+    project = os.environ.get("BASE_PROJECT", "base")
+    venv_dir = Path.home() / ".base.d" / project / ".venv"
     python_bin = venv_dir / "bin" / "python"
     requirement = f"{definition.package}=={version}" if version != "latest" else definition.package
+
+    if python_artifact_installed(python_bin, definition.package, version):
+        ctx.log.info("Python artifact '%s' is already installed in the project virtual environment.", definition.name)
+        return
 
     if dry_run:
         if not python_bin.exists():
@@ -155,6 +201,21 @@ def reconcile_python_artifact(
 
     ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
     run_command([str(python_bin), "-m", "pip", "install", requirement])
+
+
+def python_artifact_installed(python_bin: Path, package: str, version: str) -> bool:
+    if not python_bin.exists():
+        return False
+    command = [str(python_bin), "-m", "pip", "show", package]
+    completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
+    if completed.returncode:
+        return False
+    if version == "latest":
+        return True
+    for line in completed.stdout.splitlines():
+        if line.startswith("Version: "):
+            return line.removeprefix("Version: ").strip() == version
+    return False
 
 
 def command_exists(name: str) -> bool:

--- a/cli/python/base_setup/registry.py
+++ b/cli/python/base_setup/registry.py
@@ -13,6 +13,20 @@ class ArtifactDefinition:
 
 
 _ARTIFACTS = {
+    ("python-package", "click"): ArtifactDefinition(
+        name="click",
+        artifact_type="python-package",
+        manager="pip",
+        package="click",
+        target="project-venv",
+    ),
+    ("python-package", "PyYAML"): ArtifactDefinition(
+        name="PyYAML",
+        artifact_type="python-package",
+        manager="pip",
+        package="PyYAML",
+        target="project-venv",
+    ),
     ("tool", "terraform"): ArtifactDefinition(
         name="terraform",
         artifact_type="tool",

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -9,7 +9,8 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_setup.engine import main
+from base_setup.engine import ArtifactError, main, merge_artifacts
+from base_setup.manifest import ArtifactRequest
 from base_setup.manifest import read_manifest
 
 
@@ -17,13 +18,42 @@ def run_engine(args: list[str]) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
     with tempfile.TemporaryDirectory() as home_dir:
-        with mock.patch.dict(os.environ, {"HOME": home_dir}):
+        with mock.patch.dict(os.environ, {"HOME": home_dir, "BASE_HOME": str(Path(__file__).resolve().parents[4])}):
             with redirect_stdout(stdout), redirect_stderr(stderr):
                 status = main(args)
     return status, stdout.getvalue(), stderr.getvalue()
 
 
 class ManifestTests(unittest.TestCase):
+    def test_merge_artifacts_keeps_defaults_and_manifest_artifacts(self) -> None:
+        merged = merge_artifacts(
+            (
+                ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1"),
+            ),
+            (
+                ArtifactRequest(artifact_type="tool", name="terraform", version="1.8.5"),
+            ),
+        )
+
+        self.assertEqual(
+            [(artifact.artifact_type, artifact.name, artifact.version) for artifact in merged],
+            [
+                ("python-package", "click", "8.4.1"),
+                ("tool", "terraform", "1.8.5"),
+            ],
+        )
+
+    def test_merge_artifacts_rejects_conflicting_default_versions(self) -> None:
+        with self.assertRaises(ArtifactError):
+            merge_artifacts(
+                (
+                    ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1"),
+                ),
+                (
+                    ArtifactRequest(artifact_type="python-package", name="click", version="1.0.0"),
+                ),
+            )
+
     def test_reads_basic_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"
@@ -68,7 +98,7 @@ class ManifestTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            status, _stdout, stderr = run_engine(["--manifest", str(manifest_path)])
+            status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
 
         self.assertEqual(status, 1)
         self.assertIn("Unsupported artifact 'not-a-real-artifact' of type 'tool'", stderr)
@@ -154,7 +184,7 @@ class ManifestTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            status, _stdout, stderr = run_engine(["--manifest", str(manifest_path)])
+            status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
 
         self.assertEqual(status, 0)
         self.assertIn("Project 'demo' declares no artifacts.", stderr)

--- a/docs/design.md
+++ b/docs/design.md
@@ -282,7 +282,7 @@ active, its venv is active. Showing both would be redundant. The prompt stays cl
 ### Base Venv
 
 - Created once during `basectl setup`
-- Lives at `~/.base.d/.venv`
+- Lives at `~/.base.d/base/.venv`
 - Used to run Base's own Python orchestration code (manifest parsing, project discovery,
   etc.)
 - Not activated in the user's interactive shell by default — it runs internally when
@@ -354,8 +354,8 @@ When `basectl setup` runs on a fresh Mac:
 1. Check for Homebrew — install if missing
 2. Check for Xcode CLI tools — install if missing
 3. Install Python (target version) via Homebrew
-4. Create Base's own virtual environment at `~/.base.d/.venv`
-5. Install Base's Python dependencies into `~/.base.d/.venv`
+4. Create Base's own virtual environment at `~/.base.d/base/.venv`
+5. Install Base's Python dependencies into `~/.base.d/base/.venv`
 6. Prepare the managed shell startup model with `basectl update-profile`
 7. Scan the parent directory for peer repos with base manifests
 8. For each discovered project, run project-level setup (install declared dependencies,

--- a/lib/base/default_manifest.yaml
+++ b/lib/base/default_manifest.yaml
@@ -1,0 +1,11 @@
+project:
+  name: __base_defaults__
+
+artifacts:
+  - type: python-package
+    name: click
+    version: "8.4.1"
+
+  - type: python-package
+    name: PyYAML
+    version: "6.0.3"


### PR DESCRIPTION
## Summary

- Add `bin/base-wrapper` as the internal Python package execution path for Base
- Move Base’s virtual environment location to `~/.base.d/base/.venv`
- Route `basectl setup` Python handoff through `base-wrapper --project <project> base_setup`
- Add `lib/base/default_manifest.yaml` for default project artifacts
- Teach `base_setup` to merge default artifacts with project manifest artifacts
- Add registry support for default Python packages `click` and `PyYAML`
- Install Python artifacts into `~/.base.d/<project>/.venv`
- Update docs, TODO/context, and tests for the new wrapper and venv model

## Testing

- `bash -n bin/base-wrapper cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/check.sh cli/bash/commands/basectl/subcommands/setup.sh cli/bash/commands/basectl/basectl.sh`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bin/basectl setup --dry-run`

Note: non-dry `basectl setup` was not run because it would create `~/.base.d/base/.venv` and install packages from the network.