### PR TITLE
Order check JSON by dependency

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,13 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Put `base_virtualenv` before Python packages in check JSON.
-  - Problem: JSON output currently reports PyYAML and click before the venv even
-    though the venv is their prerequisite.
-  - Goal: make JSON check ordering communicate dependency order.
-  - Expected behavior: emit Homebrew, Xcode, Python, Base virtualenv, PyYAML,
-    click, then optional dev/project checks.
-
 - [ ] Add JSON output to `basectl doctor`.
   - Problem: `basectl check` supports `--format text|json`, but
     `basectl doctor` is text-only even though project artifact checks already

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -870,9 +870,9 @@ setup_run_check_json() {
     setup_print_check_json_item "," "homebrew" "$homebrew_ok" "$homebrew_message"
     setup_print_check_json_item "," "xcode_command_line_tools" "$xcode_ok" "$xcode_message"
     setup_print_check_json_item "," "python" "$python_ok" "$python_message"
+    setup_print_check_json_item "," "base_virtualenv" "$venv_ok" "$venv_message"
     setup_print_check_json_item "," "pyyaml" "$pyyaml_ok" "$pyyaml_message"
-    setup_print_check_json_item "," "click" "$click_ok" "$click_message"
-    setup_print_check_json_item "" "base_virtualenv" "$venv_ok" "$venv_message"
+    setup_print_check_json_item "" "click" "$click_ok" "$click_message"
     printf '  ]'
     if setup_dev_dependencies_enabled || [[ -n "$project" ]]; then
         printf ',\n'

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1197,6 +1197,9 @@ EOF
 }
 
 @test "basectl check --format json writes successful check results to stdout" {
+    local click_line
+    local pyyaml_line
+    local venv_line
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_brew_stub
@@ -1227,6 +1230,11 @@ EOF
     [[ "$output" == *'"name":"pyyaml","ok":true'* ]]
     [[ "$output" == *'"name":"click","ok":true'* ]]
     [[ "$output" == *'"name":"base_virtualenv","ok":true'* ]]
+    venv_line="$(printf '%s\n' "$output" | grep -n '"name":"base_virtualenv"' | cut -d: -f1)"
+    pyyaml_line="$(printf '%s\n' "$output" | grep -n '"name":"pyyaml"' | cut -d: -f1)"
+    click_line="$(printf '%s\n' "$output" | grep -n '"name":"click"' | cut -d: -f1)"
+    [ "$venv_line" -lt "$pyyaml_line" ]
+    [ "$pyyaml_line" -lt "$click_line" ]
     [ "${stderr:-}" = "" ]
 }
 


### PR DESCRIPTION
## Summary
- Move `base_virtualenv` ahead of Python package checks in `basectl check --format json`.
- Keep the check order aligned with dependency order: Homebrew, Xcode, Python, Base virtualenv, PyYAML, click.
- Add regression coverage for the Base virtualenv/Python package ordering.
- Remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `git diff --check`