### PR TITLE
Add manifest-driven dev prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,10 @@ with `BASE_SETUP_PYTHON_FORMULA` when a workspace needs a different formula.
 After this Bash bootstrap layer creates Base's own Python environment, setup
 installs `PyYAML` into that environment and invokes the Python project setup
 layer to read `base_manifest.yaml` and reconcile project artifacts.
-Developer/test dependencies such as BATS are opt-in; use `basectl setup --dev`
-to install them and `basectl check --dev` to verify them.
+Developer prerequisites such as BATS and the GitHub CLI are opt-in and
+manifest-driven through `lib/base/dev_manifest.yaml`; use `basectl setup --dev`
+to install them and `basectl check --dev` or `basectl doctor --dev` to verify
+them.
 
 ## Quick Start
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,12 +7,6 @@ they are merged.
 
 ## P1 — High-Value Product Capabilities
 
-- [ ] Manage GitHub CLI as a Base developer dependency.
-  - Files: `cli/bash/commands/basectl/subcommands/setup_common.sh`, setup/check tests.
-  - Goal: keep `basectl setup --dev`, `basectl check --dev`, and `basectl doctor --dev` aligned.
-  - Expected behavior: install `gh` through Homebrew during `setup --dev`, check it during `check --dev`, and keep doctor diagnostics consistent with both.
-  - Notes: `gh` supports Base development workflows such as PR creation, CI inspection, and GitHub operations.
-
 - [ ] Add Docker and Colima to the artifact registry.
   - File: `cli/python/base_setup/registry.py`
   - Expected behavior: support `type: tool`, `name: docker`, `version: latest` and `type: tool`, `name: colima`, `version: latest` through Homebrew.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -42,6 +42,8 @@ that delegate to `basectl`.
   Python project setup layer for `base_manifest.yaml` artifacts. The optional
   project argument validates `project.name`.
 - `basectl check` verifies the same local requirements without making changes.
