### PR TITLE
Escape all Bash JSON control characters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,14 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Make Bash JSON escaping strict for all control characters.
-  - Problem: `setup_json_escape` handles `"`, `\`, newline, carriage return, and
-    tab, but not the rest of U+0000 through U+001F.
-  - Goal: ensure `basectl check --format json` always emits structurally valid
-    JSON.
-  - Expected behavior: either use a trusted JSON encoder when available or add a
-    complete control-character escape path with regression tests.
-
 - [ ] Put `base_virtualenv` before Python packages in check JSON.
   - Problem: JSON output currently reports PyYAML and click before the venv even
     though the venv is their prerequisite.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -706,13 +706,47 @@ setup_run_check() {
 
 setup_json_escape() {
     local value="${1:-}"
+    local char code escaped i
+    local output=""
+    local LC_ALL=C
 
-    value="${value//\\/\\\\}"
-    value="${value//\"/\\\"}"
-    value="${value//$'\n'/\\n}"
-    value="${value//$'\r'/\\r}"
-    value="${value//$'\t'/\\t}"
-    printf '%s' "$value"
+    for ((i = 0; i < ${#value}; i++)); do
+        char="${value:i:1}"
+        case "$char" in
+            '"')
+                output+='\"'
+                ;;
+            '\')
+                output+='\\'
+                ;;
+            $'\b')
+                output+='\b'
+                ;;
+            $'\f')
+                output+='\f'
+                ;;
+            $'\n')
+                output+='\n'
+                ;;
+            $'\r')
+                output+='\r'
+                ;;
+            $'\t')
+                output+='\t'
+                ;;
+            *)
+                printf -v code '%d' "'$char"
+                if ((code < 32)); then
+                    printf -v escaped '\\u%04x' "$code"
+                    output+="$escaped"
+                else
+                    output+="$char"
+                fi
+                ;;
+        esac
+    done
+
+    printf '%s' "$output"
 }
 
 setup_print_check_json_item() {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1230,6 +1230,39 @@ EOF
     [ "${stderr:-}" = "" ]
 }
 
+@test "basectl check --format json escapes all C0 control characters in strings" {
+    local control_package
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    control_package=$'Py\vYAML'
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/bats-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        OSTYPE="darwin24" \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_PYYAML_PACKAGE="$control_package" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
+        "$BASE_REPO_ROOT/bin/basectl" check --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Py\\u000bYAML"* ]]
+    [[ "$output" != *"$control_package"* ]]
+    [ "${stderr:-}" = "" ]
+}
+
 @test "basectl check project --format json includes project check results" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
     local workspace="$TEST_TMPDIR/workspace"


### PR DESCRIPTION
## Summary
- Replace the Bash JSON string escaper with a byte-wise encoder.
- Preserve standard JSON escapes for quotes, backslashes, newline, carriage return, tab, backspace, and form feed.
- Emit `\u00XX` escapes for the remaining C0 control characters.
- Add regression coverage for a vertical-tab byte in `basectl check --format json` output.
- Remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `git diff --check`