### PR TITLE
Add basectl clean for runtime artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Current implemented commands include:
 
 - `basectl setup`
 - `basectl check`
+- `basectl clean --older-than <age>`
 - `basectl update-profile`
 - `basectl projects list`
 - `basectl activate <project>`
@@ -120,6 +121,18 @@ original environment.
 Invoking `basectl` with no arguments in a terminal is equivalent to
 `basectl activate base`, so the default interactive Base shell uses Base's own
 project virtual environment.
+
+Clean old Base CLI runtime logs, retained temp files, and cache entries with:
+
+```bash
+basectl clean --older-than 30d --dry-run
+basectl clean --older-than 30d
+```
+
+Cleanup only targets runtime artifacts under the Base cache root, which defaults
+to `~/Library/Caches/base` on macOS. Set `BASE_CACHE_DIR` to override it. Durable
+state such as `~/.base.d/config.yaml` and project virtual environments under
+`~/.base.d/<project>/.venv` are outside this scope.
 
 ### 2. Shell Environment Management
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,6 @@ Action items from the May 2026 Base product review.
 Use this as a commit-by-commit work queue. Completed items are removed after
 they are merged.
 
-## P0 — Core Workspace Loop
-
-- [ ] Add log cleanup with `basectl clean`.
-  - Goal: prevent Base logs and retained temp/cache files from growing indefinitely.
-  - Expected behavior: support at least `basectl clean --older-than 30d`, with dry-run output and clear scope.
-
 ## P1 — High-Value Product Capabilities
 
 - [ ] Implement `basectl doctor`.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -26,10 +26,10 @@ that delegate to `basectl`.
 - `activate`
 - `setup`
 - `check`
+- `clean`
 - `update-profile`
 - `projects list`
 - `version`
-- `shell`
 - `help`
 
 ## Notes
@@ -41,6 +41,7 @@ that delegate to `basectl`.
   Python project setup layer for `base_manifest.yaml` artifacts. The optional
   project argument validates `project.name`.
 - `basectl check` verifies the same local requirements without making changes.
