### PR TITLE
Add JSON output for basectl check

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -26,10 +26,9 @@ This file is the shared working memory for future AI-assisted development in thi
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change replaces the silent `git pull || git pull`
-  retry in `lib/bash/git/lib_git.sh` with `_git_pull_with_retry`, which logs a
-  warning after the first failure, retries once, and preserves final failure
-  logging.
+- Most recent uncommitted change adds `basectl check --format json` for
+  automation-friendly stdout output while preserving the default human logging
+  contract on stderr.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -80,11 +80,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
 
 ## Usability Issues
 
-- [ ] Make `basectl check` more automation-friendly.
+- [x] Make `basectl check` more automation-friendly.
   - Files: `cli/bash/commands/basectl/subcommands/check.sh`, `lib/bash/std/lib_std.sh`
   - Problem: all log output goes to stderr, so `basectl check > result.txt` captures nothing and scripting requires `2>&1`.
   - Expected fix: consider `--format json`, `--quiet`, or a documented stdout/stderr contract.
   - Add tests for any new output mode.
+  - Done locally with `basectl check --format json`; pending commit.
 
 - [x] Add a CLI path to disable profile defaults.
   - File: `cli/bash/commands/basectl/subcommands/update_profile.sh`

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -14,8 +14,9 @@ Usage:
   basectl check [options]
 
 Options:
-  -v          Enable DEBUG logging for this subcommand.
-  -h, --help  Show this help text.
+  --format <text|json>  Select output format. Defaults to text.
+  -v                    Enable DEBUG logging for this subcommand.
+  -h, --help            Show this help text.
 
 Purpose:
   Verify the local Base CLI environment on macOS without making changes.
@@ -30,11 +31,31 @@ EOF
 }
 
 base_check_subcommand_main() {
+    local output_format="text"
+
     while (($#)); do
         case "$1" in
             -h|--help|help)
                 base_check_subcommand_usage
                 return 0
+                ;;
+            --format)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    print_error "Option '--format' requires an argument."
+                    base_check_subcommand_usage >&2
+                    return 1
+                fi
+                case "$1" in
+                    text|json)
+                        output_format="$1"
+                        ;;
+                    *)
+                        print_error "Unsupported check output format '$1'."
+                        base_check_subcommand_usage >&2
+                        return 1
+                        ;;
+                esac
                 ;;
             -v)
                 setup_enable_debug_logging
@@ -49,5 +70,9 @@ base_check_subcommand_main() {
     done
 
     log_debug "Running 'basectl check'."
-    setup_run_check
+    if [[ "$output_format" == json ]]; then
+        setup_run_check_json
+    else
+        setup_run_check
+    fi
 }

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -480,6 +480,100 @@ setup_run_check() {
     return 1
 }
 
