### PR TITLE
Add basectl projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Current implemented commands include:
 - `basectl setup`
 - `basectl check`
 - `basectl update-profile`
+- `basectl projects list`
 - `basectl version`
 - `basectl shell`
 
@@ -47,7 +48,6 @@ Planned commands include:
 - `basectl test`
 - `basectl test <project>`
 - `basectl doctor`
-- `basectl projects list`
 
 The important idea is that the user should not need to memorize a different
 bootstrap story for every repository in the workspace. Planned commands are
@@ -95,6 +95,16 @@ The supported artifact registry lives in
 into the project virtual environment at `~/.base.d/<project>/.venv`.
 Homebrew-managed `tool` artifacts currently support `version: latest`; pinned
 Homebrew versions fail clearly until Base grows explicit versioned tool support.
+
+You can inspect the projects Base can see with:
+
+```bash
+basectl projects list
+```
+
+By default this scans the parent directory of `BASE_HOME`, which matches the
+recommended sibling-repo workspace layout. Use `--workspace <path>` to inspect a
+different workspace root. Output is tab-separated as `<project-name><TAB><path>`.
 
 ### 2. Shell Environment Management
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,11 +12,6 @@ they are merged.
   - Expected behavior: discover the project, set `BASE_PROJECT` and project-root environment, activate `~/.base.d/<project>/.venv`, layer project shell behavior, and spawn a subshell that cleans up when it exits.
   - Notes: the activation model is already described in `docs/design.md`; implementation should follow that design before expanding scope.
 
-- [ ] Implement `basectl projects list`.
-  - Goal: make workspace discovery visible and inspectable.
-  - Expected behavior: scan the workspace for repos with `base_manifest.yaml`, parse project names, and print a stable list of discovered projects.
-  - Follow-up: later use the same discovery layer for completions, activation, setup, and project commands.
-
 - [ ] Split runtime artifacts out of `~/.base.d`.
   - Files: `lib/python/base_cli/paths.py`, `lib/python/base_cli/app.py`, tests.
   - Problem: `~/.base.d` currently mixes durable config and project venvs with ephemeral CLI logs, temp files, and caches.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -26,6 +26,7 @@ that delegate to `basectl`.
 - `setup`
 - `check`
 - `update-profile`
+- `projects list`
 - `version`
 - `shell`
 - `help`
@@ -38,6 +39,7 @@ that delegate to `basectl`.
   project argument validates `project.name`.
 - `basectl check` verifies the same local requirements without making changes.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
