### PR TITLE
Add setup option to recreate project venv

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -30,8 +30,9 @@ This file is the shared working memory for future AI-assisted development in thi
   `basectl setup` creates/uses `~/.base.d/base/.venv`, seeds PyYAML and Click
   there, and invokes Python setup through `base-wrapper`. If the target `.venv`
   path exists but is not a valid venv, setup moves it to
-  `.venv.backup.<timestamp>` before creating a clean venv. This was verified
-  with real non-dry setup locally.
+  `.venv.backup.<timestamp>` before creating a clean venv. `basectl setup
+  --recreate-venv` intentionally backs up and rebuilds even a valid venv. This
+  was verified with real non-dry setup locally.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -145,8 +145,9 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Move any existing non-venv path aside as `.venv.backup.<timestamp>` before creating the project venv.
   - Verified locally with real `bin/basectl setup` and `bin/basectl setup --dry-run`.
 
-- [ ] Add an explicit project venv rebuild option.
+- [x] Add an explicit project venv rebuild option.
   - Files: `cli/bash/commands/basectl/subcommands/setup.sh`, `cli/bash/commands/basectl/subcommands/setup_common.sh`, `cli/bash/commands/basectl/tests/setup.bats`
   - Goal: preserve idempotent setup by reusing valid venvs by default, while offering an intentional option such as `basectl setup --recreate-venv`.
   - Expected behavior: when requested, move the existing `~/.base.d/<project>/.venv` to `.venv.backup.<timestamp>` before creating a fresh venv.
   - Add dry-run and non-dry coverage.
+  - Done locally; pending commit.

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -16,6 +16,7 @@ Usage:
 Options:
   --dry-run          Log what would happen without making changes.
   --manifest <path>  Use a specific base_manifest.yaml path.
+  --recreate-venv    Back up and recreate the project virtual environment.
   -v                 Enable DEBUG logging for this subcommand.
   -h, --help         Show this help text.
 
