### PR TITLE
Back up invalid Base venv paths during setup

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -26,9 +26,12 @@ This file is the shared working memory for future AI-assisted development in thi
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change adds `base-wrapper`, moves Base's venv to
-  `~/.base.d/base/.venv`, and teaches the Python setup layer to merge default
-  artifacts from `lib/base/default_manifest.yaml`.
+- Most recent uncommitted change dogfoods the new Base project venv bootstrap:
+  `basectl setup` creates/uses `~/.base.d/base/.venv`, seeds PyYAML and Click
+  there, and invokes Python setup through `base-wrapper`. If the target `.venv`
+  path exists but is not a valid venv, setup moves it to
+  `.venv.backup.<timestamp>` before creating a clean venv. This was verified
+  with real non-dry setup locally.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -134,6 +134,19 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Files: `bin/base-wrapper`, `cli/bash/commands/basectl/subcommands/setup_common.sh`, `lib/base/default_manifest.yaml`
   - Goal: expose one internal Python package execution path that selects `~/.base.d/<project>/.venv`, sets `BASE_HOME`, `BASE_PROJECT`, and `PYTHONPATH`, and runs `python -m <package>`.
   - Use `base` as the default project for now.
-  - Move Base's venv from `~/.base.d/.venv` to `~/.base.d/base/.venv`.
+  - Standardize Base's venv on `~/.base.d/base/.venv`.
   - Add default artifact manifest using the same manifest shape as project manifests.
   - Done locally; pending commit.
+
+- [x] Dogfood the new Base project venv bootstrap.
+  - Files: `cli/bash/commands/basectl/subcommands/setup_common.sh`, `cli/bash/commands/basectl/tests/setup.bats`
+  - Goal: make non-dry `basectl setup` create/use `~/.base.d/base/.venv`, seed Base bootstrap packages there, and invoke the Python layer through `base-wrapper`.
+  - Standardize on the project-scoped venv path without carrying compatibility code for older local bootstrap experiments.
+  - Move any existing non-venv path aside as `.venv.backup.<timestamp>` before creating the project venv.
+  - Verified locally with real `bin/basectl setup` and `bin/basectl setup --dry-run`.
+
+- [ ] Add an explicit project venv rebuild option.
+  - Files: `cli/bash/commands/basectl/subcommands/setup.sh`, `cli/bash/commands/basectl/subcommands/setup_common.sh`, `cli/bash/commands/basectl/tests/setup.bats`
+  - Goal: preserve idempotent setup by reusing valid venvs by default, while offering an intentional option such as `basectl setup --recreate-venv`.
+  - Expected behavior: when requested, move the existing `~/.base.d/<project>/.venv` to `.venv.backup.<timestamp>` before creating a fresh venv.
+  - Add dry-run and non-dry coverage.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -47,6 +47,25 @@ setup_venv_dir() {
     printf '%s\n' "${BASE_SETUP_VENV_DIR:-$HOME/.base.d/base/.venv}"
 }
 
+setup_backup_existing_venv_path() {
+    local backup_path timestamp venv_dir
+
+    venv_dir="$(setup_venv_dir)"
+    [[ -e "$venv_dir" ]] || return 0
+
+    timestamp="$(date +%Y%m%dT%H%M%S)"
+    backup_path="${venv_dir}.backup.${timestamp}"
+    [[ ! -e "$backup_path" ]] || fatal_error "Virtual environment backup path already exists at '$backup_path'."
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Would move existing non-venv path '$venv_dir' to '$backup_path'."
+        return 0
+    fi
+
+    log_info "Moving existing non-venv path '$venv_dir' to '$backup_path'."
+    run mv "$venv_dir" "$backup_path"
+}
+
 setup_python_formula() {
     printf '%s\n' "${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
 }
@@ -288,6 +307,8 @@ setup_create_virtualenv() {
         log_info "Virtual environment already exists at '$venv_dir'."
         return 0
     fi
+
+    setup_backup_existing_venv_path
 
     if setup_is_dry_run; then
         log_info "[DRY-RUN] Would create Python virtual environment at '$venv_dir'."

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -418,6 +418,46 @@ EOF
     [ -f "$venv_dir/pyvenv.cfg" ]
 }
 
+@test "basectl setup backs up an existing non-venv path before creating the Base virtual environment" {
+    local backup_path
+    local installer
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_xcode_stubs
+    installer="$(create_homebrew_installer_stub)"
+    mkdir -p "$venv_dir"
+    printf 'stale content\n' > "$venv_dir/stale.txt"
+
+    run_base_command \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
+        setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Moving existing non-venv path '$venv_dir' to '$venv_dir.backup."* ]]
+    [[ "$output" == *"Creating Python virtual environment at '$venv_dir'."* ]]
+    backup_path="$(find "$TEST_HOME/.base.d/base" -maxdepth 1 -type d -name '.venv.backup.*' -print)"
+    [[ -n "$backup_path" ]]
+    [ -f "$backup_path/stale.txt" ]
+    [ -f "$venv_dir/pyvenv.cfg" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
+}
+
+@test "basectl setup dry-run reports backup for an existing non-venv path without moving it" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    mkdir -p "$venv_dir"
+    printf 'stale content\n' > "$venv_dir/stale.txt"
+
+    run_base_command setup --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would move existing non-venv path '$venv_dir' to '$venv_dir.backup."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$venv_dir'."* ]]
+    [ -f "$venv_dir/stale.txt" ]
+    [ -z "$(find "$TEST_HOME/.base.d/base" -maxdepth 1 -type d -name '.venv.backup.*' -print)" ]
+}
+
 @test "basectl setup supports dry-run without making changes" {
     run_base_command setup --dry-run
 


### PR DESCRIPTION
## Summary

- Standardize Base bootstrap notes on `~/.base.d/base/.venv`
- Back up an existing non-venv `.venv` path to `.venv.backup.<timestamp>` before creating a clean Base venv
- Preserve idempotent behavior by reusing valid venvs
- Add dry-run and non-dry BATS coverage for the backup behavior
- Add TODO for a future explicit `--recreate-venv` style option

## Testing

- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/check.sh cli/bash/commands/basectl/subcommands/setup.sh`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`