### PR TITLE
Add JSON output for basectl doctor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,15 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Add JSON output to `basectl doctor`.
-  - Problem: `basectl check` supports `--format text|json`, but
-    `basectl doctor` is text-only even though project artifact checks already
-    have structured data internally.
-  - Goal: make doctor usable in automation, CI health checks, and dashboards.
-  - Expected behavior: support `basectl doctor --format json` and
-    `basectl doctor <project> --format json` with stable `ok`, `warn`, and
-    `error` finding objects.
-
 - [ ] Add warning severity to doctor findings.
   - Problem: doctor findings are currently effectively binary `ok` or `error`.
   - Goal: distinguish optional or non-blocking recommendations from setup

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -14,9 +14,10 @@ Usage:
   basectl doctor [project] [options]
 
 Options:
-  --dev       Include manifest-declared developer prerequisite checks.
-  -v          Enable DEBUG logging for this subcommand.
-  -h, --help  Show this help text.
+  --dev                 Include manifest-declared developer prerequisite checks.
+  --format <text|json>  Select output format. Defaults to text.
+  -v                    Enable DEBUG logging for this subcommand.
+  -h, --help            Show this help text.
 
 Purpose:
   Diagnose the local Base CLI environment and, when provided, project artifacts.
@@ -33,6 +34,21 @@ base_doctor_print_finding() {
     if [[ -n "$fix" ]]; then
         printf '       Fix: %s\n' "$fix"
     fi
+}
+
+base_doctor_print_json_finding() {
+    local trailing_comma="$1"
+    local status="$2"
+    local name="$3"
+    local message="$4"
+    local fix="${5:-}"
+
+    printf '    {"status":"%s","name":"%s","message":"%s","fix":"%s"}%s\n' \
+        "$(setup_json_escape "$status")" \
+        "$(setup_json_escape "$name")" \
+        "$(setup_json_escape "$message")" \
+        "$(setup_json_escape "$fix")" \
+        "$trailing_comma"
 }
 
 base_doctor_check_homebrew() {
@@ -110,8 +126,148 @@ base_doctor_check_python_package() {
     return 1
 }
 
+base_doctor_run_json() {
+    local brew_bin click_package dev_errors=0 dev_json="[]" errors=0
+    local homebrew_fix="" homebrew_message homebrew_status
+    local project="$1"
+    local project_errors=0 project_json="[]"
+    local pyyaml_fix="" pyyaml_message pyyaml_package pyyaml_status
+    local python_fix="" python_message python_status
+    local venv_dir venv_fix="" venv_message venv_status
+    local xcode_fix="" xcode_message xcode_status
+
+    click_package="$(setup_click_package)"
+    pyyaml_package="$(setup_pyyaml_package)"
+    venv_dir="$(setup_venv_dir)"
+
+    if brew_bin="$(setup_find_brew_bin)"; then
+        if setup_refresh_brew_path; then
+            homebrew_status="ok"
+            homebrew_message="Homebrew is installed."
+            log_debug "Resolved Homebrew binary: $brew_bin"
+        else
+            homebrew_status="error"
+            homebrew_message="Homebrew is installed, but its bin directory could not be added to PATH."
+            homebrew_fix="Check Homebrew installation and PATH."
+            errors=$((errors + 1))
+        fi
+    else
+        homebrew_status="error"
+        homebrew_message="Homebrew is not installed."
+        homebrew_fix="basectl setup"
+        errors=$((errors + 1))
+    fi
+
+    if setup_xcode_tools_installed; then
+        xcode_status="ok"
+        xcode_message="Xcode Command Line Tools are installed."
+    else
+        xcode_status="error"
+        xcode_message="Xcode Command Line Tools are not installed."
+        xcode_fix="basectl setup"
+        errors=$((errors + 1))
+    fi
+
+    if setup_python_installed; then
+        python_status="ok"
+        python_message="Python formula '$(setup_python_formula)' is installed via Homebrew."
+    else
+        python_status="error"
+        python_message="Python formula '$(setup_python_formula)' is not installed via Homebrew."
+        python_fix="basectl setup"
+        errors=$((errors + 1))
+    fi
+
+    if setup_virtualenv_exists; then
+        venv_status="ok"
+        venv_message="Virtual environment exists at '$venv_dir'."
+    else
+        venv_status="error"
+        venv_message="Virtual environment is missing at '$venv_dir'."
+        venv_fix="basectl setup"
+        errors=$((errors + 1))
+    fi
+
+    if setup_base_python_package_installed "$pyyaml_package"; then
+        pyyaml_status="ok"
+        pyyaml_message="$(setup_base_python_package_check_message "$pyyaml_package" true)"
+        pyyaml_fix=""
+    else
+        pyyaml_status="error"
+        pyyaml_message="$(setup_base_python_package_check_message "$pyyaml_package" false)"
+        pyyaml_fix="basectl setup"
+        errors=$((errors + 1))
+    fi
+
+    if setup_base_python_package_installed "$click_package"; then
+        click_status="ok"
+        click_message="$(setup_base_python_package_check_message "$click_package" true)"
+        click_fix=""
+    else
+        click_status="error"
+        click_message="$(setup_base_python_package_check_message "$click_package" false)"
+        click_fix="basectl setup"
+        errors=$((errors + 1))
+    fi
+
+    if setup_dev_dependencies_enabled; then
+        if dev_json="$(setup_run_base_dev_layer doctor --format json)"; then
+            dev_errors=0
+        else
+            dev_errors=$?
+            [[ -n "$dev_json" ]] || dev_json="[]"
+            errors=$((errors + dev_errors))
+        fi
+    fi
+
+    if [[ -n "$project" ]]; then
+        if project_json="$(setup_run_project_artifact_doctor_json)"; then
+            project_errors=0
+        else
+            project_errors=$?
+            [[ -n "$project_json" ]] || project_json="[]"
+            errors=$((errors + project_errors))
+        fi
+    fi
+
+    printf '{\n'
+    printf '  "ok": %s' "$([[ "$errors" -eq 0 ]] && printf true || printf false)"
+    if [[ -n "$project" ]]; then
+        printf ',\n'
+        printf '  "project": "%s"' "$(setup_json_escape "$project")"
+    fi
+    printf ',\n'
+    printf '  "findings": [\n'
+    base_doctor_print_json_finding "," "$homebrew_status" "Homebrew" "$homebrew_message" "$homebrew_fix"
+    base_doctor_print_json_finding "," "$xcode_status" "Xcode Command Line Tools" "$xcode_message" "$xcode_fix"
+    base_doctor_print_json_finding "," "$python_status" "Python" "$python_message" "$python_fix"
+    base_doctor_print_json_finding "," "$venv_status" "Base virtualenv" "$venv_message" "$venv_fix"
+    base_doctor_print_json_finding "," "$pyyaml_status" "$pyyaml_package" "$pyyaml_message" "$pyyaml_fix"
+    base_doctor_print_json_finding "" "$click_status" "$click_package" "$click_message" "$click_fix"
+    printf '  ]'
+    if setup_dev_dependencies_enabled || [[ -n "$project" ]]; then
+        printf ',\n'
+    else
+        printf '\n'
+    fi
+    if setup_dev_dependencies_enabled; then
+        setup_print_json_property_value "dev_findings" "$dev_json"
+        if [[ -n "$project" ]]; then
+            printf ',\n'
+        else
+            printf '\n'
+        fi
+    fi
+    if [[ -n "$project" ]]; then
+        setup_print_json_property_value "project_findings" "$project_json"
+    fi
+    printf '}\n'
+
+    [[ "$errors" -eq 0 ]]
+}
+
 base_doctor_subcommand_main() {
-    local dev_errors=0 errors=0 project=""
+    local dev_errors=0 errors=0 output_format="text" project=""
 
     while (($#)); do
         case "$1" in
@@ -121,6 +277,24 @@ base_doctor_subcommand_main() {
                 ;;
             --dev)
                 setup_enable_dev_dependencies
+                ;;
+            --format)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    print_error "Option '--format' requires an argument."
+                    base_doctor_subcommand_usage >&2
+                    return 2
+                fi
+                case "$1" in
+                    text|json)
+                        output_format="$1"
+                        ;;
+                    *)
+                        print_error "Unsupported doctor output format '$1'."
+                        base_doctor_subcommand_usage >&2
+                        return 2
+                        ;;
+                esac
                 ;;
             -v)
                 setup_enable_debug_logging
