### PR TITLE
Log successful setup commands at debug level

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -84,13 +84,6 @@ they are merged.
 
 ## P2 — Operational Excellence
 
-- [ ] Add successful command debug logging in the Python setup engine.
-  - Problem: `run_command` logs failures but has no `ctx`, so successful command
-    completion is silent beyond the caller's "installing..." message.
-  - Goal: make setup logs more useful without noisy terminal output.
-  - Expected behavior: pass `ctx` or a logger into command execution helpers and
-    log successful commands at DEBUG with `format_command(command)`.
-
 - [ ] Add log rotation or retention policy.
   - Goal: prevent Base CLI logs from growing indefinitely.
   - Expected behavior: keep a fixed number of recent log files per CLI, or add a

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -433,7 +433,7 @@ def reconcile_brewfile(ctx: base_cli.Context, manifest: BaseManifest, dry_run: b
         raise ArtifactError(f"Homebrew is required to install Brewfile dependencies from '{brewfile_path}'.")
 
     ctx.log.info("Installing Homebrew dependencies from Brewfile '%s'.", brewfile_path)
-    run_command(command)
+    run_command(ctx, command)
 
 
 def resolve_brewfile_path(manifest: BaseManifest) -> Path:
@@ -503,7 +503,7 @@ def reconcile_homebrew_artifact(
         definition.package,
         version,
     )
-    run_command(command)
+    run_command(ctx, command)
 
 
 def reconcile_python_artifact(
@@ -532,7 +532,7 @@ def reconcile_python_artifact(
         venv.create(venv_dir, with_pip=True)
 
     ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
-    run_command([str(python_bin), "-m", "pip", "install", requirement])
+    run_command(ctx, [str(python_bin), "-m", "pip", "install", requirement])
 
 
 def project_venv_dir(project: str) -> Path:
@@ -568,7 +568,7 @@ def run_check(command: list[str]) -> bool:
     return subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False).returncode == 0
 
 
-def run_command(command: list[str]) -> None:
+def run_command(ctx: base_cli.Context, command: list[str]) -> None:
     # Keep stdout live for installer progress; capture stderr for persistent failure logs.
     completed = subprocess.run(command, stderr=subprocess.PIPE, text=True, check=False)
     if completed.returncode:
@@ -577,6 +577,7 @@ def run_command(command: list[str]) -> None:
         if stderr:
             message = f"{message}\n{stderr}"
         raise ArtifactError(message)
+    ctx.log.debug("Command succeeded: %s", format_command(command))
 
 
 def dry_run_command(ctx: base_cli.Context, command: list[str]) -> None:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -262,7 +262,7 @@ class ManifestTests(unittest.TestCase):
         ), mock.patch("base_setup.engine.run_command") as run_command:
             engine.reconcile_homebrew_artifact(ctx, definition, "latest", dry_run=False)
 
-        run_command.assert_called_once_with(["brew", "install", "terraform"])
+        run_command.assert_called_once_with(ctx, ["brew", "install", "terraform"])
 
     def test_python_artifact_honors_project_venv_dir_override(self) -> None:
         definition = get_artifact_definition("python-package", "requests")
@@ -288,12 +288,28 @@ class ManifestTests(unittest.TestCase):
         )
 
     def test_run_command_includes_stderr_on_failure(self) -> None:
+        ctx = fake_context()
+
         with mock.patch(
             "base_setup.engine.subprocess.run",
             return_value=mock.Mock(returncode=17, stderr="installer exploded\n"),
         ):
             with self.assertRaisesRegex(ArtifactError, "installer exploded"):
-                engine.run_command(["installer", "--bad"])
+                engine.run_command(ctx, ["installer", "--bad"])
+
+    def test_run_command_logs_success_at_debug(self) -> None:
+        ctx = fake_context()
+
+        with mock.patch(
+            "base_setup.engine.subprocess.run",
+            return_value=mock.Mock(returncode=0, stderr=""),
+        ):
+            engine.run_command(ctx, ["installer", "--good", "two words"])
+
+        ctx.log.debug.assert_called_once_with(
+            "Command succeeded: %s",
+            "installer --good 'two words'",
+        )
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_project_argument_validates_manifest_project_name(self) -> None:
@@ -614,7 +630,7 @@ class BrewfileTests(unittest.TestCase):
             ) as run_command:
                 engine.reconcile_brewfile(ctx, manifest, dry_run=False)
 
-        run_command.assert_called_once_with(["brew", "bundle", f"--file={expected_brewfile}"])
+        run_command.assert_called_once_with(ctx, ["brew", "bundle", f"--file={expected_brewfile}"])
 
     def test_brewfile_missing_file_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Pass the Base CLI context into the Python setup command runner.
- Log successful Brewfile, Homebrew, and Python package install commands at DEBUG using the existing shell-quoted formatter.
- Remove the completed TODO item.

## Tests
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/engine.py cli/python/base_setup/tests/test_engine.py`
- `git diff --check`