### PR TITLE
Document Base CLI libraries

### DIFF
--- a/lib/bash/std/README.md
+++ b/lib/bash/std/README.md
@@ -1,41 +1,347 @@
 # `lib_std.sh`
 
-Shared foundation library for Bash code under `cli/bash`.
+`lib_std.sh` is Base's foundation library for Bash scripts.
 
-## What It Provides
+Bash is excellent glue, but raw Bash makes it too easy for every script to
+invent its own logging, path handling, argument conventions, dry-run behavior,
+error reporting, and import rules. `lib_std.sh` gives Base Bash code one shared
+toolbox so scripts can stay small, readable, and consistent.
 
-- Passive Bash version check helpers and one-time initialization when sourced
-- Shared globals for callers: `__SCRIPT_ARGS__` and `__SCRIPT_DIR__`
-- Library importing with `import`
-- PATH helpers: `add_to_path`, `dedupe_path`, `print_path`
-- Structured logging with `set_log_level`, `log_*`, and `print_*`
-- Failure helpers: `exit_if_error`, `fatal_error`, `dump_trace`
-- Safe command execution via `run`
-- Filesystem helpers such as `safe_mkdir`, `safe_touch`, `safe_truncate`, `safe_cd`
-- Validation helpers such as `assert_not_null`, `assert_integer`, `assert_integer_range`, `assert_arg_count`
-- Small interactive helpers such as `ask_yes_no` and `wait_for_enter`
+## Why This Makes Bash Scripting Better
 
-## Usage
+The library improves Bash-based scripting in a few practical ways:
 
-Standalone script usage:
+- **Consistent logs**: every script can emit timestamped logs with level and
+  source location.
+- **Logs stay on stderr**: stdout remains available for real program output that
+  another command may pipe or capture.
+- **Readable failures**: fatal errors include a message and Bash stack trace
+  instead of a mysterious non-zero exit.
+- **Safe command execution**: `run` preserves argument boundaries, supports
+  dry-run mode, and can either exit or return a status.
+- **Shared dry-run behavior**: scripts do not need to reimplement "print what
+  would happen" logic.
+- **Simple library imports**: scripts can import helpers relative to their own
+  source directory.
+- **Predictable PATH edits**: PATH additions avoid duplicates and can prepend or
+  append intentionally.
+- **Batch validation**: required variables, files, directories, commands, and
+  integer ranges can be checked with one helper call.
+- **Safer filesystem helpers**: common operations report all failures in one
+  clear error.
+- **Base wrapper integration**: wrapper flags are recognized once and removed
+  before command-specific argument parsing begins.
+
+The goal is not to hide Bash. The goal is to make Base scripts look like they
+belong to the same product and fail in ways a user or developer can understand.
+
+## Loading The Library
+
+Standalone scripts can source the library directly:
 
 ```bash
 source "/absolute/path/to/lib/bash/std/lib_std.sh"
-
-add_to_path -p "/opt/my-tools/bin"
-set_log_level DEBUG
-run echo "hello"
 ```
 
-## Notes
+Most Base command scripts do not need to do this manually. `base_init.sh`
+preloads `lib_std.sh` when commands run through `basectl`, which means Base-run
+scripts already have functions such as `log_info`, `run`, and `fatal_error`
+available.
 
