### PR TITLE
Add Brewfile integration to project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ root. It declares the project name and the project artifacts Base should manage:
 project:
   name: example
 
+brewfile: Brewfile
+
 artifacts:
   - type: tool
     name: terraform
@@ -91,6 +93,12 @@ The manifest intentionally describes what the project needs, not how to install
 it. Base owns the artifact registry and chooses the manager for each supported
 `type` and `name` pair. Unknown artifacts fail setup clearly instead of running
 arbitrary user-provided install commands.
+
+The optional top-level `brewfile` field points to a Homebrew `Brewfile` relative
+to the project root. When present, `basectl setup` runs
+`brew bundle --file=<project-root>/<brewfile>` before reconciling artifacts. Use
+this for ordinary Homebrew formulae and casks; keep Base-aware dependencies in
+`artifacts`.
 
 The supported artifact registry lives in
 `cli/python/base_setup/registry.py`. Today, `python-package` artifacts install

--- a/TODO.md
+++ b/TODO.md
@@ -12,11 +12,6 @@ they are merged.
   - Goal: document how Base should eventually orchestrate Docker Compose without replacing Docker.
   - Expected design topics: compose file path, `docker compose pull/build`, daemon checks, image existence checks, activation-time service startup, health checks, and Colima vs Docker Desktop tradeoffs.
 
-- [ ] Add Brewfile integration for project setup.
-  - Goal: support arbitrary Homebrew project dependencies without hand-curating every package in the Base registry.
-  - Expected behavior: allow a project manifest to reference a `Brewfile` and have setup run `brew bundle --file=<path>`.
-  - Notes: this should complement the registry, not replace Base-specific known artifacts.
-
 ## P2 — Adoption And Expansion
 
 - [ ] Improve setup recovery messages for technically-adjacent users.

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -3,6 +3,12 @@ project:
   # environment at ~/.base.d/<project>/.venv.
   name: base
 
