### PR TITLE
Add Docker and Colima artifacts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,6 @@ they are merged.
 
 ## P1 — High-Value Product Capabilities
 
-- [ ] Add Docker and Colima to the artifact registry.
-  - File: `cli/python/base_setup/registry.py`
-  - Expected behavior: support `type: tool`, `name: docker`, `version: latest` and `type: tool`, `name: colima`, `version: latest` through Homebrew.
-  - Notes: do not build a docker-service reconciler in this task.
-
 - [ ] Design future `docker-service` artifacts.
   - File: `docs/tool-boundaries.md`
   - Goal: document how Base should eventually orchestrate Docker Compose without replacing Docker.

--- a/cli/python/base_setup/registry.py
+++ b/cli/python/base_setup/registry.py
@@ -62,6 +62,20 @@ _ARTIFACTS = {
         package="gh",
         target="system",
     ),
+    ("tool", "docker"): ArtifactDefinition(
+        name="docker",
+        artifact_type="tool",
+        manager="homebrew",
+        package="docker",
+        target="system",
+    ),
+    ("tool", "colima"): ArtifactDefinition(
+        name="colima",
+        artifact_type="tool",
+        manager="homebrew",
+        package="colima",
+        target="system",
+    ),
     ("tool", "kubectl"): ArtifactDefinition(
         name="kubectl",
         artifact_type="tool",

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -111,6 +111,17 @@ class ManifestTests(unittest.TestCase):
         self.assertIsNotNone(get_artifact_definition("tool", "bats-core"))
         self.assertIsNotNone(get_artifact_definition("tool", "gh"))
 
+    def test_docker_and_colima_are_supported_tools(self) -> None:
+        docker = get_artifact_definition("tool", "docker")
+        colima = get_artifact_definition("tool", "colima")
+
+        self.assertIsNotNone(docker)
+        self.assertEqual(docker.package, "docker")
+        self.assertEqual(docker.manager, "homebrew")
+        self.assertIsNotNone(colima)
+        self.assertEqual(colima.package, "colima")
+        self.assertEqual(colima.manager, "homebrew")
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_unknown_artifact_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -158,6 +169,34 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: brew install terraform", stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_docker_and_colima_artifacts_dry_run_through_homebrew(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: tool",
+                        "    name: docker",
+                        "    version: latest",
+                        "  - type: tool",
+                        "    name: colima",
+                        "    version: latest",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
+
+        self.assertEqual(status, 0)
+        self.assertIn("[DRY-RUN] Would run: brew install docker", stderr)
+        self.assertIn("[DRY-RUN] Would run: brew install colima", stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_discovers_manifest_from_start_dir(self) -> None:


### PR DESCRIPTION
## Summary
- Add `docker` and `colima` as Homebrew-managed `tool` artifacts in the Base artifact registry.
- Add tests proving both artifacts are known and dry-run through `brew install`.
- Remove the completed Docker/Colima registry item from `TODO.md`.

## Why
Projects can now declare Docker or Colima in `base_manifest.yaml` without Base adding Docker Compose orchestration yet. The future `docker-service` artifact remains a separate design task.

## Validation
- `PYTHONPATH=lib/python:cli/python python3 -m unittest cli.python.base_setup.tests.test_engine`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/registry.py cli/python/base_setup/tests/test_engine.py`
- `git diff --check`