### PR TITLE
Add basectl project activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Current implemented commands include:
 - `basectl check`
 - `basectl update-profile`
 - `basectl projects list`
+- `basectl activate <project>`
 - `basectl version`
-- `basectl shell`
 
 Planned commands include:
 
@@ -105,6 +105,21 @@ basectl projects list
 By default this scans the parent directory of `BASE_HOME`, which matches the
 recommended sibling-repo workspace layout. Use `--workspace <path>` to inspect a
 different workspace root. Output is tab-separated as `<project-name><TAB><path>`.
+
+Once a project is discoverable, activate it with:
+
+```bash
+basectl activate example
+```
+
+Activation spawns a project-specific subshell, changes to the project root, sets
+`BASE_PROJECT` and related project variables, and activates the project virtual
+environment at `~/.base.d/<project>/.venv`. Exit that shell to return to the
+original environment.
+
+Invoking `basectl` with no arguments in a terminal is equivalent to
+`basectl activate base`, so the default interactive Base shell uses Base's own
+project virtual environment.
 
 ### 2. Shell Environment Management
 
@@ -298,12 +313,13 @@ They do not source `base_init.sh`. Base runtime setup happens only when the
 `basectl` command runs a Base command, runs an explicit script path, or starts a
 Base-enabled Bash shell.
 
-When `basectl` starts an interactive Bash runtime shell, it uses Base's runtime
-rcfile rather than making Bash read `~/.bashrc` directly. That runtime rcfile
-loads `base_init.sh`, sources the user's `~/.bashrc` once with guardrails, and
-finally sets the Base runtime prompt. This keeps user aliases and normal
-interactive Bash behavior available while making Base stdlib functions such as
-`import_base_lib` available during user Bash startup.
+When `basectl activate <project>` starts an interactive Bash runtime shell, it
+uses Base's runtime rcfile rather than making Bash read `~/.bashrc` directly.
+That runtime rcfile loads `base_init.sh`, sources the user's `~/.bashrc` once
+with guardrails, activates the project virtual environment, and finally sets the
+Base runtime prompt. This keeps user aliases and normal interactive Bash
+behavior available while making Base stdlib functions such as `import_base_lib`
+available during user Bash startup.
 
 ### Debugging Shell Startup
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,6 @@ they are merged.
 
 ## P0 — Core Workspace Loop
 
-- [ ] Implement `basectl activate <project>`.
-  - Goal: make Base a daily workspace tool, not only a setup tool.
-  - Expected behavior: discover the project, set `BASE_PROJECT` and project-root environment, activate `~/.base.d/<project>/.venv`, layer project shell behavior, and spawn a subshell that cleans up when it exits.
-  - Notes: the activation model is already described in `docs/design.md`; implementation should follow that design before expanding scope.
-
 - [ ] Split runtime artifacts out of `~/.base.d`.
   - Files: `lib/python/base_cli/paths.py`, `lib/python/base_cli/app.py`, tests.
   - Problem: `~/.base.d` currently mixes durable config and project venvs with ephemeral CLI logs, temp files, and caches.

--- a/bin/basectl
+++ b/bin/basectl
@@ -5,7 +5,7 @@
 #     Public control-plane command for Base.
 #
 # Responsibilities:
-#     - start a Bash shell with the Base runtime established
+#     - start a Bash shell with the Base project runtime established
 #     - run the umbrella Base command implementation
 #     - run Base command implementations by convention
 #     - run explicit Bash script paths inside the Base runtime
@@ -185,17 +185,6 @@ basectl_run_bash_script() {
     main "${basectl_runtime_args[@]}"
 }
 