@@ -61,6 +62,9 @@ base_setup_subcommand_main() {
                 fi
                 BASE_SETUP_MANIFEST="$1"
                 export BASE_SETUP_MANIFEST
+                ;;
+            --recreate-venv)
+                setup_enable_recreate_venv
                 ;;
             -v)
                 setup_enable_debug_logging

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -20,7 +20,7 @@ readonly _base_setup_common_sourced
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset dry_run DRY_RUN BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_PYYAML_READY BASE_PROJECT
+    unset dry_run DRY_RUN BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_PYYAML_READY BASE_SETUP_RECREATE_VENV BASE_PROJECT
 }
 
 setup_enable_dry_run() {
@@ -36,6 +36,14 @@ setup_is_dry_run() {
     [[ "${DRY_RUN-}" == true ]]
 }
 
+setup_enable_recreate_venv() {
+    export BASE_SETUP_RECREATE_VENV=true
+}
+
+setup_recreate_venv_enabled() {
+    [[ "${BASE_SETUP_RECREATE_VENV:-false}" == true ]]
+}
+
 setup_virtualenv_exists() {
     local venv_dir
 
@@ -48,8 +56,9 @@ setup_venv_dir() {
 }
 
 setup_backup_existing_venv_path() {
-    local backup_path timestamp venv_dir
+    local backup_path description timestamp venv_dir
 
+    description="${1:-existing path}"
     venv_dir="$(setup_venv_dir)"
     [[ -e "$venv_dir" ]] || return 0
 
@@ -58,11 +67,11 @@ setup_backup_existing_venv_path() {
     [[ ! -e "$backup_path" ]] || fatal_error "Virtual environment backup path already exists at '$backup_path'."
 
     if setup_is_dry_run; then
-        log_info "[DRY-RUN] Would move existing non-venv path '$venv_dir' to '$backup_path'."
+        log_info "[DRY-RUN] Would move $description '$venv_dir' to '$backup_path'."
         return 0
     fi
 
-    log_info "Moving existing non-venv path '$venv_dir' to '$backup_path'."
+    log_info "Moving $description '$venv_dir' to '$backup_path'."
     run mv "$venv_dir" "$backup_path"
 }
 
@@ -303,12 +312,16 @@ setup_create_virtualenv() {
 
     venv_dir="$(setup_venv_dir)"
 
-    if setup_virtualenv_exists; then
+    if setup_virtualenv_exists && ! setup_recreate_venv_enabled; then
         log_info "Virtual environment already exists at '$venv_dir'."
         return 0
     fi
 
-    setup_backup_existing_venv_path
+    if setup_virtualenv_exists; then
+        setup_backup_existing_venv_path "existing virtual environment"
+    else
+        setup_backup_existing_venv_path "existing non-venv path"
+    fi
 
     if setup_is_dry_run; then
         log_info "[DRY-RUN] Would create Python virtual environment at '$venv_dir'."
@@ -333,6 +346,10 @@ setup_base_venv_python_bin() {
 setup_base_python_package_installed() {
     local package="$1"
     local venv_dir python_bin
+
+    if setup_is_dry_run && setup_recreate_venv_enabled; then
+        return 1
+    fi
 
     venv_dir="$(setup_venv_dir)"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -303,6 +303,7 @@ run_base_command() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl setup [options]"* ]]
+    [[ "$output" == *"--recreate-venv"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on macOS."* ]]
 }
 
@@ -455,6 +456,59 @@ EOF
     [[ "$output" == *"[DRY-RUN] Would move existing non-venv path '$venv_dir' to '$venv_dir.backup."* ]]
     [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$venv_dir'."* ]]
     [ -f "$venv_dir/stale.txt" ]
+    [ -z "$(find "$TEST_HOME/.base.d/base" -maxdepth 1 -type d -name '.venv.backup.*' -print)" ]
+}
+
+@test "basectl setup --recreate-venv backs up a valid venv before creating a fresh one" {
+    local backup_path
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/bats-installed"
+    mkdir -p "$venv_dir/bin"
+    printf 'python-home = old\n' > "$venv_dir/pyvenv.cfg"
+    printf 'old venv marker\n' > "$venv_dir/old.txt"
+    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+
+    run_base_command setup --recreate-venv
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Moving existing virtual environment '$venv_dir' to '$venv_dir.backup."* ]]
+    [[ "$output" == *"Creating Python virtual environment at '$venv_dir'."* ]]
+    backup_path="$(find "$TEST_HOME/.base.d/base" -maxdepth 1 -type d -name '.venv.backup.*' -print)"
+    [[ -n "$backup_path" ]]
+    [ -f "$backup_path/old.txt" ]
+    [ -f "$venv_dir/pyvenv.cfg" ]
+    [ ! -f "$venv_dir/old.txt" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
+}
+
+@test "basectl setup --recreate-venv dry-run reports rebuild without moving a valid venv" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/bats-installed"
+    mkdir -p "$venv_dir/bin"
+    printf 'python-home = old\n' > "$venv_dir/pyvenv.cfg"
+    printf 'old venv marker\n' > "$venv_dir/old.txt"
+    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+
+    run_base_command setup --dry-run --recreate-venv
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would move existing virtual environment '$venv_dir' to '$venv_dir.backup."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$venv_dir'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would install Python package 'PyYAML' in the Base virtual environment."* ]]
+    [[ "$output" == *"[DRY-RUN] Would install Python package 'click' in the Base virtual environment."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run Python project setup layer after PyYAML is installed."* ]]
+    [ -f "$venv_dir/old.txt" ]
     [ -z "$(find "$TEST_HOME/.base.d/base" -maxdepth 1 -type d -name '.venv.backup.*' -print)" ]
 }
 


### PR DESCRIPTION
## Summary

- Add `basectl setup --recreate-venv`
- Keep default setup idempotent by reusing a valid existing project venv
- Back up an existing valid venv to `.venv.backup.<timestamp>` when recreate is requested
- Continue backing up an existing non-venv `.venv` path before creating a clean venv
- Update setup help, TODO/context notes, and BATS coverage

## Testing

- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/check.sh cli/bash/commands/basectl/subcommands/setup.sh`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bin/basectl setup --dry-run --recreate-venv`