### PR TITLE
Check Base Python bootstrap packages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,10 +27,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Add focused failure-path coverage in `lib/bash/file/tests/lib_file.bats` if practical.
   - Done.
 
-- [ ] Fix Homebrew artifact version handling.
+- [x] Fix Homebrew artifact version handling.
   - File: `cli/python/base_setup/engine.py`
   - Problem: `reconcile_homebrew_artifact` receives and logs an artifact version, but runs `brew install <package>` without honoring non-latest versions.
   - Expected fix: either implement supported Homebrew version handling or raise `ArtifactError` when a Homebrew artifact specifies anything other than `latest`.
+  - Done.
 
 - [ ] Deduplicate Base manifest discovery.
   - Files: `cli/python/base_setup/manifest.py`, `lib/python/base_cli/paths.py`
@@ -42,10 +43,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: `_quote_arg` reimplements shell quoting and passes empty strings through unquoted.
   - Expected fix: replace `format_command`/`_quote_arg` internals with `shlex.join(command)` and cover empty-string formatting.
 
-- [ ] Honor `BASE_PROJECT_VENV_DIR` in Python artifact installs.
+- [x] Honor `BASE_PROJECT_VENV_DIR` in Python artifact installs.
   - Files: `cli/python/base_setup/engine.py`, `bin/base-wrapper`
   - Problem: `base-wrapper` honors `BASE_PROJECT_VENV_DIR`, but `reconcile_python_artifact` hardcodes `~/.base.d/<project>/.venv`.
   - Expected fix: make Python artifact installation use `BASE_PROJECT_VENV_DIR` when present, falling back to the standard project venv path.
+  - Done.
 
 ## Design Issues
 
@@ -98,10 +100,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Add tests around the intended retry or non-retry behavior.
   - Done.
 
-- [ ] Capture subprocess error output in artifact setup.
+- [x] Capture subprocess error output in artifact setup.
   - File: `cli/python/base_setup/engine.py`
   - Problem: failed subprocesses inherit stderr/stdout, so the persistent log only gets the command and exit code, not the tool's failure reason.
   - Expected fix: capture stderr in `run_command`, include it in `ArtifactError`, and log it before raising.
+  - Done.
 
 - [ ] Make `Context.cleanup` resilient to cleanup failures.
   - File: `lib/python/base_cli/context.py`
@@ -128,15 +131,17 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: `CliRunner()` may mix stderr into stdout depending on Click behavior, while tests and callers expect `result.stderr`.
   - Expected fix: construct `CliRunner(mix_stderr=False)` when supported and keep tests explicit about stderr capture.
 
-- [ ] Clarify default-only artifact setup logging.
+- [x] Clarify default-only artifact setup logging.
   - File: `cli/python/base_setup/engine.py`
   - Problem: `reconcile_manifest` logs that a project declares no artifacts even when default manifest artifacts are still merged and installed.
   - Expected fix: log based on the merged artifact list, or explicitly say that Base defaults are being installed.
+  - Done.
 
-- [ ] Add PyYAML and Click checks to `basectl check`.
+- [x] Add PyYAML and Click checks to `basectl check`.
   - File: `cli/bash/commands/basectl/subcommands/setup_common.sh`
   - Problem: `basectl check` verifies the venv exists but not whether required bootstrap packages are installed.
   - Expected fix: check both `$(setup_pyyaml_package)` and `$(setup_click_package)` in text and JSON check modes.
+  - Done.
 
 - [ ] Deduplicate Zsh baserc protection.
   - Files: `lib/shell/zprofile`, `lib/shell/zshrc`

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -408,6 +408,16 @@ setup_install_click() {
     setup_install_base_python_package "$(setup_click_package)"
 }
 
