### PR TITLE
Make caff PID detection more robust

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -26,10 +26,10 @@ This file is the shared working memory for future AI-assisted development in thi
 - Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
   and `version`; users do not specify managers. The Python registry maps known
   `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change makes BATS a developer/test dependency:
-  default `basectl setup` no longer installs BATS and default `basectl check`
-  no longer fails when BATS is missing. Use `basectl setup --dev` and
-  `basectl check --dev` to install/check developer dependencies.
+- Most recent uncommitted change makes `caff` PID detection more robust:
+  `pgrep` results are captured without `head`, pgrep errors are reported
+  separately from "not running", and existing caffeinate commands are parsed
+  for `-w` PIDs across multiple argument shapes.
 - The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
 - The previous change added the supported `--version` flag to `basectl --help`.
 - The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.

--- a/TODO.md
+++ b/TODO.md
@@ -101,11 +101,12 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Update setup/check tests and README accordingly.
   - Done locally with BATS as an opt-in `--dev` dependency; pending commit.
 
-- [ ] Make `caff` PID detection more robust.
+- [x] Make `caff` PID detection more robust.
   - File: `cli/bash/commands/caff/caff.sh`
   - Problem: parsing `ps -o args` assumes a fixed `caffeinate -iw <pid>` argument position, and `pgrep | head -1` hides non-not-found errors.
   - Expected fix: use a more reliable relationship check, or parse arguments defensively with error handling.
   - Add tests for alternate caffeinate argument shapes and pgrep failures if feasible.
+  - Done locally; pending commit.
 
 - [x] Add `--version` to `basectl` help.
   - File: `cli/bash/commands/basectl/basectl.sh`

--- a/cli/bash/commands/caff/caff.sh
+++ b/cli/bash/commands/caff/caff.sh
@@ -21,12 +21,67 @@ caff_describe() {
     printf '%s\n' "Caffeinate a named process"
 }
 
+caff_first_pgrep_match() {
+    local pattern="$1"
+    local pgrep_output status
+
+    pgrep_output="$(pgrep "$pattern" 2>/dev/null)"
+    status=$?
+    if [[ "$status" -eq 0 ]]; then
+        [[ -n "$pgrep_output" ]] || return 1
+        printf '%s\n' "$pgrep_output" | sed -n '1p'
+        return 0
+    fi
+    if [[ "$status" -eq 1 ]]; then
+        return 1
+    fi
+
+    print_error "Unable to query process list for '$pattern'."
+    return 2
+}
+
+caff_wait_pid_from_caffeinate_args() {
+    local args_line="$1"
+    local arg rest
+    local waiting_for_pid=false
+    local args=()
+
+    read -r -a args <<< "$args_line"
+    for arg in "${args[@]:1}"; do
+        if [[ "$waiting_for_pid" == true ]]; then
+            printf '%s\n' "$arg"
+            return 0
+        fi
+
+        case "$arg" in
+            -w)
+                waiting_for_pid=true
+                ;;
+            -w[0-9]*)
+                printf '%s\n' "${arg#-w}"
+                return 0
+                ;;
+            -*w*)
+                rest="${arg#*w}"
+                if [[ -n "$rest" ]]; then
+                    printf '%s\n' "$rest"
+                    return 0
+                fi
+                waiting_for_pid=true
+                ;;
+        esac
+    done
+
+    return 1
+}
+
 main() {
     local silent=0
     local process_name
     local target_pid
     local caffeinate_pid
     local caffeinated_pid
+    local pgrep_status
 
     case "${1:-}" in
         -h|--help)
@@ -55,15 +110,21 @@ main() {
     fi
 
     process_name="$1"
-    target_pid="$(pgrep "$process_name" | head -1)"
-    if [[ ! "$target_pid" ]]; then
+    target_pid="$(caff_first_pgrep_match "$process_name")"
+    pgrep_status=$?
+    if [[ "$pgrep_status" -eq 1 ]]; then
         print_warn "'$process_name' process is not running."
         return 1
     fi
+    [[ "$pgrep_status" -eq 0 ]] || return 1
 
-    caffeinate_pid="$(pgrep caffeinate | head -1)"
-    if [[ "$caffeinate_pid" ]]; then
-        caffeinated_pid="$(ps -o args -p "$caffeinate_pid" | awk 'NR==2 {print $3}')"
+    caffeinate_pid="$(caff_first_pgrep_match caffeinate)"
+    pgrep_status=$?
+    if [[ "$pgrep_status" -eq 2 ]]; then
+        return 1
+    fi
+    if [[ "$pgrep_status" -eq 0 ]]; then
+        caffeinated_pid="$(ps -o args= -p "$caffeinate_pid" | while IFS= read -r line; do caff_wait_pid_from_caffeinate_args "$line" && break; done)"
         if [[ "$caffeinated_pid" == "$target_pid" ]]; then
             ((silent)) || printf '%s\n' "Already caffeinating: $process_name pid=$target_pid, caffeinate pid=$caffeinate_pid"
             return 0

--- a/cli/bash/commands/caff/tests/caff.bats
+++ b/cli/bash/commands/caff/tests/caff.bats
@@ -31,6 +31,10 @@ EOF
 create_pgrep_stub() {
     cat > "$TEST_MOCKBIN/pgrep" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${CAFF_TEST_PGREP_FAIL:-}" == "${1:-}" ]]; then
+    printf 'pgrep failed for %s\n' "$1" >&2
+    exit 2
+fi
 case "${1:-}" in
     caffeinate)
         [[ -n "${CAFF_TEST_CAFFEINATE_PID:-}" ]] && printf '%s\n' "$CAFF_TEST_CAFFEINATE_PID"
@@ -47,7 +51,9 @@ create_ps_stub() {
     cat > "$TEST_MOCKBIN/ps" <<'EOF'
 #!/usr/bin/env bash
 printf 'ARGS\n'
-if [[ -n "${CAFF_TEST_CAFFEINATED_PID:-}" ]]; then
+if [[ -n "${CAFF_TEST_PS_ARGS:-}" ]]; then
+    printf '%s\n' "$CAFF_TEST_PS_ARGS"
+elif [[ -n "${CAFF_TEST_CAFFEINATED_PID:-}" ]]; then
     printf 'caffeinate -iw %s\n' "$CAFF_TEST_CAFFEINATED_PID"
 fi
 EOF
@@ -157,4 +163,63 @@ wait_for_record() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Already caffeinating: worker pid=1234, caffeinate pid=9999"* ]]
     [ ! -e "$record_file" ]
+}
+
+@test "caff recognizes already caffeinated process when -w is a separate option" {
+    local record_file="$TEST_STATE_DIR/caffeinate.args"
+
+    create_caffeinate_stub
+    create_pgrep_stub
+    create_ps_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        CAFF_TEST_PROCESS_NAME=worker \
+        CAFF_TEST_TARGET_PID=1234 \
+        CAFF_TEST_CAFFEINATE_PID=9999 \
+        CAFF_TEST_PS_ARGS="caffeinate -i -w 1234" \
+        CAFF_TEST_RECORD="$record_file" \
+        "$BASE_REPO_ROOT/bin/basectl" caff worker
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Already caffeinating: worker pid=1234, caffeinate pid=9999"* ]]
+    [ ! -e "$record_file" ]
+}
+
+@test "caff recognizes already caffeinated process when -w appears before other options" {
+    local record_file="$TEST_STATE_DIR/caffeinate.args"
+
+    create_caffeinate_stub
+    create_pgrep_stub
+    create_ps_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        CAFF_TEST_PROCESS_NAME=worker \
+        CAFF_TEST_TARGET_PID=1234 \
+        CAFF_TEST_CAFFEINATE_PID=9999 \
+        CAFF_TEST_PS_ARGS="caffeinate -w 1234 -i" \
+        CAFF_TEST_RECORD="$record_file" \
+        "$BASE_REPO_ROOT/bin/basectl" caff worker
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Already caffeinating: worker pid=1234, caffeinate pid=9999"* ]]
+    [ ! -e "$record_file" ]
+}
+
+@test "caff reports pgrep errors instead of treating them as not running" {
+    create_caffeinate_stub
+    create_pgrep_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        CAFF_TEST_PGREP_FAIL=worker \
+        "$BASE_REPO_ROOT/bin/basectl" caff worker
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unable to query process list for 'worker'."* ]]
+    [[ "$output" != *"'worker' process is not running."* ]]
 }


### PR DESCRIPTION
## Summary

- Replace `pgrep ... | head -1` in `caff` with explicit `pgrep` status handling
- Distinguish missing target processes from real `pgrep` failures
- Parse existing `caffeinate` command arguments defensively instead of assuming a fixed argument position
- Recognize multiple valid `caffeinate -w` forms:
  - `caffeinate -iw <pid>`
  - `caffeinate -i -w <pid>`
  - `caffeinate -w <pid> -i`
- Add focused BATS coverage for alternate caffeinate argument shapes and pgrep failures
- Mark the TODO item complete

## Testing

- `bash -n cli/bash/commands/caff/caff.sh`
- `bats cli/bash/commands/caff/tests/caff.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`