### PR TITLE
Move CLI runtime artifacts to cache root

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,16 +7,9 @@ they are merged.
 
 ## P0 — Core Workspace Loop
 
-- [ ] Split runtime artifacts out of `~/.base.d`.
-  - Files: `lib/python/base_cli/paths.py`, `lib/python/base_cli/app.py`, tests.
-  - Problem: `~/.base.d` currently mixes durable config and project venvs with ephemeral CLI logs, temp files, and caches.
-  - Expected behavior: keep durable state under `~/.base.d`, but move CLI runtime artifacts under a cache root such as `${BASE_CACHE_DIR:-~/.cache/base}`.
-  - Notes: macOS `~/Library/Caches/base` is a later option; start with an overrideable default that is simple and testable.
-
 - [ ] Add log cleanup with `basectl clean`.
   - Goal: prevent Base logs and retained temp/cache files from growing indefinitely.
   - Expected behavior: support at least `basectl clean --older-than 30d`, with dry-run output and clear scope.
-  - Dependency: easiest after the runtime artifact cache root is split from `~/.base.d`.
 
 ## P1 — High-Value Product Capabilities
 

--- a/docs/base-cli-design.md
+++ b/docs/base-cli-design.md
@@ -73,7 +73,7 @@ ctx.run_id         # str
 ctx.base_home      # Path | None
 ctx.project_root   # Path | None
 ctx.manifest_path  # Path | None
-ctx.state_dir      # ~/.base.d/cli/<cli-name>
+ctx.state_dir      # ${BASE_CACHE_DIR:-~/.cache/base}/cli/<cli-name>
 ctx.log_dir        # state_dir/logs
 ctx.cache_dir      # state_dir/cache
 ctx.temp_dir       # state_dir/tmp/<run-id>

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -148,7 +148,7 @@ Important fields include:
 - `ctx.base_home`: resolved `BASE_HOME`, when available.
 - `ctx.project_root`: directory containing the nearest `base_manifest.yaml`.
 - `ctx.manifest_path`: nearest discovered Base manifest.
-- `ctx.state_dir`: per-CLI state directory under `~/.base.d/cli/<name>`.
+- `ctx.state_dir`: per-CLI runtime directory under the Base cache root.
 - `ctx.log_dir`: persistent log directory.
 - `ctx.cache_dir`: persistent cache directory.
 - `ctx.temp_dir`: per-run temp directory.
@@ -239,17 +239,21 @@ actionable message.
 
 ## Runtime Directories
 
-Current runtime state is rooted at:
+Current runtime state is rooted at `${BASE_CACHE_DIR:-~/.cache/base}`:
 
 ```text
-~/.base.d/cli/<cli-name>/
+~/.cache/base/cli/<cli-name>/
   logs/
   cache/
   tmp/<run-id>/
 ```
 
-`logs/` and `cache/` are persistent. `tmp/<run-id>/` is deleted automatically
-after the command returns unless `--keep-temp` is set.
+Use `BASE_CACHE_DIR` to override the root for tests, CI, or unusual local
+environments.
+
+`logs/` and `cache/` are runtime artifacts that can be pruned by Base cleanup
+tools. `tmp/<run-id>/` is deleted automatically after the command returns unless
+`--keep-temp` is set.
 
 Use `ctx.on_cleanup()` for cleanup work that should happen even when helper code
 does not own the main command wrapper:

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 from .config import load_config
 from .context import Context, reset_current_context, set_current_context
 from .logging import configure_logger, log_invocation
-from .paths import base_state_root, discover_manifest, make_run_id, normalize_cli_name, resolve_base_home
+from .paths import base_cache_root, discover_manifest, make_run_id, normalize_cli_name, resolve_base_home
 from .redaction import parameter_name_from_decls
 
 
@@ -91,7 +91,7 @@ class App:
         debug = bool(standard.get("debug") or str(config.get("log_level", "")).lower() == "debug")
         keep_temp = bool(standard.get("keep_temp") or config.get("keep_temp"))
 
-        state_dir = base_state_root() / "cli" / self.name
+        state_dir = base_cache_root() / "cli" / self.name
         log_dir = state_dir / "logs"
         cache_dir = state_dir / "cache"
         temp_dir = state_dir / "tmp" / run_id

--- a/lib/python/base_cli/paths.py
+++ b/lib/python/base_cli/paths.py
@@ -10,6 +10,13 @@ def base_state_root(home: Path | None = None) -> Path:
     return (home or Path.home()) / ".base.d"
 
 
