### PR TITLE
Secure Python CLI log permissions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,13 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Lock down Python CLI log file permissions.
-  - Problem: `logging.FileHandler` creates log files using the process umask,
-    commonly `0644`, while Base logs include argv and runtime context.
-  - Goal: ensure Python CLI log files are readable only by the current user.
-  - Expected behavior: create or chmod log files to `0600` and cover with a unit
-    test in `lib/python/base_cli/tests`.
-
 - [ ] Restrict setup test-only environment escape hatches.
   - Problem: `BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT` and `BASE_SETUP_PYTHON_BIN`
     can redirect setup to arbitrary executables when present in the environment.

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -28,10 +28,15 @@ def configure_logger(
     logger.addHandler(user_handler)
 
     file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    secure_log_file_permissions(log_file)
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(BaseCliFormatter())
     logger.addHandler(file_handler)
     return logger
+
+
+def secure_log_file_permissions(log_file: Path) -> None:
+    log_file.chmod(0o600)
 
 
 class BaseCliFormatter(logging.Formatter):

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -184,7 +184,11 @@ class BaseCliTests(unittest.TestCase):
             self.assertEqual(seen["name"], "Ada")
             self.assertFalse(seen["temp_dir"].exists())
             self.assertTrue(seen["cache_dir"].is_dir())
-            self.assertTrue((home / "Library" / "Caches" / "base" / "cli" / "demo" / "logs").is_dir())
+            log_dir = home / "Library" / "Caches" / "base" / "cli" / "demo" / "logs"
+            self.assertTrue(log_dir.is_dir())
+            log_files = tuple(log_dir.glob("*.log"))
+            self.assertEqual(len(log_files), 1)
+            self.assertEqual(log_files[0].stat().st_mode & 0o777, 0o600)
             self.assertFalse((home / ".base.d" / "cli").exists())
             self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} INFO\s+")
             self.assertIn("hello Ada", result.stderr)
@@ -261,6 +265,7 @@ class BaseCliTests(unittest.TestCase):
             self.assertEqual(seen["project_root"], project.resolve())
 
             log_text = log_file.read_text(encoding="utf-8")
+            self.assertEqual(log_file.stat().st_mode & 0o777, 0o600)
             self.assertIn("--token", log_text)
             self.assertIn("[REDACTED]", log_text)
             self.assertNotIn("super-secret", log_text)


### PR DESCRIPTION
## Summary
- Set Python CLI log files to `0600` immediately after `logging.FileHandler` creates them.
- Add regression coverage for both default per-run log files and explicit `--log-file` paths.
- Remove the completed log-permissions item from `TODO.md`.

## Validation
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest lib/python/base_cli/tests/test_base_cli.py`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`
- `git diff --check`