### PR TITLE
Run project artifact layer through base-wrapper

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -1,87 +1,125 @@
 # AI Context
 
-This file is the shared working memory for future AI-assisted development in this repository. Keep it current when project direction, recent fixes, or useful debugging context changes.
+This file is shared working memory for future AI-assisted development in this
+repository. Keep it current when project direction, execution model, or useful
+debugging context changes.
 
 ## Current State
 
-- Branch: `hpr/fix-claude-findings2`.
-- Current work is moving through `TODO.md`, which tracks Claude's code-analysis findings item by item.
-- New in-progress feature work adds the first artifact setup layer: root
-  `base_manifest.yaml`, a Python `base_setup` package under `cli/python/`, and
-  a Bash setup handoff after Base bootstrap.
-- The Bash setup layer seeds Base's own project virtual environment at
-  `~/.base.d/base/.venv` with PyYAML and Click before invoking Python setup.
-- Current in-progress work rewrites `docs/base-cli-design.md` around explicit
-  `base_cli.App`/`Context` initialization and starts v1 under `lib/python/base_cli/`.
-  Click is a Base Python bootstrap dependency installed into `~/.base.d/base/.venv`.
-- Most recent local work dogfoods `base_cli` in `base_setup`: the Python setup
-  engine now uses `base_cli.App`, `base_cli.argument`, `base_cli.option`, and
-  `Context` logging while preserving the existing module CLI shape.
-- `bin/base-wrapper` is the single Python command wrapper, uses
-  `~/.base.d/<project>/.venv`, and invokes package commands such as
-  `base_setup`. Base itself uses project name `base`.
-- Default project artifacts are declared in `lib/base/default_manifest.yaml`
-  using the same manifest shape as project manifests; the Python setup layer
-  merges defaults with the project manifest before reconciling artifacts.
-- Artifact manifests declare `project.name` and `artifacts` with `type`, `name`,
-  and `version`; users do not specify managers. The Python registry maps known
-  `(type, name)` pairs to managers and errors on unknown artifacts.
-- Most recent uncommitted change makes `caff` PID detection more robust:
-  `pgrep` results are captured without `head`, pgrep errors are reported
-  separately from "not running", and existing caffeinate commands are parsed
-  for `-w` PIDs across multiple argument shapes.
-- The previous change makes `basectl shell` reject unexpected arguments with a usage error instead of silently ignoring them.
-- The previous change added the supported `--version` flag to `basectl --help`.
-- The previous change consolidated `basectl setup` dry-run state on exported `DRY_RUN` while still clearing legacy inherited `dry_run`.
-- The previous change consolidated Base version reading in `lib/bash/version/lib_version.sh`, shared by early `basectl --version` handling and the runtime `basectl version` command.
-- `lib/bash/version` and `lib/bash/runtime` now have local README files and colocated BATS coverage, in addition to existing basectl integration coverage.
-- Confirmed there are no symlinked snippets in the repo; `basectl update-profile` writes direct `source $BASE_HOME/lib/shell/<snippet>` lines into managed dotfile sections.
-- The recent extension cleanup is considered complete.
-- The broader development thread remains improving focused tests and startup/public utility coverage while closing TODO items in small commits.
-
-## Project Shape
-
-- Base is a macOS-first developer tooling foundation for a multi-repo workspace.
+- Base is a macOS-first developer tooling foundation for multi-repo workspaces.
+- Current work is moving through `TODO.md`, which tracks May 2026 product-review
+  follow-ups by priority.
 - Public commands live in `bin/`; `bin/basectl` is the control-plane command.
 - Command implementations live under `cli/bash/commands/<command>/`.
 - Shared Bash libraries live under `lib/bash/`.
+- Shared Python libraries live under `lib/python/`.
+- Python command packages live under `cli/python/`.
 - Shell startup snippets live under `lib/shell/`.
