### PR TITLE
Add basectl update and completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Current implemented commands include:
 - `basectl doctor`
 - `basectl clean --older-than <age>`
 - `basectl update-profile`
+- `basectl update`
 - `basectl projects list`
 - `basectl activate <project>`
 - `basectl version`
@@ -281,7 +282,9 @@ adds or replaces its marked section.
 `basectl update-profile` also creates `~/.base.d/profile.conf`, which records
 whether the user has opted into Base's optional shell defaults. The managed
 dotfile sections stay minimal and defer PATH/default handling to the sourced
-Base snippets.
+Base snippets. The same sourced snippets also register `basectl` shell
+completions, so future completion improvements arrive when Base is updated
+without rewriting user dotfiles.
 
 Run `basectl update-profile --defaults` to enable those optional defaults, and
 run `basectl update-profile --no-defaults` to disable them again. Plain
@@ -289,6 +292,15 @@ run `basectl update-profile --no-defaults` to disable them again. Plain
 
 `BASE_PROFILE_VERSION` records the schema version of this Base-managed file. It
 is reserved for future migrations and is not intended to be edited by users.
+
+Update Base itself from the checked-out repository with:
+
+```bash
+basectl update
+```
+
+This command is intentionally conservative: it only runs from a clean `master`
+worktree, pulls the latest changes through Git, and then runs `basectl setup`.
 
 Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
 is user-managed and may be hand-edited. It is intended for simple,

--- a/TODO.md
+++ b/TODO.md
@@ -17,16 +17,6 @@ they are merged.
   - Expected behavior: allow a project manifest to reference a `Brewfile` and have setup run `brew bundle --file=<path>`.
   - Notes: this should complement the registry, not replace Base-specific known artifacts.
 
-- [ ] Add shell completions for `basectl`.
-  - Goal: improve daily ergonomics for commands and project names.
-  - Expected behavior: complete subcommands and, once project discovery exists, complete project names for commands such as `activate`.
-  - Notes: wire completion setup through `basectl update-profile` if practical.
-
-- [ ] Implement `basectl update`.
-  - Goal: provide a simple self-update path until Base has a Homebrew formula.
-  - Expected behavior: update the Base repo safely, then run `basectl setup`.
-  - Notes: build on the existing Git update helpers and keep dirty-worktree handling explicit.
-
 ## P2 — Adoption And Expansion
 
 - [ ] Improve setup recovery messages for technically-adjacent users.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -29,6 +29,7 @@ that delegate to `basectl`.
 - `clean`
 - `doctor`
 - `update-profile`
+- `update`
 - `projects list`
 - `version`
 - `help`
@@ -48,6 +49,7 @@ that delegate to `basectl`.
 - `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
 - `basectl doctor` diagnoses the local Base environment and prints suggested fixes.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
+- `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -21,6 +21,8 @@ Commands:
     Diagnose the local Base CLI environment and suggest fixes.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
+  update [options]
+    Update Base from Git and run setup.
   projects list [options]
     List Base-managed projects discovered in the workspace.
   version
@@ -162,6 +164,11 @@ basectl_do_update_profile() {
     base_update_profile_subcommand_main "$@"
 }
 
