### PR TITLE
[codex] Suppress project completion log during dry run

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -96,7 +96,8 @@ def reconcile_manifest(
     for artifact, definition in zip(artifacts, definitions, strict=True):
         reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
 
-    ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
+    if not dry_run:
+        ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
 
 
 def resolve_artifact_definitions(artifacts: tuple[ArtifactRequest, ...]) -> tuple[ArtifactDefinition, ...]:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 from base_setup import engine
 from base_setup.engine import ArtifactError, format_command, main, merge_artifacts
-from base_setup.manifest import ArtifactRequest
+from base_setup.manifest import ArtifactRequest, BaseManifest
 from base_setup.manifest import read_manifest
 from base_setup.registry import get_artifact_definition
 
@@ -149,6 +149,17 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: brew install terraform", stderr)
+        self.assertNotIn("Project 'demo' artifact setup is complete.", stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_successful_non_dry_run_logs_project_artifact_completion(self) -> None:
+        ctx = fake_context()
+        default_manifest = BaseManifest(path=Path("default_manifest.yaml"), project_name="defaults", artifacts=())
+        manifest = BaseManifest(path=Path("base_manifest.yaml"), project_name="demo", artifacts=())
+
+        engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=False)
+
+        ctx.log.info.assert_any_call("Project '%s' artifact setup is complete.", "demo")
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_discovers_manifest_from_start_dir(self) -> None:


### PR DESCRIPTION
## Summary

Suppresses the Python project artifact completion log when `base_setup` is running in dry-run mode.

## What Changed

- Only logs `Project '<name>' artifact setup is complete.` for non-dry-run executions.
- Adds test coverage that dry-run output does not include the completion message.
- Adds test coverage that successful non-dry-run reconciliation still emits the completion message.

## Why

During `basectl setup brew --dry-run`, the Python setup layer can report planned actions, but saying artifact setup "is complete" is misleading because dry-run mode intentionally does not reconcile anything. The surrounding Bash layer already emits the appropriate dry-run completion line.

## Impact

Dry-run setup output now stays action-oriented and avoids implying that project artifacts were installed or reconciled. Normal setup runs continue to log completion after reconciliation succeeds.

## Validation

- `PYTHONPATH=/Users/rameshhp/work/base/cli/python:/Users/rameshhp/work/base/lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`
- Verified from `/Users/rameshhp/work/brew` that `/Users/rameshhp/work/base/bin/basectl setup brew --dry-run` completes without the project artifact completion log.