### PR TITLE
Use resolved fallback paths in Python logs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -114,10 +114,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: catch and log cleanup hook and temp removal failures while continuing cleanup.
   - Done.
 
-- [ ] Return unambiguous fallback source paths in Python logs.
+- [x] Return unambiguous fallback source paths in Python logs.
   - File: `lib/python/base_cli/logging.py`
   - Problem: `_source_path` falls back to a bare filename when the log source is outside `BASE_HOME` and the current working directory.
   - Expected fix: return the resolved absolute path as the fallback.
+  - Done.
 
 - [ ] Remove or guard system-wide Base config loading.
   - File: `lib/python/base_cli/config.py`

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -66,7 +66,7 @@ def _source_path(record: logging.LogRecord) -> str:
             return str(path.resolve().relative_to(root.resolve()))
         except ValueError:
             continue
-    return path.name
+    return str(path.resolve())
 
 
 def log_invocation(logger: logging.Logger, argv: list[str], sensitive_options: set[str]) -> None:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import logging
 import os
 import tempfile
 import unittest
@@ -10,6 +11,7 @@ from pathlib import Path
 from unittest import mock
 
 import base_cli
+from base_cli.logging import BaseCliFormatter
 from base_cli.paths import base_state_root, discover_manifest, normalize_cli_name
 from base_cli.redaction import redact_argv
 
@@ -72,6 +74,31 @@ class BaseCliTests(unittest.TestCase):
             redact_argv(argv, {"api_key", "token"}),
             ["tool", "--api-key", "[REDACTED]", "--token=[REDACTED]", "--name", "visible"],
         )
+
+    def test_log_source_fallback_uses_resolved_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            base_home = root / "base-home"
+            cwd = root / "cwd"
+            external = root / "external" / "same_name.py"
+            base_home.mkdir()
+            cwd.mkdir()
+            external.parent.mkdir()
+            external.write_text("# test\n", encoding="utf-8")
+            record = logging.LogRecord(
+                name="base_cli.test",
+                level=logging.INFO,
+                pathname=str(external),
+                lineno=7,
+                msg="hello",
+                args=(),
+                exc_info=None,
+            )
+
+            with mock.patch.dict(os.environ, {"BASE_HOME": str(base_home)}), change_directory(cwd):
+                formatted = BaseCliFormatter().format(record)
+
+        self.assertIn(f"{external.resolve()}:7 hello", formatted)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_runs_with_context_and_cleans_temp_dir(self) -> None:


### PR DESCRIPTION
## Summary

- Use resolved absolute fallback paths for Python log source formatting
- Add coverage for log records outside `BASE_HOME` and cwd
- Mark the TODO item complete

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`