+- `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -15,6 +15,8 @@ Commands:
     Install and bootstrap the local Base CLI environment on macOS.
   check [options]
     Verify the local Base CLI environment without making changes.
+  clean --older-than <age> [options]
+    Remove old Base CLI runtime logs, temp files, and cache entries.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
   projects list [options]
@@ -143,6 +145,11 @@ basectl_do_check() {
     base_check_subcommand_main "$@"
 }
 
+basectl_do_clean() {
+    basectl_source_subcommand_module clean || return 1
+    base_clean_subcommand_main "$@"
+}
+
 basectl_do_update_profile() {
     basectl_source_subcommand_module update_profile || return 1
     base_update_profile_subcommand_main "$@"
@@ -234,6 +241,7 @@ basectl_main() {
     case "$command" in
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
+        clean)            basectl_do_clean "$@" ;;
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/clean.sh
+++ b/cli/bash/commands/basectl/subcommands/clean.sh
@@ -1,0 +1,70 @@
+[[ -n "${_base_clean_subcommand_sourced:-}" ]] && return
+_base_clean_subcommand_sourced=1
+readonly _base_clean_subcommand_sourced
+
+base_clean_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl clean --older-than <age> [options]
+
+Options:
+  --older-than <age>  Remove runtime artifacts older than an age such as 30d.
+  --dry-run           Print what would be removed without deleting anything.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Remove old Base CLI runtime logs, temp files, and cache entries.
+EOF
+}
+
+base_clean_subcommand_main() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local has_older_than=0
+    local args=()
+
+    while (($# > 0)); do
+        case "$1" in
+            -h|--help)
+                base_clean_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --older-than|--dry-run)
+                args+=("$1")
+                if [[ "$1" == "--older-than" ]]; then
+                    has_older_than=1
+                    [[ -n "${2:-}" ]] || {
+                        base_clean_subcommand_usage >&2
+                        printf 'ERROR: Option '\''--older-than'\'' requires an argument.\n' >&2
+                        return 2
+                    }
+                    args+=("$2")
+                    shift 2
+                else
+                    shift
+                fi
+                ;;
+            --older-than=*)
+                has_older_than=1
+                args+=("$1")
+                shift
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    if (( ! has_older_than )); then
+        base_clean_subcommand_usage >&2
+        printf 'ERROR: Option '\''--older-than'\'' is required.\n' >&2
+        return 2
+    fi
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_clean "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -23,6 +23,7 @@ run_basectl() {
     [[ "$output" == *"activate <project> [options]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [options]"* ]]
+    [[ "$output" == *"clean --older-than <age> [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command is equivalent to \`basectl activate base\`"* ]]
     [[ "$output" == *"--version"* ]]
@@ -175,6 +176,52 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl projects list [options]"* ]]
+}
+
+@test "basectl clean delegates to the Python cleanup layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_clean" ]]; then
+    printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected clean python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl clean --older-than 30d --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=base"* ]]
+    [[ "$output" == *"ARGS=--older-than 30d --dry-run"* ]]
+}
+
+@test "basectl clean prints help without requiring the Base Python venv" {
+    run_basectl clean --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl clean --older-than <age> [options]"* ]]
+}
+
+@test "basectl clean reports missing age as a usage error" {
+    run_basectl clean
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--older-than' is required."* ]]
+    [[ "$output" != *"Traceback"* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl clean --older-than
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--older-than' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
 }
 
 @test "basectl activate resolves a project and execs a project subshell" {

--- a/cli/python/base_clean/__init__.py
+++ b/cli/python/base_clean/__init__.py
@@ -1,0 +1,1 @@
+"""Clean Base runtime artifacts."""

--- a/cli/python/base_clean/__main__.py
+++ b/cli/python/base_clean/__main__.py
@@ -1,0 +1,5 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import base_cli
+import click
+from base_cli.paths import base_cache_root
+
+
+app = base_cli.App(name="base_clean")
+
+
+@dataclass(frozen=True)
+class CleanCandidate:
+    path: Path
+    category: str
+    age_seconds: int
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        result = app.click_command.main(args=argv, standalone_mode=False)
+    except click.ClickException as exc:
+        exc.show()
+        return int(exc.exit_code)
+    return int(result or 0)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.option("--older-than", help="Remove runtime artifacts older than an age such as 30d.")
+@base_cli.option("--dry-run", is_flag=True, help="Print what would be removed without deleting anything.")
+def run(ctx: base_cli.Context, older_than: str | None, dry_run: bool) -> int:
+    if not older_than:
+        ctx.log.error("Option '--older-than' is required.")
+        return 2
+
+    try:
+        threshold_seconds = parse_age(older_than)
+    except ValueError as exc:
+        ctx.log.error(str(exc))
+        return 2
+
+    cutoff = time.time() - threshold_seconds
+    cache_root = base_cache_root()
+    ctx.log.debug("Scanning Base cache root '%s'.", cache_root)
+    candidates = tuple(find_clean_candidates(cache_root, cutoff, ctx.log))
+
+    if not candidates:
+        ctx.log.info("No Base runtime artifacts older than %s were found.", older_than)
+        return 0
+
+    for candidate in candidates:
+        action = "Would remove" if dry_run else "Removing"
+        print(f"{action}\t{candidate.category}\t{candidate.path}")
+        if not dry_run:
+            remove_path(candidate.path)
+
+    ctx.log.info(
+        "%s %s Base runtime artifact(s) older than %s.",
+        "Would remove" if dry_run else "Removed",
+        len(candidates),
+        older_than,
+    )
+    return 0
+
+
+def parse_age(value: str) -> int:
+    units = {
+        "d": 24 * 60 * 60,
+        "h": 60 * 60,
+        "m": 60,
+        "s": 1,
+    }
+    if len(value) < 2:
+        raise ValueError("Option '--older-than' must be an age such as 30d, 12h, 45m, or 60s.")
+
+    number = value[:-1]
+    unit = value[-1].lower()
+    if unit not in units or not number.isdigit():
+        raise ValueError("Option '--older-than' must be an age such as 30d, 12h, 45m, or 60s.")
+
+    amount = int(number)
+    if amount <= 0:
+        raise ValueError("Option '--older-than' must be greater than zero.")
+    return amount * units[unit]
+
+
+def find_clean_candidates(cache_root: Path, cutoff: float, logger: object | None = None) -> list[CleanCandidate]:
+    cli_root = cache_root / "cli"
+    if logger is not None:
+        logger.debug("Scanning Base CLI runtime root '%s'.", cli_root)
+    if not cli_root.is_dir():
+        return []
+
+    candidates: list[CleanCandidate] = []
+    for cli_dir in sorted(cli_root.iterdir(), key=lambda path: path.name):
+        if not cli_dir.is_dir():
+            continue
+        candidates.extend(find_category_candidates(cli_dir / "logs", "log", cutoff, logger))
+        candidates.extend(find_category_candidates(cli_dir / "tmp", "temp", cutoff, logger))
+        candidates.extend(find_category_candidates(cli_dir / "cache", "cache", cutoff, logger))
+    return sorted(candidates, key=lambda candidate: str(candidate.path))
+
+
+def find_category_candidates(
+    category_root: Path,
+    category: str,
+    cutoff: float,
+    logger: object | None = None,
+) -> list[CleanCandidate]:
+    if logger is not None:
+        logger.debug("Scanning %s runtime artifacts in '%s'.", category, category_root)
+    if not category_root.is_dir():
+        return []
+
+    candidates = []
+    for path in sorted(category_root.iterdir(), key=lambda item: item.name):
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < cutoff:
+            candidates.append(CleanCandidate(path=path, category=category, age_seconds=int(time.time() - mtime)))
+    return candidates
+
+
+def remove_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()

--- a/cli/python/base_clean/tests/test_engine.py
+++ b/cli/python/base_clean/tests/test_engine.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from base_clean import engine
+
+
+class BaseCleanTests(unittest.TestCase):
+    def test_parse_age_accepts_supported_units(self) -> None:
+        self.assertEqual(engine.parse_age("30d"), 30 * 24 * 60 * 60)
+        self.assertEqual(engine.parse_age("12h"), 12 * 60 * 60)
+        self.assertEqual(engine.parse_age("45m"), 45 * 60)
+        self.assertEqual(engine.parse_age("60s"), 60)
+
+    def test_parse_age_rejects_invalid_values(self) -> None:
+        for value in ("", "d", "0d", "-1d", "30", "1w"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    engine.parse_age(value)
+
+    def test_find_clean_candidates_only_includes_old_runtime_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
+            new_log = cache_root / "cli" / "demo" / "logs" / "new.log"
+            old_temp = cache_root / "cli" / "demo" / "tmp" / "old-run"
+            old_cache = cache_root / "cli" / "demo" / "cache" / "old-cache"
+            durable_state = cache_root / "durable-state" / ".base.d" / "cli" / "demo" / "logs" / "durable.log"
+
+            old_temp.mkdir(parents=True)
+            old_cache.mkdir(parents=True)
+            old_log.parent.mkdir(parents=True, exist_ok=True)
+            durable_state.parent.mkdir(parents=True)
+            for path in (old_log, new_log, durable_state):
+                path.write_text("x", encoding="utf-8")
+
+            old_time = time.time() - 40 * 24 * 60 * 60
+            new_time = time.time()
+            for path in (old_log, old_temp, old_cache, durable_state):
+                os.utime(path, (old_time, old_time))
+            os.utime(new_log, (new_time, new_time))
+
+            candidates = engine.find_clean_candidates(cache_root, time.time() - 30 * 24 * 60 * 60)
+
+        self.assertEqual(
+            [(candidate.category, candidate.path.name) for candidate in candidates],
+            [("cache", "old-cache"), ("log", "old.log"), ("temp", "old-run")],
+        )
+
+    def test_find_clean_candidates_logs_examined_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            (cache_root / "cli" / "demo" / "logs").mkdir(parents=True)
+            logger = mock.Mock()
+
+            engine.find_clean_candidates(cache_root, time.time(), logger)
+
+        logger.debug.assert_any_call("Scanning Base CLI runtime root '%s'.", cache_root / "cli")
+        logger.debug.assert_any_call(
+            "Scanning %s runtime artifacts in '%s'.",
+            "log",
+            cache_root / "cli" / "demo" / "logs",
+        )
+        logger.debug.assert_any_call(
+            "Scanning %s runtime artifacts in '%s'.",
+            "temp",
+            cache_root / "cli" / "demo" / "tmp",
+        )
+        logger.debug.assert_any_call(
+            "Scanning %s runtime artifacts in '%s'.",
+            "cache",
+            cache_root / "cli" / "demo" / "cache",
+        )
+
+    def test_remove_path_removes_files_and_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            file_path = root / "file.log"
+            dir_path = root / "run"
+            file_path.write_text("x", encoding="utf-8")
+            dir_path.mkdir()
+            (dir_path / "temp.txt").write_text("x", encoding="utf-8")
+
+            engine.remove_path(file_path)
+            engine.remove_path(dir_path)
+
+            self.assertFalse(file_path.exists())
+            self.assertFalse(dir_path.exists())
+
+    def test_clean_dry_run_reports_without_removing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
+            old_log.parent.mkdir(parents=True)
+            old_log.write_text("x", encoding="utf-8")
+            old_time = time.time() - 40 * 24 * 60 * 60
+            os.utime(old_log, (old_time, old_time))
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                result = engine.main(["--older-than", "30d", "--dry-run"])
+
+            self.assertEqual(result, 0)
+            self.assertTrue(old_log.exists())
+
+    def test_clean_removes_old_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
+            old_log.parent.mkdir(parents=True)
+            old_log.write_text("x", encoding="utf-8")
+            old_time = time.time() - 40 * 24 * 60 * 60
+            os.utime(old_log, (old_time, old_time))
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                result = engine.main(["--older-than", "30d"])
+
+            self.assertEqual(result, 0)
+            self.assertFalse(old_log.exists())
+
+    def test_clean_invalid_older_than_returns_usage_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(Path(tmpdir) / "cache-root")}):
+                result = engine.main(["--older-than", "forever"])
+
+        self.assertEqual(result, 2)
+
+    def test_clean_missing_older_than_returns_usage_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(Path(tmpdir) / "cache-root")}):
+                result = engine.main([])
+
+        self.assertEqual(result, 2)
+
+    def test_clean_click_usage_errors_do_not_traceback(self) -> None:
+        result = engine.main(["--unknown"])
+
+        self.assertEqual(result, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/base-cli-design.md
+++ b/docs/base-cli-design.md
@@ -73,7 +73,7 @@ ctx.run_id         # str
 ctx.base_home      # Path | None
 ctx.project_root   # Path | None
 ctx.manifest_path  # Path | None
-ctx.state_dir      # ${BASE_CACHE_DIR:-~/.cache/base}/cli/<cli-name>
+ctx.state_dir      # Base cache root / cli / <cli-name>
 ctx.log_dir        # state_dir/logs
 ctx.cache_dir      # state_dir/cache
 ctx.temp_dir       # state_dir/tmp/<run-id>

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -116,9 +116,11 @@ It owns the current Base subcommands:
 
 - `setup`
 - `check`
+- `clean`
+- `activate`
+- `projects list`
 - `update-profile`
 - `version`
-- `shell`
 - `help`
 
 Subcommand modules for the umbrella command live under:

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -239,21 +239,23 @@ actionable message.
 
 ## Runtime Directories
 
-Current runtime state is rooted at `${BASE_CACHE_DIR:-~/.cache/base}`:
+On macOS, current runtime state is rooted at `~/Library/Caches/base`:
 
 ```text