@@ -146,6 +320,11 @@ base_doctor_subcommand_main() {
     export BASE_SETUP_PROJECT_NAME
     log_debug "Running 'basectl doctor'."
     setup_require_macos
+
+    if [[ "$output_format" == json ]]; then
+        base_doctor_run_json "$project"
+        return $?
+    fi
 
     if [[ -n "$project" ]]; then
         printf "Base doctor for project '%s'\n\n" "$project"

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -547,7 +547,7 @@ setup_run_project_artifact_layer() {
     }
     if [[ "$resolve_output" == *$'\t'* ]]; then
         IFS=$'\t' read -r resolved_root manifest_path <<<"$resolve_output"
-        if [[ "$action" != check || "$output_format" != json ]]; then
+        if [[ "$output_format" != json ]]; then
             log_info "Resolved project '$project' at '$resolved_root'."
         fi
     else
@@ -559,12 +559,12 @@ setup_run_project_artifact_layer() {
     fi
     args+=(--manifest "$manifest_path")
     args+=(--action "$action")
-    if [[ "$action" == check ]]; then
+    if [[ "$action" == check || "$action" == doctor ]]; then
         args+=(--format "$output_format")
     fi
     args+=("$project")
 
-    if [[ "$action" != check || "$output_format" != json ]]; then
+    if [[ "$output_format" != json ]]; then
         log_info "Running Python project $action layer."
     fi
 
@@ -595,6 +595,10 @@ setup_run_project_artifact_check_json() {
 
 setup_run_project_artifact_doctor() {
     setup_run_project_artifact_layer doctor text
+}
+
+setup_run_project_artifact_doctor_json() {
+    setup_run_project_artifact_layer doctor json
 }
 
 setup_run_base_dev_layer() {

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load ../../../../../lib/bash/tests/test_helper.sh
+bats_require_minimum_version 1.5.0
 
 setup() {
     setup_test_tmpdir
@@ -509,6 +510,23 @@ EOF
     [[ "$output" == *"Base doctor found"*"blocking issue(s)."* ]]
 }
 
+@test "basectl doctor --format json reports structured findings" {
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_SETUP_BREW_BIN="$TEST_TMPDIR/missing-brew" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/missing-xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor --format json
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"findings":'* ]]
+    [[ "$output" == *'"status":"error","name":"Homebrew","message":"Homebrew is not installed.","fix":"basectl setup"'* ]]
+    [[ "$output" == *'"status":"error","name":"Base virtualenv"'* ]]
+    [[ "$output" != *"Base doctor"* ]]
+    [ "${stderr:-}" = "" ]
+}
+
 @test "basectl doctor project includes project artifact findings" {
     local fake_bin="$TEST_TMPDIR/bin"
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
@@ -580,6 +598,81 @@ EOF
     [[ "$output" == *"Running Python project doctor layer."* ]]
     [[ "$output" == *"ok"*"demo-artifact"*"Project artifact check passed."* ]]
     [[ "$output" == *"Base doctor found no blocking issues for project 'demo'."* ]]
+}
+
+@test "basectl doctor project --format json includes project findings" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$workspace/demo"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-f" && "${2:-}" == "clang" ]]; then
+    printf '/tmp/fake-clang\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    printf '[{"status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""}]\n'
+    exit 0
+fi
+printf 'unexpected doctor project json python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor demo --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"ok": true'* ]]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"project_findings":'* ]]
+    [[ "$output" == *'"status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""'* ]]
+    [[ "$output" != *"Running Python project doctor layer."* ]]
+    [ "${stderr:-}" = "" ]
 }
 
 @test "basectl activate resolves a project and execs a project subshell" {

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -29,7 +29,7 @@ def main(argv: list[str] | None = None) -> int:
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.argument("action", required=True)
 @base_cli.option("--dry-run", is_flag=True, help="Log planned setup changes without making them.")
-@base_cli.option("--format", "output_format", default="text", help="Output format for check: text or json.")
+@base_cli.option("--format", "output_format", default="text", help="Output format for check/doctor: text or json.")
 def run(ctx: base_cli.Context, action: str, dry_run: bool, output_format: str) -> int:
     try:
         manifest = read_dev_manifest(ctx)
@@ -43,7 +43,7 @@ def run(ctx: base_cli.Context, action: str, dry_run: bool, output_format: str) -
     if action == "check":
         return check_dev_artifacts(ctx, manifest.artifacts, definitions, output_format=output_format)
     if action == "doctor":
-        return doctor_dev_artifacts(manifest.artifacts, definitions)
+        return doctor_dev_artifacts(manifest.artifacts, definitions, output_format=output_format)
 
     ctx.log.error("Unsupported base_dev action '%s'. Expected setup, check, or doctor.", action)
     return 2
@@ -106,10 +106,18 @@ def check_dev_artifacts(
 def doctor_dev_artifacts(
     artifacts: tuple[ArtifactRequest, ...],
     definitions: tuple[ArtifactDefinition, ...],
+    output_format: str,
 ) -> int:
     checks = tuple(
         check_homebrew_artifact(artifact, definition) for artifact, definition in zip(artifacts, definitions)
     )
+    if output_format == "json":
+        print(json.dumps([check_to_doctor_json(check) for check in checks], indent=2))
+        return min(sum(1 for check in checks if not check.ok), 125)
+    if output_format != "text":
+        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
+        return 2
+
     error_count = 0
     for check in checks:
         if check.ok:
@@ -158,6 +166,15 @@ def check_to_json(check: DevCheck) -> dict[str, str | bool]:
     return {
         "name": check.name,
         "ok": check.ok,
+        "message": check.message,
+        "fix": check.fix,
+    }
+
+
+def check_to_doctor_json(check: DevCheck) -> dict[str, str]:
+    return {
+        "status": "ok" if check.ok else "error",
+        "name": check.name,
         "message": check.message,
         "fix": check.fix,
     }

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import importlib.util
+import json
 import os
 import tempfile
 import unittest
@@ -57,11 +58,25 @@ class DevManifestTests(unittest.TestCase):
         with mock.patch("base_dev.engine.run_check", return_value=False):
             stdout = io.StringIO()
             with redirect_stdout(stdout):
-                status = engine.doctor_dev_artifacts(manifest.artifacts, definitions)
+                status = engine.doctor_dev_artifacts(manifest.artifacts, definitions, output_format="text")
 
         self.assertEqual(status, 2)
         self.assertIn("error", stdout.getvalue())
         self.assertIn("Fix: basectl setup --dev", stdout.getvalue())
+
+    def test_doctor_supports_json_output(self) -> None:
+        manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
+        definitions = engine.resolve_artifact_definitions(manifest.artifacts)
+
+        with mock.patch("base_dev.engine.run_check", return_value=False):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                status = engine.doctor_dev_artifacts(manifest.artifacts, definitions, output_format="json")
+
+        findings = json.loads(stdout.getvalue())
+        self.assertEqual(status, 2)
+        self.assertEqual(findings[0]["status"], "error")
+        self.assertEqual(findings[0]["fix"], "basectl setup --dev")
 
 
 if __name__ == "__main__":

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -48,7 +48,7 @@ def main(argv: list[str] | None = None) -> int:
     default="setup",
     help="Action to run: setup, check, or doctor. Defaults to setup.",
 )
-@base_cli.option("--format", "output_format", default="text", help="Output format for check: text or json.")
+@base_cli.option("--format", "output_format", default="text", help="Output format for check/doctor: text or json.")
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
@@ -93,7 +93,7 @@ def run_manifest_action(
     if action == "check":
         return check_manifest(ctx, default_manifest, base_manifest, output_format=manifest_action.output_format)
     if action == "doctor":
-        return doctor_manifest(default_manifest, base_manifest)
+        return doctor_manifest(default_manifest, base_manifest, output_format=manifest_action.output_format)
     ctx.log.error("Unsupported base_setup action '%s'. Expected setup, check, or doctor.", action)
     return 2
 
@@ -168,8 +168,15 @@ def check_manifest(
     return 0 if all(check.ok for check in checks) else 1
 
 
-def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest) -> int:
+def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest, output_format: str) -> int:
     checks = manifest_checks(default_manifest, manifest)
+    if output_format == "json":
+        print(json.dumps([check_to_doctor_json(check) for check in checks], indent=2))
+        return min(sum(1 for check in checks if not check.ok), 125)
+    if output_format != "text":
+        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
+        return 2
+
     error_count = 0
     print(f"\nProject doctor: {manifest.project_name}\n")
     for check in checks:
@@ -320,6 +327,15 @@ def check_to_json(check: ArtifactCheck) -> dict[str, str | bool]:
     return {
         "name": check.name,
         "ok": check.ok,
+        "message": check.message,
+        "fix": check.fix,
+    }
+
+
+def check_to_doctor_json(check: ArtifactCheck) -> dict[str, str]:
+    return {
+        "status": "ok" if check.ok else "error",
+        "name": check.name,
         "message": check.message,
         "fix": check.fix,
     }

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import importlib.util
+import json
 import os
 import tempfile
 import unittest
@@ -415,11 +416,33 @@ class ProjectCheckTests(unittest.TestCase):
         )
 
         with redirect_stdout(io.StringIO()) as stdout:
-            status = engine.doctor_manifest(default_manifest, manifest)
+            status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
 
         self.assertEqual(status, 1)
         self.assertIn("Project doctor: demo", stdout.getvalue())
         self.assertIn("Fix: basectl setup demo", stdout.getvalue())
+
+    def test_doctor_manifest_supports_json_output(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(ArtifactRequest(artifact_type="python-package", name="requests", version="latest"),),
+        )
+
+        with redirect_stdout(io.StringIO()) as stdout:
+            status = engine.doctor_manifest(default_manifest, manifest, output_format="json")
+
+        findings = json.loads(stdout.getvalue())
+        self.assertEqual(status, 1)
+        self.assertEqual(findings[0]["status"], "error")
+        self.assertEqual(findings[0]["fix"], "basectl setup demo")
 
 
 class BrewfileTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `--format text|json` support to `basectl doctor`.
- Emit structured Base doctor findings with `status`, `name`, `message`, and `fix` fields.
- Teach the `base_dev` and `base_setup` Python doctor paths to emit JSON findings too.
- Compose project and developer prerequisite doctor findings into `dev_findings` and `project_findings` sections.
- Add Bash integration tests and Python unit coverage, and remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bash -n cli/bash/commands/basectl/subcommands/doctor.sh`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest cli/python/base_dev/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_dev/engine.py cli/python/base_setup/engine.py cli/python/base_dev/tests/test_engine.py cli/python/base_setup/tests/test_engine.py`
- `bin/basectl doctor --format json`
- `git diff --check`