### PR TITLE
Add git context to Zsh defaults prompt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -221,10 +221,11 @@ Use this as a commit-by-commit work queue. When an item is fixed, update the che
   - Expected fix: document the venv location and how it relates to python-package artifacts.
   - Done.
 
-- [ ] Add git branch context to Zsh defaults prompt.
+- [x] Add git branch context to Zsh defaults prompt.
   - File: `lib/shell/zsh_defaults.sh`
   - Problem: Bash defaults show git branch context in the prompt, but Zsh defaults do not.
   - Expected fix: add a Zsh git prompt helper and include it in `PROMPT`.
+  - Done.
 
 - [x] Avoid subprocess-per-prompt host lookup.
   - File: `lib/bash/runtime/bashrc`

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1061,6 +1061,18 @@ EOF
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
     [[ "$output" == *"git=("* ]]
     [[ "$output" == *'PS1=\[\033[0;35m\]\T \h\[\033[0;33m\] $(_base_bash_defaults_git_prompt)\w\[\033[00m\]: '* ]]
+
+    if command -v zsh >/dev/null 2>&1; then
+        run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u EDITOR -u VISUAL -u EXINIT \
+            HOME="$TEST_HOME" \
+            PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+            zsh -f -i -c 'source "$HOME/.zshrc"; cd "$BASE_HOME"; printf "git=%s\n" "$(_base_zsh_defaults_git_prompt)"; printf "PROMPT=%s\n" "$PROMPT"; setopt | grep -q "^promptsubst$"; printf "prompt_subst=enabled\n"'
+
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"git=("* ]]
+        [[ "$output" == *'PROMPT=%* %m $(_base_zsh_defaults_git_prompt)%1~: '* ]]
+        [[ "$output" == *"prompt_subst=enabled"* ]]
+    fi
 }
 
 @test "basectl update-profile preserves an existing defaults preference" {

--- a/lib/shell/zsh_defaults.sh
+++ b/lib/shell/zsh_defaults.sh
@@ -42,11 +42,25 @@ unset base_zsh_defaults_file
 
 bindkey -v
 
+_base_zsh_defaults_git_prompt() {
+    local branch
+
+    command -v git >/dev/null 2>&1 || return 0
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+    branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)" || \
+        branch="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
+    [[ -n "$branch" ]] || return 0
+
+    printf '(%s) ' "$branch"
+}
+
 export HISTSIZE="${HISTSIZE:-5000}"
 export SAVEHIST="${SAVEHIST:-5000}"
 setopt appendhistory
 setopt hist_ignore_dups
 setopt hist_ignore_all_dups
+setopt prompt_subst
 setopt share_history
 
-PROMPT='%* %m %1~: '
+PROMPT='%* %m $(_base_zsh_defaults_git_prompt)%1~: '


### PR DESCRIPTION
## Summary

- add a Zsh defaults helper that shows the current git branch or detached commit
- include the helper in the default Zsh prompt with prompt substitution enabled
- add BATS coverage for the Zsh defaults prompt path
- mark the TODO item complete

## Testing

- `bats cli/bash/commands/basectl/tests/setup.bats`