### PR TITLE
Move Bash upgrade handling out of stdlib

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -26,13 +26,12 @@ This file is the shared working memory for future AI-assisted development in thi
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change dogfoods the new Base project venv bootstrap:
-  `basectl setup` creates/uses `~/.base.d/base/.venv`, seeds PyYAML and Click
-  there, and invokes Python setup through `base-wrapper`. If the target `.venv`
-  path exists but is not a valid venv, setup moves it to
-  `.venv.backup.<timestamp>` before creating a clean venv. `basectl setup
-  --recreate-venv` intentionally backs up and rebuilds even a valid venv. This
-  was verified with real non-dry setup locally.
+- Most recent uncommitted change removes interactive Bash upgrade behavior from
+  `lib/bash/std/lib_std.sh`: sourcing stdlib now initializes logging and wrapper
+  flags without prompting, installing Homebrew/Bash, or re-execing the caller.
+  Bash version enforcement stays in entrypoints. `bin/basectl` auto-reexecs via
+  an already-installed supported Bash when available, otherwise it prints setup
+  and `brew install bash` guidance.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -56,11 +56,13 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Verify dry-run setup/check tests and inherited `DRY_RUN` behavior.
   - Done locally; pending commit.
 
-- [ ] Remove interactive Bash upgrade behavior from `lib_std.sh`.
+- [x] Remove interactive Bash upgrade behavior from `lib_std.sh`.
   - File: `lib/bash/std/lib_std.sh`
   - Problem: `__stdlib_init__` calls `check_bash_version_and_upgrade`, which can trigger interactive Homebrew/Bash installation from a library source path.
   - Expected fix: keep Bash version enforcement in the entrypoint layer; make the library non-interactive when sourced.
   - Review tests that cover `check_bash_version_and_upgrade` and adjust the public contract.
+  - `bin/basectl` still auto-reexecs through an already-installed supported Bash and prints setup/manual-install guidance when none is found.
+  - Done locally; pending commit.
 
 - [ ] Avoid exporting multi-line `AWK_NEW_TEXT`.
   - File: `lib/bash/file/lib_file.sh`

--- a/bin/basectl
+++ b/bin/basectl
@@ -72,19 +72,43 @@ basectl_print_version() {
 }
 
 basectl_ensure_supported_bash() {
-    local current_version
     local candidate
+    local candidates=()
+    local current_version
+    local display_version
 
-    current_version="${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}"
+    current_version="${BASE_TEST_BASH_VERSION:-${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}}"
     ((current_version >= 42)) && return 0
 
-    for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -n "${BASE_TEST_BASH_CANDIDATES:-}" ]]; then
+        IFS=: read -r -a candidates <<<"$BASE_TEST_BASH_CANDIDATES"
+    else
+        candidates=(/opt/homebrew/bin/bash /usr/local/bin/bash)
+    fi
+
+    for candidate in "${candidates[@]}"; do
         [[ -x "$candidate" ]] || continue
         [[ "$candidate" == "${BASH:-}" ]] && continue
         exec "$candidate" "$0" "$@"
     done
 
