### PR TITLE
Document artifact manifest schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,23 @@ project:
 artifacts:
   - type: tool
     name: terraform
-    version: "1.8.5"
+    version: latest
+
+  - type: python-package
+    name: requests
+    version: latest
 ```
 
 The manifest intentionally describes what the project needs, not how to install
 it. Base owns the artifact registry and chooses the manager for each supported
 `type` and `name` pair. Unknown artifacts fail setup clearly instead of running
 arbitrary user-provided install commands.
+
+The supported artifact registry lives in
+`cli/python/base_setup/registry.py`. Today, `python-package` artifacts install
+into the project virtual environment at `~/.base.d/<project>/.venv`.
+Homebrew-managed `tool` artifacts currently support `version: latest`; pinned
+Homebrew versions fail clearly until Base grows explicit versioned tool support.
 
 ### 2. Shell Environment Management
 

--- a/TODO.md
+++ b/TODO.md
@@ -196,15 +196,17 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Add tests for the chosen behavior.
   - Done.
 
-- [ ] Add schema documentation to `base_manifest.yaml`.
+- [x] Add schema documentation to `base_manifest.yaml`.
   - File: `base_manifest.yaml`
   - Problem: the root manifest is the first artifact schema many developers will see, but it has no comments explaining supported artifact types, version semantics, or the artifact registry.
   - Expected fix: add concise schema comments and point readers to `cli/python/base_setup/registry.py` for supported `(type, name)` pairs.
+  - Done.
 
-- [ ] Document project virtual environment location.
+- [x] Document project virtual environment location.
   - Files: `docs/design.md`, `README.md`, possibly `base_manifest.yaml`
   - Problem: project virtual environments live at `~/.base.d/<project>/.venv`, but that convention is not easy for developers to discover.
   - Expected fix: document the venv location and how it relates to python-package artifacts.
+  - Done.
 
 - [ ] Add git branch context to Zsh defaults prompt.
   - File: `lib/shell/zsh_defaults.sh`

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -1,7 +1,31 @@
 project:
+  # Project name used by Base for setup logs and the project virtual
+  # environment at ~/.base.d/<project>/.venv.
   name: base
 
 artifacts:
+  # Artifact declarations are intentionally declarative:
+  #   type:    artifact category understood by Base, such as "python-package"
+  #            or "tool".
+  #   name:    artifact name from Base's registry.
+  #   version: requested artifact version. Use "latest" when Base should install
+  #            the manager's default/current version.
+  #
+  # Base chooses the manager from the registry instead of accepting install
+  # commands in the manifest. The source of truth for supported (type, name)
+  # pairs is cli/python/base_setup/registry.py.
+  #
+  # python-package artifacts are installed into the project virtual environment:
+  #   ~/.base.d/<project>/.venv
+  #
+  # tool artifacts are currently managed through Homebrew. For Homebrew-managed
+  # artifacts, Base currently supports version: latest only.
+  #
+  # Example:
+  #   - type: tool
+  #     name: terraform
+  #     version: latest
+
   - type: python-package
     name: pylint
     version: latest

--- a/docs/design.md
+++ b/docs/design.md
@@ -309,41 +309,38 @@ conflict because Base venv is not surfaced in the interactive shell.
 Each Base-managed project declares its dependencies in a YAML manifest file at the
 project root. Base reads this manifest to know what to install and configure.
 
-File: `base.yaml` (name TBD)
+File: `base_manifest.yaml`
 
-Conceptual structure:
+Current structure:
 
 ```yaml
 project:
   name: myproject
-  description: A short description
 
-dependencies:
-  system:
-    - kubernetes
-    - terraform
-    - docker
-  python:
-    - version: "3.12"
-      packages:
-        - requests
-        - rich
-  go:
-    - version: "1.22"
+artifacts:
+  - type: tool
+    name: terraform
+    version: latest
 
-shell:
-  env:
-    MY_PROJECT_ENV: production
-  path:
-    - ./bin
+  - type: python-package
+    name: requests
+    version: latest
 ```
 
-The Python layer interprets this declarative manifest and translates each item into
-concrete installation actions. Base knows how to install system tools via Homebrew,
-manage Python versions and packages, and handle language-specific package managers.
+The Python layer interprets this declarative manifest and translates each
+artifact into concrete installation actions. Base owns the artifact registry and
+chooses the manager for each supported `(type, name)` pair. The current registry
+is `cli/python/base_setup/registry.py`.
 
-Version conflicts across projects are a known complexity — addressed in a later
-iteration, not in the initial build.
+`python-package` artifacts install into the project virtual environment at
+`~/.base.d/<project>/.venv`. Base's own project venv is therefore
+`~/.base.d/base/.venv`. The wrapper `bin/base-wrapper` runs Python packages
+through that project-scoped venv.
+
+Homebrew-managed `tool` artifacts currently support `version: latest`. If a
+project requests a pinned Homebrew version, setup fails clearly instead of
+silently installing a different version. Richer version conflict handling across
+projects is a later iteration, not part of the initial build.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add schema comments to the root `base_manifest.yaml`
- Document the current `base_manifest.yaml` artifact format in README and design docs
- Explain that `python-package` artifacts install into `~/.base.d/<project>/.venv`
- Point developers to `cli/python/base_setup/registry.py` as the supported artifact registry
- Clarify that Homebrew-managed tool artifacts currently support `version: latest`
- Mark the manifest schema and project venv documentation TODOs complete

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`