### PR TITLE
Make base_cli cleanup resilient

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,10 +108,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: capture stderr in `run_command`, include it in `ArtifactError`, and log it before raising.
   - Done.
 
-- [ ] Make `Context.cleanup` resilient to cleanup failures.
+- [x] Make `Context.cleanup` resilient to cleanup failures.
   - File: `lib/python/base_cli/context.py`
   - Problem: one failing cleanup hook can skip later hooks, log handler cleanup, and temp directory removal; `rmtree` failures can also mask the original command result.
   - Expected fix: catch and log cleanup hook and temp removal failures while continuing cleanup.
+  - Done.
 
 - [ ] Return unambiguous fallback source paths in Python logs.
   - File: `lib/python/base_cli/logging.py`

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -38,13 +38,25 @@ class Context:
 
     def cleanup(self) -> None:
         for hook in self.cleanup_hooks:
-            hook()
-        for handler in list(self.log.handlers):
-            handler.flush()
-            handler.close()
-            self.log.removeHandler(handler)
+            try:
+                hook()
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.log.warning("Cleanup hook failed: %s", exc)
         if not self.keep_temp and self.temp_dir.exists():
-            shutil.rmtree(self.temp_dir)
+            try:
+                shutil.rmtree(self.temp_dir)
+            except OSError as exc:
+                self.log.warning("Temp directory cleanup failed for '%s': %s", self.temp_dir, exc)
+        for handler in list(self.log.handlers):
+            try:
+                handler.flush()
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.log.warning("Log handler flush failed: %s", exc)
+            try:
+                handler.close()
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.log.warning("Log handler close failed: %s", exc)
+            self.log.removeHandler(handler)
 
 
 def set_current_context(context: Context | None) -> contextvars.Token[Context | None]:
@@ -60,4 +72,3 @@ def get_current_context() -> Context:
     if context is None:
         raise RuntimeError("base_cli context is not active. Run inside a base_cli.App command.")
     return context
-

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -25,6 +25,29 @@ def change_directory(path: Path):
 
 
 class BaseCliTests(unittest.TestCase):
+    @staticmethod
+    def make_context(tmpdir: str) -> tuple[base_cli.Context, mock.Mock]:
+        root = Path(tmpdir)
+        temp_dir = root / "tmp"
+        temp_dir.mkdir()
+        log = mock.Mock()
+        log.handlers = []
+        context = base_cli.Context(
+            cli_name="demo",
+            run_id="run",
+            state_dir=root / "state",
+            log_dir=root / "logs",
+            cache_dir=root / "cache",
+            temp_dir=temp_dir,
+            log_file=root / "logs" / "run.log",
+            config={},
+            environment="dev",
+            debug=False,
+            keep_temp=False,
+            log=log,
+        )
+        return context, log
+
     def test_import_has_no_state_directory_side_effect(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
@@ -132,6 +155,53 @@ class BaseCliTests(unittest.TestCase):
             self.assertNotIn("super-secret", log_text)
             self.assertIn("manifest_path=", log_text)
             self.assertIn("project_root=", log_text)
+
+    def test_cleanup_continues_after_hook_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            context, log = self.make_context(tmpdir)
+            calls = []
+
+            def failing_hook() -> None:
+                calls.append("failing")
+                raise RuntimeError("hook exploded")
+
+            def later_hook() -> None:
+                calls.append("later")
+
+            context.on_cleanup(failing_hook)
+            context.on_cleanup(later_hook)
+
+            context.cleanup()
+
+            self.assertEqual(calls, ["failing", "later"])
+            self.assertFalse(context.temp_dir.exists())
+            log.warning.assert_any_call("Cleanup hook failed: %s", mock.ANY)
+
+    def test_cleanup_logs_temp_removal_failure_without_raising(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            context, log = self.make_context(tmpdir)
+
+            with mock.patch("base_cli.context.shutil.rmtree", side_effect=OSError("permission denied")):
+                context.cleanup()
+
+            log.warning.assert_any_call(
+                "Temp directory cleanup failed for '%s': %s",
+                context.temp_dir,
+                mock.ANY,
+            )
+
+    def test_cleanup_removes_handler_after_flush_and_close_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            context, log = self.make_context(tmpdir)
+            handler = mock.Mock()
+            handler.flush.side_effect = RuntimeError("flush exploded")
+            handler.close.side_effect = RuntimeError("close exploded")
+            log.handlers = [handler]
+
+            context.cleanup()
+
+            log.removeHandler.assert_called_once_with(handler)
+            self.assertEqual(log.warning.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Make `Context.cleanup()` continue after cleanup hook failures
- Log temp directory cleanup failures without raising
- Make log handler flush/close best-effort while still removing handlers
- Add focused tests for cleanup failure paths
- Mark the TODO item complete

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`