### PR TITLE
Add Pylint config and dev tooling setup

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,26 @@
+[MAIN]
+py-version=3.10
+init-hook='import sys; sys.path.extend(["lib/python", "cli/python"])'
+jobs=1
+persistent=no
+
+[MESSAGES CONTROL]
+disable=
+    import-outside-toplevel,
+    invalid-name,
+    missing-module-docstring,
+    missing-class-docstring,
+    missing-function-docstring,
+    not-callable,
+    too-many-instance-attributes,
+    too-many-locals,
+    too-few-public-methods,
+    trailing-newlines,
+    duplicate-code,
+    fixme
+
+[FORMAT]
+max-line-length=120
+
+[REPORTS]
+score=no

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -1,4 +1,11 @@
 project:
   name: base
 
-artifacts: []
+artifacts:
+  - type: python-package
+    name: pylint
+    version: latest
+
+  - type: python-package
+    name: pytest
+    version: latest

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -219,7 +219,10 @@ def python_artifact_installed(python_bin: Path, package: str, version: str) -> b
 
 
 def command_exists(name: str) -> bool:
-    return any((Path(directory) / name).is_file() and os.access(Path(directory) / name, os.X_OK) for directory in os.environ.get("PATH", "").split(os.pathsep))
+    return any(
+        (Path(directory) / name).is_file() and os.access(Path(directory) / name, os.X_OK)
+        for directory in os.environ.get("PATH", "").split(os.pathsep)
+    )
 
 
 def run_check(command: list[str]) -> bool:

--- a/cli/python/base_setup/registry.py
+++ b/cli/python/base_setup/registry.py
@@ -27,6 +27,20 @@ _ARTIFACTS = {
         package="PyYAML",
         target="project-venv",
     ),
+    ("python-package", "pylint"): ArtifactDefinition(
+        name="pylint",
+        artifact_type="python-package",
+        manager="pip",
+        package="pylint",
+        target="project-venv",
+    ),
+    ("python-package", "pytest"): ArtifactDefinition(
+        name="pytest",
+        artifact_type="python-package",
+        manager="pip",
+        package="pytest",
+        target="project-venv",
+    ),
     ("tool", "terraform"): ArtifactDefinition(
         name="terraform",
         artifact_type="tool",

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -12,6 +12,7 @@ from unittest import mock
 from base_setup.engine import ArtifactError, main, merge_artifacts
 from base_setup.manifest import ArtifactRequest
 from base_setup.manifest import read_manifest
+from base_setup.registry import get_artifact_definition
 
 
 def run_engine(args: list[str]) -> tuple[int, str, str]:
@@ -78,6 +79,15 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(manifest.artifacts[0].artifact_type, "tool")
         self.assertEqual(manifest.artifacts[0].name, "terraform")
         self.assertEqual(manifest.artifacts[0].version, "1.8.5")
+
+    def test_base_manifest_declares_python_dev_tools(self) -> None:
+        manifest = read_manifest(Path(__file__).resolve().parents[4] / "base_manifest.yaml")
+        tools = {(artifact.artifact_type, artifact.name) for artifact in manifest.artifacts}
+
+        self.assertIn(("python-package", "pylint"), tools)
+        self.assertIn(("python-package", "pytest"), tools)
+        self.assertIsNotNone(get_artifact_definition("python-package", "pylint"))
+        self.assertIsNotNone(get_artifact_definition("python-package", "pytest"))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_unknown_artifact_fails(self) -> None:

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import os
 import sys
 from pathlib import Path
 from typing import Any, Callable

--- a/lib/python/base_cli/redaction.py
+++ b/lib/python/base_cli/redaction.py
@@ -25,7 +25,7 @@ def redact_argv(argv: list[str], sensitive_options: set[str]) -> list[str]:
             skip_next = False
             continue
 
-        option, separator, value = arg.partition("=")
+        option, separator, _value = arg.partition("=")
         normalized = option_name_to_parameter(option) if option.startswith("--") else option
         if option.startswith("--") and normalized in sensitive_options:
             if separator:
@@ -37,4 +37,3 @@ def redact_argv(argv: list[str], sensitive_options: set[str]) -> list[str]:
 
         redacted.append(arg)
     return redacted
-

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 import io
 import os
-import re
 import tempfile
 import unittest
 from contextlib import redirect_stderr


### PR DESCRIPTION
## Summary

- Add a repo-level `.pylintrc` for the Base Python code
- Configure Pylint for Python 3.10+ and local import paths
- Add `pylint` and `pytest` to the Base project manifest so `basectl setup` installs them into the project venv
- Register `pylint` and `pytest` as supported Python package artifacts
- Add coverage to ensure the Base manifest declares the expected Python dev tools
- Clean up small lint findings surfaced by the first Pylint run

## Validation

- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/pylint $(git ls-files '*.py')`
- `PYTHONPATH=lib/python:cli/python python3 -m unittest discover -s lib/python/base_cli/tests -p 'test_*.py'`
- `PYTHONPATH=lib/python:cli/python python3 -m unittest discover -s cli/python/base_setup/tests -p 'test_*.py'`
- `PYTHONPATH=lib/python:cli/python python3 -m compileall -q lib/python cli/python`