### PR TITLE
Capture base_cli test stderr separately

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -130,10 +130,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: `BASE_SETUP_PYYAML_READY` is exported and used as cross-function run state for dry-run gating.
   - Expected fix: inline the package-installed check in `setup_run_project_artifact_setup` instead of exporting a readiness flag.
 
-- [ ] Capture `base_cli.testing` stderr separately.
+- [x] Capture `base_cli.testing` stderr separately.
   - File: `lib/python/base_cli/testing.py`
   - Problem: `CliRunner()` may mix stderr into stdout depending on Click behavior, while tests and callers expect `result.stderr`.
   - Expected fix: construct `CliRunner(mix_stderr=False)` when supported and keep tests explicit about stderr capture.
+  - Done.
 
 - [x] Clarify default-only artifact setup logging.
   - File: `cli/python/base_setup/engine.py`

--- a/lib/python/base_cli/testing.py
+++ b/lib/python/base_cli/testing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -13,5 +14,8 @@ def invoke(app: Any, args: list[str] | None = None, home: Path | None = None):
     env = {}
     if home is not None:
         env["HOME"] = str(home)
-    runner = CliRunner()
+    runner_kwargs = {}
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        runner_kwargs["mix_stderr"] = False
+    runner = CliRunner(**runner_kwargs)
     return runner.invoke(app.click_command, args or [], env=env)

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -131,6 +131,27 @@ class BaseCliTests(unittest.TestCase):
             self.assertIn("hello Ada", result.stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_testing_invoke_captures_stderr_separately(self) -> None:
+        app = base_cli.App(name="streams", version="0.1.0")
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            print("stdout text")
+            ctx.log.info("stderr text")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+                from base_cli.testing import invoke
+
+                result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("stdout text", result.stdout)
+        self.assertNotIn("stderr text", result.stdout)
+        self.assertIn("stderr text", result.stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_standard_options_manifest_context_and_sensitive_redaction(self) -> None:
         app = base_cli.App(name="secret-tool", version="0.1.0")
         seen = {}


### PR DESCRIPTION
## Summary

- Configure `base_cli.testing.invoke` to request separate stderr capture when supported by Click
- Preserve compatibility with newer Click versions that no longer expose `mix_stderr`
- Add coverage proving stdout and stderr are available separately
- Mark the TODO item complete

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`