### PR TITLE
Deduplicate Base manifest discovery

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,10 +33,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: either implement supported Homebrew version handling or raise `ArtifactError` when a Homebrew artifact specifies anything other than `latest`.
   - Done.
 
-- [ ] Deduplicate Base manifest discovery.
+- [x] Deduplicate Base manifest discovery.
   - Files: `cli/python/base_setup/manifest.py`, `lib/python/base_cli/paths.py`
   - Problem: upward discovery for `base_manifest.yaml` is implemented in both modules.
   - Expected fix: keep the shared implementation in `base_cli.paths`, remove the duplicate from `base_setup.manifest`, and update imports/tests.
+  - Done.
 
 - [ ] Use `shlex.join` for setup command formatting.
   - File: `cli/python/base_setup/engine.py`

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -6,8 +6,9 @@ import venv
 from pathlib import Path
 
 import base_cli
+from base_cli.paths import discover_manifest
 
-from .manifest import ArtifactRequest, BaseManifest, ManifestError, discover_manifest, read_manifest
+from .manifest import ArtifactRequest, BaseManifest, ManifestError, read_manifest
 from .registry import ArtifactDefinition, get_artifact_definition
 
 

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -31,20 +31,6 @@ class BaseManifest:
     artifacts: tuple[ArtifactRequest, ...]
 
 
-def discover_manifest(start: Path) -> Path | None:
-    current = start.resolve()
-    if current.is_file():
-        current = current.parent
-
-    while True:
-        candidate = current / "base_manifest.yaml"
-        if candidate.is_file():
-            return candidate
-        if current.parent == current:
-            return None
-        current = current.parent
-
-
 def read_manifest(path: Path) -> BaseManifest:
     if yaml is None:
         raise ManifestError(

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -144,6 +144,30 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: brew install terraform", stderr)
 
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_discovers_manifest_from_start_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            nested = root / "nested"
+            nested.mkdir()
+            manifest_path = root / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, _stdout, stderr = run_engine(["--dry-run", "--start-dir", str(nested)])
+
+        self.assertEqual(status, 0)
+        self.assertIn(f"Reading Base manifest at '{manifest_path.resolve()}'.", stderr)
+
     def test_homebrew_artifact_rejects_non_latest_version(self) -> None:
         definition = get_artifact_definition("tool", "terraform")
         self.assertIsNotNone(definition)


### PR DESCRIPTION
## Summary

- Remove the duplicate `discover_manifest` implementation from `base_setup.manifest`
- Reuse `base_cli.paths.discover_manifest` from the setup engine
- Add coverage for manifest discovery via `base_setup --start-dir`
- Mark the TODO item complete

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`