### PR TITLE
Document project installer guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ After the shell restarts, Base's managed startup section adds `~/work/base/bin`
 to `PATH`, so `basectl` can be run without spelling out the full path. Use
 `basectl version` or `basectl --version` to report the installed Base version.
 
+Project-specific onboarding should live in project installers that call Base
+internally. See [Project Installers](docs/project-installers.md) for the
+recommended boundary between Base and scripts such as `banyanlabs/install.sh`.
+
 ## Compatibility
 
 Base is currently macOS-first. The implemented and tested support contract is

--- a/TODO.md
+++ b/TODO.md
@@ -43,10 +43,6 @@ they are merged.
   - Goal: provide a guided checklist-style setup experience without making `basectl setup` itself interactive-heavy.
   - Expected behavior: explain each prerequisite, confirm before performing major steps, and call existing setup/check primitives internally.
 
-- [ ] Define project-level installer guidance.
-  - Goal: document that true end-user onboarding belongs in project-specific installers, not in `basectl` itself.
-  - Expected output: guidance for scripts such as `banyanlabs/install.sh` that bootstrap Base and then call `basectl setup`.
-
 - [ ] Add macOS notification on long setup completion.
   - Goal: make long-running setup friendlier.
   - Expected behavior: optionally display a macOS notification when `basectl setup` completes or fails.

--- a/docs/design.md
+++ b/docs/design.md
@@ -432,7 +432,10 @@ These extras emerge organically from real needs — they are not designed upfron
 Base is the prerequisite for banyanlabs. Banyanlabs (a multi-cloud, polyglot DevOps
 learning environment) will be a Base-managed project — it will have a base manifest
 declaring all its infrastructure tool dependencies. Base handles the bootstrapping.
-Banyanlabs handles the learning environment. Base must ship first.
+Banyanlabs handles the learning environment. A Banyanlabs-specific installer can
+bootstrap or locate Base, clone the project, and call `basectl setup` with
+friendlier product-specific messaging. See [Project Installers](project-installers.md)
+for that boundary. Base must ship first.
 
 ---
 

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -1,0 +1,109 @@
+# Project Installers
+
+Base should stay a developer workspace engine. Project-specific installers should
+own the friendlier, product-specific onboarding experience.
+
+This distinction matters because Base and a project installer serve different
+audiences:
+
+- `basectl setup` is for developers and technically-adjacent users who are
+  willing to run a terminal command and read setup output.
+- A project installer is for someone who wants to use a specific project and
+  should not need to understand Base first.
+
+For example, a future `banyanlabs/install.sh` can present Banyanlabs-specific
+language, explain what will happen, bootstrap Base if needed, and then call Base
+internally. Base should provide the reliable mechanics; Banyanlabs should provide
+the product-shaped welcome mat.
+
+## Responsibilities
+
+Base owns:
+
+- macOS workstation bootstrap primitives
+- Homebrew, Xcode Command Line Tools, Base Python, and Base venv setup
+- project discovery through `base_manifest.yaml`
+- artifact reconciliation through `basectl setup`
+- diagnostics through `basectl check` and `basectl doctor`
+- shell integration through `basectl update-profile`
+
+A project installer owns:
+
+- project-specific framing and instructions
+- preflight messaging for that project's audience
+- choosing where the project workspace should live
+- cloning or updating the project repository
+- installing or locating Base
+- calling Base commands in the right order
+- explaining next steps after setup succeeds or fails
+
+The installer should not reimplement Base's setup logic. It should call Base.
+
+## Recommended Flow
+
+A project installer should be a thin Bash script with a predictable sequence:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_name="banyanlabs"
+workspace_dir="${HOME}/work"
+base_dir="${workspace_dir}/base"
+project_dir="${workspace_dir}/${project_name}"
+
+mkdir -p "$workspace_dir"
+
+if [[ ! -d "$base_dir/.git" ]]; then
+    git clone https://github.com/codeforester/base.git "$base_dir"
+else
+    git -C "$base_dir" pull --ff-only
+fi
+
+if [[ ! -d "$project_dir/.git" ]]; then
+    git clone https://github.com/codeforester/banyanlabs.git "$project_dir"
+else
+    git -C "$project_dir" pull --ff-only
+fi
+
+"$base_dir/bin/basectl" setup --manifest "$project_dir/base_manifest.yaml" "$project_name"
+"$base_dir/bin/basectl" update-profile
+```
+
+This is only a sketch. A real installer should add friendlier output, better
+error handling, and project-specific next steps.
+
+## User Experience Guidelines
+
+Project installers should:
+
+- say what they are about to do before making changes
+- keep project-specific language in the project, not in Base
+- call `basectl check` or `basectl doctor` when setup fails
+- point users to the project documentation for next steps
+- avoid hiding the underlying Base command that failed
+
+Project installers should not:
+
+- duplicate Homebrew, Python, venv, or artifact reconciliation logic
+- write directly into Base-managed shell startup sections
+- make Base itself responsible for product-specific onboarding
+- assume every Base-managed project has the same audience
+
+## Relationship To `basectl onboard`
+
+`basectl onboard` is still useful, but it should target a different layer.
+
+`basectl onboard` should be a guided Base setup experience for
+technically-adjacent users who are installing Base itself. A project installer
+should be a guided product setup experience for users installing a particular
+project.
+
+In short:
+
+- use `basectl setup` for direct developer setup
+- use `basectl onboard` for guided Base setup
+- use `<project>/install.sh` for guided project setup
+
+Keeping these layers separate lets Base stay small and reusable while each
+project can speak naturally to its own users.


### PR DESCRIPTION
## Summary
- add `docs/project-installers.md` to define the boundary between Base and project-specific installers
- document a recommended `install.sh` flow for projects such as Banyanlabs
- link the guidance from the README and design doc
- remove the completed TODO item

## Validation
- `git diff --check`

Docs-only change.