### PR TITLE
Make git pull retry explicit

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -26,10 +26,10 @@ This file is the shared working memory for future AI-assisted development in thi
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change updates `update_file_section` in
-  `lib/bash/file/lib_file.sh` so replacement content is passed to `awk` through
-  a temporary file instead of the exported `AWK_NEW_TEXT` environment variable.
-  Multi-line section replacement remains supported.
+- Most recent uncommitted change replaces the silent `git pull || git pull`
+  retry in `lib/bash/git/lib_git.sh` with `_git_pull_with_retry`, which logs a
+  warning after the first failure, retries once, and preserves final failure
+  logging.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -71,11 +71,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Preserve support for multi-line replacement sections.
   - Done locally; pending commit.
 
-- [ ] Investigate and replace double `git pull` retry.
+- [x] Investigate and replace double `git pull` retry.
   - File: `lib/bash/git/lib_git.sh`
   - Problem: `git pull || git pull` hides the underlying failure or warning mode.
   - Expected fix: identify the root cause and use explicit git configuration or clearer failure handling.
   - Add tests around the intended retry or non-retry behavior.
+  - Done locally; pending commit.
 
 ## Usability Issues
 

--- a/lib/bash/git/lib_git.sh
+++ b/lib/bash/git/lib_git.sh
@@ -75,6 +75,29 @@ _git_update_repo_finish() {
     return "$status"
 }
 
+_git_pull_with_retry() {
+    local git_log="$1"
+    local max_attempts=2
+    local attempt=1
+
+    while ((attempt <= max_attempts)); do
+        if git pull >"$git_log" 2>&1; then
+            if ((attempt > 1)); then
+                log_debug "git pull succeeded on attempt $attempt."
+            fi
+            return 0
+        fi
+
+        if ((attempt == max_attempts)); then
+            return 1
+        fi
+
+        log_warn "git pull failed on attempt $attempt; retrying once."
+        [[ -s "$git_log" ]] && log_debug_file "$git_log"
+        attempt=$((attempt + 1))
+    done
+}
+
 #
 # Safely updates a Git repository and its submodules after checking that the
 # current branch is the repo default branch or an explicit expected branch.
@@ -144,8 +167,7 @@ git_update_repo() {
         fi
     fi
 
-    # sometimes git pull throws warnings and we need a second git pull to address it
-    if ! { git pull || git pull; } >"$git_log" 2>&1; then
+    if ! _git_pull_with_retry "$git_log"; then
         log_error "git pull failed on repo '$git_repo'"
         [[ -s "$git_log" ]] && log_info_file "$git_log"
         _git_update_repo_finish "$git_log" true 1

--- a/lib/bash/git/tests/lib_git.bats
+++ b/lib/bash/git/tests/lib_git.bats
@@ -127,6 +127,61 @@ setup() {
     ! compgen -G "$temp_dir/git_log.*" >/dev/null
 }
 
+@test "_git_pull_with_retry retries once after a transient pull failure" {
+    local git_log="$TEST_TMPDIR/git.log"
+    local pull_count="$TEST_TMPDIR/pull-count"
+
+    printf '0\n' > "$pull_count"
+    git() {
+        local count
+
+        if [[ "${1:-}" == "pull" ]]; then
+            count="$(cat "$pull_count")"
+            count=$((count + 1))
+            printf '%s\n' "$count" > "$pull_count"
+            printf 'pull attempt %s\n' "$count" >&2
+            [[ "$count" -ge 2 ]]
+            return $?
+        fi
+        command git "$@"
+    }
+
+    bats_run _git_pull_with_retry "$git_log"
+    unset -f git
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$pull_count")" = "2" ]
+    [[ "$output" == *"git pull failed on attempt 1; retrying once."* ]]
+    [ "$(cat "$git_log")" = "pull attempt 2" ]
+}
+
+@test "_git_pull_with_retry fails after two pull attempts" {
+    local git_log="$TEST_TMPDIR/git.log"
+    local pull_count="$TEST_TMPDIR/pull-count"
+
+    printf '0\n' > "$pull_count"
+    git() {
+        local count
+
+        if [[ "${1:-}" == "pull" ]]; then
+            count="$(cat "$pull_count")"
+            count=$((count + 1))
+            printf '%s\n' "$count" > "$pull_count"
+            printf 'pull attempt %s\n' "$count" >&2
+            return 1
+        fi
+        command git "$@"
+    }
+
+    bats_run _git_pull_with_retry "$git_log"
+    unset -f git
+
+    [ "$status" -eq 1 ]
+    [ "$(cat "$pull_count")" = "2" ]
+    [[ "$output" == *"git pull failed on attempt 1; retrying once."* ]]
+    [ "$(cat "$git_log")" = "pull attempt 2" ]
+}
+
 @test "check_script_up_to_date reports success for an up-to-date tracked script" {
     local repo="$TEST_TMPDIR/repo"
     local remote="$TEST_TMPDIR/remote.git"


### PR DESCRIPTION
## Summary

- Replace silent `git pull || git pull` with `_git_pull_with_retry`
- Preserve one retry for transient `git pull` failures
- Log a warning after the first failed pull attempt
- Keep final failure behavior and git log reporting intact
- Add focused tests for retry success and retry exhaustion
- Mark the TODO item complete

## Why

The previous double pull preserved useful retry behavior, but hid the first failure and made the retry policy hard to test. This keeps the practical retry while making it explicit and observable.

## Testing

- `bash -n lib/bash/git/lib_git.sh`
- `bats lib/bash/git/tests/lib_git.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`