### PR TITLE
Use shlex for setup command formatting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,10 +39,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: keep the shared implementation in `base_cli.paths`, remove the duplicate from `base_setup.manifest`, and update imports/tests.
   - Done.
 
-- [ ] Use `shlex.join` for setup command formatting.
+- [x] Use `shlex.join` for setup command formatting.
   - File: `cli/python/base_setup/engine.py`
   - Problem: `_quote_arg` reimplements shell quoting and passes empty strings through unquoted.
   - Expected fix: replace `format_command`/`_quote_arg` internals with `shlex.join(command)` and cover empty-string formatting.
+  - Done.
 
 - [x] Honor `BASE_PROJECT_VENV_DIR` in Python artifact installs.
   - Files: `cli/python/base_setup/engine.py`, `bin/base-wrapper`

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import venv
 from pathlib import Path
@@ -266,10 +267,4 @@ def dry_run_command(ctx: base_cli.Context, command: list[str]) -> None:
 
 
 def format_command(command: list[str]) -> str:
-    return " ".join(_quote_arg(arg) for arg in command)
-
-
-def _quote_arg(arg: str) -> str:
-    if arg and all(char.isalnum() or char in "/._=:@+-" for char in arg):
-        return arg
-    return "'" + arg.replace("'", "'\"'\"'") + "'"
+    return shlex.join(command)

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from unittest import mock
 
 from base_setup import engine
-from base_setup.engine import ArtifactError, main, merge_artifacts
+from base_setup.engine import ArtifactError, format_command, main, merge_artifacts
 from base_setup.manifest import ArtifactRequest
 from base_setup.manifest import read_manifest
 from base_setup.registry import get_artifact_definition
@@ -61,6 +61,12 @@ class ManifestTests(unittest.TestCase):
                     ArtifactRequest(artifact_type="python-package", name="click", version="1.0.0"),
                 ),
             )
+
+    def test_format_command_uses_shell_quoting_for_empty_and_spaced_args(self) -> None:
+        self.assertEqual(
+            format_command(["tool", "", "two words", "plain"]),
+            "tool '' 'two words' plain",
+        )
 
     def test_reads_basic_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Replace custom setup command quoting with `shlex.join`
- Remove the unused `_quote_arg` implementation
- Add coverage for empty-string and spaced argument formatting
- Mark the TODO item complete

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`