+- `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -15,6 +15,8 @@ Commands:
     Verify the local Base CLI environment without making changes.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
+  projects list [options]
+    List Base-managed projects discovered in the workspace.
   version
     Show the installed Base version.
   shell
@@ -149,6 +151,11 @@ basectl_do_update_profile() {
     base_update_profile_subcommand_main "$@"
 }
 
+basectl_do_projects() {
+    basectl_source_subcommand_module projects || return 1
+    base_projects_subcommand_main "$@"
+}
+
 basectl_do_shell() {
     local shell_rc
 
@@ -249,6 +256,7 @@ basectl_main() {
         check)            basectl_do_check "$@" ;;
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
+        projects)         basectl_do_projects "$@" ;;
         shell)            basectl_do_shell "$@" ;;
         update-profile)   basectl_do_update_profile "$@" ;;
         version)          basectl_do_version ;;

--- a/cli/bash/commands/basectl/subcommands/projects.sh
+++ b/cli/bash/commands/basectl/subcommands/projects.sh
@@ -1,0 +1,57 @@
+[[ -n "${_base_projects_subcommand_sourced:-}" ]] && return
+_base_projects_subcommand_sourced=1
+readonly _base_projects_subcommand_sourced
+
+base_projects_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl projects list [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+List Base-managed projects discovered through base_manifest.yaml files.
+EOF
+}
+
+base_projects_subcommand_main() {
+    local project_command="${1:-}"
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    case "$project_command" in
+        ""|-h|--help)
+            base_projects_subcommand_usage
+            return 0
+            ;;
+        list)
+            shift
+            ;;
+        *)
+            base_projects_subcommand_usage >&2
+            fatal_error "Unknown projects command '$project_command'."
+            ;;
+    esac
+
+    while (($# > 0)); do
+        case "$1" in
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            -h|--help)
+                base_projects_subcommand_usage
+                return 0
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_projects list "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -22,6 +22,7 @@ run_basectl() {
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [options]"* ]]
+    [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
     [[ "$output" == *"--debug-wrapper"* ]]
@@ -113,6 +114,47 @@ EOF
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl setup [options]"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on macOS."* ]]
+}
+
+@test "basectl projects list discovers manifests in a workspace" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base" "$workspace/demo" "$workspace/notes"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" && "${4:-}" == "--workspace" ]]; then
+    printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT" > "${BASE_TEST_PROJECTS_LIST_STATE:?}"
+    printf '%s\t%s\n' base "$5/base"
+    printf '%s\t%s\n' demo "$5/demo"
+    exit 0
+fi
+printf 'unexpected projects list python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: base\nartifacts: []\n' > "$workspace/base/base_manifest.yaml"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECTS_LIST_STATE="$TEST_TMPDIR/projects-list-state" \
+        "$BASE_REPO_ROOT/bin/basectl" projects list --workspace "$workspace"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'base\t'"$workspace/base"* ]]
+    [[ "$output" == *$'demo\t'"$workspace/demo"* ]]
+    [ "$(cat "$TEST_TMPDIR/projects-list-state")" = "BASE_PROJECT=base" ]
+}
+
+@test "basectl projects list prints help without requiring the Base Python venv" {
+    run_basectl projects list --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl projects list [options]"* ]]
 }
 
 @test "basectl rejects removed legacy commands" {

--- a/cli/python/base_projects/__init__.py
+++ b/cli/python/base_projects/__init__.py
@@ -1,0 +1,1 @@
+"""Base workspace project discovery."""

--- a/cli/python/base_projects/__main__.py
+++ b/cli/python/base_projects/__main__.py
@@ -1,0 +1,5 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import base_cli
+from base_setup.manifest import ManifestError, read_manifest
+
+
+app = base_cli.App(name="base_projects")
+
+
+@dataclass(frozen=True, order=True)
+class Project:
+    name: str
+    root: Path
+    manifest_path: Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    result = app.click_command.main(args=argv, standalone_mode=False)
+    return int(result or 0)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("command", required=False)
+@base_cli.option("--workspace", help="Workspace directory to scan. Defaults to BASE_HOME's parent.")
+def run(ctx: base_cli.Context, command: str | None, workspace: str | None) -> int:
+    if command in (None, "list"):
+        return list_projects_command(ctx, workspace)
+
+    ctx.log.error("Unknown projects command '%s'. Supported command: list.", command)
+    return 2
+
+
+def list_projects_command(ctx: base_cli.Context, workspace: str | None) -> int:
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        projects = discover_projects(workspace_root)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    for project in projects:
+        print(f"{project.name}\t{project.root}")
+    return 0
+
+
+class ProjectDiscoveryError(RuntimeError):
+    pass
+
+
+def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path:
+    if workspace:
+        return Path(workspace).expanduser().resolve()
+    if ctx.base_home is None:
+        raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
+    return ctx.base_home.parent.resolve()
+
+
+def discover_projects(workspace_root: Path) -> tuple[Project, ...]:
+    if not workspace_root.is_dir():
+        raise ProjectDiscoveryError(f"Workspace '{workspace_root}' is not a directory.")
+
+    projects = []
+    for candidate in sorted(workspace_root.iterdir(), key=lambda path: path.name):
+        if not candidate.is_dir():
+            continue
+        manifest_path = candidate / "base_manifest.yaml"
+        if not manifest_path.is_file():
+            continue
+        projects.append(read_project(manifest_path))
+
+    return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def read_project(manifest_path: Path) -> Project:
+    try:
+        manifest = read_manifest(manifest_path)
+    except ManifestError as exc:
+        raise ProjectDiscoveryError(str(exc)) from exc
+    return Project(
+        name=manifest.project_name,
+        root=manifest_path.parent.resolve(),
+        manifest_path=manifest_path.resolve(),
+    )
+
+
+def validate_unique_project_names(projects: tuple[Project, ...]) -> tuple[Project, ...]:
+    seen: dict[str, Project] = {}
+    duplicates = []
+    for project in projects:
+        existing = seen.get(project.name)
+        if existing is not None:
+            duplicates.append((project, existing))
+        else:
+            seen[project.name] = project
+
+    if duplicates:
+        details = "; ".join(
+            f"{project.name}: {existing.root} and {project.root}" for project, existing in duplicates
+        )
+        raise ProjectDiscoveryError(f"Duplicate project names found: {details}.")
+
+    return projects

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_projects import engine
+
+
+def write_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
+def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with tempfile.TemporaryDirectory() as home_dir:
+        with mock.patch.dict(os.environ, {"HOME": home_dir, "BASE_HOME": str(base_home)}):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class ProjectDiscoveryTests(unittest.TestCase):
+    def test_discovers_projects_under_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            write_manifest(workspace / "zeta", "zeta")
+            write_manifest(workspace / "alpha", "alpha")
+            (workspace / "notes").mkdir()
+
+            projects = engine.discover_projects(workspace)
+
+        self.assertEqual([project.name for project in projects], ["alpha", "zeta"])
+
+    def test_projects_list_defaults_to_base_home_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            write_manifest(base_home, "base")
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(["list"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"base\t{base_home.resolve()}", stdout)
+        self.assertIn(f"demo\t{(workspace / 'demo').resolve()}", stdout)
+
+    def test_projects_list_supports_workspace_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "custom"
+            base_home = Path(tmpdir) / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(["list", "--workspace", str(workspace)], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{(workspace / 'demo').resolve()}\n")
+
+    def test_projects_list_reports_invalid_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            bad = workspace / "bad"
+            bad.mkdir()
+            (bad / "base_manifest.yaml").write_text("project: []\n", encoding="utf-8")
+
+            status, _stdout, stderr = run_engine(["list"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("project must be a mapping", stderr)
+
+    def test_projects_list_rejects_duplicate_project_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            write_manifest(workspace / "one", "demo")
+            write_manifest(workspace / "two", "demo")
+
+            with self.assertRaisesRegex(engine.ProjectDiscoveryError, "Duplicate project names"):
+                engine.discover_projects(workspace)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/design.md
+++ b/docs/design.md
@@ -74,9 +74,9 @@ layers. This keeps the product name and the control-plane action separate:
 - `basectl setup`
 - `basectl check`
 - `basectl update-profile`
+- `basectl projects list`
 - `basectl shell`
-- future commands such as `basectl projects list`, `basectl test`, and
-  `basectl activate`
+- future commands such as `basectl test` and `basectl activate`
 
 Shebang-based Bash scripts can also use:
 


### PR DESCRIPTION
## Summary

- add `basectl projects list` as the first visible workspace discovery command
- add a `base_projects` Python package that scans a workspace for `base_manifest.yaml` files
- default discovery to the parent of `BASE_HOME`, with `--workspace <path>` override
- print tab-separated `<project-name>\t<path>` output
- reject invalid manifests and duplicate project names
- document the new command in README/design docs
- remove the completed TODO item

## Testing

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py') cli/python/base_projects/*.py cli/python/base_projects/tests/*.py`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bin/basectl projects list --workspace /Users/rameshhp/work`