-- `basectl update-profile` manages marked sections in `~/.bash_profile`, `~/.bashrc`, `~/.zprofile`, and `~/.zshrc`.
-- `~/.base.d/profile.conf` records whether optional Bash/Zsh defaults are enabled.
-- `~/.baserc` is user-managed and may set startup-safe preferences such as `BASE_DEBUG=1`, but must not set Base-owned variables like `BASE_HOME` or `BASE_ENABLE_BASH_DEFAULTS`.
+- Durable Base state lives under `~/.base.d`; project virtual environments live
+  at `~/.base.d/<project>/.venv`.
+- Runtime cache/log/temp data lives under the Base cache root, which defaults to
+  `~/Library/Caches/base` on macOS.
+
+## Artifact Setup Model
+
+- Projects declare `base_manifest.yaml` at the repo root.
+- `base_manifest.yaml` declares `project.name`, optional `brewfile`, and
+  `artifacts` with `type`, `name`, `version`, and optional `bootstrap`.
+- Users do not specify artifact managers. The Python registry maps supported
+  `(type, name)` pairs to managers and errors on unknown artifacts.
+- Default project artifacts are declared in `lib/base/default_manifest.yaml`
+  using the same manifest shape as project manifests.
+- `click` and `PyYAML` are marked `bootstrap: true` in
+  `lib/base/default_manifest.yaml`; they are the minimum Python packages needed
+  before Base can run its Python CLI layer inside a project venv.
+- `basectl setup` first ensures Base's own venv exists at
+  `~/.base.d/base/.venv` and installs Base bootstrap packages there from Bash.
+- For project artifact setup, Bash resolves the project manifest using Base's
+  venv, runs `base_setup --action bootstrap` from Base's venv to seed the
+  project's venv with `bootstrap: true` default artifacts, then invokes:
+
+```bash
+base-wrapper --project <project> base_setup ...
+```
+
+- `basectl check <project>` and `basectl doctor <project>` also run the project
+  artifact layer through `base-wrapper`, but remain non-mutating. If the project
+  venv is missing, they report the missing project runtime instead of creating
+  it.
+- `python-package` artifacts install into the project virtual environment at
+  `~/.base.d/<project>/.venv`.
+- Homebrew `tool` artifacts currently support `version: latest`; ordinary
+  Homebrew packages should move toward Brewfile delegation instead of registry
+  growth.
+
+## Python CLI Model
+
+- `lib/python/base_cli` provides the standard Python CLI framework:
+  `base_cli.App`, decorators, `Context`, logging, and runtime directories.
+- `bin/base-wrapper` is the authoritative Python command wrapper. It selects
+  `~/.base.d/<project>/.venv`, sets `BASE_HOME` and `BASE_PROJECT`, adds
+  `lib/python` and `cli/python` to `PYTHONPATH`, and executes package commands
+  with `python -m <package>`.
+- Base itself uses project name `base`.
+- End users normally invoke `basectl` or project `bin/` launchers rather than
+  calling Python packages directly.
 
 ## Shell Startup Model
 
+- `basectl update-profile` manages marked sections in `~/.bash_profile`,
+  `~/.bashrc`, `~/.zprofile`, and `~/.zshrc`.
 - Managed login/interactive snippets must not source `base_init.sh`.
 - `lib/shell/bash_profile` only bridges Bash login shells into `~/.bashrc`.
-- `lib/shell/bashrc` derives `BASE_HOME`, prepends `$BASE_HOME/bin` to `PATH`, reads optional defaults from `profile.conf`, and sources `lib/shell/bash_defaults.sh` only when defaults are enabled.
+- `lib/shell/bashrc` derives `BASE_HOME`, prepends `$BASE_HOME/bin` to `PATH`,
+  reads optional defaults from `~/.base.d/profile.conf`, and sources
+  `lib/shell/bash_defaults.sh` only when defaults are enabled.
 - `lib/shell/zshrc` mirrors the same integration model for Zsh.
