### PR TITLE
Avoid duplicate stderr logging in artifact setup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,6 @@ they are merged.
 
 ## Design Issues — Python Layer
 
-- [ ] Fix `run_command` double-logging of stderr.
-  - File: `cli/python/base_setup/engine.py`
-  - Problem: `run_command` logs stderr directly, then embeds the same stderr in `ArtifactError`; the top-level handler logs that exception again.
-  - Expected fix: surface failed command stderr exactly once, preferably by including it in the exception message and letting the top-level error handler log it.
-
 - [ ] Decide how artifact setup should handle subprocess stdout.
   - File: `cli/python/base_setup/engine.py`
   - Problem: `run_command` captures stderr but leaves stdout inherited from the parent process, so `brew` and `pip` output appears live in the terminal but is absent from the persistent Base log.

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -186,7 +186,7 @@ def reconcile_homebrew_artifact(
         definition.package,
         version,
     )
-    run_command(ctx, command)
+    run_command(command)
 
 
 def reconcile_python_artifact(
@@ -215,7 +215,7 @@ def reconcile_python_artifact(
         venv.create(venv_dir, with_pip=True)
 
     ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
-    run_command(ctx, [str(python_bin), "-m", "pip", "install", requirement])
+    run_command([str(python_bin), "-m", "pip", "install", requirement])
 
 
 def project_venv_dir(project: str) -> Path:
@@ -251,13 +251,12 @@ def run_check(command: list[str]) -> bool:
     return subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False).returncode == 0
 
 
-def run_command(ctx: base_cli.Context, command: list[str]) -> None:
+def run_command(command: list[str]) -> None:
     completed = subprocess.run(command, stderr=subprocess.PIPE, text=True, check=False)
     if completed.returncode:
         stderr = (completed.stderr or "").strip()
         message = f"Command failed with exit {completed.returncode}: {format_command(command)}"
         if stderr:
-            ctx.log.error("Command stderr: %s", stderr)
             message = f"{message}\n{stderr}"
         raise ArtifactError(message)
 

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -192,7 +192,7 @@ class ManifestTests(unittest.TestCase):
         ), mock.patch("base_setup.engine.run_command") as run_command:
             engine.reconcile_homebrew_artifact(ctx, definition, "latest", dry_run=False)
 
-        run_command.assert_called_once_with(ctx, ["brew", "install", "terraform"])
+        run_command.assert_called_once_with(["brew", "install", "terraform"])
 
     def test_python_artifact_honors_project_venv_dir_override(self) -> None:
         definition = get_artifact_definition("python-package", "requests")
@@ -218,16 +218,12 @@ class ManifestTests(unittest.TestCase):
         )
 
     def test_run_command_includes_stderr_on_failure(self) -> None:
-        ctx = fake_context()
-
         with mock.patch(
             "base_setup.engine.subprocess.run",
             return_value=mock.Mock(returncode=17, stderr="installer exploded\n"),
         ):
             with self.assertRaisesRegex(ArtifactError, "installer exploded"):
-                engine.run_command(ctx, ["installer", "--bad"])
-
-        ctx.log.error.assert_called_once_with("Command stderr: %s", "installer exploded")
+                engine.run_command(["installer", "--bad"])
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_project_argument_validates_manifest_project_name(self) -> None:


### PR DESCRIPTION
## Summary

- avoid double-logging subprocess stderr from artifact setup failures
- keep stderr in the raised `ArtifactError` so the top-level handler logs it once
- update focused engine coverage
- remove the completed TODO item

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`