### PR TITLE
Remove implicit system Base config

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -120,10 +120,16 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: return the resolved absolute path as the fallback.
   - Done.
 
-- [ ] Remove or guard system-wide Base config loading.
+- [x] Remove or guard system-wide Base config loading.
   - File: `lib/python/base_cli/config.py`
   - Problem: `load_config` always reads `/etc/base.d/config.yaml`, which can unexpectedly affect local developer tooling.
   - Expected fix: either remove system config from v1 or gate it behind an explicit environment variable such as `BASE_SYSTEM_CONFIG`.
+  - Done.
+
+- [ ] Design optional organization-wide Base config policy.
+  - File: `docs/base-cli-design.md`
+  - Goal: decide whether Base should support machine- or organization-managed config, where it should live, and how users can inspect or opt into it.
+  - Note: v1 intentionally does not read `/etc/base.d/config.yaml` implicitly.
 
 - [ ] Simplify PyYAML readiness state in setup.
   - File: `cli/bash/commands/basectl/subcommands/setup_common.sh`

--- a/docs/base-cli-design.md
+++ b/docs/base-cli-design.md
@@ -171,12 +171,11 @@ shape is stable.
 Configuration is resolved from lowest to highest precedence:
 
 1. Code defaults
-2. System config: `/etc/base.d/config.yaml`
-3. User config: `~/.base.d/config.yaml`
-4. Project config: `<project-root>/.base/config.yaml`
-5. Environment variables
-6. Command line options
-7. Explicit runtime API overrides
+2. User config: `~/.base.d/config.yaml`
+3. Project config: `<project-root>/.base/config.yaml`
+4. Environment variables
+5. Command line options
+6. Explicit runtime API overrides
 
 V1 implements the shape and context fields, but only needs a minimal config
 loader: YAML files are merged when present, environment is read from

--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -39,7 +39,6 @@ def load_config(
 ) -> dict[str, Any]:
     root = home or Path.home()
     config: dict[str, Any] = {}
-    config = merge_dicts(config, load_yaml_file(Path("/etc/base.d/config.yaml")))
     config = merge_dicts(config, load_yaml_file(root / ".base.d" / "config.yaml"))
     if project_root is not None:
         config = merge_dicts(config, load_yaml_file(project_root / ".base" / "config.yaml"))
@@ -54,4 +53,3 @@ def load_config(
     if "BASE_CLI_KEEP_TEMP" in os.environ:
         env_config["keep_temp"] = os.environ["BASE_CLI_KEEP_TEMP"].lower() == "true"
     return merge_dicts(config, env_config)
-

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from unittest import mock
 
 import base_cli
+from base_cli import config as config_module
+from base_cli.config import load_config
 from base_cli.logging import BaseCliFormatter
 from base_cli.paths import base_state_root, discover_manifest, normalize_cli_name
 from base_cli.redaction import redact_argv
@@ -99,6 +101,36 @@ class BaseCliTests(unittest.TestCase):
                 formatted = BaseCliFormatter().format(record)
 
         self.assertIn(f"{external.resolve()}:7 hello", formatted)
+
+    def test_config_precedence_excludes_implicit_system_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project = root / "project"
+            explicit = root / "explicit.yaml"
+            home_config = home / ".base.d" / "config.yaml"
+            project_config = project / ".base" / "config.yaml"
+            home_config.parent.mkdir(parents=True)
+            project_config.parent.mkdir(parents=True)
+            home_config.write_text("environment: user\nlog_level: info\n", encoding="utf-8")
+            project_config.write_text("environment: project\n", encoding="utf-8")
+            explicit.write_text("log_level: warning\n", encoding="utf-8")
+
+            original_load_yaml_file = config_module.load_yaml_file
+
+            def load_without_system_config(path: Path) -> dict:
+                if path == Path("/etc/base.d/config.yaml"):
+                    raise AssertionError("system config should not be loaded")
+                return original_load_yaml_file(path)
+
+            with mock.patch.dict(os.environ, {"BASE_CLI_ENVIRONMENT": "env"}), mock.patch(
+                "base_cli.config.load_yaml_file",
+                side_effect=load_without_system_config,
+            ):
+                config = load_config(project, explicit, home=home)
+
+        self.assertEqual(config["environment"], "env")
+        self.assertEqual(config["log_level"], "warning")
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_runs_with_context_and_cleans_temp_dir(self) -> None:


### PR DESCRIPTION
## Summary

- Remove implicit `/etc/base.d/config.yaml` loading from `base_cli`
- Update `base_cli` config precedence docs for v1
- Add a future TODO for optional organization-wide Base config policy
- Add regression coverage that system config is not loaded implicitly
- Mark the current TODO complete

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python/base_cli/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`