-- Base entrypoints require Bash 4.2 or newer before sourcing this library.
-- Sourcing the file runs `__stdlib_init__`, which initializes logging and wrapper flags without prompting, installing packages, or re-executing the caller.
-- `base_init.sh` preloads this library for Base-run scripts so commands do not need per-command stdlib sourcing boilerplate.
-- `bin/basectl` sets `BASE_BASH_BOOTSTRAP_SOURCE` before runtime bootstrap so `__SCRIPT_DIR__` still points at the command script rather than the Base entrypoint.
-- Runtime flags such as `--debug-wrapper` and `--verbose-wrapper` are consumed during initialization for compatibility.
-- Other Bash libraries in this tree rely on this file for logging and error handling.
+Base entrypoints require Bash 4.2 or newer before sourcing this library. The
+library has passive Bash version helpers, but sourcing it does not prompt,
+install packages, or re-exec the caller.
+
+## Initialization Contract
+
+Sourcing `lib_std.sh` runs a small one-time initializer:
+
+- initializes the logging level map
+- records the original script arguments in `__SCRIPT_ARGS__`
+- derives the caller's source directory in `__SCRIPT_DIR__`
+- consumes Base wrapper flags such as `--debug-wrapper`, `--verbose-wrapper`,
+  `--utc-wrapper`, and `--color`
+- resets the caller's positional parameters to the filtered argument list
+
+Caller-visible globals:
+
+- `__SCRIPT_ARGS__`: original arguments before wrapper flags were stripped
+- `__SCRIPT_DIR__`: absolute source directory for the script being bootstrapped
+
+When a Base wrapper preloads the stdlib for another command, it can set
+`BASE_BASH_BOOTSTRAP_SOURCE` so `__SCRIPT_DIR__` still points at the command
+script rather than the wrapper.
+
+## Logging
+
+Use structured logging for operational messages:
+
+```bash
+log_info "Installing package '$name'."
+log_warn "Cache directory does not exist: $cache_dir"
+log_error "Unable to read manifest '$manifest_path'."
+log_debug "resolved_home=$resolved_home"
+log_verbose "raw_response=$response"
+```
+
+Available levels:
+
+- `FATAL`
+- `ERROR`
+- `WARN`
+- `INFO`
+- `DEBUG`
+- `VERBOSE`
+
+Change the default logger's level with:
+
+```bash
+set_log_level DEBUG
+```
+
+Named loggers are also supported:
+
+```bash
+set_log_level -l artifact DEBUG
+log_debug -l artifact "registry key: $key"
+```
+
+For user-facing messages that should not include timestamps or source
+locations, use:
+
+```bash
+print_error "Invalid project name."
+print_warn "Using default workspace."
+print_info "Setup complete."
+print_success "Done."
+print_message "plain stdout message"
+```
+
+`log_*`, `print_error`, `print_warn`, `print_info`, and `print_success` write to
+stderr. `print_message` writes to stdout.
+
+## Error Handling
+
+Use `fatal_error` when the script cannot continue:
+
+```bash
+[[ -f "$manifest_path" ]] || fatal_error "Manifest '$manifest_path' was not found."
+```
+
+Use `exit_if_error` when checking a command's explicit status:
+
+```bash
+some_command
+exit_if_error $? "some_command failed."
+```
+
+Fatal failures log the message, dump a Bash stack trace, and exit with the
+original failing status when possible.
+
+Not every user mistake should be fatal. Command-line usage errors should usually
+print usage and return `2` rather than calling `fatal_error`, because the command
+itself is fine and the user simply gave invalid arguments.
+
+## Running Commands Safely
+
+`run` is the preferred helper for simple external command execution:
+
+```bash
+run git status --short
+run touch "file with spaces.txt"
+```
+
+It improves on ad hoc command strings because it:
+
+- executes commands as argument arrays, not through `eval`
+- preserves spaces and special characters
+- logs a copy-pastable command in dry-run mode
+- exits through `exit_if_error` by default when a command fails
+
+Dry-run mode:
+
+```bash
+DRY_RUN=true
+run brew install jq
+```
+
+Handle a failing command yourself with `--no-exit`:
+
+```bash
+if ! run --no-exit grep "needle" "$file"; then
+    log_info "needle was not present; continuing"
+fi
+```
+
+Use `run` for commands plus arguments. Keep shell features such as pipelines,
+redirection, process substitution, and complex conditionals explicit in the
+calling script so the code remains clear.
+
+## Importing Other Bash Libraries
+
+Use `import` to source helper libraries:
+
+```bash
+import file/lib_file.sh
+import /absolute/path/to/another_lib.sh
+```
+
+Relative imports resolve from `__SCRIPT_DIR__`, which is the directory of the
+script being bootstrapped.
+
+Important Bash detail: imported files are sourced inside the `import` function.
+If an imported library needs global variables, declare them with `-g`:
+
+```bash
+declare -gA MY_LOOKUP=()
+```
+
+Without `-g`, Bash may create locals scoped to the import function.
+
+## PATH Helpers
+
+Use `add_to_path` instead of hand-editing PATH:
+
+```bash
+add_to_path "/opt/tool/bin"
+add_to_path -p "$HOME/.local/bin"
+add_to_path -n "$maybe_created_later/bin"
+```
+
+Options:
+
+- `-p`: prepend instead of append
+- `-n`: do not require the directory to already exist
+
+`add_to_path` de-duplicates PATH after adding entries. You can also call:
+
+```bash
+dedupe_path
+print_path
+```
+
+## Filesystem Helpers
+
+The safe filesystem helpers collect failures and report them clearly:
+
+```bash
+safe_mkdir -p "$state_dir" "$cache_dir"
+safe_touch "$log_file"
+safe_truncate "$log_file"
+safe_cd "$project_root"
+```
+
+These helpers are useful in setup scripts where a partially completed operation
+should fail loudly and explain which path could not be created, touched, or
+entered.
+
+## Validation Helpers
+
+Use assertions near the top of functions to make assumptions explicit:
+
+```bash
+assert_arg_count "$#" 2
+assert_not_null BASE_HOME project_name
+assert_integer retry_count
+assert_integer_range retry_count 0 5
+assert_command_exists git brew
+assert_file_exists "$manifest_path"
+assert_dir_exists "$project_root"
+```
+
+The assertions favor clear failure messages over scattered one-off tests. Some
+helpers check all provided values and report all missing items together.
+
+## Interactive Helpers
+
+For interactive scripts:
+
+```bash
+if ask_yes_no "Continue?"; then
+    log_info "Continuing."
+fi
+
+wait_for_enter "Press Enter after reviewing the output."
+```
+
+Use `is_interactive` before prompting from code paths that might run in CI,
+cron, or another non-interactive environment:
+
+```bash
+if is_interactive; then
+    ask_yes_no "Install optional tools?" || return 0
+fi
+```
+
+## Suggested Script Pattern
+
+A small Base-style Bash command should look like this:
+
+```bash
+#!/usr/bin/env bash
+
+main() {
+    local project="${1:-}"
+
+    if [[ -z "$project" ]]; then
+        print_error "Project name is required."
+        return 2
+    fi
+
+    assert_command_exists git
+    log_info "Checking project '$project'."
+    run git status --short
+}
+
+main "$@"
+```
+
+When the script runs through `basectl`, the Base runtime provides the stdlib and
+calls `main` with wrapper flags already filtered out.
+
+For standalone scripts that source the library directly:
+
+```bash
+#!/usr/bin/env bash
+source "/path/to/base/lib/bash/std/lib_std.sh"
+
+main() {
+    set_log_level DEBUG
+    run echo "hello"
+}
+
+main "$@"
+```
+
+## What Belongs Here
+
+`lib_std.sh` should contain small, broadly useful primitives for Bash code:
+
+- logging
+- error handling
+- path manipulation
+- command execution
+- imports
+- validation
+- simple filesystem safety wrappers
+
+Domain-specific behavior should live in other libraries or command modules. For
+example, Git helpers belong in a Git library, file editing helpers belong in a
+file library, and artifact setup behavior belongs in setup code.
 
 ## Tests
 