-- `lib/bash/runtime/bashrc` is separate from managed dotfiles and is used by `basectl shell`; it sources `base_init.sh`, then user `~/.bashrc`, then owns the final runtime prompt.
+- `~/.baserc` is user-managed and may set startup-safe preferences such as
+  `BASE_DEBUG=1`, but must not set Base-owned variables like `BASE_HOME` or
+  `BASE_ENABLE_BASH_DEFAULTS`.
+- `basectl activate <project>` starts a runtime shell using
+  `lib/bash/runtime/bashrc`; that runtime sources `base_init.sh`, loads the user
+  shell config, activates the project venv, and owns the final runtime prompt.
+- Invoking `basectl` with no command in an interactive terminal is equivalent to
+  `basectl activate base`.
 
-## Recent Bug Context
+## Useful Validation
 
-- Previously observed bug: after `basectl update-profile` and `exec bash`, the prompt inside `/Users/rameshhp/work/base` did not show the git branch.
-- `basectl shell` did show the branch because it uses `lib/bash/runtime/bashrc`, whose prompt calls `_base_runtime_git_prompt`.
-- Root cause: normal Bash shells with optional Base defaults use `lib/shell/bash_defaults.sh`, whose prompt only showed time, host, and cwd.
-- Fix: keep ordinary shell startup separate from runtime bootstrap, but make `bash_defaults.sh` include a small dynamic git prompt helper so normal interactive Bash defaults show the active repo branch.
+- Full Bash test suite:
 
-## Current TODO Progress
+```bash
+bats lib/bash/git/tests/lib_git.bats \
+  lib/bash/version/tests/lib_version.bats \
+  lib/bash/std/tests/lib_std.bats \
+  lib/bash/runtime/tests/runtime_bashrc.bats \
+  lib/bash/file/tests/lib_file.bats \
+  cli/bash/commands/sort-in-place/tests/sort-in-place.bats \
+  cli/bash/commands/basectl/tests/setup.bats \
+  cli/bash/commands/basectl/tests/basectl.bats \
+  cli/bash/commands/caff/tests/caff.bats
+```
 
-- Completed and committed: Claude findings TODO list, `_git_only_path_dirty` directory matching, `sort-in-place` flag quoting, `update_file_section` temp cleanup, wrapper runtime flag documentation, simplified shell snippet path discovery, and shared version reading.
-- Current uncommitted TODO item: add a CLI path to disable profile defaults.
-- Next likely TODO item after that commit: remove interactive Bash upgrade behavior from `lib_std.sh`.
-
-## Testing Notes
-
-- Tests are BATS-based.
-- Shared BATS helper: `lib/bash/tests/test_helper.sh`.
-- Main basectl startup/profile coverage: `cli/bash/commands/basectl/tests/setup.bats`.
-- Runtime shell prompt coverage: `cli/bash/commands/basectl/tests/basectl.bats`.
-- Good focused verification after startup changes:
+- Focused setup/control-plane validation:
 
 ```bash
 bats cli/bash/commands/basectl/tests/setup.bats
 bats cli/bash/commands/basectl/tests/basectl.bats
 ```
 
-- Latest verification in this session: full BATS suite passed, 137 tests with the existing pseudo-tty `wait_for_enter` case skipped.
+- Python setup validation:
+
+```bash
+env PYTHONPATH=lib/python:cli/python \
+  ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine
+
+env PYTHONPATH=lib/python:cli/python \
+  ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc \
+  cli/python/base_setup/engine.py cli/python/base_setup/tests/test_engine.py
+```
+
+- Smoke validation:
+
+```bash
+bin/basectl check
+bin/basectl setup --dry-run
+```

--- a/README.md
+++ b/README.md
@@ -258,8 +258,10 @@ exec "$BASE_HOME/bin/base-wrapper" --project "${BASE_PROJECT:-example}" example_
 reproducible across machines. The current default is `python@3.13`. Override it
 with `BASE_SETUP_PYTHON_FORMULA` when a workspace needs a different formula.
 After this Bash bootstrap layer creates Base's own Python environment, setup
-installs `PyYAML` into that environment and invokes the Python project setup
-layer to read `base_manifest.yaml` and reconcile project artifacts.
+installs Base bootstrap Python packages into that environment. For project
+artifact setup, Base first seeds the target project venv with `bootstrap: true`
+default artifacts and then invokes the Python project setup layer through
+`base-wrapper --project <project>`.
 Developer prerequisites such as BATS and the GitHub CLI are opt-in and
 manifest-driven through `lib/base/dev_manifest.yaml`; use `basectl setup --dev`
 to install them and `basectl check --dev` or `basectl doctor --dev` to verify

