### PR TITLE
Complete base_cli v1 TODO reconciliation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -123,12 +123,13 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
 
 ## Base CLI Python Layer
 
-- [ ] Implement `base_cli` v1 for Python CLIs.
+- [x] Implement `base_cli` v1 for Python CLIs.
   - Files: `lib/python/base_cli/`, `docs/base-cli-design.md`, `cli/bash/commands/basectl/subcommands/setup_common.sh`
   - Goal: provide explicit `App`/decorator-driven initialization for Base and Base-supported project CLIs.
   - V1 scope: `Context`, Click wrapper decorators, standard options, `~/.base.d/cli/<name>` paths, user/file logging, temp/cache directories, sensitive option redaction for invocation logging, project manifest discovery, and a test helper.
   - Bootstrap: install Click into Base's Python virtual environment alongside PyYAML.
   - Add focused Python tests and keep existing setup tests passing.
+  - Done locally; pending commit.
 
 - [x] Dogfood `base_cli` in `base_setup`.
   - Files: `cli/python/base_setup/engine.py`, `cli/python/base_setup/tests/test_engine.py`, `lib/python/base_cli/`

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -5,13 +5,23 @@ import io
 import os
 import tempfile
 import unittest
-from contextlib import chdir, redirect_stderr
+from contextlib import contextmanager, redirect_stderr
 from pathlib import Path
 from unittest import mock
 
 import base_cli
 from base_cli.paths import base_state_root, discover_manifest, normalize_cli_name
 from base_cli.redaction import redact_argv
+
+
+@contextmanager
+def change_directory(path: Path):
+    original = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(original)
 
 
 class BaseCliTests(unittest.TestCase):
@@ -99,7 +109,7 @@ class BaseCliTests(unittest.TestCase):
                 os.sys,
                 "argv",
                 ["secret-tool", "--debug", "--token", "super-secret"],
-            ), chdir(project):
+            ), change_directory(project):
                 from base_cli.testing import invoke
 
                 result = invoke(

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -5,7 +5,7 @@ import io
 import os
 import tempfile
 import unittest
-from contextlib import redirect_stderr
+from contextlib import chdir, redirect_stderr
 from pathlib import Path
 from unittest import mock
 
@@ -69,6 +69,59 @@ class BaseCliTests(unittest.TestCase):
             self.assertTrue((home / ".base.d" / "cli" / "demo" / "logs").is_dir())
             self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} INFO\s+")
             self.assertIn("hello Ada", result.stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_standard_options_manifest_context_and_sensitive_redaction(self) -> None:
+        app = base_cli.App(name="secret-tool", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        @base_cli.option("--token", sensitive=True, required=True)
+        def main(ctx: base_cli.Context, token: str) -> None:
+            seen["token"] = token
+            seen["debug"] = ctx.debug
+            seen["temp_dir"] = ctx.temp_dir
+            seen["log_file"] = ctx.log_file
+            seen["manifest_path"] = ctx.manifest_path
+            seen["project_root"] = ctx.project_root
+            ctx.log.info("processed token")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            project = Path(tmpdir) / "project"
+            home.mkdir()
+            project.mkdir()
+            manifest_path = project / "base_manifest.yaml"
+            manifest_path.write_text("project:\n  name: demo\n", encoding="utf-8")
+            log_file = home / "custom.log"
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}), mock.patch.object(
+                os.sys,
+                "argv",
+                ["secret-tool", "--debug", "--token", "super-secret"],
+            ), chdir(project):
+                from base_cli.testing import invoke
+
+                result = invoke(
+                    app,
+                    ["--debug", "--keep-temp", "--log-file", str(log_file), "--token", "super-secret"],
+                    home=home,
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(seen["token"], "super-secret")
+            self.assertTrue(seen["debug"])
+            self.assertTrue(seen["temp_dir"].exists())
+            self.assertEqual(seen["log_file"], log_file)
+            self.assertEqual(seen["manifest_path"], manifest_path.resolve())
+            self.assertEqual(seen["project_root"], project.resolve())
+
+            log_text = log_file.read_text(encoding="utf-8")
+            self.assertIn("--token", log_text)
+            self.assertIn("[REDACTED]", log_text)
+            self.assertNotIn("super-secret", log_text)
+            self.assertIn("manifest_path=", log_text)
+            self.assertIn("project_root=", log_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Mark `base_cli` v1 as complete in `TODO.md`
- Add focused `base_cli` tests for v1 behavior that was already implemented
- Cover standard options, custom log files, temp retention, manifest discovery, and sensitive invocation redaction

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`