### PR TITLE
Speed up setup hot paths

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -138,31 +138,6 @@ they are merged.
 
 ## P3 — Performance And CI Hardening
 
-- [ ] Speed up Homebrew Python discovery.
-  - Problem: `brew --prefix <formula>` adds noticeable startup cost to setup and
-    check runs.
-  - Goal: check known Homebrew opt paths before invoking `brew --prefix`.
-  - Expected behavior: try `/opt/homebrew/opt/<formula>/bin/python3` and
-    `/usr/local/opt/<formula>/bin/python3` first, then fall back to Homebrew.
-
-- [ ] Speed up Xcode Command Line Tools detection.
-  - Problem: `xcrun -f clang` can be slow because it validates the active
-    toolchain.
-  - Goal: replace the slow probe with direct filesystem checks when reliable.
-  - Expected behavior: after `xcode-select -p` and the configured tools
-    directory exist, check for `usr/bin/clang` under the tools directory.
-
-- [ ] Optimize Bash log caller detection.
-  - Problem: `_print_log` walks the caller stack on every log call.
-  - Goal: use `BASH_SOURCE` and `BASH_LINENO` fast paths for common direct
-    callers and keep the stack walk only as a rare fallback.
-
-- [ ] Reduce repeated subshell calls for setup paths.
-  - Problem: helpers such as `setup_venv_dir` and `setup_pythonpath` are often
-    called through command substitution even though they build deterministic
-    strings.
-  - Goal: cache or initialize these values once per command run.
-
 - [ ] Evaluate parallelizing independent `basectl check` probes.
   - Goal: reduce check wall time by running independent probes concurrently.
   - Expected behavior: preserve deterministic output order while collecting

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -100,7 +100,8 @@ base_doctor_check_python() {
 base_doctor_check_virtualenv() {
     local venv_dir
 
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     if setup_virtualenv_exists; then
         base_doctor_print_finding "ok" "Base virtualenv" "Virtual environment exists at '$venv_dir'."
         return 0
@@ -138,7 +139,8 @@ base_doctor_run_json() {
 
     click_package="$(setup_click_package)"
     pyyaml_package="$(setup_pyyaml_package)"
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
 
     if brew_bin="$(setup_find_brew_bin)"; then
         if setup_refresh_brew_path; then

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -17,10 +17,33 @@
 _base_setup_common_sourced=1
 readonly _base_setup_common_sourced
 
+_BASE_SETUP_VENV_DIR_CACHE=""
+_BASE_SETUP_PYTHONPATH_CACHE=""
+
+setup_refresh_cached_paths() {
+    local base_pythonpath old_pythonpath
+
+    _BASE_SETUP_VENV_DIR_CACHE="${BASE_SETUP_VENV_DIR:-$HOME/.base.d/base/.venv}"
+
+    base_pythonpath="$BASE_HOME/lib/python:$BASE_HOME/cli/python"
+    old_pythonpath="${PYTHONPATH-}"
+    if [[ -n "$old_pythonpath" ]]; then
+        base_pythonpath="$base_pythonpath:$old_pythonpath"
+    fi
+    _BASE_SETUP_PYTHONPATH_CACHE="$base_pythonpath"
+}
+
+setup_ensure_cached_paths() {
+    if [[ -z "${_BASE_SETUP_VENV_DIR_CACHE:-}" || -z "${_BASE_SETUP_PYTHONPATH_CACHE:-}" ]]; then
+        setup_refresh_cached_paths
+    fi
+}
+
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
     unset dry_run DRY_RUN BASE_SETUP_DEV BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_RECREATE_VENV BASE_PROJECT
+    setup_refresh_cached_paths
 }
 
 setup_enable_dry_run() {
@@ -76,19 +99,22 @@ setup_notifications_forced() {
 setup_virtualenv_exists() {
     local venv_dir
 
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     [[ -f "$venv_dir/bin/activate" || -f "$venv_dir/pyvenv.cfg" ]]
 }
 
 setup_venv_dir() {
-    printf '%s\n' "${BASE_SETUP_VENV_DIR:-$HOME/.base.d/base/.venv}"
+    setup_ensure_cached_paths
+    printf '%s\n' "$_BASE_SETUP_VENV_DIR_CACHE"
 }
 
 setup_backup_existing_venv_path() {
     local backup_path description timestamp venv_dir
 
     description="${1:-existing path}"
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     [[ -e "$venv_dir" ]] || return 0
 
     timestamp="$(date +%Y%m%dT%H%M%S)"
@@ -295,7 +321,7 @@ setup_xcode_tools_installed() {
     tools_dir="$(setup_xcode_tools_dir)"
     xcode-select -p >/dev/null 2>&1 &&
         [[ -d "$tools_dir" ]] &&
-        xcrun -f clang >/dev/null 2>&1
+        [[ -f "$tools_dir/usr/bin/clang" ]]
 }
 
 setup_install_xcode_tools() {
@@ -373,6 +399,17 @@ setup_find_python_bin() {
     fi
 
     formula="$(setup_python_formula)"
+    candidates+=("/opt/homebrew/opt/$formula/bin/python3")
+    candidates+=("/usr/local/opt/$formula/bin/python3")
+
+    for candidate in "${candidates[@]}"; do
+        if [[ -x "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    candidates=()
     if command -v brew >/dev/null 2>&1; then
         prefix="$(brew --prefix "$formula" 2>/dev/null || true)"
         if [[ -n "$prefix" ]]; then
@@ -402,7 +439,8 @@ setup_find_python_bin() {
 setup_create_virtualenv() {
     local venv_dir python_bin
 
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
 
     if setup_virtualenv_exists && ! setup_recreate_venv_enabled; then
         log_info "Virtual environment already exists at '$venv_dir'."
@@ -443,7 +481,8 @@ setup_base_python_package_installed() {
         return 1
     fi
 
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1
     "$python_bin" -m pip show "$package" >/dev/null 2>&1
 }
@@ -452,7 +491,8 @@ setup_install_base_python_package() {
     local package="$1"
     local venv_dir python_bin
 
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
 
     if setup_base_python_package_installed "$package"; then
         log_info "Python package '$package' is already installed in the Base virtual environment."
@@ -490,14 +530,8 @@ setup_base_python_package_check_message() {
 }
 
 setup_pythonpath() {
-    local base_pythonpath old_pythonpath
-
-    base_pythonpath="$BASE_HOME/lib/python:$BASE_HOME/cli/python"
-    old_pythonpath="${PYTHONPATH-}"
-    if [[ -n "$old_pythonpath" ]]; then
-        base_pythonpath="$base_pythonpath:$old_pythonpath"
-    fi
-    printf '%s\n' "$base_pythonpath"
+    setup_ensure_cached_paths
+    printf '%s\n' "$_BASE_SETUP_PYTHONPATH_CACHE"
 }
 
 setup_resolve_project_manifest() {
@@ -515,8 +549,9 @@ setup_resolve_project_manifest() {
         return 0
     fi
 
+    setup_ensure_cached_paths
     resolve_output="$(
-        env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$(setup_pythonpath)" \
+        env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
             "$python_bin" -m base_projects resolve "$project"
     )" || return 1
 
@@ -542,7 +577,8 @@ setup_run_project_artifact_layer() {
     fi
 
     project="${BASE_SETUP_PROJECT_NAME:-base}"
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
     resolve_output="$(setup_resolve_project_manifest "$project" "$python_bin")" || {
         log_error "Unable to resolve Base project '$project'."
@@ -572,7 +608,7 @@ setup_run_project_artifact_layer() {
         log_info "Running Python project $action layer."
     fi
 
-    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$(setup_pythonpath)" "$python_bin" -m base_setup "${args[@]}"
+    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" "$python_bin" -m base_setup "${args[@]}"
     exit_code=$?
 
     if ((exit_code)) && [[ "$action" == setup ]]; then
@@ -616,7 +652,8 @@ setup_run_base_dev_layer() {
         return 0
     fi
 
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     if ! setup_base_venv_python_bin "$venv_dir" >/dev/null 2>&1; then
         log_warn "Python developer prerequisite layer cannot run because Base virtual environment Python was not found at '$venv_dir/bin/python'."
         log_warn "$(setup_recovery_venv)"
@@ -633,7 +670,8 @@ setup_run_check() {
     setup_require_macos
     click_package="$(setup_click_package)"
     pyyaml_package="$(setup_pyyaml_package)"
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
 
     if brew_bin="$(setup_find_brew_bin)"; then
         setup_refresh_brew_path || fatal_error "Homebrew is installed, but its bin directory could not be added to PATH. $(setup_recovery_brew_path)"
@@ -802,7 +840,8 @@ setup_run_check_json() {
     setup_require_macos
     click_package="$(setup_click_package)"
     pyyaml_package="$(setup_pyyaml_package)"
-    venv_dir="$(setup_venv_dir)"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
 
     if brew_bin="$(setup_find_brew_bin)"; then
         if setup_refresh_brew_path; then

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -411,7 +411,8 @@ fi
 exit 1
 EOF
     chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$fake_bin/gh" "$venv_python"
-    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
 
     run env \
@@ -480,7 +481,8 @@ fi
 exit 1
 EOF
     chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
-    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
 
     run env \
@@ -582,7 +584,8 @@ printf 'unexpected doctor project python args: %s\n' "$*" >&2
 exit 1
 EOF
     chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
-    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
 
     run env \
@@ -655,7 +658,8 @@ printf 'unexpected doctor project json python args: %s\n' "$*" >&2
 exit 1
 EOF
     chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
-    mkdir -p "$TEST_TMPDIR/xcode-tools"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
 
     run --separate-stderr env \

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -24,6 +24,8 @@ installed_file="$state_dir/xcode-installed"
 case "${1:-}" in
     -p)
         if [[ -f "$installed_file" ]]; then
+            mkdir -p "$tools_dir/usr/bin"
+            touch "$tools_dir/usr/bin/clang"
             printf '%s\n' "$tools_dir"
             exit 0
         fi
@@ -31,7 +33,8 @@ case "${1:-}" in
         ;;
     --install)
         touch "$installed_file"
-        mkdir -p "$tools_dir"
+        mkdir -p "$tools_dir/usr/bin"
+        touch "$tools_dir/usr/bin/clang"
         exit 0
         ;;
     *)

--- a/lib/bash/runtime/tests/runtime_bashrc.bats
+++ b/lib/bash/runtime/tests/runtime_bashrc.bats
@@ -28,7 +28,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"USER_BASHRC_HAS_BASE_IMPORT=1"* ]]
     [[ "$output" == *"BASE_SHELL=1"* ]]
-    [[ "$output" == *'PS1=\T $(_base_runtime_host_prompt) $(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
+    [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 
 @test "runtime bashrc sources baserc debug preferences" {

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -393,16 +393,21 @@ _print_log() {
             *)           color="";; # No color for VERBOSE or others
         esac
 
-        local source_path="" source_line="" frame=1 caller_info caller_line _caller_func caller_file
-        while caller_info=$(caller "$frame"); do
-            read -r caller_line _caller_func caller_file <<<"$caller_info"
-            if [[ -n "$caller_file" && "$caller_file" != "$__LIB_STD_PATH__" ]]; then
-                source_path="$caller_file"
-                source_line="$caller_line"
-                break
-            fi
-            ((frame++))
-        done
+        local source_path="${BASH_SOURCE[2]:-}" source_line="${BASH_LINENO[1]:-0}"
+        local frame=1 caller_info caller_line _caller_func caller_file
+        if [[ -z "$source_path" || "$source_path" == "$__LIB_STD_PATH__" ]]; then
+            source_path=""
+            source_line=""
+            while caller_info=$(caller "$frame"); do
+                read -r caller_line _caller_func caller_file <<<"$caller_info"
+                if [[ -n "$caller_file" && "$caller_file" != "$__LIB_STD_PATH__" ]]; then
+                    source_path="$caller_file"
+                    source_line="$caller_line"
+                    break
+                fi
+                ((frame++))
+            done
+        fi
 
         if [[ -z "$source_path" ]]; then
             source_path="${BASH_SOURCE[2]:-${BASH_SOURCE[1]:-${BASH_SOURCE[0]:-unknown}}}"


### PR DESCRIPTION
## Summary

- Check canonical Homebrew Python locations before paying the `brew --prefix` cost.
- Replace the slow `xcrun -f clang` Xcode CLT probe with a direct `usr/bin/clang` filesystem check under the configured tools directory.
- Cache setup venv/PYTHONPATH values and use those cached values in setup/check/doctor hot paths.
- Add a fast-path for Bash log caller detection using `BASH_SOURCE`/`BASH_LINENO`, keeping the existing stack walk as fallback.
- Update tests for the direct CLT probe and remove the completed P3 TODOs.

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bash -n cli/bash/commands/basectl/subcommands/doctor.sh`
- `bash -n lib/bash/std/lib_std.sh`
- `git diff --check`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bats lib/bash/std/tests/lib_std.bats`
- Full BATS suite: 205 tests passed
- `bin/basectl check`
- `bin/basectl setup --dry-run`