### PR TITLE
Support default branch in basectl update

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,14 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Support non-`master` default branches in `basectl update`.
-  - Problem: `basectl update` currently refuses to run unless the checked-out
-    branch is exactly `master`, which blocks repositories whose default branch
-    is `main` or another remote default.
-  - Goal: make self-update work with modern GitHub default branch conventions.
-  - Expected behavior: accept both `master` and `main`, or discover the remote
-    default branch from `origin/HEAD` and use that consistently.
-
 - [ ] Make Bash JSON escaping strict for all control characters.
   - Problem: `setup_json_escape` handles `"`, `\`, newline, carriage return, and
     tab, but not the rest of U+0000 through U+001F.

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -22,7 +22,7 @@ Purpose:
   Update the Base repository from Git, then run basectl setup.
 
 Notes:
-  - The repository must be on master.
+  - The repository must be on its default branch.
   - The worktree must be clean, including untracked files.
 EOF
 }
@@ -34,6 +34,31 @@ base_update_source_git_library() {
 base_update_current_branch() {
     local repo="$1"
     git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null
+}
+
+base_update_default_branch() {
+    local repo="$1"
+    local default_branch
+
+    if default_branch="$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+        default_branch="${default_branch#origin/}"
+        if [[ -n "$default_branch" ]]; then
+            printf '%s\n' "$default_branch"
+            return 0
+        fi
+    fi
+
+    if git -C "$repo" show-ref --verify --quiet refs/heads/main; then
+        printf '%s\n' main
+        return 0
+    fi
+
+    if git -C "$repo" show-ref --verify --quiet refs/heads/master; then
+        printf '%s\n' master
+        return 0
+    fi
+
+    return 1
 }
 
 base_update_worktree_clean() {
@@ -54,6 +79,7 @@ base_update_subcommand_main() {
     local after_revision
     local before_revision
     local branch
+    local update_branch
     local dry_run=0
 
     while (($#)); do
@@ -83,8 +109,12 @@ base_update_subcommand_main() {
         log_error "Base home '$BASE_HOME' is not a Git repository."
         return 1
     }
-    if [[ "$branch" != "master" ]]; then
-        log_error "Base update only runs on branch 'master'; current branch is '$branch'."
+    update_branch="$(base_update_default_branch "$BASE_HOME")" || {
+        log_error "Unable to determine the Base repository default branch."
+        return 1
+    }
+    if [[ "$branch" != "$update_branch" ]]; then
+        log_error "Base update only runs on default branch '$update_branch'; current branch is '$branch'."
         return 1
     fi
 
@@ -106,16 +136,16 @@ base_update_subcommand_main() {
     }
 
     log_info "Updating Base repository at '$BASE_HOME'."
-    git_update_repo "$BASE_HOME" "" master || return 1
+    git_update_repo "$BASE_HOME" "" "$update_branch" || return 1
     after_revision="$(base_update_head_revision "$BASE_HOME")" || {
         log_error "Unable to read updated Base repository revision."
         return 1
     }
 
     if [[ "$before_revision" == "$after_revision" ]]; then
-        log_info "Base repository is already up to date on 'master' at '$after_revision'."
+        log_info "Base repository is already up to date on '$update_branch' at '$after_revision'."
     else
-        log_info "Base repository updated from '$before_revision' to '$after_revision' on 'master'."
+        log_info "Base repository updated from '$before_revision' to '$after_revision' on '$update_branch'."
     fi
 
     log_info "Running basectl setup after update."

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -71,6 +71,7 @@ run_basectl() {
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
             base_update_current_branch() { printf "%s\n" master; }
+            base_update_default_branch() { printf "%s\n" master; }
             base_update_worktree_clean() { return 0; }
             base_update_subcommand_main --dry-run
         '
@@ -88,6 +89,7 @@ run_basectl() {
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
             base_update_current_branch() { printf "%s\n" master; }
+            base_update_default_branch() { printf "%s\n" master; }
             base_update_worktree_clean() { return 1; }
             base_update_run_setup() { printf "setup should not run\n"; return 99; }
             base_update_subcommand_main
@@ -95,6 +97,26 @@ run_basectl() {
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"Base repository has local changes."* ]]
+    [[ "$output" != *"setup should not run"* ]]
+}
+
+@test "basectl update refuses non-default branches" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_current_branch() { printf "%s\n" feature/example; }
+            base_update_default_branch() { printf "%s\n" main; }
+            base_update_worktree_clean() { printf "clean should not run\n"; return 99; }
+            base_update_run_setup() { printf "setup should not run\n"; return 99; }
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Base update only runs on default branch 'main'; current branch is 'feature/example'."* ]]
+    [[ "$output" != *"clean should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
 }
 
@@ -106,6 +128,7 @@ run_basectl() {
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
             base_update_current_branch() { printf "%s\n" master; }
+            base_update_default_branch() { printf "%s\n" master; }
             base_update_worktree_clean() { return 0; }
             base_update_source_git_library() { :; }
             git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
@@ -130,10 +153,11 @@ run_basectl() {
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
-            base_update_current_branch() { printf "%s\n" master; }
+            base_update_current_branch() { printf "%s\n" main; }
+            base_update_default_branch() { printf "%s\n" main; }
             base_update_worktree_clean() { return 0; }
             base_update_source_git_library() { :; }
-            git_update_repo() { :; }
+            git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
             base_update_head_revision() {
                 if [[ -f "$BASE_TEST_AFTER_UPDATE" ]]; then
                     printf "%s\n" new5678
@@ -147,7 +171,8 @@ run_basectl() {
         '
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Base repository updated from 'old1234' to 'new5678' on 'master'."* ]]
+    [[ "$output" == *"git update repo=$BASE_REPO_ROOT branch=main"* ]]
+    [[ "$output" == *"Base repository updated from 'old1234' to 'new5678' on 'main'."* ]]
     [[ "$output" == *"setup ran"* ]]
     [[ "$output" == *"Base update is complete."* ]]
 }

--- a/lib/bash/git/README.md
+++ b/lib/bash/git/README.md
@@ -9,7 +9,7 @@ Source `lib/bash/std/lib_std.sh` before this library so logging and shared error
 ## Public API
 
 - `git_update_repo`
-  Update a repository on branch `master`, optionally allowing tracked changes in one specific path.
+  Update a repository on its detected default branch, optionally allowing tracked changes in one specific path.
 - `git_get_current_branch`
   Return the current branch name through a caller-provided variable, or `detached head`.
 - `check_script_up_to_date`
@@ -33,7 +33,7 @@ log_info "Current branch: $branch"
 
 ## Behavior Notes
 
-- `git_update_repo` currently only attempts updates when the checked-out branch is `master`.
+- `git_update_repo` only attempts updates when the checked-out branch is the detected default branch, or an explicit expected branch passed by the caller.
 - `check_script_up_to_date` treats missing git state, untracked scripts, or missing upstreams as skip conditions rather than hard failures.
 
 ## Tests


### PR DESCRIPTION
## Summary
- Resolve the Base repository default branch from `origin/HEAD`, with local `main`/`master` fallbacks.
- Require `basectl update` to run on that default branch instead of hardcoding `master`.
- Pass the resolved branch through to `git_update_repo` and update status messages accordingly.
- Add regression coverage for non-default branches and `main` branch updates.
- Refresh Git helper docs and remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/update.sh`
- `git diff --check`