-~/.cache/base/cli/<cli-name>/
+~/Library/Caches/base/cli/<cli-name>/
   logs/
   cache/
   tmp/<run-id>/
 ```
 
-Use `BASE_CACHE_DIR` to override the root for tests, CI, or unusual local
+On Linux and other non-macOS platforms, the default is `~/.cache/base`. Use
+`BASE_CACHE_DIR` to override the root for tests, CI, or unusual local
 environments.
 
-`logs/` and `cache/` are runtime artifacts that can be pruned by Base cleanup
-tools. `tmp/<run-id>/` is deleted automatically after the command returns unless
-`--keep-temp` is set.
+`logs/` and `cache/` are runtime artifacts that can be pruned with
+`basectl clean --older-than <age>`. `tmp/<run-id>/` is deleted automatically
+after the command returns unless `--keep-temp` is set; retained temp entries can
+also be pruned by `basectl clean`.
 
 Use `ctx.on_cleanup()` for cleanup work that should happen even when helper code
 does not own the main command wrapper:

--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -50,6 +50,8 @@ def load_config(
         env_config["environment"] = os.environ["BASE_CLI_ENVIRONMENT"]
     if "BASE_CLI_LOG_LEVEL" in os.environ:
         env_config["log_level"] = os.environ["BASE_CLI_LOG_LEVEL"]
+    elif os.environ.get("LOG_DEBUG", "").lower() in ("1", "true"):
+        env_config["log_level"] = "debug"
     if "BASE_CLI_KEEP_TEMP" in os.environ:
         env_config["keep_temp"] = os.environ["BASE_CLI_KEEP_TEMP"].lower() == "true"
     return merge_dicts(config, env_config)

--- a/lib/python/base_cli/paths.py
+++ b/lib/python/base_cli/paths.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -14,7 +15,10 @@ def base_cache_root(home: Path | None = None) -> Path:
     value = os.environ.get("BASE_CACHE_DIR")
     if value:
         return Path(value).expanduser()
-    return (home or Path.home()) / ".cache" / "base"
+    root = home or Path.home()
+    if sys.platform == "darwin":
+        return root / "Library" / "Caches" / "base"
+    return root / ".cache" / "base"
 
 
 def make_run_id() -> str:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -57,7 +57,7 @@ class BaseCliTests(unittest.TestCase):
             home = Path(tmpdir)
             with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
                 self.assertFalse((home / ".base.d").exists())
-                self.assertFalse((home / ".cache" / "base").exists())
+                self.assertFalse((home / "Library" / "Caches" / "base").exists())
 
     def test_path_helpers(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -67,9 +67,20 @@ class BaseCliTests(unittest.TestCase):
             (root / "base_manifest.yaml").write_text("project:\n  name: demo\n", encoding="utf-8")
 
             self.assertEqual(base_state_root(root), root / ".base.d")
-            self.assertEqual(base_cache_root(root), root / ".cache" / "base")
             self.assertEqual(normalize_cli_name("/tmp/demo.py"), "demo")
             self.assertEqual(discover_manifest(nested), (root / "base_manifest.yaml").resolve())
+
+    def test_base_cache_root_uses_macos_cache_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with mock.patch("base_cli.paths.sys.platform", "darwin"):
+                self.assertEqual(base_cache_root(root), root / "Library" / "Caches" / "base")
+
+    def test_base_cache_root_uses_xdg_cache_directory_off_macos(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with mock.patch("base_cli.paths.sys.platform", "linux"):
+                self.assertEqual(base_cache_root(root), root / ".cache" / "base")
 
     def test_base_cache_root_honors_environment_override(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -140,6 +151,13 @@ class BaseCliTests(unittest.TestCase):
         self.assertEqual(config["environment"], "env")
         self.assertEqual(config["log_level"], "warning")
 
+    def test_log_debug_enables_python_debug_logging(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"LOG_DEBUG": "1"}):
+                config = load_config(None, None, home=Path(tmpdir))
+
+        self.assertEqual(config["log_level"], "debug")
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_runs_with_context_and_cleans_temp_dir(self) -> None:
         app = base_cli.App(name="demo", version="0.1.0")
@@ -166,7 +184,7 @@ class BaseCliTests(unittest.TestCase):
             self.assertEqual(seen["name"], "Ada")
             self.assertFalse(seen["temp_dir"].exists())
             self.assertTrue(seen["cache_dir"].is_dir())
-            self.assertTrue((home / ".cache" / "base" / "cli" / "demo" / "logs").is_dir())
+            self.assertTrue((home / "Library" / "Caches" / "base" / "cli" / "demo" / "logs").is_dir())
             self.assertFalse((home / ".base.d" / "cli").exists())
             self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} INFO\s+")
             self.assertIn("hello Ada", result.stderr)
@@ -235,7 +253,10 @@ class BaseCliTests(unittest.TestCase):
             self.assertTrue(seen["debug"])
             self.assertTrue(seen["temp_dir"].exists())
             self.assertEqual(seen["log_file"], log_file)
-            self.assertEqual(seen["temp_dir"].parents[1], home / ".cache" / "base" / "cli" / "secret-tool")
+            self.assertEqual(
+                seen["temp_dir"].parents[1],
+                home / "Library" / "Caches" / "base" / "cli" / "secret-tool",
+            )
             self.assertEqual(seen["manifest_path"], manifest_path.resolve())
             self.assertEqual(seen["project_root"], project.resolve())
 


### PR DESCRIPTION
## Summary
- add `basectl clean --older-than <age> [--dry-run]`
- add a Python `base_clean` package that reuses `base_cli.paths.base_cache_root()` for cleanup scope
- default the Base cache root to `~/Library/Caches/base` on macOS and `~/.cache/base` elsewhere, with `BASE_CACHE_DIR` as an override
- prune old entries under the Base cache root's `cli/*/{logs,tmp,cache}` without touching durable `~/.base.d` state
- print clear dry-run/removal output with artifact category and path
- report missing/invalid clean arguments as usage errors instead of tracebacks
- honor top-level `basectl -v` in Python `base_cli` commands through `LOG_DEBUG=1`
- log scanned cleanup roots and category directories at DEBUG level
- document the command and remove the completed TODO item

## Testing
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_clean.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest lib.python.base_cli.tests.test_base_cli cli.python.base_clean.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py') cli/python/base_clean/*.py cli/python/base_clean/tests/*.py`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/clean.sh`
- `bash -n cli/bash/commands/basectl/basectl.sh`
- `basectl -v clean`
- `env BASE_CACHE_DIR=/private/tmp/base-clean-verify basectl -v clean --older-than 30d`