### PR TITLE
Report basectl update status

### DIFF
--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -45,7 +45,14 @@ base_update_run_setup() {
     "$BASE_HOME/bin/basectl" setup
 }
 
+base_update_head_revision() {
+    local repo="$1"
+    git -C "$repo" rev-parse --short HEAD 2>/dev/null
+}
+
 base_update_subcommand_main() {
+    local after_revision
+    local before_revision
     local branch
     local dry_run=0
 
@@ -93,6 +100,25 @@ base_update_subcommand_main() {
     fi
 
     base_update_source_git_library || return 1
+    before_revision="$(base_update_head_revision "$BASE_HOME")" || {
+        log_error "Unable to read current Base repository revision."
+        return 1
+    }
+
+    log_info "Updating Base repository at '$BASE_HOME'."
     git_update_repo "$BASE_HOME" "" master || return 1
-    base_update_run_setup
+    after_revision="$(base_update_head_revision "$BASE_HOME")" || {
+        log_error "Unable to read updated Base repository revision."
+        return 1
+    }
+
+    if [[ "$before_revision" == "$after_revision" ]]; then
+        log_info "Base repository is already up to date on 'master' at '$after_revision'."
+    else
+        log_info "Base repository updated from '$before_revision' to '$after_revision' on 'master'."
+    fi
+
+    log_info "Running basectl setup after update."
+    base_update_run_setup || return $?
+    log_info "Base update is complete."
 }

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -98,6 +98,60 @@ run_basectl() {
     [[ "$output" != *"setup should not run"* ]]
 }
 
+@test "basectl update reports already up-to-date repositories" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_current_branch() { printf "%s\n" master; }
+            base_update_worktree_clean() { return 0; }
+            base_update_source_git_library() { :; }
+            git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
+            base_update_head_revision() { printf "%s\n" abc1234; }
+            base_update_run_setup() { printf "setup ran\n"; }
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Updating Base repository at '$BASE_REPO_ROOT'."* ]]
+    [[ "$output" == *"Base repository is already up to date on 'master' at 'abc1234'."* ]]
+    [[ "$output" == *"Running basectl setup after update."* ]]
+    [[ "$output" == *"setup ran"* ]]
+    [[ "$output" == *"Base update is complete."* ]]
+}
+
+@test "basectl update reports changed revisions" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_AFTER_UPDATE="$TEST_TMPDIR/after-update" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_current_branch() { printf "%s\n" master; }
+            base_update_worktree_clean() { return 0; }
+            base_update_source_git_library() { :; }
+            git_update_repo() { :; }
+            base_update_head_revision() {
+                if [[ -f "$BASE_TEST_AFTER_UPDATE" ]]; then
+                    printf "%s\n" new5678
+                else
+                    touch "$BASE_TEST_AFTER_UPDATE"
+                    printf "%s\n" old1234
+                fi
+            }
+            base_update_run_setup() { printf "setup ran\n"; }
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base repository updated from 'old1234' to 'new5678' on 'master'."* ]]
+    [[ "$output" == *"setup ran"* ]]
+    [[ "$output" == *"Base update is complete."* ]]
+}
+
 @test "basectl prints help when no command is given in a non-interactive shell" {
     run_basectl
 


### PR DESCRIPTION
## Summary
- log when `basectl update` starts updating the Base repository
- report whether the repository was already up to date or moved from one revision to another
- log when setup starts after the repository update and when the full update completes
- add BATS coverage for both unchanged and changed revision paths

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/update.sh`
- `bats --filter "basectl update" cli/bash/commands/basectl/tests/basectl.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`