-basectl_start_shell() {
-    local base_home="$1"
-    local shell_rc="$base_home/lib/bash/runtime/bashrc"
-
-    [[ -f "$shell_rc" ]] || basectl_die "Base runtime Bash rcfile '$shell_rc' was not found."
-
-    export BASE_HOME="$base_home"
-    export BASE_SHELL=1
-    exec "${BASH:-bash}" --rcfile "$shell_rc"
-}
-
 basectl_command_script() {
     local base_home="$1"
     local command_name="${2:-}"
@@ -246,7 +235,7 @@ main() {
     fi
 
     if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
-        basectl_start_shell "$base_home"
+        basectl_run_control_command "$base_home" activate base
         return $?
     fi
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -23,6 +23,7 @@ that delegate to `basectl`.
 
 ## Current subcommands
 
+- `activate`
 - `setup`
 - `check`
 - `update-profile`
@@ -34,6 +35,8 @@ that delegate to `basectl`.
 ## Notes
 
 - `basectl setup` is the default local bootstrap path.
+- `basectl activate <project>` starts a project-specific runtime subshell with
+  the project virtual environment active.
 - `basectl setup [project]` runs the Bash bootstrap layer first, then invokes the
   Python project setup layer for `base_manifest.yaml` artifacts. The optional
   project argument validates `project.name`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -9,6 +9,8 @@ basectl_show_help() {
 Usage: basectl [options] <command> [args...]
 
 Commands:
+  activate <project> [options]
+    Start an interactive Base runtime subshell for a project.
   setup [options]
     Install and bootstrap the local Base CLI environment on macOS.
   check [options]
@@ -19,8 +21,6 @@ Commands:
     List Base-managed projects discovered in the workspace.
   version
     Show the installed Base version.
-  shell
-    Start an interactive Bash shell with the Base runtime loaded.
   help
     Show this help text.
 
@@ -40,8 +40,8 @@ Wrapper options:
 Notes:
   - `basectl setup` is the preferred entrypoint for machine bootstrap.
   - `basectl check` verifies the same local requirements without making changes.
-  - Invoking `basectl` with no command opens an interactive shell when attached to
-    a terminal; otherwise it prints this help text.
+  - Invoking `basectl` with no command is equivalent to `basectl activate base`
+    when attached to a terminal; otherwise it prints this help text.
   - Use `-v` for command-level debug logs. Use `--debug-wrapper` when debugging
     startup before command dispatch or Base runtime initialization.
 EOF
@@ -110,14 +110,6 @@ basectl_runtime_base_home() {
     return 1
 }
 
-basectl_shell_rc_path() {
-    local base_home
-
-    base_home="$(basectl_runtime_base_home)" || return 1
-    printf '%s\n' "$base_home/lib/bash/runtime/bashrc"
-}
-
-
 basectl_enable_debug_logging() {
     set_log_level DEBUG
     export LOG_DEBUG=1
@@ -141,6 +133,11 @@ basectl_do_setup() {
     base_setup_subcommand_main "$@"
 }
 
+basectl_do_activate() {
+    basectl_source_subcommand_module activate || return 1
+    base_activate_subcommand_main "$@"
+}
+
 basectl_do_check() {
     basectl_source_subcommand_module check || return 1
     base_check_subcommand_main "$@"
@@ -154,24 +151,6 @@ basectl_do_update_profile() {
 basectl_do_projects() {
     basectl_source_subcommand_module projects || return 1
     base_projects_subcommand_main "$@"
-}
-
-basectl_do_shell() {
-    local shell_rc
-
-    if (($# > 0)); then
-        basectl_usage_error "The 'shell' command does not accept arguments."
-        return $?
-    fi
-
-    shell_rc="$(basectl_shell_rc_path)" || {
-        basectl_error "$BASE_CLI_ERROR_MESSAGE"
-        return 1
-    }
-
-    export BASE_HOME
-    export BASE_SHELL=1
-    exec "${BASH:-bash}" --rcfile "$shell_rc"
 }
 
 basectl_source_version_library() {
@@ -253,16 +232,16 @@ basectl_main() {
     log_debug "Running basectl command '${command:-<none>}' with args: $*"
 
     case "$command" in
+        activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;
-        shell)            basectl_do_shell "$@" ;;
         update-profile)   basectl_do_update_profile "$@" ;;
         version)          basectl_do_version ;;
         "")
             if basectl_should_start_shell; then
-                basectl_do_shell
+                basectl_do_activate base
             else
                 basectl_show_help
             fi

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -1,0 +1,108 @@
+[[ -n "${_base_activate_subcommand_sourced:-}" ]] && return
+_base_activate_subcommand_sourced=1
+readonly _base_activate_subcommand_sourced
+
+base_activate_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl activate <project> [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Start an interactive Base runtime subshell for a project.
+EOF
+}
+
+base_activate_usage_error() {
+    base_activate_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_activate_resolve_project() {
+    local project="$1"
+    local wrapper="$2"
+    shift 2
+
+    "$wrapper" --project base base_projects resolve "$project" "$@"
+}
+
+base_activate_subcommand_main() {
+    local project="" wrapper resolve_output activate_shell
+    local resolved_name project_root manifest_path venv_dir shell_rc
+    local args=()
+
+    while (($# > 0)); do
+        case "$1" in
+            -h|--help)
+                base_activate_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --workspace)
+                [[ -n "${2:-}" ]] || {
+                    base_activate_usage_error "Option '--workspace' requires an argument."
+                    return $?
+                }
+                args+=(--workspace "$2")
+                shift 2
+                ;;
+            --workspace=*)
+                args+=("$1")
+                shift
+                ;;
+            -*)
+                base_activate_usage_error "Unknown activate option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$project" ]]; then
+                    base_activate_usage_error "The 'activate' command accepts exactly one project name."
+                    return $?
+                fi
+                project="$1"
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$project" ]] || {
+        base_activate_usage_error "Project name is required."
+        return $?
+    }
+
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    resolve_output="$(base_activate_resolve_project "$project" "$wrapper" "${args[@]}")" || return $?
+    IFS=$'\t' read -r resolved_name project_root manifest_path <<<"$resolve_output"
+
+    [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
+        fatal_error "Unable to resolve project '$project'."
+    }
+
+    venv_dir="$HOME/.base.d/$resolved_name/.venv"
+    [[ -x "$venv_dir/bin/python" ]] || {
+        fatal_error "Project virtual environment Python was not found at '$venv_dir/bin/python'. Run 'basectl setup $resolved_name' first."
+    }
+
+    shell_rc="$BASE_HOME/lib/bash/runtime/bashrc"
+    [[ -f "$shell_rc" ]] || fatal_error "Base runtime shell rcfile '$shell_rc' was not found."
+
+    export BASE_PROJECT="$resolved_name"
+    export BASE_PROJECT_ROOT="$project_root"
+    export BASE_PROJECT_MANIFEST="$manifest_path"
+    export BASE_PROJECT_VENV_DIR="$venv_dir"
+    export BASE_HOME
+    export BASE_SHELL=1
+
+    cd "$project_root" || fatal_error "Unable to enter project root '$project_root'."
+    activate_shell="${BASE_ACTIVATE_SHELL:-${BASH:-bash}}"
+    exec "$activate_shell" --rcfile "$shell_rc"
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -20,9 +20,11 @@ run_basectl() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
+    [[ "$output" == *"activate <project> [options]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
+    [[ "$output" == *"Invoking \`basectl\` with no command is equivalent to \`basectl activate base\`"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
     [[ "$output" == *"--debug-wrapper"* ]]
@@ -43,6 +45,7 @@ run_basectl() {
     ! grep -Fqx '  man' <<<"$output"
     ! grep -Fqx '  embrace' <<<"$output"
     ! grep -Fqx '  install' <<<"$output"
+    ! grep -Fqx '  shell' <<<"$output"
     grep -Fqx '  version' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
@@ -54,6 +57,23 @@ run_basectl() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
+}
+
+@test "basectl with no command activates the base project in an interactive shell" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            log_debug() { :; }
+            basectl_should_start_shell() { return 0; }
+            basectl_get_base_home() { export BASE_HOME; }
+            basectl_do_activate() { printf "activate=%s\n" "$*"; }
+            basectl_main
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "activate=base" ]
 }
 
 @test "basectl prints version with --version and version" {
@@ -157,22 +177,97 @@ EOF
     [[ "$output" == *"basectl projects list [options]"* ]]
 }
 
+@test "basectl activate resolves a project and execs a project subshell" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local project_python="$TEST_HOME/.base.d/demo/.venv/bin/python"
+    local project_activate="$TEST_HOME/.base.d/demo/.venv/bin/activate"
+    local workspace="$TEST_TMPDIR/workspace"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'args=%s\n' "$*"
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'BASE_PROJECT_ROOT=%s\n' "$BASE_PROJECT_ROOT"
+printf 'BASE_PROJECT_MANIFEST=%s\n' "$BASE_PROJECT_MANIFEST"
+printf 'BASE_PROJECT_VENV_DIR=%s\n' "$BASE_PROJECT_VENV_DIR"
+printf 'PWD=%s\n' "$PWD"
+EOF
+    printf '#!/usr/bin/env bash\n' > "$project_python"
+    printf 'VIRTUAL_ENV=%s\nexport VIRTUAL_ENV\n' "$TEST_HOME/.base.d/demo/.venv" > "$project_activate"
+    chmod +x "$base_python" "$project_python" "$fake_bash"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_ACTIVATE_SHELL="$fake_bash" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"args=--rcfile $BASE_REPO_ROOT/lib/bash/runtime/bashrc"* ]]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"BASE_PROJECT_ROOT=$workspace/demo"* ]]
+    [[ "$output" == *"BASE_PROJECT_MANIFEST=$workspace/demo/base_manifest.yaml"* ]]
+    [[ "$output" == *"BASE_PROJECT_VENV_DIR=$TEST_HOME/.base.d/demo/.venv"* ]]
+    [[ "$output" == *"PWD=$workspace/demo"* ]]
+}
+
+@test "basectl activate prints help without requiring the Base Python venv" {
+    run_basectl activate --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl activate <project> [options]"* ]]
+}
+
+@test "basectl activate reports missing project as a usage error" {
+    run_basectl activate
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"ERROR: Project name is required."* ]]
+    [[ "$output" != *"FATAL"* ]]
+    [[ "$output" != *"Encountered a fatal error"* ]]
+}
+
+@test "basectl activate reports invalid arguments as usage errors" {
+    run_basectl activate --workspace
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--workspace' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl activate --unknown demo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unknown activate option '--unknown'."* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl activate demo extra
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: The 'activate' command accepts exactly one project name."* ]]
+    [[ "$output" != *"FATAL"* ]]
+}
+
 @test "basectl rejects removed legacy commands" {
     local legacy_command
 
-    for legacy_command in status update run set-team set-shared-teams man embrace install; do
+    for legacy_command in status update run set-team set-shared-teams man embrace install shell; do
         run_basectl "$legacy_command"
         [ "$status" -eq 2 ]
         [[ "$output" == *"Unrecognized command: $legacy_command"* ]]
     done
-}
-
-@test "basectl shell rejects arguments" {
-    run_basectl shell -c 'echo ignored'
-
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"The 'shell' command does not accept arguments."* ]]
-    [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
 }
 
 @test "Base home verification does not require a git repository" {
@@ -299,11 +394,41 @@ EOF
             printf "disable=%s\n" "${VIRTUAL_ENV_DISABLE_PROMPT:-}"'
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
     [[ "$output" == *"host=aadhara"* ]]
     [[ "$output" == *"venv=[.venv] "* ]]
     [[ "$output" == *"git=("* ]]
     [[ "$output" == *"disable=1"* ]]
+}
+
+@test "Base runtime shell activates project virtual environment" {
+    local venv_dir="$TEST_TMPDIR/demo-venv"
+
+    mkdir -p "$venv_dir/bin"
+    cat > "$venv_dir/bin/activate" <<'EOF'
+VIRTUAL_ENV="$BASE_PROJECT_VENV_DIR"
+PATH="$VIRTUAL_ENV/bin:$PATH"
+export VIRTUAL_ENV PATH
+EOF
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_PROJECT=demo \
+        BASE_PROJECT_ROOT="$BASE_REPO_ROOT" \
+        BASE_PROJECT_VENV_DIR="$venv_dir" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            printf "BASE_PROJECT=%s\n" "$BASE_PROJECT"; \
+            printf "VIRTUAL_ENV=%s\n" "$VIRTUAL_ENV"; \
+            printf "PATH=%s\n" "$PATH"; \
+            printf "PS1=%s\n" "$PS1"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"VIRTUAL_ENV=$venv_dir"* ]]
+    [[ "$output" == *"PATH=$venv_dir/bin:"* ]]
+    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 
 