+setup_json_escape() {
+    local value="${1:-}"
+
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\t'/\\t}"
+    printf '%s' "$value"
+}
+
+setup_print_check_json_item() {
+    local trailing_comma="$1"
+    local name="$2"
+    local ok="$3"
+    local message="$4"
+
+    printf '    {"name":"%s","ok":%s,"message":"%s"}%s\n' \
+        "$(setup_json_escape "$name")" \
+        "$ok" \
+        "$(setup_json_escape "$message")" \
+        "$trailing_comma"
+}
+
+setup_run_check_json() {
+    local bats_message bats_ok=false brew_bin homebrew_message homebrew_ok=false
+    local missing=0
+    local python_message python_ok=false
+    local venv_dir venv_message venv_ok=false
+    local xcode_message xcode_ok=false
+
+    setup_require_macos
+    venv_dir="$(setup_venv_dir)"
+
+    if brew_bin="$(setup_find_brew_bin)"; then
+        if setup_refresh_brew_path; then
+            homebrew_ok=true
+            homebrew_message="Homebrew is installed."
+        else
+            homebrew_message="Homebrew is installed, but its bin directory could not be added to PATH."
+            missing=1
+        fi
+    else
+        homebrew_message="Homebrew is not installed."
+        missing=1
+    fi
+
+    if setup_xcode_tools_installed; then
+        xcode_ok=true
+        xcode_message="Xcode Command Line Tools are installed."
+    else
+        xcode_message="Xcode Command Line Tools are not installed."
+        missing=1
+    fi
+
+    if setup_python_installed; then
+        python_ok=true
+        python_message="Python formula '$(setup_python_formula)' is installed via Homebrew."
+    else
+        python_message="Python formula '$(setup_python_formula)' is not installed via Homebrew."
+        missing=1
+    fi
+
+    if setup_bats_installed; then
+        bats_ok=true
+        bats_message="BATS formula '$(setup_bats_formula)' is installed via Homebrew."
+    else
+        bats_ok=false
+        bats_message="BATS formula '$(setup_bats_formula)' is not installed via Homebrew."
+        missing=1
+    fi
+
+    if setup_virtualenv_exists; then
+        venv_ok=true
+        venv_message="Virtual environment exists at '$venv_dir'."
+    else
+        venv_message="Virtual environment is missing at '$venv_dir'."
+        missing=1
+    fi
+
+    printf '{\n'
+    printf '  "ok": %s,\n' "$([[ "$missing" -eq 0 ]] && printf true || printf false)"
+    printf '  "checks": [\n'
+    setup_print_check_json_item "," "homebrew" "$homebrew_ok" "$homebrew_message"
+    setup_print_check_json_item "," "xcode_command_line_tools" "$xcode_ok" "$xcode_message"
+    setup_print_check_json_item "," "python" "$python_ok" "$python_message"
+    setup_print_check_json_item "," "bats" "$bats_ok" "$bats_message"
+    setup_print_check_json_item "" "base_virtualenv" "$venv_ok" "$venv_message"
+    printf '  ]\n'
+    printf '}\n'
+
+    [[ "$missing" -eq 0 ]]
+}
+
 setup_run_install() {
     setup_require_macos
     setup_install_homebrew

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load ../../../../../lib/bash/tests/test_helper.sh
+bats_require_minimum_version 1.5.0
 
 setup() {
     setup_test_tmpdir
@@ -573,6 +574,58 @@ EOF
     [[ "$output" == *"Base CLI environment check passed."* ]]
 }
 
+@test "basectl check --format json writes successful check results to stdout" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/bats-installed"
+    mkdir -p "$venv_dir/bin"
+    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        OSTYPE="darwin24" \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
+        "$BASE_REPO_ROOT/bin/basectl" check --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"ok": true'* ]]
+    [[ "$output" == *'"name":"homebrew","ok":true'* ]]
+    [[ "$output" == *'"name":"base_virtualenv","ok":true'* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl check --format json writes failed check results to stdout" {
+    create_xcode_stubs
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        OSTYPE="darwin24" \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
+        "$BASE_REPO_ROOT/bin/basectl" check --format json
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"name":"homebrew","ok":false'* ]]
+    [[ "$output" == *'"name":"base_virtualenv","ok":false'* ]]
+    [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/base/.venv'."* ]]
+    [ "${stderr:-}" = "" ]
+}
+
 @test "basectl check fails when required components are missing" {
     run_base_command check
 
@@ -583,6 +636,13 @@ EOF
     [[ "$output" == *"BATS formula 'bats-core' is not installed via Homebrew."* ]]
     [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [[ "$output" == *"Base CLI environment check found missing requirements."* ]]
+}
+
+@test "basectl check rejects unsupported output formats" {
+    run_base_command check --format xml
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unsupported check output format 'xml'."* ]]
 }
 
 @test "basectl -v setup enables DEBUG logs" {


### PR DESCRIPTION
## Summary

- Add `basectl check --format json`
- Preserve the default human-readable logging behavior on stderr
- Emit structured check results to stdout for automation
- Keep existing exit-code semantics:
  - `0` when all checks pass
  - `1` when any requirement is missing
- Validate unsupported output formats
- Mark the TODO item complete

## JSON Output

Example:

```json
{
  "ok": true,
  "checks": [
    {"name":"homebrew","ok":true,"message":"Homebrew is installed."},
    {"name":"xcode_command_line_tools","ok":true,"message":"Xcode Command Line Tools are installed."},
    {"name":"python","ok":true,"message":"Python formula 'python@3.13' is installed via Homebrew."},
    {"name":"bats","ok":true,"message":"BATS formula 'bats-core' is installed via Homebrew."},
    {"name":"base_virtualenv","ok":true,"message":"Virtual environment exists at '/Users/rameshhp/.base.d/base/.venv'."}
  ]
}