### PR TITLE
Mark bootstrap default artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ The supported artifact registry lives in
 delegation. Pinned Homebrew versions fail clearly until Base grows explicit
 versioned tool support.
 
+Artifacts may include `bootstrap: true` when they are part of the minimum Python
+runtime contract needed before Base can reconcile a project's remaining
+artifacts. Base currently uses this marker in `lib/base/default_manifest.yaml`
+for `click` and `PyYAML`.
+
 You can inspect the projects Base can see with:
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -91,6 +91,8 @@ they are merged.
   - Expected behavior: use `"$BASE_HOME/bin/base-wrapper" --project <project>
     base_setup ...` while preserving manifest resolution and JSON stdout
     cleanliness.
+  - Bootstrap note: `lib/base/default_manifest.yaml` marks the minimum Python
+    packages required before this project-scoped invocation can run.
 
 - [ ] Add successful command debug logging in the Python setup engine.
   - Problem: `run_command` logs failures but has no `ctx`, so successful command

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -385,6 +385,13 @@ def merge_artifacts(
                 f"'{artifact.name}' of type '{artifact.artifact_type}' is declared by defaults "
                 f"as version '{existing.version}' and by the project manifest as version '{artifact.version}'."
             )
+        if existing is not None:
+            artifact = ArtifactRequest(
+                artifact_type=artifact.artifact_type,
+                name=artifact.name,
+                version=artifact.version,
+                bootstrap=existing.bootstrap or artifact.bootstrap,
+            )
         merged[key] = artifact
 
     return tuple(merged.values())

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -22,6 +22,7 @@ class ArtifactRequest:
     artifact_type: str
     name: str
     version: str
+    bootstrap: bool = False
 
 
 @dataclass(frozen=True)
@@ -100,14 +101,15 @@ def _read_artifact(path: Path, artifact_data: Any, index: int) -> ArtifactReques
     if not isinstance(artifact_data, dict):
         raise ManifestError(f"{path}: artifacts[{index}] must be a mapping.")
 
-    allowed_artifact_keys = {"type", "name", "version"}
+    required_artifact_keys = {"type", "name", "version"}
+    allowed_artifact_keys = required_artifact_keys | {"bootstrap"}
     unknown_artifact_keys = sorted(set(artifact_data) - allowed_artifact_keys)
     if unknown_artifact_keys:
         raise ManifestError(
             f"{path}: artifacts[{index}] has unsupported keys: {', '.join(unknown_artifact_keys)}."
         )
 
-    missing = sorted(key for key in allowed_artifact_keys if not artifact_data.get(key))
+    missing = sorted(key for key in required_artifact_keys if not artifact_data.get(key))
     if missing:
         raise ManifestError(f"{path}: artifacts[{index}] is missing required keys: {', '.join(missing)}.")
 
@@ -116,9 +118,13 @@ def _read_artifact(path: Path, artifact_data: Any, index: int) -> ArtifactReques
     version = artifact_data["version"]
     if not all(isinstance(value, str) for value in (artifact_type, name, version)):
         raise ManifestError(f"{path}: artifacts[{index}] type, name, and version must be strings.")
+    bootstrap = artifact_data.get("bootstrap", False)
+    if not isinstance(bootstrap, bool):
+        raise ManifestError(f"{path}: artifacts[{index}] bootstrap must be a boolean when provided.")
 
     return ArtifactRequest(
         artifact_type=artifact_type,
         name=name,
         version=version,
+        bootstrap=bootstrap,
     )

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 from base_setup import engine
 from base_setup.engine import ArtifactError, format_command, main, merge_artifacts
-from base_setup.manifest import ArtifactRequest, BaseManifest
+from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError
 from base_setup.manifest import read_manifest
 from base_setup.registry import get_artifact_definition
 