--- a/TODO.md
+++ b/TODO.md
@@ -84,16 +84,6 @@ they are merged.
 
 ## P2 — Operational Excellence
 
-- [ ] Route project artifact setup/check/doctor through `base-wrapper`.
-  - Problem: `setup_run_base_dev_layer` uses `base-wrapper`, but the project
-    artifact layer still invokes Python directly with a hand-built `PYTHONPATH`.
-  - Goal: make `base-wrapper` the single authoritative Python invocation path.
-  - Expected behavior: use `"$BASE_HOME/bin/base-wrapper" --project <project>
-    base_setup ...` while preserving manifest resolution and JSON stdout
-    cleanliness.
-  - Bootstrap note: `lib/base/default_manifest.yaml` marks the minimum Python
-    packages required before this project-scoped invocation can run.
-
 - [ ] Add successful command debug logging in the Python setup engine.
   - Problem: `run_command` logs failures but has no `ctx`, so successful command
     completion is silent beyond the caller's "installing..." message.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -561,8 +561,56 @@ setup_resolve_project_manifest() {
     printf '%s\t%s\n' "$resolved_root" "$resolved_manifest"
 }
 
+setup_project_venv_dir() {
+    local project="$1"
+
+    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+        printf '%s\n' "$BASE_PROJECT_VENV_DIR"
+        return 0
+    fi
+    printf '%s\n' "$HOME/.base.d/$project/.venv"
+}
+
+setup_project_venv_python_bin() {
+    local project="$1"
+    local venv_dir
+
+    venv_dir="$(setup_project_venv_dir "$project")"
+    [[ -x "$venv_dir/bin/python" ]] || return 1
+    printf '%s\n' "$venv_dir/bin/python"
+}
+
 setup_run_project_artifact_setup() {
     setup_run_project_artifact_layer setup text
+}
+
+setup_run_project_bootstrap_layer() {
+    local manifest_path="$1"
+    local project="$2"
+    local output_format="$3"
+    local python_bin venv_dir
+    local args=()
+
+    if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
+        log_info "[DRY-RUN] Would bootstrap project Python runtime after PyYAML is installed."
+        return 0
+    fi
+
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
+
+    if setup_is_dry_run; then
+        args+=(--dry-run)
+    fi
+    args+=(--manifest "$manifest_path" --action bootstrap "$project")
+
+    if [[ "$output_format" != json ]]; then
+        log_info "Bootstrapping Python runtime for project '$project'."
+    fi
+
+    setup_ensure_cached_paths
+    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" "$python_bin" -m base_setup "${args[@]}"
 }
 
 setup_run_project_artifact_layer() {
@@ -608,7 +656,29 @@ setup_run_project_artifact_layer() {
         log_info "Running Python project $action layer."
     fi
 
-    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" "$python_bin" -m base_setup "${args[@]}"
+    if [[ "$action" == setup ]]; then
+        setup_run_project_bootstrap_layer "$manifest_path" "$project" "$output_format"
+        exit_code=$?
+        if ((exit_code)); then
+            log_error "$(setup_recovery_project_layer)"
+            log_error "Python project $action layer failed."
+            return "$exit_code"
+        fi
+    fi
+
+    if ! setup_project_venv_python_bin "$project" >/dev/null 2>&1; then
+        if setup_is_dry_run && [[ "$action" == setup ]]; then
+            log_info "[DRY-RUN] Would run Python project setup layer through base-wrapper for project '$project'."
+            return 0
+        fi
+        if [[ "$output_format" != json ]]; then
+            log_warn "Project virtual environment Python was not found at '$(setup_project_venv_dir "$project")/bin/python'."
+            log_warn "Run 'basectl setup $project' to bootstrap the project virtual environment."
+        fi
+        return 1
+    fi
+
+    "$BASE_HOME/bin/base-wrapper" --project "$project" base_setup "${args[@]}"
     exit_code=$?
 
     if ((exit_code)) && [[ "$action" == setup ]]; then

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -531,10 +531,11 @@ EOF
 
 @test "basectl doctor project includes project artifact findings" {
     local fake_bin="$TEST_TMPDIR/bin"
+    local project_python="$TEST_HOME/.base.d/demo/.venv/bin/python"
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
 
-    mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$workspace/demo"
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$(dirname "$project_python")" "$workspace/demo"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
@@ -583,7 +584,8 @@ fi
 printf 'unexpected doctor project python args: %s\n' "$*" >&2
 exit 1
 EOF
-    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
+    cp "$venv_python" "$project_python"
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python" "$project_python"
     mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
     touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
@@ -605,10 +607,11 @@ EOF
 
 @test "basectl doctor project --format json includes project findings" {
     local fake_bin="$TEST_TMPDIR/bin"
+    local project_python="$TEST_HOME/.base.d/demo/.venv/bin/python"
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
 
-    mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$workspace/demo"
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$(dirname "$project_python")" "$workspace/demo"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
@@ -657,7 +660,8 @@ fi
 printf 'unexpected doctor project json python args: %s\n' "$*" >&2
 exit 1
 EOF
-    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python"
+    cp "$venv_python" "$project_python"
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$fake_bin/xcrun" "$venv_python" "$project_python"
     mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
     touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -783,7 +783,7 @@ EOF
     [[ "$output" == *"Setup notification was requested, but 'osascript' is not available on this Mac."* ]]
 }
 
-@test "basectl setup forwards project setup arguments through the Base venv" {
+@test "basectl setup forwards project setup arguments through the project wrapper" {
     local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
     local demo_venv_dir="$TEST_HOME/.base.d/demo/.venv"
     local manifest_path="$TEST_TMPDIR/demo_manifest.yaml"
@@ -796,6 +796,7 @@ EOF
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
     create_project_setup_venv_stub "$base_venv_dir"
+    create_project_setup_venv_stub "$demo_venv_dir"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest_path"
 
     run_base_command setup --dry-run --manifest "$manifest_path" demo
@@ -805,7 +806,6 @@ EOF
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]
-    [ ! -e "$demo_venv_dir/bin/python" ]
 }
 
 @test "project setup resolves named project manifests from the workspace" {
@@ -815,6 +815,7 @@ EOF
     mkdir -p "$workspace/brew"
     printf 'project:\n  name: brew\nartifacts: []\n' > "$workspace/brew/base_manifest.yaml"
     create_project_setup_venv_stub "$base_venv_dir"
+    create_project_setup_venv_stub "$TEST_HOME/.base.d/brew/.venv"
 
     run env \
         HOME="$TEST_HOME" \
@@ -1187,6 +1188,7 @@ EOF
     touch "$TEST_STATE_DIR/click-installed"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$TEST_HOME/.base.d/demo/.venv"
 
     run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
 
@@ -1288,6 +1290,7 @@ EOF
     touch "$TEST_STATE_DIR/click-installed"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$TEST_HOME/.base.d/demo/.venv"
 
     run --separate-stderr env \
         HOME="$TEST_HOME" \

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -47,7 +47,7 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option(
     "--action",
     default="setup",
-    help="Action to run: setup, check, or doctor. Defaults to setup.",
+    help="Action to run: setup, bootstrap, check, or doctor. Defaults to setup.",
 )
 @base_cli.option("--format", "output_format", default="text", help="Output format for check/doctor: text or json.")
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -91,11 +91,14 @@ def run_manifest_action(
     if action == "setup":
         reconcile_manifest(ctx, default_manifest, base_manifest, dry_run=manifest_action.dry_run)
         return 0
+    if action == "bootstrap":
+        reconcile_bootstrap_artifacts(ctx, default_manifest, base_manifest, dry_run=manifest_action.dry_run)
+        return 0
     if action == "check":
         return check_manifest(ctx, default_manifest, base_manifest, output_format=manifest_action.output_format)
     if action == "doctor":
         return doctor_manifest(default_manifest, base_manifest, output_format=manifest_action.output_format)
-    ctx.log.error("Unsupported base_setup action '%s'. Expected setup, check, or doctor.", action)
+    ctx.log.error("Unsupported base_setup action '%s'. Expected setup, bootstrap, check, or doctor.", action)
     return 2
 
 
@@ -143,6 +146,24 @@ def reconcile_manifest(
         reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
 
     ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
+
+
+def reconcile_bootstrap_artifacts(
+    ctx: base_cli.Context,
+    default_manifest: BaseManifest,
+    manifest: BaseManifest,
+    dry_run: bool,
+) -> None:
+    ctx.log.info("Bootstrapping project '%s' Python runtime.", manifest.project_name)
+
+    artifacts = tuple(artifact for artifact in default_manifest.artifacts if artifact.bootstrap)
+    definitions = resolve_artifact_definitions(artifacts)
+    if not artifacts:
+        ctx.log.info("Base default manifest declares no bootstrap artifacts.")
+        return
+
+    for artifact, definition in zip(artifacts, definitions, strict=True):
+        reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
 
 
 def check_manifest(

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -359,6 +359,30 @@ class ManifestTests(unittest.TestCase):
 
 
 class BootstrapManifestTests(unittest.TestCase):
+    def test_reconcile_bootstrap_artifacts_uses_only_bootstrap_defaults(self) -> None:
+        ctx = fake_context()
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="__base_defaults__",
+            brewfile=None,
+            artifacts=(
+                ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1", bootstrap=True),
+                ArtifactRequest(artifact_type="python-package", name="pytest", version="latest"),
+            ),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+
+        with mock.patch("base_setup.engine.reconcile_artifact") as reconcile_artifact:
+            engine.reconcile_bootstrap_artifacts(ctx, default_manifest, manifest, dry_run=True)
+
+        self.assertEqual(reconcile_artifact.call_count, 1)
+        self.assertEqual(reconcile_artifact.call_args.args[1].name, "click")
+
     def test_merge_artifacts_preserves_default_bootstrap_marker(self) -> None:
         merged = merge_artifacts(
             (

--- a/docs/design.md
+++ b/docs/design.md
@@ -388,11 +388,12 @@ When `basectl setup` runs on a fresh Mac:
 2. Check for Xcode CLI tools — install if missing
 3. Install Python (target version) via Homebrew
 4. Create Base's own virtual environment at `~/.base.d/base/.venv`
-5. Install Base's Python dependencies into `~/.base.d/base/.venv`
+5. Install Base's Python bootstrap dependencies into `~/.base.d/base/.venv`
 6. Prepare the managed shell startup model with `basectl update-profile`
 7. Scan the parent directory for peer repos with base manifests
-8. For each discovered project, run project-level setup (install declared dependencies,
-   create project venv)
+8. For each project setup target, seed the project venv with `bootstrap: true`
+   default artifacts, then run project artifact reconciliation through
+   `base-wrapper --project <project>`
 
 Homebrew installation follows Homebrew's official `install/HEAD/install.sh`
 bootstrap command. That means Base intentionally trusts Homebrew's mutable


### PR DESCRIPTION
## Summary

- Add a `base_setup --action bootstrap` path that reconciles only `bootstrap: true` default artifacts.
- Bootstrap project Python runtimes from the Base venv during `basectl setup <project>` before invoking the project artifact layer.
- Run project artifact setup/check/doctor through `base-wrapper --project <project> base_setup ...` instead of launching Python directly with a hand-built `PYTHONPATH`.
- Keep check/doctor non-mutating: they require an existing project venv and report missing project runtime as a missing requirement.
- Update README, design docs, and `AI_CONTEXT.md` to document the current project artifact execution model.
- Update Bash and Python tests and remove the completed TODO item.

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/engine.py cli/python/base_setup/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m py_compile cli/python/base_setup/engine.py`
- `git diff --check`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- Full BATS suite: 205 tests passed
- `bin/basectl check`
- `bin/basectl setup --dry-run`