### PR TITLE
Document artifact subprocess output policy

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,9 +5,4 @@ Action items from Claude's Base code analysis for version `0.1.0`.
 Use this as a commit-by-commit work queue. Completed items are removed after
 they are merged.
 
-## Design Issues — Python Layer
-
-- [ ] Decide how artifact setup should handle subprocess stdout.
-  - File: `cli/python/base_setup/engine.py`
-  - Problem: `run_command` captures stderr but leaves stdout inherited from the parent process, so `brew` and `pip` output appears live in the terminal but is absent from the persistent Base log.
-  - Expected fix: either capture and log stdout, stream it while also preserving it for the log, or document live-only stdout as intentional behavior.
+No open TODO items.

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -252,6 +252,7 @@ def run_check(command: list[str]) -> bool:
 
 
 def run_command(command: list[str]) -> None:
+    # Keep stdout live for installer progress; capture stderr for persistent failure logs.
     completed = subprocess.run(command, stderr=subprocess.PIPE, text=True, check=False)
     if completed.returncode:
         stderr = (completed.stderr or "").strip()

--- a/docs/design.md
+++ b/docs/design.md
@@ -342,6 +342,12 @@ project requests a pinned Homebrew version, setup fails clearly instead of
 silently installing a different version. Richer version conflict handling across
 projects is a later iteration, not part of the initial build.
 
+Artifact install commands keep stdout attached to the terminal so long-running
+tools such as `brew` and `pip` remain live and readable while setup runs. Base's
+persistent log records the command intent and captures stderr on failures. If
+Base later needs full install transcripts, it should add tee-style streaming so
+users still see progress while stdout is also preserved in the log.
+
 ---
 
 ## Mac Bootstrap Sequence


### PR DESCRIPTION
## Summary

- document artifact installer stdout behavior
- clarify that stdout remains live for user-facing progress
- note that persistent logs capture command intent and stderr on failures
- add a code comment to preserve the intent in `run_command`
- clear the final TODO item

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`