@@ -331,7 +456,7 @@ EOF
     [[ "$output" == *"alias user_bashrc_alias='printf user-bashrc'"* ]]
     [[ "$output" == *"USER_BASHRC_LOADED=1"* ]]
     [[ "$output" == *"USER_BASHRC_HAS_BASE_IMPORT=1"* ]]
-    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 
 @test "BASE_DEBUG traces Base runtime shell startup" {

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -24,12 +24,15 @@ def main(argv: list[str] | None = None) -> int:
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.argument("command", required=False)
+@base_cli.argument("project", required=False)
 @base_cli.option("--workspace", help="Workspace directory to scan. Defaults to BASE_HOME's parent.")
-def run(ctx: base_cli.Context, command: str | None, workspace: str | None) -> int:
+def run(ctx: base_cli.Context, command: str | None, project: str | None, workspace: str | None) -> int:
     if command in (None, "list"):
         return list_projects_command(ctx, workspace)
+    if command == "resolve":
+        return resolve_project_command(ctx, project, workspace)
 
-    ctx.log.error("Unknown projects command '%s'. Supported command: list.", command)
+    ctx.log.error("Unknown projects command '%s'. Supported commands: list, resolve.", command)
     return 2
 
 
@@ -43,6 +46,22 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None) -> int:
 
     for project in projects:
         print(f"{project.name}\t{project.root}")
