### PR TITLE
Avoid exporting file section replacement content

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -26,12 +26,10 @@ This file is the shared working memory for future AI-assisted development in thi
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change removes interactive Bash upgrade behavior from
-  `lib/bash/std/lib_std.sh`: sourcing stdlib now initializes logging and wrapper
-  flags without prompting, installing Homebrew/Bash, or re-execing the caller.
-  Bash version enforcement stays in entrypoints. `bin/basectl` auto-reexecs via
-  an already-installed supported Bash when available, otherwise it prints setup
-  and `brew install bash` guidance.
+- Most recent uncommitted change updates `update_file_section` in
+  `lib/bash/file/lib_file.sh` so replacement content is passed to `awk` through
+  a temporary file instead of the exported `AWK_NEW_TEXT` environment variable.
+  Multi-line section replacement remains supported.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -64,11 +64,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - `bin/basectl` still auto-reexecs through an already-installed supported Bash and prints setup/manual-install guidance when none is found.
   - Done locally; pending commit.
 
-- [ ] Avoid exporting multi-line `AWK_NEW_TEXT`.
+- [x] Avoid exporting multi-line `AWK_NEW_TEXT`.
   - File: `lib/bash/file/lib_file.sh`
   - Problem: `update_file_section` passes replacement content through an exported environment variable.
   - Expected fix: pass multi-line content through a temp file, stdin, or another scoped mechanism that does not leak into subprocess environments.
   - Preserve support for multi-line replacement sections.
+  - Done locally; pending commit.
 
 - [ ] Investigate and replace double `git pull` retry.
   - File: `lib/bash/git/lib_git.sh`

--- a/lib/bash/file/lib_file.sh
+++ b/lib/bash/file/lib_file.sh
@@ -82,11 +82,26 @@ update_file_section() {
         fi
     fi
 
-    local temp_file
+    local temp_file new_content_file
     temp_file=$(mktemp "${target_file}.XXXXXX")
     if [[ ! -f "$temp_file" ]]; then
         log_error "Failed to create temporary file for '$target_file'."
         return 1
+    fi
+
+    new_content_file=$(mktemp "${target_file}.new.XXXXXX")
+    if [[ ! -f "$new_content_file" ]]; then
+        log_error "Failed to create temporary content file for '$target_file'."
+        rm -f "$temp_file"
+        return 1
+    fi
+
+    if [[ "$remove_section" == false ]]; then
+        if ! printf '%s' "$new_content_string" > "$new_content_file"; then
+            log_error "Failed to write replacement content for '$target_file'."
+            rm -f "$temp_file" "$new_content_file"
+            return 1
+        fi
     fi
 
     if grep -qF -- "$beginning_marker" "$target_file" && grep -qF -- "$end_marker" "$target_file"; then
@@ -101,18 +116,21 @@ update_file_section() {
                 }
             }
             ' "$target_file" > "$temp_file" && mv -f "$temp_file" "$target_file"; then
+                rm -f "$new_content_file"
                 return 0
             fi
         else
             # FIX: This awk script now correctly handles multiple sections. It only replaces the first one.
-            export AWK_NEW_TEXT="$new_content_string"
-            if awk -v START_M="$beginning_marker" -v END_M="$end_marker" '
+            if awk -v START_M="$beginning_marker" -v END_M="$end_marker" -v NEW_TEXT_FILE="$new_content_file" '
             BEGIN {
                 processed = 0 # 0 = not yet processed, 1 = processing, 2 = done
             }
             $0 == START_M && processed == 0 {
                 print START_M
-                printf "%s", ENVIRON["AWK_NEW_TEXT"] # Insert new content
+                while ((getline line < NEW_TEXT_FILE) > 0) {
+                    print line
+                }
+                close(NEW_TEXT_FILE)
                 processed = 1 # We are now inside the section to be replaced
                 next
             }
@@ -125,31 +143,30 @@ update_file_section() {
                 print $0
             }
             ' "$target_file" > "$temp_file" && mv -f "$temp_file" "$target_file"; then
-                unset AWK_NEW_TEXT
+                rm -f "$new_content_file"
                 return 0
             fi
