### PR TITLE
Support warning doctor findings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,13 +7,6 @@ they are merged.
 
 ## P0 — Security And Correctness
 
-- [ ] Add warning severity to doctor findings.
-  - Problem: doctor findings are currently effectively binary `ok` or `error`.
-  - Goal: distinguish optional or non-blocking recommendations from setup
-    failures.
-  - Expected behavior: support `warn` findings in Base, dev, and project doctor
-    output; reserve non-zero exit status for blocking `error` findings.
-
 - [ ] Document or harden the Homebrew installer trust decision.
   - Problem: Base follows Homebrew's official mutable `HEAD` installer pattern,
     which executes downloaded code.

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -648,7 +648,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
-    printf '[{"status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""}]\n'
+    printf '[{"status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"}]\n'
     exit 0
 fi
 printf 'unexpected doctor project json python args: %s\n' "$*" >&2
@@ -670,7 +670,7 @@ EOF
     [[ "$output" == *'"ok": true'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_findings":'* ]]
-    [[ "$output" == *'"status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""'* ]]
+    [[ "$output" == *'"status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"'* ]]
     [[ "$output" != *"Running Python project doctor layer."* ]]
     [ "${stderr:-}" = "" ]
 }

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -19,6 +19,7 @@ class DevCheck:
     ok: bool
     message: str
     fix: str
+    status: str = ""
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -113,18 +114,19 @@ def doctor_dev_artifacts(
     )
     if output_format == "json":
         print(json.dumps([check_to_doctor_json(check) for check in checks], indent=2))
-        return min(sum(1 for check in checks if not check.ok), 125)
+        return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
     if output_format != "text":
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
         return 2
 
     error_count = 0
     for check in checks:
-        if check.ok:
-            print_doctor_finding("ok", check.name, check.message)
-        else:
+        status = doctor_status(check)
+        if status == "error":
             print_doctor_finding("error", check.name, check.message, check.fix)
             error_count += 1
+        else:
+            print_doctor_finding(status, check.name, check.message, check.fix)
     return min(error_count, 125)
 
 
@@ -173,11 +175,15 @@ def check_to_json(check: DevCheck) -> dict[str, str | bool]:
 
 def check_to_doctor_json(check: DevCheck) -> dict[str, str]:
     return {
-        "status": "ok" if check.ok else "error",
+        "status": doctor_status(check),
         "name": check.name,
         "message": check.message,
         "fix": check.fix,
     }
+
+
+def doctor_status(check: DevCheck) -> str:
+    return check.status or ("ok" if check.ok else "error")
 
 
 def print_doctor_finding(status: str, name: str, message: str, fix: str = "") -> None:

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -78,6 +78,28 @@ class DevManifestTests(unittest.TestCase):
         self.assertEqual(findings[0]["status"], "error")
         self.assertEqual(findings[0]["fix"], "basectl setup --dev")
 
+    def test_doctor_warning_status_does_not_fail(self) -> None:
+        check = engine.DevCheck(
+            name="optional-tool",
+            ok=False,
+            message="Optional developer tool is not installed.",
+            fix="brew install optional-tool",
+            status="warn",
+        )
+
+        self.assertEqual(engine.doctor_status(check), "warn")
+        self.assertEqual(engine.check_to_doctor_json(check)["status"], "warn")
+
+        manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
+        definitions = engine.resolve_artifact_definitions(manifest.artifacts)
+        with mock.patch("base_dev.engine.check_homebrew_artifact", return_value=check):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                status = engine.doctor_dev_artifacts(manifest.artifacts, definitions, output_format="text")
+
+        self.assertEqual(status, 0)
+        self.assertIn("warn", stdout.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -24,6 +24,7 @@ class ArtifactCheck:
     ok: bool
     message: str
     fix: str
+    status: str = ""
 
 
 @dataclass(frozen=True)
@@ -172,7 +173,7 @@ def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest, outp
     checks = manifest_checks(default_manifest, manifest)
     if output_format == "json":
         print(json.dumps([check_to_doctor_json(check) for check in checks], indent=2))
-        return min(sum(1 for check in checks if not check.ok), 125)
+        return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
     if output_format != "text":
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
         return 2
@@ -180,11 +181,12 @@ def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest, outp
     error_count = 0
     print(f"\nProject doctor: {manifest.project_name}\n")
     for check in checks:
-        if check.ok:
-            print_doctor_finding("ok", check.name, check.message)
-        else:
+        status = doctor_status(check)
+        if status == "error":
             print_doctor_finding("error", check.name, check.message, check.fix)
             error_count += 1
+        else:
+            print_doctor_finding(status, check.name, check.message, check.fix)
     return min(error_count, 125)
 
 
@@ -334,11 +336,15 @@ def check_to_json(check: ArtifactCheck) -> dict[str, str | bool]:
 
 def check_to_doctor_json(check: ArtifactCheck) -> dict[str, str]:
     return {
-        "status": "ok" if check.ok else "error",
+        "status": doctor_status(check),
         "name": check.name,
         "message": check.message,
         "fix": check.fix,
     }
+
+
+def doctor_status(check: ArtifactCheck) -> str:
+    return check.status or ("ok" if check.ok else "error")
 
 
 def print_doctor_finding(status: str, name: str, message: str, fix: str = "") -> None:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -444,6 +444,38 @@ class ProjectCheckTests(unittest.TestCase):
         self.assertEqual(findings[0]["status"], "error")
         self.assertEqual(findings[0]["fix"], "basectl setup demo")
 
+    def test_doctor_warning_status_does_not_fail(self) -> None:
+        check = engine.ArtifactCheck(
+            name="optional-artifact",
+            ok=False,
+            message="Optional project artifact is not installed.",
+            fix="basectl setup demo",
+            status="warn",
+        )
+
+        self.assertEqual(engine.doctor_status(check), "warn")
+        self.assertEqual(engine.check_to_doctor_json(check)["status"], "warn")
+
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+        with mock.patch("base_setup.engine.manifest_checks", return_value=(check,)):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
+
+        self.assertEqual(status, 0)
+        self.assertIn("warn", stdout.getvalue())
+
 
 class BrewfileTests(unittest.TestCase):
     def test_brewfile_dry_run_invokes_brew_bundle(self) -> None:


### PR DESCRIPTION
## Summary
- Add an explicit doctor `status` field to dev and project artifact checks.
- Preserve existing `ok`/`error` behavior when no explicit status is set.
- Allow `warn` findings in text and JSON doctor output without contributing to non-zero exit status.
- Add Python unit coverage for warning status behavior and Bash integration coverage for warning pass-through in project doctor JSON.
- Remove the completed TODO item.

## Validation
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest cli/python/base_dev/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_dev/engine.py cli/python/base_setup/engine.py cli/python/base_dev/tests/test_engine.py cli/python/base_setup/tests/test_engine.py`
- `bash -n cli/bash/commands/basectl/subcommands/doctor.sh`
- `bin/basectl doctor --format json`
- `git diff --check`