### PR TITLE
[codex] Fix project setup dry-run bootstrap

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -406,7 +406,7 @@ setup_base_python_package_check_message() {
 }
 
 setup_run_project_artifact_setup() {
-    local exit_code project wrapper
+    local base_pythonpath exit_code old_pythonpath project python_bin venv_dir
     local args=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
@@ -415,8 +415,8 @@ setup_run_project_artifact_setup() {
     fi
 
     project="${BASE_SETUP_PROJECT_NAME:-base}"
-    wrapper="$BASE_HOME/bin/base-wrapper"
-    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    venv_dir="$(setup_venv_dir)"
+    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'."
 
     if setup_is_dry_run; then
         args+=(--dry-run)
@@ -427,7 +427,13 @@ setup_run_project_artifact_setup() {
     args+=("$project")
 
     log_info "Running Python project setup layer."
-    "$wrapper" --project "$project" base_setup "${args[@]}"
+    base_pythonpath="$BASE_HOME/lib/python:$BASE_HOME/cli/python"
+    old_pythonpath="${PYTHONPATH-}"
+    if [[ -n "$old_pythonpath" ]]; then
+        base_pythonpath="$base_pythonpath:$old_pythonpath"
+    fi
+
+    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$base_pythonpath" "$python_bin" -m base_setup "${args[@]}"
     exit_code=$?
 
     exit_if_error "$exit_code" "Python project setup layer failed."

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -479,7 +479,7 @@ EOF
     [ -f "$venv_dir/pyvenv.cfg" ]
 }
 
-@test "basectl setup forwards project setup arguments through base-wrapper" {
+@test "basectl setup forwards project setup arguments through the Base venv" {
     local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
     local demo_venv_dir="$TEST_HOME/.base.d/demo/.venv"
     local manifest_path="$TEST_TMPDIR/demo_manifest.yaml"
@@ -491,8 +491,7 @@ EOF
     touch "$TEST_STATE_DIR/python-installed"
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
-    create_base_venv_stub "$base_venv_dir"
-    create_project_setup_venv_stub "$demo_venv_dir"
+    create_project_setup_venv_stub "$base_venv_dir"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest_path"
 
     run_base_command setup --dry-run --manifest "$manifest_path" demo
@@ -502,6 +501,7 @@ EOF
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" demo)" ]
+    [ ! -e "$demo_venv_dir/bin/python" ]
 }
 
 @test "basectl setup propagates Python project setup failure" {


### PR DESCRIPTION
## Summary

Fixes `basectl setup <project> --dry-run` when the target project virtual environment does not exist yet.

## What Changed

- Runs the Python project setup layer with Base's bootstrap virtual environment instead of the target project's virtual environment.
- Preserves the target project context by exporting `BASE_PROJECT=<project>` before invoking `base_setup`.
- Updates the setup BATS coverage to verify that project setup arguments are forwarded through the Base venv and that the target project venv does not need to exist first.

## Why

`basectl setup brew --dry-run` failed before the Python setup layer could run because the Bash layer invoked `base_setup` through `base-wrapper --project brew`. `base-wrapper` requires `~/.base.d/brew/.venv/bin/python` to already exist, but setup is responsible for creating or dry-running creation of that venv. This made first-time project setup fail in dry-run mode.

## Impact

First-time project setup dry-runs now reach the Python artifact reconciliation layer and correctly report the project venv and package install actions they would perform. Existing project setup behavior still targets the requested project through `BASE_PROJECT`.

## Validation

- `bats cli/bash/commands/basectl/tests/setup.bats` passed all 40 tests.
- Verified from `/Users/rameshhp/work/brew` that `/Users/rameshhp/work/base/bin/basectl setup brew --dry-run` completes and reports planned creation of `~/.base.d/brew/.venv`.