### PR TITLE
Cache runtime shell host prompt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -226,10 +226,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Problem: Bash defaults show git branch context in the prompt, but Zsh defaults do not.
   - Expected fix: add a Zsh git prompt helper and include it in `PROMPT`.
 
-- [ ] Avoid subprocess-per-prompt host lookup.
+- [x] Avoid subprocess-per-prompt host lookup.
   - File: `lib/bash/runtime/bashrc`
   - Problem: `_base_runtime_host_prompt` can run `scutil`/`hostname` on every prompt render.
   - Expected fix: compute the host prompt value once during runtime initialization and reference the cached variable in `PS1`.
+  - Done.
 
 ## Base CLI Python Layer
 

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -257,7 +257,7 @@ EOF
             printf "disable=%s\n" "${VIRTUAL_ENV_DISABLE_PROMPT:-}"'
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *'PS1=\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
     [[ "$output" == *"host=aadhara"* ]]
     [[ "$output" == *"venv=[.venv] "* ]]
     [[ "$output" == *"git=("* ]]
@@ -289,7 +289,7 @@ EOF
     [[ "$output" == *"alias user_bashrc_alias='printf user-bashrc'"* ]]
     [[ "$output" == *"USER_BASHRC_LOADED=1"* ]]
     [[ "$output" == *"USER_BASHRC_HAS_BASE_IMPORT=1"* ]]
-    [[ "$output" == *'PS1=\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 
 @test "BASE_DEBUG traces Base runtime shell startup" {

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -109,7 +109,8 @@ _base_runtime_set_prompt() {
     # Base owns this runtime shell prompt, so disable prompt mutation by Python
     # virtualenv activation and render the active venv dynamically instead.
     export VIRTUAL_ENV_DISABLE_PROMPT=1
-    PS1='\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '
+    _BASE_RUNTIME_HOST_PROMPT="$(_base_runtime_host_prompt)"
+    PS1='\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '
 }
 
 _base_runtime_main() {


### PR DESCRIPTION
## Summary

- Cache the Base runtime shell host prompt during prompt initialization
- Avoid running host lookup commands on every prompt render
- Update runtime prompt tests for the cached host variable
- Mark the TODO item complete

## Testing

- `bats cli/bash/commands/basectl/tests/basectl.bats`