### PR TITLE
Clear setup state before check

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,15 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Clear inherited setup state in `basectl check`.
-  - Problem: `basectl setup` calls `setup_clear_run_state`, but `basectl check`
-    does not, so inherited variables such as `DRY_RUN` or
-    `BASE_SETUP_RECREATE_VENV` can affect check behavior.
-  - Goal: make `check` deterministic and insulated from ambient setup state.
-  - Expected behavior: call `setup_clear_run_state` at the start of
-    `base_check_subcommand_main`, then preserve only flags explicitly passed to
-    `check`.
-
 - [ ] Support non-`master` default branches in `basectl update`.
   - Problem: `basectl update` currently refuses to run unless the checked-out
     branch is exactly `master`, which blocks repositories whose default branch

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -36,6 +36,8 @@ base_check_subcommand_main() {
     local output_format="text"
     local project=""
 
+    setup_clear_run_state
+
     while (($#)); do
         case "$1" in
             -h|--help|help)

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1102,6 +1102,32 @@ EOF
     [ "$(grep -c '^click$' "$TEST_STATE_DIR/pip-show.log")" -eq 1 ]
 }
 
+@test "basectl check ignores inherited setup dry-run and recreate state" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/bats-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command \
+        DRY_RUN=true \
+        BASE_SETUP_RECREATE_VENV=true \
+        check
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Python package 'PyYAML' is installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Python package 'click' is installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Base CLI environment check passed."* ]]
+    [ "$(grep -c '^PyYAML$' "$TEST_STATE_DIR/pip-show.log")" -eq 1 ]
+    [ "$(grep -c '^click$' "$TEST_STATE_DIR/pip-show.log")" -eq 1 ]
+}
+
 @test "basectl check fails when a required Base Python package is missing" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 


### PR DESCRIPTION
## Summary
- Clear inherited setup state at the start of `basectl check` before parsing check-specific flags.
- Add regression coverage for ambient `DRY_RUN=true` and `BASE_SETUP_RECREATE_VENV=true` leaking into `check`.
- Remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/check.sh`
- `git diff --check`