+- `basectl setup --dev`, `basectl check --dev`, and `basectl doctor --dev`
+  manage developer prerequisites through `lib/base/dev_manifest.yaml`.
 - `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
 - `basectl doctor` diagnoses the local Base environment and prints suggested fixes.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -14,7 +14,7 @@ Usage:
   basectl check [options]
 
 Options:
-  --dev                 Include developer/test dependency checks such as BATS.
+  --dev                 Include manifest-declared developer prerequisite checks.
   --format <text|json>  Select output format. Defaults to text.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
@@ -27,7 +27,7 @@ Check does:
   2. Verify Xcode Command Line Tools are installed.
   3. Verify Python 3.13 is installed via Homebrew.
   4. Verify ~/.base.d/base/.venv exists.
-  5. Verify BATS is installed via Homebrew when --dev is passed.
+  5. Verify developer prerequisites from lib/base/dev_manifest.yaml when --dev is passed.
 EOF
 }
 

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -14,7 +14,7 @@ Usage:
   basectl doctor [options]
 
 Options:
-  --dev       Include developer/test dependency checks such as BATS and gh.
+  --dev       Include manifest-declared developer prerequisite checks.
   -v          Enable DEBUG logging for this subcommand.
   -h, --help  Show this help text.
 
@@ -81,36 +81,6 @@ base_doctor_check_python() {
     return 1
 }
 
-base_doctor_check_bats() {
-    local formula
-
-    formula="$(setup_bats_formula)"
-    if setup_bats_installed; then
-        base_doctor_print_finding "ok" "BATS" "BATS formula '$formula' is installed via Homebrew."
-        return 0
-    fi
-
-    base_doctor_print_finding "error" "BATS" \
-        "BATS formula '$formula' is not installed via Homebrew." \
-        "basectl setup --dev"
-    return 1
-}
-
-base_doctor_check_github_cli() {
-    local gh_bin
-
-    if gh_bin="$(command -v gh 2>/dev/null)"; then
-        base_doctor_print_finding "ok" "GitHub CLI" "GitHub CLI is installed."
-        log_debug "Resolved GitHub CLI binary: $gh_bin"
-        return 0
-    fi
-
-    base_doctor_print_finding "error" "GitHub CLI" \
-        "GitHub CLI command 'gh' is not installed or not on PATH." \
-        "brew install gh"
-    return 1
-}
-
 base_doctor_check_virtualenv() {
     local venv_dir
 
@@ -141,7 +111,7 @@ base_doctor_check_python_package() {
 }
 
 base_doctor_subcommand_main() {
-    local errors=0
+    local dev_errors=0 errors=0
 
     while (($#)); do
         case "$1" in
@@ -172,13 +142,14 @@ base_doctor_subcommand_main() {
     base_doctor_check_homebrew || errors=$((errors + 1))
     base_doctor_check_xcode || errors=$((errors + 1))
     base_doctor_check_python || errors=$((errors + 1))
-    if setup_dev_dependencies_enabled; then
-        base_doctor_check_bats || errors=$((errors + 1))
-        base_doctor_check_github_cli || errors=$((errors + 1))
-    fi
     base_doctor_check_virtualenv || errors=$((errors + 1))
     base_doctor_check_python_package "$(setup_pyyaml_package)" || errors=$((errors + 1))
     base_doctor_check_python_package "$(setup_click_package)" || errors=$((errors + 1))
+    if setup_dev_dependencies_enabled; then
+        setup_run_base_dev_layer doctor
+        dev_errors=$?
+        errors=$((errors + dev_errors))
+    fi
 
     printf '\n'
     if ((errors == 0)); then

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -14,7 +14,7 @@ Usage:
   basectl setup [options] [project]
 
 Options:
-  --dev             Install developer/test dependencies such as BATS.
+  --dev             Install manifest-declared developer prerequisites.
   --dry-run          Log what would happen without making changes.
   --manifest <path>  Use a specific base_manifest.yaml path.
   --recreate-venv    Back up and recreate the project virtual environment.
@@ -28,7 +28,7 @@ Setup does:
   1. Install Homebrew if needed.
   2. Install Xcode Command Line Tools if needed.
   3. Install Python 3.13 via Homebrew if needed.
-  4. Install BATS via Homebrew if --dev is passed.
+  4. Install developer prerequisites from lib/base/dev_manifest.yaml if --dev is passed.
   5. Create ~/.base.d/base/.venv if it does not already exist.
   6. Install Base Python bootstrap packages into the Base virtual environment.
   7. Invoke the Python project setup layer for base_manifest.yaml artifacts.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -87,10 +87,6 @@ setup_python_formula() {
     printf '%s\n' "${BASE_SETUP_PYTHON_FORMULA:-python@3.13}"
 }
 
-setup_bats_formula() {
-    printf '%s\n' "${BASE_SETUP_BATS_FORMULA:-bats-core}"
-}
-
 setup_pyyaml_package() {
     printf '%s\n' "${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 }
@@ -248,34 +244,6 @@ setup_install_python() {
     command -v brew >/dev/null 2>&1 || fatal_error "Homebrew is required to install Python formula '$formula'."
 
     log_info "Installing Python formula '$formula' via Homebrew."
-    run brew install "$formula"
-}
-
-setup_bats_installed() {
-    local formula
-
-    formula="$(setup_bats_formula)"
-    command -v brew >/dev/null 2>&1 && brew list "$formula" >/dev/null 2>&1
-}
-
-setup_install_bats() {
-    local formula
-
-    formula="$(setup_bats_formula)"
-
-    if setup_bats_installed; then
-        log_info "BATS formula '$formula' is already installed via Homebrew."
-        return 0
-    fi
-
-    if setup_is_dry_run; then
-        log_info "[DRY-RUN] Would install BATS formula '$formula' via Homebrew."
-        return 0
-    fi
-
-    command -v brew >/dev/null 2>&1 || fatal_error "Homebrew is required to install BATS formula '$formula'."
-
-    log_info "Installing BATS formula '$formula' via Homebrew."
     run brew install "$formula"
 }
 
@@ -439,6 +407,26 @@ setup_run_project_artifact_setup() {
     exit_if_error "$exit_code" "Python project setup layer failed."
 }
 
+setup_run_base_dev_layer() {
+    local args=("$@")
+    local venv_dir
+
+    if setup_is_dry_run &&
+        { ! setup_base_python_package_installed "$(setup_pyyaml_package)" ||
+            ! setup_base_python_package_installed "$(setup_click_package)"; }; then
+        log_info "[DRY-RUN] Would run Python developer prerequisite layer after Base Python bootstrap dependencies are installed."
+        return 0
+    fi
+
+    venv_dir="$(setup_venv_dir)"
+    if ! setup_base_venv_python_bin "$venv_dir" >/dev/null 2>&1; then
+        log_warn "Python developer prerequisite layer cannot run because Base virtual environment Python was not found at '$venv_dir/bin/python'."
+        return 1
+    fi
+
+    "$BASE_HOME/bin/base-wrapper" --project base base_dev "${args[@]}"
+}
+
 setup_run_check() {
     local brew_bin="" click_package pyyaml_package venv_dir missing=0
 
@@ -470,15 +458,6 @@ setup_run_check() {
         missing=1
     fi
 
-    if setup_dev_dependencies_enabled; then
-        if setup_bats_installed; then
-            log_info "BATS formula '$(setup_bats_formula)' is installed via Homebrew."
-        else
-            log_warn "BATS formula '$(setup_bats_formula)' is not installed via Homebrew."
-            missing=1
-        fi
-    fi
-
     if setup_virtualenv_exists; then
         log_info "Virtual environment exists at '$venv_dir'."
     else
@@ -498,6 +477,10 @@ setup_run_check() {
     else
         log_warn "$(setup_base_python_package_check_message "$click_package" false)"
         missing=1
+    fi
+
+    if setup_dev_dependencies_enabled; then
+        setup_run_base_dev_layer check || missing=1
     fi
 
     if ((missing == 0)); then
@@ -533,9 +516,27 @@ setup_print_check_json_item() {
         "$trailing_comma"
 }
 
+setup_print_json_property_value() {
+    local first_line=true
+    local key="$1"
+    local line
+    local value="$2"
+
+    printf '  "%s": ' "$(setup_json_escape "$key")"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$first_line" == true ]]; then
+            printf '%s\n' "$line"
+            first_line=false
+        else
+            printf '  %s\n' "$line"
+        fi
+    done <<<"$value"
+}
+
 setup_run_check_json() {
-    local bats_message bats_ok=false brew_bin homebrew_message homebrew_ok=false
+    local brew_bin homebrew_message homebrew_ok=false
     local click_message click_ok=false click_package
+    local dev_json="[]"
     local missing=0
     local pyyaml_message pyyaml_ok=false pyyaml_package
     local python_message python_ok=false
@@ -576,17 +577,6 @@ setup_run_check_json() {
         missing=1
     fi
 
-    if setup_dev_dependencies_enabled; then
-        if setup_bats_installed; then
-            bats_ok=true
-            bats_message="BATS formula '$(setup_bats_formula)' is installed via Homebrew."
-        else
-            bats_ok=false
-            bats_message="BATS formula '$(setup_bats_formula)' is not installed via Homebrew."
-            missing=1
-        fi
-    fi
-
     if setup_virtualenv_exists; then
         venv_ok=true
         venv_message="Virtual environment exists at '$venv_dir'."
@@ -609,19 +599,29 @@ setup_run_check_json() {
     fi
     click_message="$(setup_base_python_package_check_message "$click_package" "$click_ok")"
 
+    if setup_dev_dependencies_enabled; then
+        if ! dev_json="$(setup_run_base_dev_layer check --format json)"; then
+            missing=1
+            [[ -n "$dev_json" ]] || dev_json="[]"
+        fi
+    fi
+
     printf '{\n'
     printf '  "ok": %s,\n' "$([[ "$missing" -eq 0 ]] && printf true || printf false)"
     printf '  "checks": [\n'
     setup_print_check_json_item "," "homebrew" "$homebrew_ok" "$homebrew_message"
     setup_print_check_json_item "," "xcode_command_line_tools" "$xcode_ok" "$xcode_message"
     setup_print_check_json_item "," "python" "$python_ok" "$python_message"
-    if setup_dev_dependencies_enabled; then
-        setup_print_check_json_item "," "bats" "$bats_ok" "$bats_message"
-    fi
     setup_print_check_json_item "," "pyyaml" "$pyyaml_ok" "$pyyaml_message"
     setup_print_check_json_item "," "click" "$click_ok" "$click_message"
     setup_print_check_json_item "" "base_virtualenv" "$venv_ok" "$venv_message"
-    printf '  ]\n'
+    printf '  ]'
+    if setup_dev_dependencies_enabled; then
+        printf ',\n'
+        setup_print_json_property_value "dev_checks" "$dev_json"
+    else
+        printf '\n'
+    fi
     printf '}\n'
 
     [[ "$missing" -eq 0 ]]
@@ -632,12 +632,16 @@ setup_run_install() {
     setup_install_homebrew
     setup_install_xcode_tools
     setup_install_python
-    if setup_dev_dependencies_enabled; then
-        setup_install_bats
-    fi
     setup_create_virtualenv
     setup_install_pyyaml
     setup_install_click
+    if setup_dev_dependencies_enabled; then
+        if setup_is_dry_run; then
+            setup_run_base_dev_layer setup --dry-run || fatal_error "Python developer prerequisite layer failed."
+        else
+            setup_run_base_dev_layer setup || fatal_error "Python developer prerequisite layer failed."
+        fi
+    fi
     setup_run_project_artifact_setup
 
     if setup_is_dry_run; then

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -279,6 +279,11 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
         PyYAML|click) exit 0 ;;
     esac
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" && "${3:-}" == "doctor" ]]; then
+    printf 'ok     bats-core                   Artifact '\''bats-core'\'' is installed via Homebrew package '\''bats-core'\''.\n'
+    printf 'ok     gh                          Artifact '\''gh'\'' is installed via Homebrew package '\''gh'\''.\n'
+    exit 0
+fi
 exit 1
 EOF
     chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$fake_bin/gh" "$venv_python"
@@ -295,8 +300,8 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Base doctor"* ]]
     [[ "$output" == *"ok"*"Homebrew"*"Homebrew is installed."* ]]
-    [[ "$output" == *"ok"*"BATS"*"BATS formula 'bats-core' is installed via Homebrew."* ]]
-    [[ "$output" == *"ok"*"GitHub CLI"*"GitHub CLI is installed."* ]]
+    [[ "$output" == *"ok"*"bats-core"*"Artifact 'bats-core' is installed via Homebrew package 'bats-core'."* ]]
+    [[ "$output" == *"ok"*"gh"*"Artifact 'gh' is installed via Homebrew package 'gh'."* ]]
     [[ "$output" == *"ok"*"Base virtualenv"*"Virtual environment exists at"* ]]
     [[ "$output" == *"Base doctor found no blocking issues."* ]]
 }
@@ -342,6 +347,12 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
         PyYAML|click) exit 0 ;;
     esac
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" && "${3:-}" == "doctor" ]]; then
+    printf 'ok     bats-core                   Artifact '\''bats-core'\'' is installed via Homebrew package '\''bats-core'\''.\n'
+    printf 'error  gh                          Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n'
+    printf '       Fix: basectl setup --dev\n'
+    exit 1
+fi
 exit 1
 EOF
     chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
@@ -356,8 +367,8 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" doctor --dev
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"error"*"GitHub CLI"*"GitHub CLI command 'gh' is not installed or not on PATH."* ]]
-    [[ "$output" == *"Fix: brew install gh"* ]]
+    [[ "$output" == *"error"*"gh"*"Artifact 'gh' is not installed via Homebrew package 'gh'."* ]]
+    [[ "$output" == *"Fix: basectl setup --dev"* ]]
 }
 
 @test "basectl doctor reports errors with suggested fixes" {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -100,6 +100,25 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
+    shift 2
+    printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/dev-args"
+    case "${1:-}" in
+        setup)
+            touch "${BASE_SETUP_TEST_STATE_DIR:?}/dev-setup-ran"
+            exit 0
+            ;;
+        check)
+            if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
+                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --dev"}]\n'
+            else
+                printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
+                printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
+            fi
+            exit 1
+            ;;
+    esac
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
     [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
     exit $?
@@ -127,6 +146,25 @@ fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
+    shift 2
+    printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/dev-args"
+    case "${1:-}" in
+        setup)
+            touch "${BASE_SETUP_TEST_STATE_DIR:?}/dev-setup-ran"
+            exit 0
+            ;;
+        check)
+            if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
+                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --dev"}]\n'
+            else
+                printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
+                printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
+            fi
+            exit 1
+            ;;
+    esac
 fi
 printf 'unexpected python3 args: %s\n' "$*" >&2
 exit 1
@@ -205,6 +243,25 @@ click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
+    shift 2
+    printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/dev-args"
+    case "${1:-}" in
+        setup)
+            touch "${BASE_SETUP_TEST_STATE_DIR:?}/dev-setup-ran"
+            exit 0
+            ;;
+        check)
+            if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
+                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --dev"}]\n'
+            else
+                printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
+                printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
+            fi
+            exit 1
+            ;;
+    esac
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
     [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
@@ -316,6 +373,21 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" ==
     printf '%s\n' "$4" >> "${BASE_SETUP_TEST_STATE_DIR:?}/pip-show.log"
     [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed" ]]
     exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
+    shift 2
+    printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/dev-args"
+    case "${1:-}" in
+        check)
+            if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
+                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --dev"}]\n'
+            else
+                printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
+                printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
+            fi
+            exit 1
+            ;;
+    esac
 fi
 printf 'unexpected check venv python args: %s\n' "$*" >&2
 exit 1
@@ -523,7 +595,7 @@ EOF
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
-@test "basectl setup --dev installs BATS with developer dependencies" {
+@test "basectl setup --dev runs the Python developer prerequisite layer" {
     local installer
 
     create_xcode_stubs
@@ -535,8 +607,8 @@ EOF
         setup --dev
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Installing BATS formula 'bats-core' via Homebrew."* ]]
-    [ -f "$TEST_STATE_DIR/bats-install-ran" ]
+    [ -f "$TEST_STATE_DIR/dev-setup-ran" ]
+    [ "$(cat "$TEST_STATE_DIR/dev-args")" = "setup" ]
 }
 
 @test "basectl setup backs up an existing non-venv path before creating the Base virtual environment" {
@@ -648,11 +720,11 @@ EOF
     [ ! -e "$TEST_HOME/.base.d/base/.venv" ]
 }
 
-@test "basectl setup --dev dry-run includes BATS" {
+@test "basectl setup --dev dry-run defers developer prerequisites until Python bootstrap dependencies exist" {
     run_base_command setup --dev --dry-run
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"[DRY-RUN] Would install BATS formula 'bats-core' via Homebrew."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run Python developer prerequisite layer after Base Python bootstrap dependencies are installed."* ]]
 }
 
 @test "basectl setup ignores inherited DRY_RUN without --dry-run" {
@@ -727,7 +799,7 @@ EOF
     [ "$(grep -c '^click$' "$TEST_STATE_DIR/pip-show.log")" -eq 1 ]
 }
 
-@test "basectl check --dev includes BATS in developer dependency checks" {
+@test "basectl check --dev includes manifest-driven developer prerequisite checks" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_brew_stub
@@ -742,7 +814,8 @@ EOF
     run_base_command check --dev
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"BATS formula 'bats-core' is not installed via Homebrew."* ]]
+    [[ "$output" == *"Artifact 'bats-core' is not installed via Homebrew package 'bats-core'."* ]]
+    [[ "$output" == *"Artifact 'gh' is not installed via Homebrew package 'gh'."* ]]
     [[ "$output" == *"Base CLI environment check found missing requirements."* ]]
 }
 
@@ -780,7 +853,7 @@ EOF
     [ "${stderr:-}" = "" ]
 }
 
-@test "basectl check --dev --format json includes BATS check results" {
+@test "basectl check --dev --format json includes developer prerequisite check results" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_brew_stub
@@ -805,7 +878,9 @@ EOF
 
     [ "$status" -eq 1 ]
     [[ "$output" == *'"ok": false'* ]]
-    [[ "$output" == *'"name":"bats","ok":false'* ]]
+    [[ "$output" == *'"dev_checks":'* ]]
+    [[ "$output" == *"bats-core"* ]]
+    [[ "$output" == *"gh"* ]]
     [[ "$output" == *'"name":"pyyaml","ok":true'* ]]
     [[ "$output" == *'"name":"click","ok":true'* ]]
     [ "${stderr:-}" = "" ]

--- a/cli/python/base_dev/__init__.py
+++ b/cli/python/base_dev/__init__.py
@@ -1,0 +1,1 @@
+"""Developer prerequisite management for Base."""

--- a/cli/python/base_dev/__main__.py
+++ b/cli/python/base_dev/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .engine import main
+
+
+raise SystemExit(main())

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import base_cli
+from base_setup.engine import ArtifactError, reconcile_artifact, resolve_artifact_definitions, run_check
+from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError, read_manifest
+from base_setup.registry import ArtifactDefinition
+
+
+app = base_cli.App(name="base_dev")
+
+
+@dataclass(frozen=True)
+class DevCheck:
+    name: str
+    ok: bool
+    message: str
+    fix: str
+
+
+def main(argv: list[str] | None = None) -> int:
+    result = app.click_command.main(args=argv, standalone_mode=False)
+    return int(result or 0)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("action", required=True)
+@base_cli.option("--dry-run", is_flag=True, help="Log planned setup changes without making them.")
+@base_cli.option("--format", "output_format", default="text", help="Output format for check: text or json.")
+def run(ctx: base_cli.Context, action: str, dry_run: bool, output_format: str) -> int:
+    try:
+        manifest = read_dev_manifest(ctx)
+        definitions = resolve_artifact_definitions(manifest.artifacts)
+    except (ManifestError, ArtifactError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    if action == "setup":
+        return setup_dev_artifacts(ctx, manifest, definitions, dry_run=dry_run)
+    if action == "check":
+        return check_dev_artifacts(ctx, manifest.artifacts, definitions, output_format=output_format)
+    if action == "doctor":
+        return doctor_dev_artifacts(manifest.artifacts, definitions)
+
+    ctx.log.error("Unsupported base_dev action '%s'. Expected setup, check, or doctor.", action)
+    return 2
+
+
+def read_dev_manifest(ctx: base_cli.Context) -> BaseManifest:
+    if ctx.base_home is None:
+        raise ManifestError("BASE_HOME is required to load Base's developer prerequisite manifest.")
+    return read_manifest(dev_manifest_path(ctx.base_home))
+
+
+def dev_manifest_path(base_home: Path) -> Path:
+    return base_home / "lib" / "base" / "dev_manifest.yaml"
+
+
+def setup_dev_artifacts(
+    ctx: base_cli.Context,
+    manifest: BaseManifest,
+    definitions: tuple[ArtifactDefinition, ...],
+    dry_run: bool,
+) -> int:
+    ctx.log.info("Reading Base developer prerequisite manifest at '%s'.", manifest.path)
+    ctx.log.info("Setting up Base developer prerequisites.")
+
+    try:
+        for artifact, definition in zip(manifest.artifacts, definitions, strict=True):
+            reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
+    except ArtifactError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    ctx.log.info("Base developer prerequisite setup is complete.")
+    return 0
+
+
+def check_dev_artifacts(
+    ctx: base_cli.Context,
+    artifacts: tuple[ArtifactRequest, ...],
+    definitions: tuple[ArtifactDefinition, ...],
+    output_format: str,
+) -> int:
+    checks = tuple(
+        check_homebrew_artifact(artifact, definition) for artifact, definition in zip(artifacts, definitions)
+    )
+    if output_format == "json":
+        print(json.dumps([check_to_json(check) for check in checks], indent=2))
+    elif output_format == "text":
+        for check in checks:
+            if check.ok:
+                ctx.log.info(check.message)
+            else:
+                ctx.log.warning(check.message)
+    else:
+        ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
+        return 2
+
+    return 0 if all(check.ok for check in checks) else 1
+
+
+def doctor_dev_artifacts(
+    artifacts: tuple[ArtifactRequest, ...],
+    definitions: tuple[ArtifactDefinition, ...],
+) -> int:
+    checks = tuple(
+        check_homebrew_artifact(artifact, definition) for artifact, definition in zip(artifacts, definitions)
+    )
+    error_count = 0
+    for check in checks:
+        if check.ok:
+            print_doctor_finding("ok", check.name, check.message)
+        else:
+            print_doctor_finding("error", check.name, check.message, check.fix)
+            error_count += 1
+    return min(error_count, 125)
+
+
+def check_homebrew_artifact(artifact: ArtifactRequest, definition: ArtifactDefinition) -> DevCheck:
+    if definition.manager != "homebrew":
+        return DevCheck(
+            name=artifact.name,
+            ok=False,
+            message=(
+                f"Artifact '{artifact.name}' uses unsupported developer prerequisite manager '{definition.manager}'."
+            ),
+            fix="Update lib/base/dev_manifest.yaml to use a Homebrew-managed tool.",
+        )
+    if artifact.version != "latest":
+        return DevCheck(
+            name=artifact.name,
+            ok=False,
+            message=f"Artifact '{artifact.name}' uses unsupported developer prerequisite version '{artifact.version}'.",
+            fix="Use version 'latest' for Homebrew-managed developer prerequisites.",
+        )
+
+    ok = run_check(["brew", "list", definition.package])
+    if ok:
+        return DevCheck(
+            name=artifact.name,
+            ok=True,
+            message=f"Artifact '{artifact.name}' is installed via Homebrew package '{definition.package}'.",
+            fix="",
+        )
+    return DevCheck(
+        name=artifact.name,
+        ok=False,
+        message=f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'.",
+        fix="basectl setup --dev",
+    )
+
+
+def check_to_json(check: DevCheck) -> dict[str, str | bool]:
+    return {
+        "name": check.name,
+        "ok": check.ok,
+        "message": check.message,
+        "fix": check.fix,
+    }
+
+
+def print_doctor_finding(status: str, name: str, message: str, fix: str = "") -> None:
+    print(f"{status:<5}  {name:<26}  {message}")
+    if fix:
+        print(f"       Fix: {fix}")

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import io
+import importlib.util
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_dev import engine
+from base_dev.engine import main
+
+
+def run_engine(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with tempfile.TemporaryDirectory() as home_dir:
+        with mock.patch.dict(os.environ, {"HOME": home_dir, "BASE_HOME": str(Path(__file__).resolve().parents[4])}):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                status = main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class DevManifestTests(unittest.TestCase):
+    def test_dev_manifest_declares_supported_developer_tools(self) -> None:
+        manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
+        artifacts = {(artifact.artifact_type, artifact.name, artifact.version) for artifact in manifest.artifacts}
+
+        self.assertIn(("tool", "bats-core", "latest"), artifacts)
+        self.assertIn(("tool", "gh", "latest"), artifacts)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_check_json_reports_manifest_artifacts(self) -> None:
+        with mock.patch("base_dev.engine.run_check", return_value=False):
+            status, stdout, stderr = run_engine(["check", "--format", "json"])
+
+        self.assertEqual(status, 1)
+        self.assertIn('"name": "bats-core"', stdout)
+        self.assertIn('"ok": false', stdout)
+        self.assertIn('"name": "gh"', stdout)
+        self.assertEqual(stderr, "")
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_setup_dry_run_uses_homebrew_registry_definitions(self) -> None:
+        status, _stdout, stderr = run_engine(["setup", "--dry-run"])
+
+        self.assertEqual(status, 0)
+        self.assertIn("[DRY-RUN] Would run: brew install bats-core", stderr)
+        self.assertIn("[DRY-RUN] Would run: brew install gh", stderr)
+
+    def test_doctor_returns_number_of_failed_manifest_artifacts(self) -> None:
+        manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
+        definitions = engine.resolve_artifact_definitions(manifest.artifacts)
+
+        with mock.patch("base_dev.engine.run_check", return_value=False):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                status = engine.doctor_dev_artifacts(manifest.artifacts, definitions)
+
+        self.assertEqual(status, 2)
+        self.assertIn("error", stdout.getvalue())
+        self.assertIn("Fix: basectl setup --dev", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/python/base_setup/registry.py
+++ b/cli/python/base_setup/registry.py
@@ -48,6 +48,20 @@ _ARTIFACTS = {
         package="terraform",
         target="system",
     ),
+    ("tool", "bats-core"): ArtifactDefinition(
+        name="bats-core",
+        artifact_type="tool",
+        manager="homebrew",
+        package="bats-core",
+        target="system",
+    ),
+    ("tool", "gh"): ArtifactDefinition(
+        name="gh",
+        artifact_type="tool",
+        manager="homebrew",
+        package="gh",
+        target="system",
+    ),
     ("tool", "kubectl"): ArtifactDefinition(
         name="kubectl",
         artifact_type="tool",

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -102,6 +102,15 @@ class ManifestTests(unittest.TestCase):
         self.assertIsNotNone(get_artifact_definition("python-package", "pylint"))
         self.assertIsNotNone(get_artifact_definition("python-package", "pytest"))
 
+    def test_base_dev_manifest_declares_supported_tools(self) -> None:
+        manifest = read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
+        tools = {(artifact.artifact_type, artifact.name) for artifact in manifest.artifacts}
+
+        self.assertIn(("tool", "bats-core"), tools)
+        self.assertIn(("tool", "gh"), tools)
+        self.assertIsNotNone(get_artifact_definition("tool", "bats-core"))
+        self.assertIsNotNone(get_artifact_definition("tool", "gh"))
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_unknown_artifact_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/base/dev_manifest.yaml
+++ b/lib/base/dev_manifest.yaml
@@ -1,0 +1,11 @@
+project:
+  name: __base_dev__
+
+artifacts:
+  - type: tool
+    name: bats-core
+    version: latest
+
+  - type: tool
+    name: gh
+    version: latest


### PR DESCRIPTION
## Summary
- Add `lib/base/dev_manifest.yaml` as the source of truth for Base developer prerequisites.
- Add the `base_dev` Python command to setup, check, and doctor manifest-declared dev tools.
- Move `basectl setup --dev`, `basectl check --dev`, and `basectl doctor --dev` off hardcoded BATS/GitHub CLI logic and through the Python layer.
- Register `bats-core` and `gh` as Homebrew-managed tool artifacts and update docs/tests/TODO accordingly.

## Why
Developer prerequisites were split across Bash setup/check logic and doctor-specific checks, which made it easy for `setup --dev`, `check --dev`, and `doctor --dev` to drift. This makes the Python artifact layer the owner of the dev prerequisite manifest while Bash remains the bootstrap/invocation layer.

## Validation
- `PYTHONPATH=lib/python:cli/python python3 -m unittest cli.python.base_dev.tests.test_engine cli.python.base_setup.tests.test_engine`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/doctor.sh cli/bash/commands/basectl/subcommands/setup.sh cli/bash/commands/basectl/subcommands/check.sh`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `env BASE_CACHE_DIR=/private/tmp/base-dev-prereq-smoke bin/basectl check --dev --format json`
- `env BASE_CACHE_DIR=/private/tmp/base-dev-prereq-smoke bin/basectl doctor --dev`
- `env BASE_CACHE_DIR=/private/tmp/base-dev-prereq-smoke bin/basectl setup --dev --dry-run`