+setup_base_python_package_check_message() {
+    local package="$1"
+
+    if setup_base_python_package_installed "$package"; then
+        printf "Python package '%s' is installed in the Base virtual environment.\n" "$package"
+    else
+        printf "Python package '%s' is not installed in the Base virtual environment.\n" "$package"
+    fi
+}
+
 setup_run_project_artifact_setup() {
     local exit_code project wrapper
     local args=()
@@ -437,9 +447,11 @@ setup_run_project_artifact_setup() {
 }
 
 setup_run_check() {
-    local brew_bin="" venv_dir missing=0
+    local brew_bin="" click_package pyyaml_package venv_dir missing=0
 
     setup_require_macos
+    click_package="$(setup_click_package)"
+    pyyaml_package="$(setup_pyyaml_package)"
     venv_dir="$(setup_venv_dir)"
 
     if brew_bin="$(setup_find_brew_bin)"; then
@@ -481,6 +493,20 @@ setup_run_check() {
         missing=1
     fi
 
+    if setup_base_python_package_installed "$pyyaml_package"; then
+        log_info "$(setup_base_python_package_check_message "$pyyaml_package")"
+    else
+        log_warn "$(setup_base_python_package_check_message "$pyyaml_package")"
+        missing=1
+    fi
+
+    if setup_base_python_package_installed "$click_package"; then
+        log_info "$(setup_base_python_package_check_message "$click_package")"
+    else
+        log_warn "$(setup_base_python_package_check_message "$click_package")"
+        missing=1
+    fi
+
     if ((missing == 0)); then
         log_info "Base CLI environment check passed."
         return 0
@@ -516,12 +542,16 @@ setup_print_check_json_item() {
 
 setup_run_check_json() {
     local bats_message bats_ok=false brew_bin homebrew_message homebrew_ok=false
+    local click_message click_ok=false click_package
     local missing=0
+    local pyyaml_message pyyaml_ok=false pyyaml_package
     local python_message python_ok=false
     local venv_dir venv_message venv_ok=false
     local xcode_message xcode_ok=false
 
     setup_require_macos
+    click_package="$(setup_click_package)"
+    pyyaml_package="$(setup_pyyaml_package)"
     venv_dir="$(setup_venv_dir)"
 
     if brew_bin="$(setup_find_brew_bin)"; then
@@ -572,6 +602,20 @@ setup_run_check_json() {
         missing=1
     fi
 
+    if setup_base_python_package_installed "$pyyaml_package"; then
+        pyyaml_ok=true
+    else
+        missing=1
+    fi
+    pyyaml_message="$(setup_base_python_package_check_message "$pyyaml_package")"
+
+    if setup_base_python_package_installed "$click_package"; then
+        click_ok=true
+    else
+        missing=1
+    fi
+    click_message="$(setup_base_python_package_check_message "$click_package")"
+
     printf '{\n'
     printf '  "ok": %s,\n' "$([[ "$missing" -eq 0 ]] && printf true || printf false)"
     printf '  "checks": [\n'
@@ -581,6 +625,8 @@ setup_run_check_json() {
     if setup_dev_dependencies_enabled; then
         setup_print_check_json_item "," "bats" "$bats_ok" "$bats_message"
     fi
+    setup_print_check_json_item "," "pyyaml" "$pyyaml_ok" "$pyyaml_message"
+    setup_print_check_json_item "," "click" "$click_ok" "$click_message"
     setup_print_check_json_item "" "base_virtualenv" "$venv_ok" "$venv_message"
     printf '  ]\n'
     printf '}\n'

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -298,6 +298,29 @@ run_base_command() {
         "$BASE_REPO_ROOT/bin/basectl" "${command_args[@]}"
 }
 
+create_base_venv_stub() {
+    local venv_dir="${1:-$TEST_HOME/.base.d/base/.venv}"
+
+    mkdir -p "$venv_dir/bin"
+    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+    cat > "$venv_dir/bin/python" <<'EOF'
+#!/usr/bin/env bash
+pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$click_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed" ]]
+    exit $?
+fi
+printf 'unexpected check venv python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$venv_dir/bin/python"
+}
+
 @test "basectl setup prints usage for help" {
     run_base_command setup --help
 
@@ -585,8 +608,9 @@ EOF
     mkdir -p "$TEST_TMPDIR/CommandLineTools"
     touch "$TEST_STATE_DIR/python-installed"
     touch "$TEST_STATE_DIR/bats-installed"
-    mkdir -p "$venv_dir/bin"
-    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
 
     run_base_command check
 
@@ -596,7 +620,29 @@ EOF
     [[ "$output" == *"Python formula 'python@3.13' is installed via Homebrew."* ]]
     [[ "$output" != *"BATS formula 'bats-core'"* ]]
     [[ "$output" == *"Virtual environment exists at '$venv_dir'."* ]]
+    [[ "$output" == *"Python package 'PyYAML' is installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Python package 'click' is installed in the Base virtual environment."* ]]
     [[ "$output" == *"Base CLI environment check passed."* ]]
+}
+
+@test "basectl check fails when a required Base Python package is missing" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command check
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Virtual environment exists at '$venv_dir'."* ]]
+    [[ "$output" == *"Python package 'PyYAML' is not installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Python package 'click' is installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Base CLI environment check found missing requirements."* ]]
 }
 
 @test "basectl check --dev includes BATS in developer dependency checks" {
@@ -607,8 +653,9 @@ EOF
     touch "$TEST_STATE_DIR/xcode-installed"
     mkdir -p "$TEST_TMPDIR/CommandLineTools"
     touch "$TEST_STATE_DIR/python-installed"
-    mkdir -p "$venv_dir/bin"
-    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
 
     run_base_command check --dev
 
@@ -626,8 +673,9 @@ EOF
     mkdir -p "$TEST_TMPDIR/CommandLineTools"
     touch "$TEST_STATE_DIR/python-installed"
     touch "$TEST_STATE_DIR/bats-installed"
-    mkdir -p "$venv_dir/bin"
-    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
 
     run --separate-stderr env \
         HOME="$TEST_HOME" \
@@ -644,6 +692,8 @@ EOF
     [[ "$output" == *'"ok": true'* ]]
     [[ "$output" == *'"name":"homebrew","ok":true'* ]]
     [[ "$output" != *'"name":"bats"'* ]]
+    [[ "$output" == *'"name":"pyyaml","ok":true'* ]]
+    [[ "$output" == *'"name":"click","ok":true'* ]]
     [[ "$output" == *'"name":"base_virtualenv","ok":true'* ]]
     [ "${stderr:-}" = "" ]
 }
@@ -656,8 +706,9 @@ EOF
     touch "$TEST_STATE_DIR/xcode-installed"
     mkdir -p "$TEST_TMPDIR/CommandLineTools"
     touch "$TEST_STATE_DIR/python-installed"
-    mkdir -p "$venv_dir/bin"
-    printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
 
     run --separate-stderr env \
         HOME="$TEST_HOME" \
@@ -673,6 +724,8 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *'"ok": false'* ]]
     [[ "$output" == *'"name":"bats","ok":false'* ]]
+    [[ "$output" == *'"name":"pyyaml","ok":true'* ]]
+    [[ "$output" == *'"name":"click","ok":true'* ]]
     [ "${stderr:-}" = "" ]
 }
 
@@ -693,6 +746,8 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *'"ok": false'* ]]
     [[ "$output" == *'"name":"homebrew","ok":false'* ]]
+    [[ "$output" == *'"name":"pyyaml","ok":false'* ]]
+    [[ "$output" == *'"name":"click","ok":false'* ]]
     [[ "$output" == *'"name":"base_virtualenv","ok":false'* ]]
     [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [ "${stderr:-}" = "" ]


### PR DESCRIPTION
## Summary

- Add PyYAML and Click validation to `basectl check`
- Include PyYAML and Click check results in `basectl check --format json`
- Add BATS coverage for successful package checks, missing package checks, and JSON output
- Mark completed artifact/setup correctness TODOs as done

## Testing

- `bats cli/bash/commands/basectl/tests/setup.bats`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`