-            unset AWK_NEW_TEXT
         fi
 
         log_error "Failed to process sections in '$target_file'."
-        rm -f "$temp_file"
+        rm -f "$temp_file" "$new_content_file"
         return 1
     else
         # Markers not found in the file
         if [[ "$remove_section" == true ]]; then
-            rm -f "$temp_file"
+            rm -f "$temp_file" "$new_content_file"
             return 0
         else
             if ! cp "$target_file" "$temp_file"; then
                 log_error "Failed to copy '$target_file' to '$temp_file'."
-                rm -f "$temp_file"
+                rm -f "$temp_file" "$new_content_file"
                 return 1
             fi
 
             if [[ $(tail -c 1 "$temp_file" 2>/dev/null | wc -l) -eq 0 ]]; then
                 if ! printf '\n' >> "$temp_file"; then
                     log_error "Failed to add trailing newline to '$temp_file'."
-                    rm -f "$temp_file"
+                    rm -f "$temp_file" "$new_content_file"
                     return 1
                 fi
             fi
@@ -160,16 +177,17 @@ update_file_section() {
                 printf '%s\n' "$end_marker"
             } >> "$temp_file"; then
                 log_error "Failed to add new section to '$target_file'."
-                rm -f "$temp_file"
+                rm -f "$temp_file" "$new_content_file"
                 return 1
             fi
 
             if ! mv -f "$temp_file" "$target_file"; then
                 log_error "Failed to replace '$target_file' with '$temp_file'."
-                rm -f "$temp_file"
+                rm -f "$temp_file" "$new_content_file"
                 return 1
             fi
 
+            rm -f "$new_content_file"
             return 0
         fi
     fi

--- a/lib/bash/file/tests/lib_file.bats
+++ b/lib/bash/file/tests/lib_file.bats
@@ -47,6 +47,48 @@ EOF
     [ "$(cat "$target")" = $'before\n# BEGIN\nnew\n# END\nafter' ]
 }
 
+@test "update_file_section replaces an existing section with multi-line content" {
+    local target="$TEST_TMPDIR/config.txt"
+    cat <<'EOF' > "$target"
+before
+# BEGIN
+old
+# END
+after
+EOF
+
+    update_file_section "$target" "# BEGIN" "# END" "first" "second" "third"
+
+    [ "$(cat "$target")" = $'before\n# BEGIN\nfirst\nsecond\nthird\n# END\nafter' ]
+}
+
+@test "update_file_section does not export replacement content to awk" {
+    local awk_log="$TEST_TMPDIR/awk-env.log"
+    local target="$TEST_TMPDIR/config.txt"
+    cat <<'EOF' > "$target"
+before
+# BEGIN
+old
+# END
+after
+EOF
+
+    awk() {
+        if [[ -n "${AWK_NEW_TEXT+x}" ]]; then
+            printf 'leaked=%s\n' "$AWK_NEW_TEXT" > "$awk_log"
+        else
+            printf 'not-leaked\n' > "$awk_log"
+        fi
+        command awk "$@"
+    }
+
+    update_file_section "$target" "# BEGIN" "# END" "secret" "value"
+    unset -f awk
+
+    [ "$(cat "$awk_log")" = "not-leaked" ]
+    [ "$(cat "$target")" = $'before\n# BEGIN\nsecret\nvalue\n# END\nafter' ]
+}
+
 @test "update_file_section removes a marked block with -r" {
     local target="$TEST_TMPDIR/config.txt"
     cat <<'EOF' > "$target"


### PR DESCRIPTION
## Summary

- Stop passing `update_file_section` replacement content through exported `AWK_NEW_TEXT`
- Write replacement content to a temporary file instead
- Have the `awk` replacement path read content from that temp file
- Preserve multi-line section replacement behavior
- Clean up both output and content temp files on success/failure paths
- Add focused tests for multi-line replacement and environment leakage

## Testing

- `bash -n lib/bash/file/lib_file.sh`
- `bats lib/bash/file/tests/lib_file.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`

Manual smoke test also confirmed replacing:

```text
# BEGIN
old
# END
with multi-line content works as expected.
```