+basectl_do_update() {
+    basectl_source_subcommand_module update || return 1
+    base_update_subcommand_main "$@"
+}
+
 basectl_do_projects() {
     basectl_source_subcommand_module projects || return 1
     base_projects_subcommand_main "$@"
@@ -253,6 +260,7 @@ basectl_main() {
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;
+        update)           basectl_do_update "$@" ;;
         update-profile)   basectl_do_update_profile "$@" ;;
         version)          basectl_do_version ;;
         "")

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_update_subcommand_sourced:-}" ]] && return
+_base_update_subcommand_sourced=1
+readonly _base_update_subcommand_sourced
+
+_base_setup_common_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/setup_common.sh"
+# shellcheck source=/dev/null
+source "$_base_setup_common_path"
+
+base_update_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl update [options]
+
+Options:
+  --dry-run   Show what would happen without pulling or running setup.
+  -v          Enable DEBUG logging for this subcommand.
+  -h, --help  Show this help text.
+
+Purpose:
+  Update the Base repository from Git, then run basectl setup.
+
+Notes:
+  - The repository must be on master.
+  - The worktree must be clean, including untracked files.
+EOF
+}
+
+base_update_source_git_library() {
+    import_base_lib git/lib_git.sh
+}
+
+base_update_current_branch() {
+    local repo="$1"
+    git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null
+}
+
+base_update_worktree_clean() {
+    local repo="$1"
+    [[ -z "$(git -C "$repo" status --porcelain --untracked-files=normal --ignore-submodules=none)" ]]
+}
+
+base_update_run_setup() {
+    "$BASE_HOME/bin/basectl" setup
+}
+
+base_update_subcommand_main() {
+    local branch
+    local dry_run=0
+
+    while (($#)); do
+        case "$1" in
+            --dry-run)
+                dry_run=1
+                ;;
+            -h|--help|help)
+                base_update_subcommand_usage
+                return 0
+                ;;
+            -v)
+                setup_enable_debug_logging
+                ;;
+            *)
+                print_error "Unknown option '$1'."
+                base_update_subcommand_usage >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    log_debug "Running 'basectl update'."
+
+    branch="$(base_update_current_branch "$BASE_HOME")" || {
+        log_error "Base home '$BASE_HOME' is not a Git repository."
+        return 1
+    }
+    if [[ "$branch" != "master" ]]; then
+        log_error "Base update only runs on branch 'master'; current branch is '$branch'."
+        return 1
+    fi
+
+    if ! base_update_worktree_clean "$BASE_HOME"; then
+        log_error "Base repository has local changes. Commit, stash, or remove them before running basectl update."
+        return 1
+    fi
+
+    if ((dry_run)); then
+        log_info "[DRY-RUN] Would update Base repository at '$BASE_HOME'."
+        log_info "[DRY-RUN] Would run 'basectl setup' after updating."
+        return 0
+    fi
+
+    base_update_source_git_library || return 1
+    git_update_repo "$BASE_HOME" "" master || return 1
+    base_update_run_setup
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -25,6 +25,7 @@ run_basectl() {
     [[ "$output" == *"check [options]"* ]]
     [[ "$output" == *"clean --older-than <age> [options]"* ]]
     [[ "$output" == *"doctor [options]"* ]]
+    [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command is equivalent to \`basectl activate base\`"* ]]
     [[ "$output" == *"--version"* ]]
@@ -39,7 +40,6 @@ run_basectl() {
     run_basectl --help
 
     [ "$status" -eq 0 ]
-    ! grep -Fqx '  update' <<<"$output"
     ! grep -Fqx '  run <command> [args...]' <<<"$output"
     ! grep -Fqx '  status' <<<"$output"
     ! grep -Fqx '  set-team TEAM' <<<"$output"
@@ -52,6 +52,50 @@ run_basectl() {
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
+}
+
+@test "basectl update prints help" {
+    run_basectl update --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl update [options]"* ]]
+    [[ "$output" == *"Update the Base repository from Git"* ]]
+}
+
+@test "basectl update dry-run reports planned update and setup" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_current_branch() { printf "%s\n" master; }
+            base_update_worktree_clean() { return 0; }
+            base_update_subcommand_main --dry-run
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would update Base repository at '$BASE_REPO_ROOT'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup' after updating."* ]]
+}
+
+@test "basectl update refuses dirty worktrees before pulling" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_current_branch() { printf "%s\n" master; }
+            base_update_worktree_clean() { return 1; }
+            base_update_run_setup() { printf "setup should not run\n"; return 99; }
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Base repository has local changes."* ]]
+    [[ "$output" != *"setup should not run"* ]]
 }
 
 @test "basectl prints help when no command is given in a non-interactive shell" {
@@ -472,7 +516,7 @@ EOF
 @test "basectl rejects removed legacy commands" {
     local legacy_command
 
-    for legacy_command in status update run set-team set-shared-teams man embrace install shell; do
+    for legacy_command in status run set-team set-shared-teams man embrace install shell; do
         run_basectl "$legacy_command"
         [ "$status" -eq 2 ]
         [[ "$output" == *"Unrecognized command: $legacy_command"* ]]

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -963,15 +963,51 @@ EOF
     [[ "$(cat "$TEST_HOME/.bash_profile")" == *"source $BASE_REPO_ROOT/lib/shell/bash_profile"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" == *"# --- BEGIN base bashrc MANAGED SECTION - DO NOT EDIT ---"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" == *"source $BASE_REPO_ROOT/lib/shell/bashrc"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" != *"completion"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" != *"PATH="* ]]
     [[ "$(cat "$TEST_HOME/.zprofile")" == *"# --- BEGIN base zprofile MANAGED SECTION - DO NOT EDIT ---"* ]]
     [[ "$(cat "$TEST_HOME/.zprofile")" == *"source $BASE_REPO_ROOT/lib/shell/zprofile"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" == *"# --- BEGIN base zshrc MANAGED SECTION - DO NOT EDIT ---"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" == *"source $BASE_REPO_ROOT/lib/shell/zshrc"* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" != *"completion"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" != *"PATH="* ]]
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_PROFILE_VERSION=1"* ]]
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_BASH_DEFAULTS=false"* ]]
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_ZSH_DEFAULTS=false"* ]]
+}
+
+@test "Base-managed Bash startup registers basectl completion and project names" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$base_python")"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
+    printf 'base\t/Users/test/base\n'
+    printf 'demo\t/Users/test/demo\n'
+    exit 0
+fi
+printf 'unexpected completion python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$base_python"
+
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    run env -u BASE_HOME -u BASE_HOST -u BASE_OS \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash --rcfile "$TEST_HOME/.bashrc" -i -c '\
+            complete -p basectl; \
+            COMP_WORDS=(basectl activate ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "projects=%s\n" "${COMPREPLY[*]}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
+    [[ "$output" == *"projects=base demo"* ]]
 }
 
 @test "basectl update-profile preserves non-Base dotfile content and is idempotent" {

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -120,6 +120,24 @@ base_bashrc_source_defaults() {
     source "$BASE_HOME/lib/shell/bash_defaults.sh"
 }
 
+base_bashrc_source_completions() {
+    local completion_file="$BASE_HOME/lib/shell/completions/basectl_completion.sh"
+
+    if [[ ! -f "$completion_file" ]]; then
+        base_bashrc_debug "Bash completion file not found; skipping"
+        return 0
+    fi
+
+    if ! type complete >/dev/null 2>&1; then
+        base_bashrc_debug "Bash completion builtin not available; skipping"
+        return 0
+    fi
+
+    base_bashrc_debug "sourcing Bash completions"
+    # shellcheck source=/dev/null
+    source "$completion_file"
+}
+
 base_bashrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard
@@ -127,8 +145,10 @@ base_bashrc_set_base_home || {
 }
 base_bashrc_prepend_path
 base_bashrc_source_defaults || return 1
+base_bashrc_source_completions || return 1
 base_bashrc_debug "complete"
 
 unset -f base_bashrc_snippet_dir base_bashrc_set_base_home
 unset -f base_bashrc_prepend_path base_bashrc_source_defaults
+unset -f base_bashrc_source_completions
 unset -f base_bashrc_source_baserc_guard base_bashrc_debug

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=bash
+
+#
+# Bash completion for basectl.
+#
+
+_base_basectl_completion_project_names() {
+    local wrapper="${BASE_HOME:-}/bin/base-wrapper"
+
+    [[ -x "$wrapper" ]] || return 0
+    "$wrapper" --project base base_projects list 2>/dev/null | awk -F '\t' '{print $1}'
+}
+
+_base_basectl_completion_compgen() {
+    local candidate
+    local words="$1"
+    local current="$2"
+
+    COMPREPLY=()
+    while IFS= read -r candidate; do
+        COMPREPLY+=("$candidate")
+    done < <(compgen -W "$words" -- "$current")
+}
+
+_base_basectl_completion() {
+    local command cur
+    local commands="activate setup check clean doctor update-profile update projects version help"
+
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]:-}"
+
+    if ((COMP_CWORD == 1)); then
+        _base_basectl_completion_compgen "$commands" "$cur"
+        return 0
+    fi
+
+    command="${COMP_WORDS[1]:-}"
+    case "$command" in
+        activate)
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "$(_base_basectl_completion_project_names)" "$cur"
+            else
+                _base_basectl_completion_compgen "--workspace -v -h --help" "$cur"
+            fi
+            ;;
+        projects)
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "list" "$cur"
+            fi
+            ;;
+        setup)
+            _base_basectl_completion_compgen "--dev --dry-run --manifest --recreate-venv -v -h --help" "$cur"
+            ;;
+        check)
+            _base_basectl_completion_compgen "--dev --format -v -h --help" "$cur"
+            ;;
+        clean)
+            _base_basectl_completion_compgen "--older-than --dry-run -v -h --help" "$cur"
+            ;;
+        doctor)
+            _base_basectl_completion_compgen "--dev -v -h --help" "$cur"
+            ;;
+        update-profile)
+            _base_basectl_completion_compgen "--defaults --no-defaults --dry-run -v -h --help" "$cur"
+            ;;
+        update)
+            _base_basectl_completion_compgen "--dry-run -v -h --help" "$cur"
+            ;;
+    esac
+}
+
+complete -F _base_basectl_completion basectl 2>/dev/null || true

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -1,0 +1,80 @@
+#
+# Zsh completion for basectl.
+#
+
+_base_basectl_completion_project_names() {
+    local wrapper="${BASE_HOME:-}/bin/base-wrapper"
+
+    [[ -x "$wrapper" ]] || return 0
+    "$wrapper" --project base base_projects list 2>/dev/null | awk -F '\t' '{print $1}'
+}
+
+_base_basectl_completion() {
+    local -a commands project_names
+
+    commands=(
+        'activate:Start an interactive Base runtime subshell for a project'
+        'setup:Install and bootstrap the local Base CLI environment'
+        'check:Verify the local Base CLI environment'
+        'clean:Remove old Base CLI runtime artifacts'
+        'doctor:Diagnose the local Base environment'
+        'update-profile:Refresh Base-managed shell startup sections'
+        'update:Update Base and rerun setup'
+        'projects:List Base-managed projects'
+        'version:Show the installed Base version'
+        'help:Show help text'
+    )
+
+    if ((CURRENT == 2)); then
+        _describe -t commands 'basectl command' commands
+        return
+    fi
+
+    case "${words[2]:-}" in
+        activate)
+            if ((CURRENT == 3)); then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            else
+                _arguments '--workspace[Workspace directory to scan]:path:_files' '-v[Enable DEBUG logging]' \
+                    '(-h --help)'{-h,--help}'[Show help text]'
+            fi
+            ;;
+        projects)
+            _arguments '1:projects command:(list)'
+            ;;
+        setup)
+            _arguments '--dev[Install developer prerequisites]' '--dry-run[Log without making changes]' \
+                '--manifest[Use a specific manifest]:path:_files' '--recreate-venv[Recreate the Base venv]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        check)
+            _arguments '--dev[Include developer prerequisite checks]' '--format[Output format]:format:(text json)' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        clean)
+            _arguments '--older-than[Artifact age]:age:' '--dry-run[Log without removing files]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        doctor)
+            _arguments '--dev[Include developer prerequisite checks]' '-v[Enable DEBUG logging]' \
+                '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        update-profile)
+            _arguments '--defaults[Enable shell defaults]' '--no-defaults[Disable shell defaults]' \
+                '--dry-run[Log without changing files]' '-v[Enable DEBUG logging]' \
+                '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        update)
+            _arguments '--dry-run[Log without pulling or running setup]' '-v[Enable DEBUG logging]' \
+                '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+    esac
+}
+
+if ! whence -w compdef >/dev/null 2>&1; then
+    autoload -Uz compinit
+    compinit -i
+fi
+
+compdef _base_basectl_completion basectl

--- a/lib/shell/zshrc
+++ b/lib/shell/zshrc
@@ -124,6 +124,18 @@ base_zshrc_source_defaults() {
     source "$BASE_HOME/lib/shell/zsh_defaults.sh"
 }
 
+base_zshrc_source_completions() {
+    local completion_file="$BASE_HOME/lib/shell/completions/basectl_completion.zsh"
+
+    if [[ ! -f "$completion_file" ]]; then
+        base_zshrc_debug "Zsh completion file not found; skipping"
+        return 0
+    fi
+
+    base_zshrc_debug "sourcing Zsh completions"
+    source "$completion_file"
+}
+
 base_zshrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base zshrc snippet. Run basectl update-profile.\n' >&2
     unset -f base_zshrc_debug base_zshrc_snippet_dir base_zshrc_source_baserc_guard
@@ -131,8 +143,10 @@ base_zshrc_set_base_home || {
 }
 base_zshrc_prepend_path
 base_zshrc_source_defaults || return 1
+base_zshrc_source_completions || return 1
 base_zshrc_debug "complete"
 
 unset -f base_zshrc_snippet_dir base_zshrc_set_base_home
 unset -f base_zshrc_prepend_path base_zshrc_source_defaults
+unset -f base_zshrc_source_completions
 unset -f base_zshrc_source_baserc_guard base_zshrc_debug


### PR DESCRIPTION
## Summary
- Add a conservative `basectl update` subcommand that requires a clean `master` worktree, updates through the existing Git helper, then runs `basectl setup`.
- Add Bash and Zsh completion scripts for `basectl`, including project-name completion for `basectl activate`.
- Source completions from Base-owned shell startup scripts so user dotfile managed sections remain small and stable.
- Update docs and remove the completed TODO entries.

## Why
This improves daily ergonomics without expanding the user dotfile surface. Completion behavior can evolve inside Base-owned scripts after `basectl update`, and the update command gives Base a simple self-update path until there is a Homebrew formula.

## Validation
- `bash -n cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/update.sh lib/shell/bashrc lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/zshrc lib/shell/completions/basectl_completion.zsh`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`