+def base_cache_root(home: Path | None = None) -> Path:
+    value = os.environ.get("BASE_CACHE_DIR")
+    if value:
+        return Path(value).expanduser()
+    return (home or Path.home()) / ".cache" / "base"
+
+
 def make_run_id() -> str:
     timestamp = time.strftime("%Y%m%dT%H%M%S")
     return f"{timestamp}_{uuid.uuid4().hex[:8]}"
@@ -41,4 +48,3 @@ def resolve_base_home() -> Path | None:
     if not value:
         return None
     return Path(value).expanduser().resolve()
-

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -14,7 +14,7 @@ import base_cli
 from base_cli import config as config_module
 from base_cli.config import load_config
 from base_cli.logging import BaseCliFormatter
-from base_cli.paths import base_state_root, discover_manifest, normalize_cli_name
+from base_cli.paths import base_cache_root, base_state_root, discover_manifest, normalize_cli_name
 from base_cli.redaction import redact_argv
 
 
@@ -52,11 +52,12 @@ class BaseCliTests(unittest.TestCase):
         )
         return context, log
 
-    def test_import_has_no_state_directory_side_effect(self) -> None:
+    def test_import_has_no_runtime_directory_side_effect(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
                 self.assertFalse((home / ".base.d").exists())
+                self.assertFalse((home / ".cache" / "base").exists())
 
     def test_path_helpers(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -66,8 +67,15 @@ class BaseCliTests(unittest.TestCase):
             (root / "base_manifest.yaml").write_text("project:\n  name: demo\n", encoding="utf-8")
 
             self.assertEqual(base_state_root(root), root / ".base.d")
+            self.assertEqual(base_cache_root(root), root / ".cache" / "base")
             self.assertEqual(normalize_cli_name("/tmp/demo.py"), "demo")
             self.assertEqual(discover_manifest(nested), (root / "base_manifest.yaml").resolve())
+
+    def test_base_cache_root_honors_environment_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(root / "custom-cache")}):
+                self.assertEqual(base_cache_root(root), root / "custom-cache")
 
     def test_redacts_sensitive_option_values(self) -> None:
         argv = ["tool", "--api-key", "secret", "--token=hidden", "--name", "visible"]
@@ -147,7 +155,7 @@ class BaseCliTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
                 from base_cli.testing import invoke
 
                 stderr = io.StringIO()
@@ -158,7 +166,8 @@ class BaseCliTests(unittest.TestCase):
             self.assertEqual(seen["name"], "Ada")
             self.assertFalse(seen["temp_dir"].exists())
             self.assertTrue(seen["cache_dir"].is_dir())
-            self.assertTrue((home / ".base.d" / "cli" / "demo" / "logs").is_dir())
+            self.assertTrue((home / ".cache" / "base" / "cli" / "demo" / "logs").is_dir())
+            self.assertFalse((home / ".base.d" / "cli").exists())
             self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} INFO\s+")
             self.assertIn("hello Ada", result.stderr)
 
@@ -173,7 +182,7 @@ class BaseCliTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
                 from base_cli.testing import invoke
 
                 result = invoke(app, [], home=home)
@@ -208,7 +217,7 @@ class BaseCliTests(unittest.TestCase):
             manifest_path.write_text("project:\n  name: demo\n", encoding="utf-8")
             log_file = home / "custom.log"
 
-            with mock.patch.dict(os.environ, {"HOME": str(home)}), mock.patch.object(
+            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}), mock.patch.object(
                 os.sys,
                 "argv",
                 ["secret-tool", "--debug", "--token", "super-secret"],
@@ -226,6 +235,7 @@ class BaseCliTests(unittest.TestCase):
             self.assertTrue(seen["debug"])
             self.assertTrue(seen["temp_dir"].exists())
             self.assertEqual(seen["log_file"], log_file)
+            self.assertEqual(seen["temp_dir"].parents[1], home / ".cache" / "base" / "cli" / "secret-tool")
             self.assertEqual(seen["manifest_path"], manifest_path.resolve())
             self.assertEqual(seen["project_root"], project.resolve())
 


### PR DESCRIPTION
## Summary
- add `base_cache_root()` with `${BASE_CACHE_DIR:-~/.cache/base}` behavior
- move `base_cli.App` log/cache/temp runtime directories from `~/.base.d/cli/<name>` to the cache root
- keep durable Base state under `~/.base.d`
- update `base_cli` docs and design notes for the new runtime artifact location
- remove the completed TODO item so `basectl clean` is next in the P0 queue

## Testing
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest lib.python.base_cli.tests.test_base_cli`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`