### PR TITLE
Restrict setup test hooks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,14 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Restrict setup test-only environment escape hatches.
-  - Problem: `BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT` and `BASE_SETUP_PYTHON_BIN`
-    can redirect setup to arbitrary executables when present in the environment.
-  - Goal: keep test hooks available without honoring them in normal user runs.
-  - Expected behavior: require an explicit test/CI guard such as
-    `BASE_TEST_MODE=true` before these overrides are accepted; otherwise ignore
-    or fail with a clear error.
-
 - [ ] Remove implicit system `python3` fallback from Base venv creation.
   - Problem: `setup_find_python_bin` can fall back to the first `python3` on
     `PATH` if Homebrew Python cannot be resolved, potentially creating Base's

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -132,6 +132,17 @@ setup_allow_noninteractive_xcode_install() {
     [[ "${BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL:-false}" == true ]]
 }
 
+setup_allow_test_hooks() {
+    [[ "${BASE_TEST_MODE:-false}" == true || "${CI:-false}" == true ]]
+}
+
+setup_reject_test_hook_if_disallowed() {
+    local variable_name="$1"
+
+    setup_allow_test_hooks && return 0
+    fatal_error "$variable_name is a test-only setup override. Set BASE_TEST_MODE=true or CI=true to use it."
+}
+
 setup_recovery_homebrew() {
     printf "%s\n" "Run 'basectl setup' to install Homebrew, or install it manually from https://brew.sh/."
 }
@@ -251,6 +262,7 @@ setup_install_homebrew() {
     log_info "Installing Homebrew."
 
     if [[ -n "${BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT:-}" ]]; then
+        setup_reject_test_hook_if_disallowed BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT
         run "$BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT"
     else
         command -v curl >/dev/null 2>&1 || fatal_error "curl is required to install Homebrew. Install curl or install Homebrew manually from https://brew.sh/, then rerun 'basectl setup'."
@@ -345,7 +357,9 @@ setup_find_python_bin() {
     local formula prefix candidate
     local candidates=()
 
-    if [[ -n "${BASE_SETUP_PYTHON_BIN:-}" && -x "${BASE_SETUP_PYTHON_BIN}" ]]; then
+    if [[ -n "${BASE_SETUP_PYTHON_BIN:-}" ]]; then
+        setup_reject_test_hook_if_disallowed BASE_SETUP_PYTHON_BIN
+        [[ -x "${BASE_SETUP_PYTHON_BIN}" ]] || return 1
         printf '%s\n' "${BASE_SETUP_PYTHON_BIN}"
         return 0
     fi

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -352,6 +352,7 @@ run_base_command() {
         HOME="$TEST_HOME" \
         PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         OSTYPE="${OSTYPE_OVERRIDE:-darwin24}" \
+        BASE_TEST_MODE=true \
         BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
         BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
         BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
@@ -593,6 +594,44 @@ EOF
     [ -f "$TEST_STATE_DIR/click-install-ran" ]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ -f "$venv_dir/pyvenv.cfg" ]
+}
+
+@test "basectl setup rejects Homebrew installer override outside test mode" {
+    local installer
+
+    create_xcode_stubs
+    installer="$(create_homebrew_installer_stub)"
+
+    run_base_command \
+        BASE_TEST_MODE=false \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
+        setup
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT is a test-only setup override."* ]]
+    [ ! -f "$TEST_STATE_DIR/homebrew-install-ran" ]
+}
+
+@test "basectl setup rejects Python binary override outside test mode" {
+    local python_bin="$TEST_TMPDIR/fake-python"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$python_bin"
+    chmod +x "$python_bin"
+
+    run_base_command \
+        BASE_TEST_MODE=false \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_PYTHON_BIN="$python_bin" \
+        setup
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"BASE_SETUP_PYTHON_BIN is a test-only setup override."* ]]
 }
 
 @test "basectl setup skips notifications for quick successful runs" {


### PR DESCRIPTION
## Summary
- Gate setup-only override environment variables behind `BASE_TEST_MODE=true` or `CI=true`.
- Keep the BATS harness explicitly opted into test mode.
- Add regression coverage that rejects the Homebrew installer and Python binary overrides in normal setup runs.
- Remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `git diff --check`