-    basectl_die "basectl requires Bash 4.2 or newer; current version is ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}."
+    if [[ -n "${BASE_TEST_BASH_VERSION:-}" ]]; then
+        display_version="${BASE_TEST_BASH_VERSION:0:1}.${BASE_TEST_BASH_VERSION:1}"
+    else
+        display_version="${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
+    fi
+
+    {
+        printf 'ERROR: Base requires Bash 4.2 or newer; current version is %s.\n' "$display_version"
+        printf 'A supported Bash was not found at /opt/homebrew/bin/bash or /usr/local/bin/bash.\n'
+        printf '\n'
+        printf 'Run:\n'
+        printf '  basectl setup\n'
+        printf '\n'
+        printf 'Or install Bash manually:\n'
+        printf '  brew install bash\n'
+    } >&2
+    exit 1
 }
 
 basectl_is_script_argument() {

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -69,6 +69,43 @@ run_basectl() {
     [ "$output" = "basectl $expected_version" ]
 }
 
+@test "basectl re-execs through an installed supported Bash when current Bash is too old" {
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'fake_bash=%s\n' "$0"
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$fake_bash"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_BASH_VERSION=32 \
+        BASE_TEST_BASH_CANDIDATES="$fake_bash" \
+        "$BASE_REPO_ROOT/bin/basectl" --version
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fake_bash=$fake_bash"* ]]
+    [[ "$output" == *"args=$BASE_REPO_ROOT/bin/basectl --version"* ]]
+}
+
+@test "basectl gives setup guidance when current Bash is too old and no supported Bash is installed" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_BASH_VERSION=32 \
+        BASE_TEST_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        "$BASE_REPO_ROOT/bin/basectl" --version
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Base requires Bash 4.2 or newer; current version is 3.2."* ]]
+    [[ "$output" == *"A supported Bash was not found"* ]]
+    [[ "$output" == *"basectl setup"* ]]
+    [[ "$output" == *"brew install bash"* ]]
+}
+
 @test "basectl setup prints setup-specific help" {
     run_basectl setup --help
 

--- a/lib/bash/std/README.md
+++ b/lib/bash/std/README.md
@@ -4,7 +4,7 @@ Shared foundation library for Bash code under `cli/bash`.
 
 ## What It Provides
 
-- Bash version checking and one-time initialization when sourced
+- Passive Bash version check helpers and one-time initialization when sourced
 - Shared globals for callers: `__SCRIPT_ARGS__` and `__SCRIPT_DIR__`
 - Library importing with `import`
 - PATH helpers: `add_to_path`, `dedupe_path`, `print_path`
@@ -29,8 +29,8 @@ run echo "hello"
 
 ## Notes
 
-- Requires Bash 4.0 or newer.
-- Sourcing the file runs `__stdlib_init__`.
+- Base entrypoints require Bash 4.2 or newer before sourcing this library.
+- Sourcing the file runs `__stdlib_init__`, which initializes logging and wrapper flags without prompting, installing packages, or re-executing the caller.
 - `base_init.sh` preloads this library for Base-run scripts so commands do not need per-command stdlib sourcing boilerplate.
 - `bin/basectl` sets `BASE_BASH_BOOTSTRAP_SOURCE` before runtime bootstrap so `__SCRIPT_DIR__` still points at the command script rather than the Base entrypoint.
 - Runtime flags such as `--debug-wrapper` and `--verbose-wrapper` are consumed during initialization for compatibility.

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 #
 # lib_std.sh - Foundation library for Bash scripts
-#              Requires Bash version 4.0 or higher.
+#              Base entrypoints require Bash 4.2 or higher before sourcing this library.
 #
 # This library provides a standardized set of functions for common tasks,
 # ensuring consistency and robustness across multiple scripts.
@@ -10,7 +10,7 @@
 #     - PATH manipulation
 #     - Logging (with levels and colors)
 #     - Error handling and stack tracing
-#     - Bash version checking
+#     - Bash version check helpers
 #     - Library importing
 #     - Miscellaneous helpers
 #
@@ -84,91 +84,26 @@ is_interactive() {
 }
 
 #
-# check_bash_version_and_upgrade - Verifies the Bash version and prompts for an upgrade if necessary.
+# check_bash_version - Verifies the Bash version without prompting or installing anything.
 #
-# This function checks if the running Bash interpreter is version 4.0 or higher.
-# If the version is too old and the shell is interactive, it will offer to
-# install/upgrade Bash via Homebrew. If the shell is not interactive, or if the OSTYPE is not darwin,
-# it will exit with an error.
+# This function checks if the running Bash interpreter is version 4.0 or higher and returns
+# non-zero when it is not. Base entrypoints should enforce the supported runtime before
+# sourcing this library; this helper is intentionally passive so sourcing lib_std.sh never
+# prompts, installs packages, or re-execs the caller.
 #
 # Note: This function is called before logging is initialized, so it uses `echo` to stderr.
 #
-check_bash_version_and_upgrade() {
+check_bash_version() {
     local -r major_version=${BASH_VERSINFO[0]}
     if ((major_version < 4)); then
-        if ! is_interactive; then
-            {
-                echo "Error: This script requires Bash 4.0 or higher."
-                echo "Your version ($BASH_VERSION) is not compatible."
-                echo "Upgrade Bash manually or run the script in interactive mode for guided upgrade."
-            } >&2
-            exit 1
-        fi
-
-        # -- Interactive Upgrade Process --
-        echo "Warning: This script requires Bash version 4.0 or higher to run correctly." >&2
-        echo "Your current version is $BASH_VERSION." >&2
-
-        local install_cmd
-        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            if command -v apt-get &>/dev/null; then
-                install_cmd="sudo apt-get update && sudo apt-get install bash"
-            elif command -v yum &>/dev/null; then
-                install_cmd="sudo yum install bash"
-            fi
-
-            echo "On your system, you can likely upgrade by running:" >&2
-            echo "  $install_cmd" >&2
-            exit 1
-        elif [[ "$OSTYPE" == "darwin"* ]]; then
-            read -p "Would you like to attempt an upgrade using Homebrew? (y/n) " -n 1 -r
-            echo >&2
-            if [[ $REPLY =~ ^[Yy]$ ]]; then
-                if ! command -v brew &>/dev/null; then
-                    echo "Homebrew is not installed." >&2
-                    read -p "May I install Homebrew for you? (y/n) " -n 1 -r
-                    echo >&2
-                    if [[ $REPLY =~ ^[Yy]$ ]]; then
-                        echo "Installing Homebrew..." >&2
-                        if ! /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
-                            echo "Error: Homebrew installation failed. Please install it manually and try again." >&2
-                            exit 1
-                        fi
-                        echo "Homebrew installed successfully." >&2
-                    else
-                        echo "Aborting. Homebrew is required to proceed." >&2
-                        exit 1
-                    fi
-                fi
-
-                echo "Updating Homebrew and installing Bash..." >&2
-                if ! { brew update && brew install bash; }; then
-                    echo "Error: Failed to install Bash via Homebrew." >&2
-                    exit 1
-                fi
-
-                echo "Bash installed successfully." >&2
-
-                local new_bash_path
-                new_bash_path="$(brew --prefix)/bin/bash"
-                if [[ -f "$new_bash_path" ]]; then
-                    printf 'Relaunching script with the new Bash from: %s' "$new_bash_path" >&2
-                    printf ' %q' "${__SCRIPT_ARGS__[@]}" >&2
-                    printf '\n' >&2
-                    exec "$new_bash_path" "$0" "${__SCRIPT_ARGS__[@]}"
-                else
-                    echo "Error: Could not find the new Bash executable at '$new_bash_path'." >&2
-                    exit 1
-                fi
-            else
-                echo "Aborting. Please upgrade Bash to version 4.0 or higher to run this script." >&2
-                exit 1
-            fi
-        else
-            echo "Unsupported OSTYPE: [$OSTYPE]" >&2
-            exit 1
-        fi
+        echo "Error: This script requires Bash 4.0 or higher." >&2
+        echo "Your version ($BASH_VERSION) is not compatible." >&2
+        return 1
     fi
+}
+
+check_bash_version_and_upgrade() {
+    check_bash_version
 }
 
 ###################################################### INIT ############################################################
@@ -178,12 +113,10 @@ check_bash_version_and_upgrade() {
 #
 # This is the only function that executes when the library is sourced.
 # It sets up the environment by:
-#   1. Checking the Bash version.
-#   2. Initializing the logging system.
-#   3. Parsing global command-line options like --debug, --verbose, --color.
+#   1. Initializing the logging system.
+#   2. Parsing global command-line options like --debug, --verbose, --color.
 #
 __stdlib_init__() {
-    check_bash_version_and_upgrade
     __log_init__
 
     #

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -133,6 +133,11 @@ EOF
     [ "$?" -eq 0 ]
 }
 
+@test "stdlib exposes passive bash version check helper" {
+    check_bash_version
+    [ "$?" -eq 0 ]
+}
+
 @test "color initialization honors tty mode when --color is passed" {
     local script="$TEST_TMPDIR/tty-colors.sh"
     local normalized


### PR DESCRIPTION
## Summary

- Remove interactive Bash upgrade/install behavior from `lib_std.sh`
- Keep stdlib source-time initialization passive and deterministic
- Preserve `check_bash_version_and_upgrade` as a passive compatibility wrapper around `check_bash_version`
- Update stdlib docs to clarify that Bash version enforcement belongs to entrypoints
- Teach `bin/basectl` to re-exec through an already-installed supported Bash when the current Bash is too old
- Add `basectl` guidance when no supported Bash is found:
  - run `basectl setup`
  - or manually run `brew install bash`
- Mark the TODO item complete and update AI context

## Why

`lib_std.sh` is imported by many Bash scripts and libraries. Having import-time behavior that can prompt, install Homebrew/Bash, or re-exec the caller makes library sourcing surprising and risky for automation.

This keeps the Oracle older-Bash support path, but moves it to the `basectl` entrypoint where user-facing bootstrap behavior belongs.

## Testing

- `bash -n bin/basectl lib/bash/std/lib_std.sh base_init.sh`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bats lib/bash/std/tests/lib_std.bats`