### PR TITLE
Document project bin command model

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ basectl activate example
 ```
 
 Activation spawns a project-specific subshell, changes to the project root, sets
-`BASE_PROJECT` and related project variables, and activates the project virtual
-environment at `~/.base.d/<project>/.venv`. Exit that shell to return to the
-original environment.
+`BASE_PROJECT` and related project variables, adds project-owned commands from
+`$PROJECT_ROOT/bin` when that directory exists, and activates the project
+virtual environment at `~/.base.d/<project>/.venv`. Exit that shell to return to
+the original environment.
 
 Invoking `basectl` with no arguments in a terminal is equivalent to
 `basectl activate base`, so the default interactive Base shell uses Base's own
@@ -180,8 +181,8 @@ invoke it from whatever shell state they already had.
 
 ## Public Command Surface
 
-Base exposes commands through a single public directory: `$BASE_HOME/bin`. That
-directory is added to `PATH` by Base's managed shell startup snippets.
+Base exposes its own commands through `$BASE_HOME/bin`. That directory is added
+to `PATH` by Base's managed shell startup snippets.
 
 `bin/basectl` is the control-plane command. Additional public commands, when
 needed, are tiny real launcher files in `bin/` that delegate to `basectl`; their
@@ -193,6 +194,21 @@ Example launcher:
 ```bash
 #!/usr/bin/env bash
 exec "$(dirname "$0")/basectl" caff "$@"
+```
+
+Projects expose their own commands through `$PROJECT_ROOT/bin`. When
+`basectl activate <project>` starts a project runtime shell, Base adds that
+directory to `PATH` if it exists, behind `$BASE_HOME/bin`. Project Python command
+packages should be treated as implementation details unless a project-owned
+launcher exposes them from `bin/`.
+
+Project launchers that need to run Python packages should delegate through
+`base-wrapper` so they use the selected project virtual environment and Base's
+Python library roots:
+
+```bash
+#!/usr/bin/env bash
+exec "$BASE_HOME/bin/base-wrapper" --project "${BASE_PROJECT:-example}" example_cli "$@"
 ```
 
 `basectl setup` deliberately pins its default Homebrew Python formula so setup is

--- a/bin/base-wrapper
+++ b/bin/base-wrapper
@@ -50,6 +50,10 @@ Options:
 Purpose:
   Run Base Python command packages through the selected project virtual
   environment with Base's Python library and command roots on PYTHONPATH.
+
+  This is primarily for Bash launchers in $BASE_HOME/bin and project bin/
+  directories. End users should normally run those launchers or basectl rather
+  than invoking Python packages directly.
 EOF
 }
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -37,7 +37,8 @@ that delegate to `basectl`.
 
 - `basectl setup` is the default local bootstrap path.
 - `basectl activate <project>` starts a project-specific runtime subshell with
-  the project virtual environment active.
+  the project virtual environment active and `$PROJECT_ROOT/bin` on `PATH` when
+  that directory exists.
 - `basectl setup [project]` runs the Bash bootstrap layer first, then invokes the
   Python project setup layer for `base_manifest.yaml` artifacts. The optional
   project argument validates `project.name`.

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -611,9 +611,10 @@ EOF
 }
 
 @test "Base runtime shell activates project virtual environment" {
+    local project_root="$TEST_TMPDIR/demo"
     local venv_dir="$TEST_TMPDIR/demo-venv"
 
-    mkdir -p "$venv_dir/bin"
+    mkdir -p "$project_root/bin" "$venv_dir/bin"
     cat > "$venv_dir/bin/activate" <<'EOF'
 VIRTUAL_ENV="$BASE_PROJECT_VENV_DIR"
 PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -624,7 +625,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
         BASE_PROJECT=demo \
-        BASE_PROJECT_ROOT="$BASE_REPO_ROOT" \
+        BASE_PROJECT_ROOT="$project_root" \
         BASE_PROJECT_VENV_DIR="$venv_dir" \
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
@@ -636,7 +637,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_PROJECT=demo"* ]]
     [[ "$output" == *"VIRTUAL_ENV=$venv_dir"* ]]
-    [[ "$output" == *"PATH=$venv_dir/bin:"* ]]
+    [[ "$output" == *"PATH=$venv_dir/bin:$BASE_REPO_ROOT/bin:$project_root/bin:"* ]]
     [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 

--- a/lib/bash/runtime/README.md
+++ b/lib/bash/runtime/README.md
@@ -10,6 +10,7 @@ arguments in a terminal is equivalent to `basectl activate base`.
 - sources `lib/shell/baserc_guard.sh`
 - sources user-managed `~/.baserc` when present
 - sources `base_init.sh`
+- adds `$BASE_PROJECT_ROOT/bin` to `PATH` when it exists, keeping `$BASE_HOME/bin` first
 - sources the user's `~/.bashrc` with guardrails
 - owns the final runtime prompt
 

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -75,6 +75,35 @@ _base_runtime_activate_project_venv() {
     source "$activate_script"
 }
 
+_base_runtime_add_project_bin_to_path() {
+    local entry
+    local new_path=""
+    local project_bin
+    local -a path_entries
+
+    [[ -n "${BASE_PROJECT_ROOT:-}" ]] || return 0
+    project_bin="$BASE_PROJECT_ROOT/bin"
+    [[ -d "$project_bin" ]] || return 0
+
+    IFS=: read -ra path_entries <<< "$PATH"
+    for entry in "${path_entries[@]}"; do
+        [[ -n "$entry" ]] || continue
+        [[ "$entry" != "$BASE_BIN_DIR" ]] || continue
+        [[ "$entry" != "$project_bin" ]] || continue
+        if [[ -n "$new_path" ]]; then
+            new_path="$new_path:$entry"
+        else
+            new_path="$entry"
+        fi
+    done
+
+    PATH="$BASE_BIN_DIR:$project_bin"
+    if [[ -n "$new_path" ]]; then
+        PATH="$PATH:$new_path"
+    fi
+    export PATH
+}
+
 _base_runtime_host_prompt() {
     local host_name=""
 
@@ -148,6 +177,7 @@ _base_runtime_main() {
     # shellcheck source=/dev/null
     source "$BASE_HOME/base_init.sh" || return $?
 
+    _base_runtime_add_project_bin_to_path || return $?
     _base_runtime_source_user_bashrc || return $?
     _base_runtime_activate_project_venv || return $?
     _base_runtime_set_prompt


### PR DESCRIPTION
## Summary
- Document the command exposure model: Base-owned commands live in `$BASE_HOME/bin`, project-owned commands live in `$PROJECT_ROOT/bin`, and Python packages stay implementation details unless exposed by launchers.
- Update `base-wrapper` help to describe its role as the supported launcher/shim path for Python packages.
- Add `$BASE_PROJECT_ROOT/bin` to activated runtime shell `PATH` when it exists, while keeping `$BASE_HOME/bin` ahead of it.
- Extend BATS coverage for the activated shell PATH order.

## Why
Base's Python CLIs are currently invoked through `basectl`/`base-wrapper`, not directly. This makes that design explicit and gives Base-supported projects a clean way to expose their own Python-backed commands without generated shims under `~/.base.d/<project>/bin`.

## Validation
- `bash -n lib/bash/runtime/bashrc bin/base-wrapper`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`