+    return 0
+
+
+def resolve_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        project = find_project(workspace_root, project_name)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    print(f"{project.name}\t{project.root}\t{project.manifest_path}")
     return 0
 
 
@@ -72,6 +91,14 @@ def discover_projects(workspace_root: Path) -> tuple[Project, ...]:
         projects.append(read_project(manifest_path))
 
     return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def find_project(workspace_root: Path, project_name: str) -> Project:
+    projects = discover_projects(workspace_root)
+    for project in projects:
+        if project.name == project_name:
+            return project
+    raise ProjectDiscoveryError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
 
 
 def read_project(manifest_path: Path) -> Project:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -68,6 +68,31 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{(workspace / 'demo').resolve()}\n")
 
+    def test_projects_resolve_prints_project_details(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["resolve", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
+
+    def test_projects_resolve_reports_missing_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+
+            status, _stdout, stderr = run_engine(["resolve", "missing"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("Project 'missing' was not found", stderr)
+
     def test_projects_list_reports_invalid_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)

--- a/docs/design.md
+++ b/docs/design.md
@@ -75,8 +75,8 @@ layers. This keeps the product name and the control-plane action separate:
 - `basectl check`
 - `basectl update-profile`
 - `basectl projects list`
-- `basectl shell`
-- future commands such as `basectl test` and `basectl activate`
+- `basectl activate`
+- future commands such as `basectl test`
 
 Shebang-based Bash scripts can also use:
 
@@ -156,7 +156,9 @@ availability.
 
 ### Layer 2 — Base Runtime Environment
 
-Applied when the user invokes `basectl`, `basectl shell`, or `basectl /path/to/script.sh`.
+Applied when the user invokes `basectl`, `basectl activate <project>`, or
+`basectl /path/to/script.sh`. Invoking `basectl` with no arguments in a terminal
+is equivalent to `basectl activate base`.
 
 Contains:
 - exported Base path contract such as `BASE_HOME`, `BASE_BIN_DIR`, and `BASE_BASH_LIB_DIR`
@@ -170,8 +172,7 @@ This layer is established by `base_init.sh`, which is sourced only through the
 
 ### Layer 3 — Project-Specific Environment
 
-Applied inside the project subshell when a future `basectl activate <project>` flow
-is run.
+Applied inside the project subshell when `basectl activate <project>` is run.
 
 Contains:
 - Project-specific PATH additions

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -38,7 +38,8 @@ The Base home check validates the expected Base files instead of checking for a
 When `basectl` starts, it uses this dispatch order:
 
 1. If no arguments are provided and stdin/stdout are attached to a terminal,
-   start a Base-enabled interactive Bash shell.
+   behave like `basectl activate base` and start a Base-enabled interactive Bash
+   shell with Base's project virtual environment activated.
 2. If the first argument is path-like or names an existing file, treat it as a
    Bash script path and run that script inside the Base runtime.
 3. If the first argument matches a Base command implementation by convention,
@@ -172,8 +173,10 @@ library cannot be found, so callers do not need to duplicate that check.
 
 ## Runtime Shell
 
-Running `basectl` with no arguments in a terminal, or running `basectl shell`,
-starts an interactive Bash shell with the Base runtime loaded.
+Running `basectl activate <project>` starts an interactive Bash shell with the
+Base runtime loaded and the project virtual environment activated. Running
+`basectl` with no arguments in a terminal is equivalent to
+`basectl activate base`.
 
 That shell uses Base's runtime rcfile:
 

--- a/lib/bash/runtime/README.md
+++ b/lib/bash/runtime/README.md
@@ -1,7 +1,8 @@
 # Runtime Bash Rcfile
 
-`lib/bash/runtime/bashrc` is the rcfile used by `basectl` and `basectl shell`
-when they start a Base-enabled interactive Bash shell.
+`lib/bash/runtime/bashrc` is the rcfile used by `basectl activate <project>`
+when it starts a Base-enabled interactive Bash shell. Invoking `basectl` with no
+arguments in a terminal is equivalent to `basectl activate base`.
 
 ## What It Does
 
@@ -22,5 +23,5 @@ when they start a Base-enabled interactive Bash shell.
 ## Tests
 
 BATS coverage lives in `tests/runtime_bashrc.bats`. Additional integration
-coverage for `basectl shell` and command startup lives in
+coverage for project activation and command startup lives in
 `cli/bash/commands/basectl/tests/basectl.bats`.

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -2,7 +2,7 @@
 
 #
 # lib/bash/runtime/bashrc
-#     Runtime rcfile used by `basectl` and `basectl shell`.
+#     Runtime rcfile used by `basectl activate <project>`.
 #
 # Purpose:
 #     - start an interactive Bash shell with the Base runtime already loaded
@@ -60,6 +60,21 @@ _base_runtime_source_user_bashrc() {
     unset __base_runtime_sourcing_user_bashrc__
 }
 
+_base_runtime_activate_project_venv() {
+    local activate_script
+
+    [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]] || return 0
+    activate_script="$BASE_PROJECT_VENV_DIR/bin/activate"
+    [[ -f "$activate_script" ]] || {
+        _base_runtime_error "Project virtual environment activation script '$activate_script' was not found."
+        return 1
+    }
+
+    export VIRTUAL_ENV_DISABLE_PROMPT=1
+    # shellcheck source=/dev/null
+    source "$activate_script"
+}
+
 _base_runtime_host_prompt() {
     local host_name=""
 
@@ -110,7 +125,7 @@ _base_runtime_set_prompt() {
     # virtualenv activation and render the active venv dynamically instead.
     export VIRTUAL_ENV_DISABLE_PROMPT=1
     _BASE_RUNTIME_HOST_PROMPT="$(_base_runtime_host_prompt)"
-    PS1='\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '
+    PS1='\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '
 }
 
 _base_runtime_main() {
@@ -134,6 +149,7 @@ _base_runtime_main() {
     source "$BASE_HOME/base_init.sh" || return $?
 
     _base_runtime_source_user_bashrc || return $?
+    _base_runtime_activate_project_venv || return $?
     _base_runtime_set_prompt
     _base_runtime_debug "complete"
 }


### PR DESCRIPTION
## Summary
- add `basectl activate <project>` to start a project-specific runtime subshell
- resolve projects through the existing `base_projects` discovery layer
- export project context (`BASE_PROJECT`, `BASE_PROJECT_ROOT`, `BASE_PROJECT_MANIFEST`, `BASE_PROJECT_VENV_DIR`)
- activate the project virtual environment from the runtime rcfile
- include active project context in the runtime prompt
- make no-argument interactive `basectl` equivalent to `basectl activate base`
- remove the unused `basectl shell` command from code, help, tests, and docs
- report `activate` argument mistakes as usage errors instead of fatal runtime errors
- document activation and remove the completed TODO item

## Testing
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n bin/basectl`
- `bash -n cli/bash/commands/basectl/basectl.sh`
- `bash -n cli/bash/commands/basectl/subcommands/activate.sh`