### PR TITLE
Make check and doctor project-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ basectl doctor
 basectl doctor --dev
 ```
 
+`basectl check <project>` and `basectl doctor <project>` extend those checks to
+a project's `base_manifest.yaml` artifacts after verifying the Base bootstrap
+environment:
+
+```bash
+basectl check example
+basectl doctor example
+```
+
 `basectl onboard` is a planned guided setup experience for technically-adjacent
 users who want a checklist-style first Base setup. Its design is captured in
 [docs/basectl-onboard.md](docs/basectl-onboard.md). Product-specific onboarding

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -47,11 +47,13 @@ that delegate to `basectl`.
 - `basectl setup [project]` runs the Bash bootstrap layer first, then invokes the
   Python project setup layer for `base_manifest.yaml` artifacts. The optional
   project argument validates `project.name`.
-- `basectl check` verifies the same local requirements without making changes.
+- `basectl check [project]` verifies the same local requirements without making
+  changes and can include project manifest artifacts.
 - `basectl setup --dev`, `basectl check --dev`, and `basectl doctor --dev`
   manage developer prerequisites through `lib/base/dev_manifest.yaml`.
 - `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
-- `basectl doctor` diagnoses the local Base environment and prints suggested fixes.
+- `basectl doctor [project]` diagnoses the local Base environment and, when
+  provided, project manifest artifacts with suggested fixes.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -13,12 +13,12 @@ Commands:
     Start an interactive Base runtime subshell for a project.
   setup [options]
     Install and bootstrap the local Base CLI environment on macOS.
