### PR TITLE
Require opt-in for system Python fallback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,15 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Remove implicit system `python3` fallback from Base venv creation.
-  - Problem: `setup_find_python_bin` can fall back to the first `python3` on
-    `PATH` if Homebrew Python cannot be resolved, potentially creating Base's
-    venv with the wrong interpreter.
-  - Goal: use the configured Homebrew Python formula unless the user explicitly
-    opts into a system Python fallback.
-  - Expected behavior: remove the fallback or gate it behind a clearly named
-    opt-in such as `BASE_SETUP_ALLOW_SYSTEM_PYTHON=true`.
-
 - [ ] Clear inherited setup state in `basectl check`.
   - Problem: `basectl setup` calls `setup_clear_run_state`, but `basectl check`
     does not, so inherited variables such as `DRY_RUN` or

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -132,6 +132,10 @@ setup_allow_noninteractive_xcode_install() {
     [[ "${BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL:-false}" == true ]]
 }
 
+setup_allow_system_python() {
+    [[ "${BASE_SETUP_ALLOW_SYSTEM_PYTHON:-false}" == true ]]
+}
+
 setup_allow_test_hooks() {
     [[ "${BASE_TEST_MODE:-false}" == true || "${CI:-false}" == true ]]
 }
@@ -383,7 +387,7 @@ setup_find_python_bin() {
         fi
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
+    if setup_allow_system_python && command -v python3 >/dev/null 2>&1; then
         command -v python3
         return 0
     fi

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -65,6 +65,52 @@ EOF
     chmod +x "$TEST_MOCKBIN/osascript"
 }
 
+create_system_python3_stub() {
+    cat > "$TEST_MOCKBIN/python3" <<'EOF'
+#!/usr/bin/env bash
+touch "${BASE_SETUP_TEST_STATE_DIR:?}/system-python-ran"
+if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
+    mkdir -p "$3/bin"
+    printf 'python-home = system-test\n' > "$3/pyvenv.cfg"
+    printf '#!/usr/bin/env bash\n' > "$3/bin/activate"
+    cat > "$3/bin/python" <<'VENVEOF'
+#!/usr/bin/env bash
+pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$pyyaml_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$click_package" ]]; then
+    [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed" ]]
+    exit $?
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "$click_package" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-install-ran"
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed"
+    exit 0
+fi
+printf 'unexpected system venv python args: %s\n' "$*" >&2
+exit 1
+VENVEOF
+    chmod +x "$3/bin/python"
+    exit 0
+fi
+printf 'unexpected system python3 args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/python3"
+}
+
 create_brew_stub() {
     cat > "$TEST_MOCKBIN/brew" <<'EOF'
 #!/usr/bin/env bash
@@ -632,6 +678,39 @@ EOF
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"BASE_SETUP_PYTHON_BIN is a test-only setup override."* ]]
+}
+
+@test "basectl setup does not fall back to system python3 by default" {
+    create_brew_stub
+    create_xcode_stubs
+    create_system_python3_stub
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+
+    run_base_command setup
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unable to locate a python3 executable after installation."* ]]
+    [ ! -f "$TEST_STATE_DIR/system-python-ran" ]
+}
+
+@test "basectl setup uses system python3 only when explicitly allowed" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    create_system_python3_stub
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+
+    run_base_command BASE_SETUP_ALLOW_SYSTEM_PYTHON=true setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Creating Python virtual environment at '$venv_dir'."* ]]
+    [ -f "$TEST_STATE_DIR/system-python-ran" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
 @test "basectl setup skips notifications for quick successful runs" {


### PR DESCRIPTION
## Summary
- Gate `setup_find_python_bin`'s ambient `python3` fallback behind `BASE_SETUP_ALLOW_SYSTEM_PYTHON=true`.
- Keep the configured Homebrew Python formula as the default source for Base venv creation.
- Add regression coverage for both the default no-fallback path and the explicit opt-in path.
- Remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `git diff --check`