### PR TITLE
Add basectl doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Current implemented commands include:
 
 - `basectl setup`
 - `basectl check`
+- `basectl doctor`
 - `basectl clean --older-than <age>`
 - `basectl update-profile`
 - `basectl projects list`
@@ -48,7 +49,6 @@ Planned commands include:
 - `basectl setup <project>`
 - `basectl test`
 - `basectl test <project>`
-- `basectl doctor`
 
 The important idea is that the user should not need to memorize a different
 bootstrap story for every repository in the workspace. Planned commands are
@@ -133,6 +133,14 @@ Cleanup only targets runtime artifacts under the Base cache root, which defaults
 to `~/Library/Caches/base` on macOS. Set `BASE_CACHE_DIR` to override it. Durable
 state such as `~/.base.d/config.yaml` and project virtual environments under
 `~/.base.d/<project>/.venv` are outside this scope.
+
+Use `basectl doctor` when you want a human-oriented diagnosis with suggested
+fixes:
+
+```bash
+basectl doctor
+basectl doctor --dev
+```
 
 ### 2. Shell Environment Management
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,10 +7,11 @@ they are merged.
 
 ## P1 — High-Value Product Capabilities
 
-- [ ] Implement `basectl doctor`.
-  - Goal: provide deeper diagnosis than `basectl check`.
-  - Expected behavior: report findings as `ok`, `warn`, or `error`, and include suggested fix commands or next steps for each issue.
-  - Notes: keep `basectl check` automation-friendly; make `doctor` human-oriented.
+- [ ] Manage GitHub CLI as a Base developer dependency.
+  - Files: `cli/bash/commands/basectl/subcommands/setup_common.sh`, setup/check tests.
+  - Goal: keep `basectl setup --dev`, `basectl check --dev`, and `basectl doctor --dev` aligned.
+  - Expected behavior: install `gh` through Homebrew during `setup --dev`, check it during `check --dev`, and keep doctor diagnostics consistent with both.
+  - Notes: `gh` supports Base development workflows such as PR creation, CI inspection, and GitHub operations.
 
 - [ ] Add Docker and Colima to the artifact registry.
   - File: `cli/python/base_setup/registry.py`

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -27,6 +27,7 @@ that delegate to `basectl`.
 - `setup`
 - `check`
 - `clean`
+- `doctor`
 - `update-profile`
 - `projects list`
 - `version`