-  check [options]
-    Verify the local Base CLI environment without making changes.
+  check [project] [options]
+    Verify the local Base CLI environment and optional project artifacts without making changes.
   clean --older-than <age> [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
-  doctor [options]
-    Diagnose the local Base CLI environment and suggest fixes.
+  doctor [project] [options]
+    Diagnose the local Base CLI environment and optional project artifacts.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
   update [options]
@@ -46,6 +46,7 @@ Wrapper options:
 Notes:
   - `basectl setup` is the preferred entrypoint for machine bootstrap.
   - `basectl check` verifies the same local requirements without making changes.
+    Pass a project name to include that project's manifest artifacts.
   - Invoking `basectl` with no command is equivalent to `basectl activate base`
     when attached to a terminal; otherwise it prints this help text.
   - Use `-v` for command-level debug logs. Use `--debug-wrapper` when debugging

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -11,7 +11,7 @@ source "$_base_setup_common_path"
 base_check_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl check [options]
+  basectl check [project] [options]
 
 Options:
   --dev                 Include manifest-declared developer prerequisite checks.
@@ -20,7 +20,7 @@ Options:
   -h, --help            Show this help text.
 
 Purpose:
-  Verify the local Base CLI environment on macOS without making changes.
+  Verify the local Base CLI environment and, when provided, project artifacts on macOS without making changes.
 
 Check does:
   1. Verify Homebrew is installed.
@@ -28,11 +28,13 @@ Check does:
   3. Verify Python 3.13 is installed via Homebrew.
   4. Verify ~/.base.d/base/.venv exists.
   5. Verify developer prerequisites from lib/base/dev_manifest.yaml when --dev is passed.
+  6. Verify project manifest artifacts when a project name is passed.
 EOF
 }
 
 base_check_subcommand_main() {
     local output_format="text"
+    local project=""
 
     while (($#)); do
         case "$1" in
@@ -65,14 +67,24 @@ base_check_subcommand_main() {
                 setup_enable_debug_logging
                 ;;
             *)
-                print_error "Unknown option '$1'."
-                base_check_subcommand_usage >&2
-                return 1
+                if [[ "$1" == -* ]]; then
+                    print_error "Unknown option '$1'."
+                    base_check_subcommand_usage >&2
+                    return 1
+                fi
+                if [[ -n "$project" ]]; then
+                    print_error "The 'check' command accepts at most one project name."
+                    base_check_subcommand_usage >&2
+                    return 1
+                fi
+                project="$1"
                 ;;
         esac
         shift
     done
 
+    BASE_SETUP_PROJECT_NAME="$project"
+    export BASE_SETUP_PROJECT_NAME
     log_debug "Running 'basectl check'."
     if [[ "$output_format" == json ]]; then
         setup_run_check_json

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -11,7 +11,7 @@ source "$_base_setup_common_path"
 base_doctor_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl doctor [options]
+  basectl doctor [project] [options]
 
 Options:
   --dev       Include manifest-declared developer prerequisite checks.
@@ -19,7 +19,7 @@ Options:
   -h, --help  Show this help text.
 
 Purpose:
-  Diagnose the local Base CLI environment and suggest fixes.
+  Diagnose the local Base CLI environment and, when provided, project artifacts.
 EOF
 }
 
@@ -111,7 +111,7 @@ base_doctor_check_python_package() {
 }
 
 base_doctor_subcommand_main() {
-    local dev_errors=0 errors=0
+    local dev_errors=0 errors=0 project=""
 
     while (($#)); do
         case "$1" in
@@ -126,18 +126,32 @@ base_doctor_subcommand_main() {
                 setup_enable_debug_logging
                 ;;
             *)
-                print_error "Unknown option '$1'."
-                base_doctor_subcommand_usage >&2
-                return 2
+                if [[ "$1" == -* ]]; then
+                    print_error "Unknown option '$1'."
+                    base_doctor_subcommand_usage >&2
+                    return 2
+                fi
+                if [[ -n "$project" ]]; then
+                    print_error "The 'doctor' command accepts at most one project name."
+                    base_doctor_subcommand_usage >&2
+                    return 2
+                fi
+                project="$1"
                 ;;
         esac
         shift
     done
 
+    BASE_SETUP_PROJECT_NAME="$project"
+    export BASE_SETUP_PROJECT_NAME
     log_debug "Running 'basectl doctor'."
     setup_require_macos
 
-    printf 'Base doctor\n\n'
+    if [[ -n "$project" ]]; then
+        printf "Base doctor for project '%s'\n\n" "$project"
+    else
+        printf 'Base doctor\n\n'
+    fi
 
     base_doctor_check_homebrew || errors=$((errors + 1))
     base_doctor_check_xcode || errors=$((errors + 1))
@@ -150,13 +164,25 @@ base_doctor_subcommand_main() {
         dev_errors=$?
         errors=$((errors + dev_errors))
     fi
+    if [[ -n "$project" ]]; then
+        setup_run_project_artifact_doctor
+        errors=$((errors + $?))
+    fi
 
     printf '\n'
     if ((errors == 0)); then
-        printf 'Base doctor found no blocking issues.\n'
+        if [[ -n "$project" ]]; then
+            printf "Base doctor found no blocking issues for project '%s'.\n" "$project"
+        else
+            printf 'Base doctor found no blocking issues.\n'
+        fi
         return 0
     fi
 
-    printf 'Base doctor found %s blocking issue(s).\n' "$errors"
+    if [[ -n "$project" ]]; then
+        printf "Base doctor found %s blocking issue(s) for project '%s'.\n" "$errors" "$project"
+    else
+        printf 'Base doctor found %s blocking issue(s).\n' "$errors"
+    fi
     return 1
 }

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -505,6 +505,12 @@ setup_resolve_project_manifest() {
 }
 
 setup_run_project_artifact_setup() {
+    setup_run_project_artifact_layer setup text
+}
+
+setup_run_project_artifact_layer() {
+    local action="$1"
+    local output_format="$2"
     local exit_code manifest_path project python_bin resolved_root resolve_output venv_dir
     local args=()
 
@@ -523,7 +529,9 @@ setup_run_project_artifact_setup() {
     }
     if [[ "$resolve_output" == *$'\t'* ]]; then
         IFS=$'\t' read -r resolved_root manifest_path <<<"$resolve_output"
-        log_info "Resolved project '$project' at '$resolved_root'."
+        if [[ "$action" != check || "$output_format" != json ]]; then
+            log_info "Resolved project '$project' at '$resolved_root'."
+        fi
     else
         manifest_path="$resolve_output"
     fi
@@ -532,20 +540,43 @@ setup_run_project_artifact_setup() {
         args+=(--dry-run)
     fi
     args+=(--manifest "$manifest_path")
+    args+=(--action "$action")
+    if [[ "$action" == check ]]; then
+        args+=(--format "$output_format")
+    fi
     args+=("$project")
 
-    log_info "Running Python project setup layer."
+    if [[ "$action" != check || "$output_format" != json ]]; then
+        log_info "Running Python project $action layer."
+    fi
 
     env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$(setup_pythonpath)" "$python_bin" -m base_setup "${args[@]}"
     exit_code=$?
 
-    if ((exit_code)); then
+    if ((exit_code)) && [[ "$action" == setup ]]; then
         log_error "$(setup_recovery_project_layer)"
-    fi
-    if ((exit_code)); then
-        log_error "Python project setup layer failed."
+        log_error "Python project $action layer failed."
         return "$exit_code"
     fi
+    if ((exit_code)) && [[ "$action" == check ]]; then
+        log_warn "Python project check layer found missing requirements."
+        return "$exit_code"
+    fi
+    if ((exit_code)); then
+        return "$exit_code"
+    fi
+}
+
+setup_run_project_artifact_check() {
+    setup_run_project_artifact_layer check text
+}
+
+setup_run_project_artifact_check_json() {
+    setup_run_project_artifact_layer check json
+}
+
+setup_run_project_artifact_doctor() {
+    setup_run_project_artifact_layer doctor text
 }
 
 setup_run_base_dev_layer() {
@@ -571,6 +602,7 @@ setup_run_base_dev_layer() {
 
 setup_run_check() {
     local brew_bin="" click_package pyyaml_package venv_dir missing=0
+    local project="${BASE_SETUP_PROJECT_NAME:-}"
 
     setup_require_macos
     click_package="$(setup_click_package)"
@@ -631,13 +663,26 @@ setup_run_check() {
         setup_run_base_dev_layer check || missing=1
     fi
 
+    if [[ -n "$project" ]]; then
+        setup_run_project_artifact_check || missing=1
+    fi
+
     if ((missing == 0)); then
-        log_info "Base CLI environment check passed."
+        if [[ -n "$project" ]]; then
+            log_info "Base CLI environment and project '$project' check passed."
+        else
+            log_info "Base CLI environment check passed."
+        fi
         return 0
     fi
 
-    log_warn "Base CLI environment check found missing requirements."
-    log_warn "Run 'basectl setup' to reconcile the missing requirements."
+    if [[ -n "$project" ]]; then
+        log_warn "Base CLI environment or project '$project' check found missing requirements."
+        log_warn "Run 'basectl setup $project' to reconcile the missing requirements."
+    else
+        log_warn "Base CLI environment check found missing requirements."
+        log_warn "Run 'basectl setup' to reconcile the missing requirements."
+    fi
     return 1
 }
 
@@ -687,6 +732,8 @@ setup_run_check_json() {
     local click_message click_ok=false click_package
     local dev_json="[]"
     local missing=0
+    local project="${BASE_SETUP_PROJECT_NAME:-}"
+    local project_json="[]"
     local pyyaml_message pyyaml_ok=false pyyaml_package
     local python_message python_ok=false
     local venv_dir venv_message venv_ok=false
@@ -755,8 +802,18 @@ setup_run_check_json() {
         fi
     fi
 
+    if [[ -n "$project" ]]; then
+        if ! project_json="$(setup_run_project_artifact_check_json)"; then
+            missing=1
+            [[ -n "$project_json" ]] || project_json="[]"
+        fi
+    fi
+
     printf '{\n'
     printf '  "ok": %s,\n' "$([[ "$missing" -eq 0 ]] && printf true || printf false)"
+    if [[ -n "$project" ]]; then
+        printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
+    fi
     printf '  "checks": [\n'
     setup_print_check_json_item "," "homebrew" "$homebrew_ok" "$homebrew_message"
     setup_print_check_json_item "," "xcode_command_line_tools" "$xcode_ok" "$xcode_message"
@@ -765,11 +822,23 @@ setup_run_check_json() {
     setup_print_check_json_item "," "click" "$click_ok" "$click_message"
     setup_print_check_json_item "" "base_virtualenv" "$venv_ok" "$venv_message"
     printf '  ]'
-    if setup_dev_dependencies_enabled; then
+    if setup_dev_dependencies_enabled || [[ -n "$project" ]]; then
         printf ',\n'
-        setup_print_json_property_value "dev_checks" "$dev_json"
     else
         printf '\n'
+    fi
+    if setup_dev_dependencies_enabled; then
+        setup_print_json_property_value "dev_checks" "$dev_json"
+        if [[ -n "$project" ]]; then
+            printf ',\n'
+        else
+            printf '\n'
+        fi
+    fi
+    if [[ -n "$project" ]]; then
+        setup_print_json_property_value "project_checks" "$project_json"
+    else
+        :
     fi
     printf '}\n'
 

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -22,9 +22,9 @@ run_basectl() {
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
     [[ "$output" == *"activate <project> [options]"* ]]
     [[ "$output" == *"setup [options]"* ]]
-    [[ "$output" == *"check [options]"* ]]
+    [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"clean --older-than <age> [options]"* ]]
-    [[ "$output" == *"doctor [options]"* ]]
+    [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command is equivalent to \`basectl activate base\`"* ]]
@@ -328,7 +328,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl doctor [options]"* ]]
+    [[ "$output" == *"basectl doctor [project] [options]"* ]]
     [[ "$output" == *"Diagnose the local Base CLI environment"* ]]
 }
 
@@ -482,6 +482,79 @@ EOF
     [[ "$output" == *"error"*"Homebrew"*"Homebrew is not installed."* ]]
     [[ "$output" == *"Fix: basectl setup"* ]]
     [[ "$output" == *"Base doctor found"*"blocking issue(s)."* ]]
+}
+
+@test "basectl doctor project includes project artifact findings" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$workspace/demo"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-f" && "${2:-}" == "clang" ]]; then
+    printf '/tmp/fake-clang\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    printf 'ok     demo-artifact               Project artifact check passed.\n'
+    exit 0
+fi
+printf 'unexpected doctor project python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base doctor for project 'demo'"* ]]
+    [[ "$output" == *"Running Python project doctor layer."* ]]
+    [[ "$output" == *"ok"*"demo-artifact"*"Project artifact check passed."* ]]
+    [[ "$output" == *"Base doctor found no blocking issues for project 'demo'."* ]]
 }
 
 @test "basectl activate resolves a project and execs a project subshell" {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -418,6 +418,28 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-args"
     printf '%s\n' "${BASE_PROJECT:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-project"
     touch "$BASE_SETUP_TEST_STATE_DIR/project-setup-ran"
+    action="setup"
+    output_format="text"
+    while (($#)); do
+        case "$1" in
+            --action)
+                shift
+                action="${1:-}"
+                ;;
+            --format)
+                shift
+                output_format="${1:-}"
+                ;;
+        esac
+        shift || true
+    done
+    if [[ "$action" == "check" && "$output_format" == "json" ]]; then
+        printf '[{"name":"demo-artifact","ok":true,"message":"Project artifact check passed.","fix":""}]\n'
+    elif [[ "$action" == "check" ]]; then
+        printf 'Project artifact check passed.\n' >&2
+    elif [[ "$action" == "doctor" ]]; then
+        printf 'ok     demo-artifact               Project artifact check passed.\n'
+    fi
     exit "$(cat "$BASE_SETUP_TEST_STATE_DIR/project-setup-exit-code")"
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" ]]; then
@@ -464,9 +486,9 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl check [options]"* ]]
+    [[ "$output" == *"basectl check [project] [options]"* ]]
     [[ "$output" == *"--dev"* ]]
-    [[ "$output" == *"Verify the local Base CLI environment on macOS without making changes."* ]]
+    [[ "$output" == *"Verify the local Base CLI environment and, when provided, project artifacts on macOS without making changes."* ]]
 }
 
 @test "basectl setup fails on unsupported operating systems" {
@@ -661,7 +683,7 @@ EOF
     [[ "$output" == *"Running Python project setup layer."* ]]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
-    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" demo)" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]
     [ ! -e "$demo_venv_dir/bin/python" ]
 }
 
@@ -689,7 +711,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Resolved project 'brew' at '$workspace/brew'."* ]]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "brew" ]
-    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/brew/base_manifest.yaml" brew)" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/brew/base_manifest.yaml" --action setup brew)" ]
 }
 
 @test "basectl setup propagates Python project setup failure" {
@@ -1005,6 +1027,31 @@ EOF
     [[ "$output" == *"Base CLI environment check found missing requirements."* ]]
 }
 
+@test "basectl check project verifies project artifacts" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Resolved project 'demo' at '$workspace/demo'."* ]]
+    [[ "$output" == *"Running Python project check layer."* ]]
+    [[ "$output" == *"Project artifact check passed."* ]]
+    [[ "$output" == *"Base CLI environment and project 'demo' check passed."* ]]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format text demo)" ]
+}
+
 @test "basectl check --format json writes successful check results to stdout" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
@@ -1036,6 +1083,40 @@ EOF
     [[ "$output" == *'"name":"pyyaml","ok":true'* ]]
     [[ "$output" == *'"name":"click","ok":true'* ]]
     [[ "$output" == *'"name":"base_virtualenv","ok":true'* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl check project --format json includes project check results" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/bats-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        OSTYPE="darwin24" \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
+        BASE_SETUP_TEST_WORKSPACE="$workspace" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
+        "$BASE_REPO_ROOT/bin/basectl" check demo --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"project_checks":'* ]]
+    [[ "$output" == *'"name":"demo-artifact","ok":true'* || "$output" == *'"name": "demo-artifact"'* ]]
     [ "${stderr:-}" = "" ]
 }
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import subprocess
 import venv
+from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
@@ -16,6 +18,21 @@ from .registry import ArtifactDefinition, get_artifact_definition
 app = base_cli.App(name="base_setup")
 
 
+@dataclass(frozen=True)
+class ArtifactCheck:
+    name: str
+    ok: bool
+    message: str
+    fix: str
+
+
+@dataclass(frozen=True)
+class ManifestAction:
+    action: str
+    dry_run: bool
+    output_format: str
+
+
 def main(argv: list[str] | None = None) -> int:
     result = app.click_command.main(args=argv, standalone_mode=False)
     return int(result or 0)
@@ -26,33 +43,59 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--manifest", help="Path to base_manifest.yaml.")
 @base_cli.option("--start-dir", default=".", help="Directory where manifest discovery should start.")
 @base_cli.option("--dry-run", is_flag=True, help="Log planned changes without making them.")
+@base_cli.option(
+    "--action",
+    default="setup",
+    help="Action to run: setup, check, or doctor. Defaults to setup.",
+)
+@base_cli.option("--format", "output_format", default="text", help="Output format for check: text or json.")
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
     project: str | None,
     manifest: str | None,
     start_dir: str,
     dry_run: bool,
+    action: str,
+    output_format: str,
 ) -> int:
     manifest_path = Path(manifest).resolve() if manifest else discover_manifest(Path(start_dir))
     if manifest_path is None:
         if project:
-            ctx.log.error("No base_manifest.yaml found while setting up project '%s'.", project)
+            ctx.log.error("No base_manifest.yaml found for project '%s'.", project)
             return 1
-        ctx.log.info("No base_manifest.yaml found; skipping project artifact setup.")
+        ctx.log.info("No base_manifest.yaml found; skipping project artifact work.")
         return 0
 
     try:
         base_manifest = read_manifest(manifest_path)
         validate_project_name(base_manifest, project)
         default_manifest = read_default_manifest(ctx)
-        reconcile_manifest(ctx, default_manifest, base_manifest, dry_run=dry_run)
-        return 0
+        return run_manifest_action(ctx, ManifestAction(action, dry_run, output_format), default_manifest, base_manifest)
     except ManifestError as exc:
         ctx.log.error(str(exc))
         return 1
     except ArtifactError as exc:
         ctx.log.error(str(exc))
         return 1
+
+
+def run_manifest_action(
+    ctx: base_cli.Context,
+    manifest_action: ManifestAction,
+    default_manifest: BaseManifest,
+    base_manifest: BaseManifest,
+) -> int:
+    action = manifest_action.action
+    if action == "setup":
+        reconcile_manifest(ctx, default_manifest, base_manifest, dry_run=manifest_action.dry_run)
+        return 0
+    if action == "check":
+        return check_manifest(ctx, default_manifest, base_manifest, output_format=manifest_action.output_format)
+    if action == "doctor":
+        return doctor_manifest(default_manifest, base_manifest)
+    ctx.log.error("Unsupported base_setup action '%s'. Expected setup, check, or doctor.", action)
+    return 2
 
 
 class ArtifactError(RuntimeError):
@@ -99,6 +142,193 @@ def reconcile_manifest(
         reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
 
     ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
+
+
+def check_manifest(
+    ctx: base_cli.Context,
+    default_manifest: BaseManifest,
+    manifest: BaseManifest,
+    output_format: str,
+) -> int:
+    checks = manifest_checks(default_manifest, manifest)
+    if output_format == "json":
+        print(json.dumps([check_to_json(check) for check in checks], indent=2))
+    elif output_format == "text":
+        ctx.log.info("Checking project '%s' artifacts.", manifest.project_name)
+        for check in checks:
+            if check.ok:
+                ctx.log.info(check.message)
+            else:
+                ctx.log.warning(check.message)
+                if check.fix:
+                    ctx.log.warning("Fix: %s", check.fix)
+    else:
+        ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
+        return 2
+    return 0 if all(check.ok for check in checks) else 1
+
+
+def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest) -> int:
+    checks = manifest_checks(default_manifest, manifest)
+    error_count = 0
+    print(f"\nProject doctor: {manifest.project_name}\n")
+    for check in checks:
+        if check.ok:
+            print_doctor_finding("ok", check.name, check.message)
+        else:
+            print_doctor_finding("error", check.name, check.message, check.fix)
+            error_count += 1
+    return min(error_count, 125)
+
+
+def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+    checks: list[ArtifactCheck] = []
+    artifacts = merge_artifacts(default_manifest.artifacts, manifest.artifacts)
+    definitions = resolve_artifact_definitions(artifacts)
+
+    if manifest.brewfile is not None:
+        checks.append(check_brewfile(manifest))
+
+    for artifact, definition in zip(artifacts, definitions, strict=True):
+        checks.append(check_artifact(manifest.project_name, artifact, definition))
+
+    if not checks:
+        checks.append(
+            ArtifactCheck(
+                name="manifest",
+                ok=True,
+                message=f"Project '{manifest.project_name}' declares no artifacts.",
+                fix="",
+            )
+        )
+    return tuple(checks)
+
+
+def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
+    try:
+        brewfile_path = resolve_brewfile_path(manifest)
+    except ArtifactError as exc:
+        return ArtifactCheck(
+            name="brewfile",
+            ok=False,
+            message=str(exc),
+            fix=f"Update '{manifest.path}' or run 'basectl setup {manifest.project_name}'.",
+        )
+
+    if not command_exists("brew"):
+        return ArtifactCheck(
+            name="brewfile",
+            ok=False,
+            message=f"Homebrew is required to check Brewfile dependencies from '{brewfile_path}'.",
+            fix="basectl setup",
+        )
+
+    ok = run_check(["brew", "bundle", "check", f"--file={brewfile_path}"])
+    if ok:
+        return ArtifactCheck(
+            name="brewfile",
+            ok=True,
+            message=f"Brewfile dependencies are satisfied for '{brewfile_path}'.",
+            fix="",
+        )
+    return ArtifactCheck(
+        name="brewfile",
+        ok=False,
+        message=f"Brewfile dependencies are not satisfied for '{brewfile_path}'.",
+        fix=f"basectl setup {manifest.project_name}",
+    )
+
+
+def check_artifact(
+    project: str,
+    artifact: ArtifactRequest,
+    definition: ArtifactDefinition,
+) -> ArtifactCheck:
+    if definition.manager == "homebrew":
+        return check_homebrew_artifact(project, artifact, definition)
+    if definition.manager == "pip":
+        return check_python_artifact(project, artifact, definition)
+    return ArtifactCheck(
+        name=artifact.name,
+        ok=False,
+        message=f"Artifact manager '{definition.manager}' is not implemented.",
+        fix=f"basectl setup {project}",
+    )
+
+
+def check_homebrew_artifact(
+    project: str,
+    artifact: ArtifactRequest,
+    definition: ArtifactDefinition,
+) -> ArtifactCheck:
+    if artifact.version != "latest":
+        return ArtifactCheck(
+            name=artifact.name,
+            ok=False,
+            message=(
+                f"Homebrew artifact '{artifact.name}' specifies version '{artifact.version}', "
+                "but Base only supports Homebrew artifact version 'latest' right now."
+            ),
+            fix=f"Update '{artifact.name}' in the project manifest to use version 'latest'.",
+        )
+    if not command_exists("brew"):
+        return ArtifactCheck(
+            name=artifact.name,
+            ok=False,
+            message=f"Homebrew is required to check artifact '{artifact.name}'.",
+            fix="basectl setup",
+        )
+    ok = run_check(["brew", "list", definition.package])
+    if ok:
+        return ArtifactCheck(
+            name=artifact.name,
+            ok=True,
+            message=f"Artifact '{artifact.name}' is installed via Homebrew package '{definition.package}'.",
+            fix="",
+        )
+    return ArtifactCheck(
+        name=artifact.name,
+        ok=False,
+        message=f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'.",
+        fix=f"basectl setup {project}",
+    )
+
+
+def check_python_artifact(
+    project: str,
+    artifact: ArtifactRequest,
+    definition: ArtifactDefinition,
+) -> ArtifactCheck:
+    venv_dir = project_venv_dir(project)
+    python_bin = venv_dir / "bin" / "python"
+    if python_artifact_installed(python_bin, definition.package, artifact.version):
+        return ArtifactCheck(
+            name=artifact.name,
+            ok=True,
+            message=f"Python artifact '{artifact.name}' is installed in the project virtual environment.",
+            fix="",
+        )
+    return ArtifactCheck(
+        name=artifact.name,
+        ok=False,
+        message=f"Python artifact '{artifact.name}' is not installed in the project virtual environment.",
+        fix=f"basectl setup {project}",
+    )
+
+
+def check_to_json(check: ArtifactCheck) -> dict[str, str | bool]:
+    return {
+        "name": check.name,
+        "ok": check.ok,
+        "message": check.message,
+        "fix": check.fix,
+    }
+
+
+def print_doctor_finding(status: str, name: str, message: str, fix: str = "") -> None:
+    print(f"{status:<5}  {name:<26}  {message}")
+    if fix:
+        print(f"       Fix: {fix}")
 
 
 def resolve_artifact_definitions(artifacts: tuple[ArtifactRequest, ...]) -> tuple[ArtifactDefinition, ...]:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -356,6 +356,72 @@ class ManifestTests(unittest.TestCase):
         self.assertIn("Project 'demo' declares no artifacts; installing Base default artifacts only.", stderr)
 
 
+class ProjectCheckTests(unittest.TestCase):
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_check_json_reports_project_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: python-package",
+                        "    name: requests",
+                        "    version: latest",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, _stderr = run_engine(
+                ["--action", "check", "--format", "json", "--manifest", str(manifest_path), "demo"]
+            )
+
+        self.assertEqual(status, 1)
+        self.assertIn('"name": "requests"', stdout)
+        self.assertIn('"ok": false', stdout)
+        self.assertIn('"fix": "basectl setup demo"', stdout)
+
+    def test_check_homebrew_artifact_reports_missing_package(self) -> None:
+        artifact = ArtifactRequest(artifact_type="tool", name="terraform", version="latest")
+        definition = get_artifact_definition("tool", "terraform")
+        self.assertIsNotNone(definition)
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.run_check",
+            return_value=False,
+        ):
+            check = engine.check_homebrew_artifact("demo", artifact, definition)
+
+        self.assertFalse(check.ok)
+        self.assertIn("not installed via Homebrew package 'terraform'", check.message)
+        self.assertEqual(check.fix, "basectl setup demo")
+
+    def test_doctor_manifest_counts_failed_project_artifacts(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(ArtifactRequest(artifact_type="python-package", name="requests", version="latest"),),
+        )
+
+        with redirect_stdout(io.StringIO()) as stdout:
+            status = engine.doctor_manifest(default_manifest, manifest)
+
+        self.assertEqual(status, 1)
+        self.assertIn("Project doctor: demo", stdout.getvalue())
+        self.assertIn("Fix: basectl setup demo", stdout.getvalue())
+
+
 class BrewfileTests(unittest.TestCase):
     def test_brewfile_dry_run_invokes_brew_bundle(self) -> None:
         ctx = fake_context()


### PR DESCRIPTION
## Summary
- Add optional project arguments to `basectl check [project]` and `basectl doctor [project]`.
- Extend the `base_setup` Python layer with `check` and `doctor` actions for project manifests, default artifacts, Brewfile checks, Homebrew tool checks, and project-venv Python package checks.
- Include project artifact results in text, doctor, and JSON check output while keeping JSON stdout clean.
- Update command help, README, basectl docs, and tests for the new project-aware behavior.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/check.sh`
- `bash -n cli/bash/commands/basectl/subcommands/doctor.sh`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bash -n cli/bash/commands/basectl/basectl.sh`
- `git diff --check`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover cli/python/base_setup/tests`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover cli/python/base_dev/tests`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup cli/python/base_dev lib/python/base_cli`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`