+# Optional relative path to a Homebrew Brewfile for ordinary macOS tools.
+# Base runs `brew bundle --file=<path>` during setup when this is set.
+# Keep Base-specific managed dependencies in `artifacts`; use Brewfile for
+# arbitrary Homebrew formulae and casks that do not need Base intelligence.
+# brewfile: Brewfile
+
 artifacts:
   # Artifact declarations are intentionally declarative:
   #   type:    artifact category understood by Base, such as "python-package"

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -93,6 +93,8 @@ def reconcile_manifest(
         else:
             ctx.log.info("Project '%s' has no artifacts to install.", manifest.project_name)
 
+    reconcile_brewfile(ctx, manifest, dry_run=dry_run)
+
     for artifact, definition in zip(artifacts, definitions, strict=True):
         reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
 
@@ -134,6 +136,41 @@ def merge_artifacts(
         merged[key] = artifact
 
     return tuple(merged.values())
+
+
+def reconcile_brewfile(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
+    if manifest.brewfile is None:
+        return
+
+    brewfile_path = resolve_brewfile_path(manifest)
+    command = ["brew", "bundle", f"--file={brewfile_path}"]
+
+    if dry_run:
+        dry_run_command(ctx, command)
+        return
+
+    if not command_exists("brew"):
+        raise ArtifactError(f"Homebrew is required to install Brewfile dependencies from '{brewfile_path}'.")
+
+    ctx.log.info("Installing Homebrew dependencies from Brewfile '%s'.", brewfile_path)
+    run_command(command)
+
+
+def resolve_brewfile_path(manifest: BaseManifest) -> Path:
+    if manifest.brewfile is None:
+        raise ArtifactError(f"{manifest.path}: brewfile is not configured.")
+
+    brewfile = Path(manifest.brewfile)
+    if brewfile.is_absolute():
+        raise ArtifactError(f"{manifest.path}: brewfile must be relative to the project root.")
+
+    project_root = manifest.path.parent.resolve()
+    brewfile_path = (project_root / brewfile).resolve()
+    if not brewfile_path.is_relative_to(project_root):
+        raise ArtifactError(f"{manifest.path}: brewfile must stay inside the project root.")
+    if not brewfile_path.is_file():
+        raise ArtifactError(f"{manifest.path}: brewfile '{manifest.brewfile}' does not exist.")
+    return brewfile_path
 
 
 def reconcile_artifact(

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -28,6 +28,7 @@ class ArtifactRequest:
 class BaseManifest:
     path: Path
     project_name: str
+    brewfile: str | None
     artifacts: tuple[ArtifactRequest, ...]
 
 
@@ -48,15 +49,16 @@ def read_manifest(path: Path) -> BaseManifest:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
-    allowed_top_level = {"project", "artifacts"}
+    allowed_top_level = {"project", "brewfile", "artifacts"}
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
 
     project_name = _read_project_name(path, data.get("project"))
+    brewfile = _read_brewfile(path, data.get("brewfile"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
-    return BaseManifest(path=path, project_name=project_name, artifacts=tuple(artifacts))
+    return BaseManifest(path=path, project_name=project_name, brewfile=brewfile, artifacts=tuple(artifacts))
 
 
 def _read_project_name(path: Path, project_data: Any) -> str:
@@ -72,6 +74,14 @@ def _read_project_name(path: Path, project_data: Any) -> str:
     if not isinstance(project_name, str) or not project_name:
         raise ManifestError(f"{path}: project.name is required.")
     return project_name
+
+
+def _read_brewfile(path: Path, brewfile_data: Any) -> str | None:
+    if brewfile_data is None:
+        return None
+    if not isinstance(brewfile_data, str) or not brewfile_data.strip():
+        raise ManifestError(f"{path}: brewfile must be a non-empty string when provided.")
+    return brewfile_data.strip()
 
 
 def _read_artifacts(path: Path, artifacts_data: Any) -> list[ArtifactRequest]:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 from base_setup import engine
 from base_setup.engine import ArtifactError, format_command, main, merge_artifacts
-from base_setup.manifest import ArtifactRequest
+from base_setup.manifest import ArtifactRequest, BaseManifest
 from base_setup.manifest import read_manifest
 from base_setup.registry import get_artifact_definition
 
@@ -89,9 +89,29 @@ class ManifestTests(unittest.TestCase):
             manifest = read_manifest(manifest_path)
 
         self.assertEqual(manifest.project_name, "demo")
+        self.assertIsNone(manifest.brewfile)
         self.assertEqual(manifest.artifacts[0].artifact_type, "tool")
         self.assertEqual(manifest.artifacts[0].name, "terraform")
         self.assertEqual(manifest.artifacts[0].version, "1.8.5")
+
+    def test_reads_manifest_brewfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "brewfile: Brewfile",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.brewfile, "Brewfile")
 
     def test_base_manifest_declares_python_dev_tools(self) -> None:
         manifest = read_manifest(Path(__file__).resolve().parents[4] / "base_manifest.yaml")
@@ -334,6 +354,75 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("Project 'demo' declares no artifacts; installing Base default artifacts only.", stderr)
+
+
+class BrewfileTests(unittest.TestCase):
+    def test_brewfile_dry_run_invokes_brew_bundle(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            brewfile = project_root / "Brewfile"
+            brewfile.write_text("brew \"jq\"\n", encoding="utf-8")
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+            expected_brewfile = brewfile.resolve()
+
+            engine.reconcile_brewfile(ctx, manifest, dry_run=True)
+
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertIn(f"[DRY-RUN] Would run: brew bundle --file={expected_brewfile}", info_messages)
+
+    def test_brewfile_invokes_brew_bundle(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            brewfile = project_root / "Brewfile"
+            brewfile.write_text("brew \"jq\"\n", encoding="utf-8")
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+            expected_brewfile = brewfile.resolve()
+
+            with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+                "base_setup.engine.run_command"
+            ) as run_command:
+                engine.reconcile_brewfile(ctx, manifest, dry_run=False)
+
+        run_command.assert_called_once_with(["brew", "bundle", f"--file={expected_brewfile}"])
+
+    def test_brewfile_missing_file_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+
+            with self.assertRaisesRegex(ArtifactError, "does not exist"):
+                engine.resolve_brewfile_path(manifest)
+
+    def test_brewfile_must_stay_inside_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="../Brewfile",
+                artifacts=(),
+            )
+
+            with self.assertRaisesRegex(ArtifactError, "must stay inside the project root"):
+                engine.resolve_brewfile_path(manifest)
 
 
 if __name__ == "__main__":

--- a/docs/design.md
+++ b/docs/design.md
@@ -319,6 +319,8 @@ Current structure:
 project:
   name: myproject
 
+brewfile: Brewfile
+
 artifacts:
   - type: tool
     name: terraform
@@ -333,6 +335,11 @@ The Python layer interprets this declarative manifest and translates each
 artifact into concrete installation actions. Base owns the artifact registry and
 chooses the manager for each supported `(type, name)` pair. The current registry
 is `cli/python/base_setup/registry.py`.
+
+The optional top-level `brewfile` field delegates ordinary Homebrew dependencies
+to Homebrew's native `brew bundle` flow. The path is relative to the project root
+and must stay inside the project. Base runs `brew bundle --file=<path>` during
+setup before reconciling Base-managed artifacts.
 
 `python-package` artifacts install into the project virtual environment at
 `~/.base.d/<project>/.venv`. Base's own project venv is therefore


### PR DESCRIPTION
## Summary
- add optional top-level `brewfile` support to `base_manifest.yaml`
- validate Brewfile paths as relative project-root paths that cannot escape the project
- run `brew bundle --file=<path>` during project setup before Base-managed artifacts
- document the new manifest field and remove the completed TODO item

## Validation
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine cli.python.base_projects.tests.test_engine cli.python.base_dev.tests.test_engine cli.python.base_clean.tests.test_engine lib.python.base_cli.tests.test_base_cli`
- `env BASE_CACHE_DIR=/private/tmp/base-cache-test PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m base_setup --dry-run --manifest base_manifest.yaml base`
- `env BASE_CACHE_DIR=/private/tmp/base-cache-test bin/basectl setup --dry-run`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`