@@ -42,6 +43,7 @@ that delegate to `basectl`.
   project argument validates `project.name`.
 - `basectl check` verifies the same local requirements without making changes.
 - `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
+- `basectl doctor` diagnoses the local Base environment and prints suggested fixes.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -17,6 +17,8 @@ Commands:
     Verify the local Base CLI environment without making changes.
   clean --older-than <age> [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
+  doctor [options]
+    Diagnose the local Base CLI environment and suggest fixes.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
   projects list [options]
@@ -150,6 +152,11 @@ basectl_do_clean() {
     base_clean_subcommand_main "$@"
 }
 
+basectl_do_doctor() {
+    basectl_source_subcommand_module doctor || return 1
+    base_doctor_subcommand_main "$@"
+}
+
 basectl_do_update_profile() {
     basectl_source_subcommand_module update_profile || return 1
     base_update_profile_subcommand_main "$@"
@@ -242,6 +249,7 @@ basectl_main() {
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
         clean)            basectl_do_clean "$@" ;;
+        doctor)           basectl_do_doctor "$@" ;;
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_doctor_subcommand_sourced:-}" ]] && return
+_base_doctor_subcommand_sourced=1
+readonly _base_doctor_subcommand_sourced
+
+_base_setup_common_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/setup_common.sh"
+# shellcheck source=/dev/null
+source "$_base_setup_common_path"
+
+base_doctor_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl doctor [options]
+
+Options:
+  --dev       Include developer/test dependency checks such as BATS and gh.
+  -v          Enable DEBUG logging for this subcommand.
+  -h, --help  Show this help text.
+
+Purpose:
+  Diagnose the local Base CLI environment and suggest fixes.
+EOF
+}
+
+base_doctor_print_finding() {
+    local status="$1"
+    local name="$2"
+    local message="$3"
+    local fix="${4:-}"
+
+    printf '%-5s  %-26s  %s\n' "$status" "$name" "$message"
+    if [[ -n "$fix" ]]; then
+        printf '       Fix: %s\n' "$fix"
+    fi
+}
+
+base_doctor_check_homebrew() {
+    local brew_bin
+
+    if brew_bin="$(setup_find_brew_bin)"; then
+        if setup_refresh_brew_path; then
+            base_doctor_print_finding "ok" "Homebrew" "Homebrew is installed."
+            log_debug "Resolved Homebrew binary: $brew_bin"
+            return 0
+        fi
+        base_doctor_print_finding "error" "Homebrew" \
+            "Homebrew is installed, but its bin directory could not be added to PATH." \
+            "Check Homebrew installation and PATH."
+        return 1
+    fi
+
+    base_doctor_print_finding "error" "Homebrew" "Homebrew is not installed." "basectl setup"
+    return 1
+}
+
+base_doctor_check_xcode() {
+    if setup_xcode_tools_installed; then
+        base_doctor_print_finding "ok" "Xcode Command Line Tools" "Xcode Command Line Tools are installed."
+        return 0
+    fi
+
+    base_doctor_print_finding "error" "Xcode Command Line Tools" \
+        "Xcode Command Line Tools are not installed." \
+        "basectl setup"
+    return 1
+}
+
+base_doctor_check_python() {
+    local formula
+
+    formula="$(setup_python_formula)"
+    if setup_python_installed; then
+        base_doctor_print_finding "ok" "Python" "Python formula '$formula' is installed via Homebrew."
+        return 0
+    fi
+
+    base_doctor_print_finding "error" "Python" \
+        "Python formula '$formula' is not installed via Homebrew." \
+        "basectl setup"
+    return 1
+}
+
+base_doctor_check_bats() {
+    local formula
+
+    formula="$(setup_bats_formula)"
+    if setup_bats_installed; then
+        base_doctor_print_finding "ok" "BATS" "BATS formula '$formula' is installed via Homebrew."
+        return 0
+    fi
+
+    base_doctor_print_finding "error" "BATS" \
+        "BATS formula '$formula' is not installed via Homebrew." \
+        "basectl setup --dev"
+    return 1
+}
+
+base_doctor_check_github_cli() {
+    local gh_bin
+
+    if gh_bin="$(command -v gh 2>/dev/null)"; then
+        base_doctor_print_finding "ok" "GitHub CLI" "GitHub CLI is installed."
+        log_debug "Resolved GitHub CLI binary: $gh_bin"
+        return 0
+    fi
+
+    base_doctor_print_finding "error" "GitHub CLI" \
+        "GitHub CLI command 'gh' is not installed or not on PATH." \
+        "brew install gh"
+    return 1
+}
+
+base_doctor_check_virtualenv() {
+    local venv_dir
+
+    venv_dir="$(setup_venv_dir)"
+    if setup_virtualenv_exists; then
+        base_doctor_print_finding "ok" "Base virtualenv" "Virtual environment exists at '$venv_dir'."
+        return 0
+    fi
+
+    base_doctor_print_finding "error" "Base virtualenv" \
+        "Virtual environment is missing at '$venv_dir'." \
+        "basectl setup"
+    return 1
+}
+
+base_doctor_check_python_package() {
+    local package="$1"
+
+    if setup_base_python_package_installed "$package"; then
+        base_doctor_print_finding "ok" "$package" "$(setup_base_python_package_check_message "$package" true)"
+        return 0
+    fi
+
+    base_doctor_print_finding "error" "$package" \
+        "$(setup_base_python_package_check_message "$package" false)" \
+        "basectl setup"
+    return 1
+}
+
+base_doctor_subcommand_main() {
+    local errors=0
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_doctor_subcommand_usage
+                return 0
+                ;;
+            --dev)
+                setup_enable_dev_dependencies
+                ;;
+            -v)
+                setup_enable_debug_logging
+                ;;
+            *)
+                print_error "Unknown option '$1'."
+                base_doctor_subcommand_usage >&2
+                return 2
+                ;;
+        esac
+        shift
+    done
+
+    log_debug "Running 'basectl doctor'."
+    setup_require_macos
+
+    printf 'Base doctor\n\n'
+
+    base_doctor_check_homebrew || errors=$((errors + 1))
+    base_doctor_check_xcode || errors=$((errors + 1))
+    base_doctor_check_python || errors=$((errors + 1))
+    if setup_dev_dependencies_enabled; then
+        base_doctor_check_bats || errors=$((errors + 1))
+        base_doctor_check_github_cli || errors=$((errors + 1))
+    fi
+    base_doctor_check_virtualenv || errors=$((errors + 1))
+    base_doctor_check_python_package "$(setup_pyyaml_package)" || errors=$((errors + 1))
+    base_doctor_check_python_package "$(setup_click_package)" || errors=$((errors + 1))
+
+    printf '\n'
+    if ((errors == 0)); then
+        printf 'Base doctor found no blocking issues.\n'
+        return 0
+    fi
+
+    printf 'Base doctor found %s blocking issue(s).\n' "$errors"
+    return 1
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -24,6 +24,7 @@ run_basectl() {
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [options]"* ]]
     [[ "$output" == *"clean --older-than <age> [options]"* ]]
+    [[ "$output" == *"doctor [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command is equivalent to \`basectl activate base\`"* ]]
     [[ "$output" == *"--version"* ]]
@@ -222,6 +223,156 @@ EOF
     [ "$status" -eq 2 ]
     [[ "$output" == *"ERROR: Option '--older-than' requires an argument."* ]]
     [[ "$output" != *"FATAL"* ]]
+}
+
+@test "basectl doctor prints help" {
+    run_basectl doctor --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl doctor [options]"* ]]
+    [[ "$output" == *"Diagnose the local Base CLI environment"* ]]
+}
+
+@test "basectl doctor reports ok findings and includes dev checks" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13|bats-core) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-f" && "${2:-}" == "clang" ]]; then
+    printf '/tmp/fake-clang\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh version test\n'
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+exit 1
+EOF
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$fake_bin/gh" "$venv_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor --dev
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base doctor"* ]]
+    [[ "$output" == *"ok"*"Homebrew"*"Homebrew is installed."* ]]
+    [[ "$output" == *"ok"*"BATS"*"BATS formula 'bats-core' is installed via Homebrew."* ]]
+    [[ "$output" == *"ok"*"GitHub CLI"*"GitHub CLI is installed."* ]]
+    [[ "$output" == *"ok"*"Base virtualenv"*"Virtual environment exists at"* ]]
+    [[ "$output" == *"Base doctor found no blocking issues."* ]]
+}
+
+@test "basectl doctor --dev reports missing GitHub CLI" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13|bats-core) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-f" && "${2:-}" == "clang" ]]; then
+    printf '/tmp/fake-clang\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+exit 1
+EOF
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor --dev
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"error"*"GitHub CLI"*"GitHub CLI command 'gh' is not installed or not on PATH."* ]]
+    [[ "$output" == *"Fix: brew install gh"* ]]
+}
+
+@test "basectl doctor reports errors with suggested fixes" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_SETUP_BREW_BIN="$TEST_TMPDIR/missing-brew" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/missing-xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Base doctor"* ]]
+    [[ "$output" == *"error"*"Homebrew"*"Homebrew is not installed."* ]]
+    [[ "$output" == *"Fix: basectl setup"* ]]
+    [[ "$output" == *"Base doctor found"*"blocking issue(s)."* ]]
 }
 
 @test "basectl activate resolves a project and execs a project subshell" {

--- a/docs/design.md
+++ b/docs/design.md
@@ -73,6 +73,7 @@ layers. This keeps the product name and the control-plane action separate:
 
 - `basectl setup`
 - `basectl check`
+- `basectl doctor`
 - `basectl update-profile`
 - `basectl projects list`
 - `basectl activate`

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -117,6 +117,7 @@ It owns the current Base subcommands:
 - `setup`
 - `check`
 - `clean`
+- `doctor`
 - `activate`
 - `projects list`
 - `update-profile`


### PR DESCRIPTION
## Summary
- add `basectl doctor [--dev]` as a human-oriented diagnostic command
- reuse existing setup/check probes for Homebrew, Xcode tools, Homebrew Python, Base virtualenv, PyYAML, click, and BATS when `--dev` is passed
- include GitHub CLI (`gh`) in `doctor --dev` diagnostics and suggest `brew install gh` when missing
- add a TODO to align `setup --dev` and `check --dev` with the new `gh` doctor check before implementing that follow-up
- print `ok`/`error` findings with suggested fix commands for blocking issues
- keep `basectl check` unchanged as the automation-friendly check path
- update docs and remove the completed doctor TODO item

## Testing
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/doctor.sh`
- `bash -n cli/bash/commands/basectl/basectl.sh`