@@ -45,10 +45,10 @@ class ManifestTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            [(artifact.artifact_type, artifact.name, artifact.version) for artifact in merged],
+            [(artifact.artifact_type, artifact.name, artifact.version, artifact.bootstrap) for artifact in merged],
             [
-                ("python-package", "click", "8.4.1"),
-                ("tool", "terraform", "1.8.5"),
+                ("python-package", "click", "8.4.1", False),
+                ("tool", "terraform", "1.8.5", False),
             ],
         )
 
@@ -94,6 +94,7 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(manifest.artifacts[0].artifact_type, "tool")
         self.assertEqual(manifest.artifacts[0].name, "terraform")
         self.assertEqual(manifest.artifacts[0].version, "1.8.5")
+        self.assertFalse(manifest.artifacts[0].bootstrap)
 
     def test_reads_manifest_brewfile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -355,6 +356,79 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("Project 'demo' declares no artifacts; installing Base default artifacts only.", stderr)
+
+
+class BootstrapManifestTests(unittest.TestCase):
+    def test_merge_artifacts_preserves_default_bootstrap_marker(self) -> None:
+        merged = merge_artifacts(
+            (
+                ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1", bootstrap=True),
+            ),
+            (
+                ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1"),
+            ),
+        )
+
+        self.assertTrue(merged[0].bootstrap)
+
+    def test_reads_bootstrap_artifact_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: python-package",
+                        "    name: click",
+                        "    version: \"8.4.1\"",
+                        "    bootstrap: true",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertTrue(manifest.artifacts[0].bootstrap)
+
+    def test_rejects_non_boolean_bootstrap_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: python-package",
+                        "    name: click",
+                        "    version: \"8.4.1\"",
+                        "    bootstrap: \"yes\"",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "bootstrap must be a boolean"):
+                read_manifest(manifest_path)
+
+    def test_default_manifest_marks_python_bootstrap_packages(self) -> None:
+        manifest = read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "default_manifest.yaml")
+        bootstrap_artifacts = {
+            (artifact.artifact_type, artifact.name): artifact.bootstrap for artifact in manifest.artifacts
+        }
+
+        self.assertEqual(
+            bootstrap_artifacts,
+            {
+                ("python-package", "click"): True,
+                ("python-package", "PyYAML"): True,
+            },
+        )
 
 
 class ProjectCheckTests(unittest.TestCase):

--- a/docs/design.md
+++ b/docs/design.md
@@ -367,6 +367,11 @@ silently installing a different version. New ordinary Homebrew tools should
 prefer Brewfile delegation over registry growth. Richer version conflict
 handling across projects is a later iteration, not part of the initial build.
 
+Default artifacts can be marked with `bootstrap: true` when they are required to
+run Base's Python CLI layer inside a project virtual environment before the rest
+of that project's artifacts are reconciled. In the current default manifest,
+`click` and `PyYAML` carry this marker.
+
 Artifact install commands keep stdout attached to the terminal so long-running
 tools such as `brew` and `pip` remain live and readable while setup runs. Base's
 persistent log records the command intent and captures stderr on failures. If

--- a/lib/base/default_manifest.yaml
+++ b/lib/base/default_manifest.yaml
@@ -5,7 +5,9 @@ artifacts:
   - type: python-package
     name: click
     version: "8.4.1"
+    bootstrap: true
 
   - type: python-package
     name: PyYAML
     version: "6.0.3"
+    bootstrap: true


### PR DESCRIPTION
## Summary

- Add an optional boolean `bootstrap` field to artifact manifest entries.
- Mark `click` and `PyYAML` as bootstrap artifacts in `lib/base/default_manifest.yaml`.
- Preserve bootstrap metadata when default artifacts are merged with duplicate project declarations at the same version.
- Document the marker in README/design docs and note it on the wrapper TODO.

## Validation

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m py_compile cli/python/base_setup/manifest.py cli/python/base_setup/engine.py`
- `git diff --check`
- `bin/basectl check`
- `bin/basectl setup --dry-run`