-BATS coverage lives in `tests/lib_std.bats`.
+BATS coverage lives in:
+
+```text
+lib/bash/std/tests/lib_std.bats
+```
+
+When changing this library, run:
+
+```bash
+bats lib/bash/std/tests/lib_std.bats
+```
+
+For command-level changes that depend on stdlib behavior, also run the relevant
+command BATS tests.

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -1,0 +1,303 @@
+# `base_cli`
+
+`base_cli` is Base's small Python framework for writing command-line tools that
+feel consistent across Base and Base-supported projects.
+
+It is intentionally thin. Click still owns argument parsing and command
+execution, while `base_cli` adds the Base-specific behavior every project CLI
+should get by default:
+
+- standard command options such as `--debug`, `--environment`, `--config`,
+  `--keep-temp`, and `--log-file`
+- structured logging to stderr and to a persistent per-run log file
+- Base project discovery through `base_manifest.yaml`
+- config loading with predictable precedence
+- per-run temp directories, persistent cache directories, and cleanup hooks
+- sensitive argument redaction in debug invocation logs
+- a command context object shared by command code and helper functions
+- test helpers built on Click's `CliRunner`
+
+## Design Goals
+
+Base CLI tools should be easy to write, but not magical. A command should be
+explicitly registered, receive an explicit `Context`, and use standard Python
+functions instead of import-time side effects.
+
+The package follows these rules:
+
+- **Decorator-driven setup**: commands opt in by creating an `App` and
+  decorating a function.
+- **Logs go to stderr**: user-facing program output can stay on stdout, while
+  logs remain redirectable and skippable.
+- **Every run has a context**: logs, paths, config, environment, manifest, and
+  cleanup are available through one object.
+- **No import-time filesystem writes**: state directories are created only when
+  a command runs.
+- **Base-aware, Click-compatible**: command authors keep using familiar Click
+  concepts such as options and arguments.
+
+## Minimal Command
+
+```python
+from __future__ import annotations
+
+import base_cli
+
+
+app = base_cli.App(name="hello", version="0.1.0")
+
+
+@app.command()
+@base_cli.option("--name", required=True)
+def main(ctx: base_cli.Context, name: str) -> None:
+    ctx.log.info("starting hello")
+    print(f"hello {name}")
+
+
+if __name__ == "__main__":
+    app()
+```
+
+Running this command automatically adds the standard Base options:
+
+```bash
+hello --name Ada
+hello --debug --name Ada
+hello --environment prod --name Ada
+hello --keep-temp --name Ada
+hello --log-file /tmp/hello.log --name Ada
+```
+
+## Command Registration
+
+Use `App` when you want a named command:
+
+```python
+app = base_cli.App(name="base-projects", version="0.1.0")
+```
+
+Register the command function explicitly:
+
+```python
+@app.command()
+def main(ctx: base_cli.Context) -> None:
+    ...
+```
+
+The command function always receives `ctx` as its first argument. User-defined
+options and arguments are passed after the Base standard options have been
+removed from Click's keyword arguments.
+
+For small scripts, the module-level decorators are available:
+
+```python
+@base_cli.command()
+def main(ctx: base_cli.Context) -> None:
+    ...
+```
+
+In Base itself, prefer an explicit `App` so command names and versions are
+obvious at the top of the module.
+
+## Options And Arguments
+
+`base_cli.option` and `base_cli.argument` mirror Click's decorators:
+
+```python
+@app.command()
+@base_cli.argument("project")
+@base_cli.option("--workspace", type=str)
+def main(ctx: base_cli.Context, project: str, workspace: str | None) -> None:
+    ...
+```
+
+Use `sensitive=True` for options whose values should not appear in invocation
+logs:
+
+```python
+@base_cli.option("--token", sensitive=True, required=True)
+def main(ctx: base_cli.Context, token: str) -> None:
+    ...
+```
+
+Both `--token secret` and `--token=secret` are redacted in debug logs.
+
+## Standard Options
+
+Every `base_cli.App` command gets these options:
+
+- `--debug`: enable DEBUG logging on the user-facing stderr stream.
+- `--environment <name>`: set `ctx.environment` for the run.
+- `--config <path>`: merge an additional YAML config file.
+- `--keep-temp`: preserve the run's temp directory after command completion.
+- `--log-file <path>`: write the persistent log to a specific file.
+- `--version`: shown when the `App` was created with a version.
+
+The command receives only its own application-specific options. Standard options
+are consumed before the command function is called.
+
+## Context
+
+`Context` is the object command code should pass around instead of rediscovering
+Base paths or global settings.
+
+Important fields include:
+
+- `ctx.cli_name`: normalized CLI name used for state paths and logger names.
+- `ctx.run_id`: timestamp plus short random suffix for this invocation.
+- `ctx.base_home`: resolved `BASE_HOME`, when available.
+- `ctx.project_root`: directory containing the nearest `base_manifest.yaml`.
+- `ctx.manifest_path`: nearest discovered Base manifest.
+- `ctx.state_dir`: per-CLI state directory under `~/.base.d/cli/<name>`.
+- `ctx.log_dir`: persistent log directory.
+- `ctx.cache_dir`: persistent cache directory.
+- `ctx.temp_dir`: per-run temp directory.
+- `ctx.log_file`: persistent log file for this run.
+- `ctx.config`: merged configuration dictionary.
+- `ctx.environment`: active environment, defaulting to `dev`.
+- `ctx.debug`: whether debug logging is enabled for the stderr stream.
+- `ctx.keep_temp`: whether `ctx.temp_dir` should survive cleanup.
+- `ctx.log`: standard Python logger configured by Base.
+
+Helpers can retrieve the active context without threading it through every call:
+
+```python
+from base_cli import get_current_context
+
+
+def helper() -> None:
+    ctx = get_current_context()
+    ctx.log.debug("helper is running")
+```
+
+`get_current_context()` is valid only while a `base_cli.App` command is running.
+
+## Logging
+
+`base_cli` configures two handlers:
+
+- a user-facing stderr handler at INFO by default, DEBUG with `--debug`
+- a persistent file handler that always records DEBUG logs
+
+Logs use the same general shape as Base Bash logs:
+
+```text
+2026-05-26 12:34:56 INFO    path/to/file.py:42 message
+```
+
+Use either `ctx.log` directly:
+
+```python
+ctx.log.info("processed %s items", count)
+```
+
+or the convenience functions:
+
+```python
+base_cli.log_debug("cache_dir=%s", ctx.cache_dir)
+base_cli.log_info("done")
+base_cli.log_warning("using fallback")
+base_cli.log_error("failed")
+```
+
+Program output should still use stdout when another command might consume it.
+Logs should stay on stderr so users can redirect or ignore logs without losing
+the real command output.
+
+## Config Precedence
+
+Configuration is loaded from YAML files and environment variables in this order:
+
+1. user config: `~/.base.d/config.yaml`
+2. project config: `<project>/.base/config.yaml`
+3. explicit config from `--config`
+4. environment variables
+5. direct command-line standard options
+
+Environment variables currently recognized by the config layer:
+
+- `BASE_CLI_ENVIRONMENT`
+- `BASE_CLI_LOG_LEVEL`
+- `BASE_CLI_KEEP_TEMP`
+
+Command-line standard options are applied after config is loaded. For example,
+`--environment prod` overrides `environment: dev` from config.
+
+## Project Discovery
+
+When a command runs, `base_cli` walks upward from the current working directory
+looking for `base_manifest.yaml`.
+
+If found:
+
+- `ctx.manifest_path` points to the manifest
+- `ctx.project_root` points to the manifest's parent directory
+
+If no manifest is found, both fields are `None`. Commands that require a Base
+project should validate this explicitly and return a clear usage error or
+actionable message.
+
+## Runtime Directories
+
+Current runtime state is rooted at:
+
+```text
+~/.base.d/cli/<cli-name>/
+  logs/
+  cache/
+  tmp/<run-id>/
+```
+
+`logs/` and `cache/` are persistent. `tmp/<run-id>/` is deleted automatically
+after the command returns unless `--keep-temp` is set.
+
+Use `ctx.on_cleanup()` for cleanup work that should happen even when helper code
+does not own the main command wrapper:
+
+```python
+def close_connection() -> None:
+    connection.close()
+
+
+ctx.on_cleanup(close_connection)
+```
+
+Cleanup hooks run before temp directory removal. Hook failures are logged as
+warnings and do not prevent later hooks from running.
+
+## Testing
+
+Use `base_cli.testing.invoke` for unit tests:
+
+```python
+from pathlib import Path
+
+from base_cli.testing import invoke
+
+
+def test_command(tmp_path: Path) -> None:
+    result = invoke(app, ["--name", "Ada"], home=tmp_path)
+
+    assert result.exit_code == 0
+    assert "hello Ada" in result.stdout
+```
+
+The helper wraps Click's `CliRunner`, sets `HOME` when requested, and keeps
+stderr separate on Click versions that support it. This makes it straightforward
+to assert that program output and logs do not get mixed.
+
+## When To Use `base_cli`
+
+Use `base_cli` for Python commands that are part of Base or a Base-supported
+project and need standard Base behavior.
+
+It is a good fit for:
+
+- project discovery commands
+- setup and artifact management commands
+- developer workflow commands
+- CLIs that need predictable logs, temp directories, and config precedence
+
+It is not meant to replace Click, Typer, argparse, or rich terminal UI
+frameworks. It is the Base layer around command lifecycle, context, logging,
+configuration, and state.


### PR DESCRIPTION
## Summary
- add a detailed `lib/python/base_cli/README.md` covering command registration, standard options, context, logging, config precedence, project discovery, runtime directories, cleanup, and testing
- expand `lib/bash/std/README.md` into a practical guide for Base Bash scripting conventions
- explain how `lib_std.sh` improves Bash scripts through consistent logging, stderr separation, safe command execution, imports, validation, dry-run behavior, and clear failure handling

## Testing
- `bats lib/bash/std/tests/lib_std.bats`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest lib.python.base_cli.tests.test_base_cli`