### PR TITLE
Add log retention mode to basectl clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Current implemented commands include:
 - `basectl check`
 - `basectl doctor`
 - `basectl clean --older-than <age>`
+- `basectl clean --keep-last <count>`
 - `basectl update-profile`
 - `basectl update`
 - `basectl projects list`
@@ -157,12 +158,18 @@ Clean old Base CLI runtime logs, retained temp files, and cache entries with:
 ```bash
 basectl clean --older-than 30d --dry-run
 basectl clean --older-than 30d
+basectl clean --keep-last 20
+basectl clean --older-than 30d --keep-last 20
 ```
 
 Cleanup only targets runtime artifacts under the Base cache root, which defaults
 to `~/Library/Caches/base` on macOS. Set `BASE_CACHE_DIR` to override it. Durable
 state such as `~/.base.d/config.yaml` and project virtual environments under
 `~/.base.d/<project>/.venv` are outside this scope.
+
+Use `--keep-last <count>` to retain the newest log files per CLI log directory
+while pruning older logs. This retention mode applies only to `*.log` files;
+temp and cache artifacts continue to use `--older-than`.
 
 Use `basectl doctor` when you want a human-oriented diagnosis with suggested
 fixes:

--- a/TODO.md
+++ b/TODO.md
@@ -84,11 +84,6 @@ they are merged.
 
 ## P2 — Operational Excellence
 
-- [ ] Add log rotation or retention policy.
-  - Goal: prevent Base CLI logs from growing indefinitely.
-  - Expected behavior: keep a fixed number of recent log files per CLI, or add a
-    retention mode to `basectl clean` such as `--keep-last 20`.
-
 - [ ] Add a standalone installer script.
   - Goal: make first-time Base adoption easier than manually cloning the repo.
   - Expected behavior: provide an install path such as

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -52,6 +52,7 @@ that delegate to `basectl`.
 - `basectl setup --dev`, `basectl check --dev`, and `basectl doctor --dev`
   manage developer prerequisites through `lib/base/dev_manifest.yaml`.
 - `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
+- `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -15,7 +15,7 @@ Commands:
     Install and bootstrap the local Base CLI environment on macOS.
   check [project] [options]
     Verify the local Base CLI environment and optional project artifacts without making changes.
-  clean --older-than <age> [options]
+  clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   doctor [project] [options]
     Diagnose the local Base CLI environment and optional project artifacts.

--- a/cli/bash/commands/basectl/subcommands/clean.sh
+++ b/cli/bash/commands/basectl/subcommands/clean.sh
@@ -5,21 +5,24 @@ readonly _base_clean_subcommand_sourced
 base_clean_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl clean --older-than <age> [options]
+  basectl clean [--older-than <age>] [--keep-last <count>] [options]
 
 Options:
   --older-than <age>  Remove runtime artifacts older than an age such as 30d.
+  --keep-last <count> Keep the newest count log files per CLI log directory.
   --dry-run           Print what would be removed without deleting anything.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
-Remove old Base CLI runtime logs, temp files, and cache entries.
+Remove old Base CLI runtime logs, temp files, and cache entries. At least one
+cleanup criterion is required.
 EOF
 }
 
 base_clean_subcommand_main() {
     local wrapper="$BASE_HOME/bin/base-wrapper"
     local has_older_than=0
+    local has_keep_last=0
     local args=()
 
     while (($# > 0)); do
@@ -32,13 +35,17 @@ base_clean_subcommand_main() {
                 args+=(--debug)
                 shift
                 ;;
-            --older-than|--dry-run)
+            --older-than|--keep-last|--dry-run)
                 args+=("$1")
-                if [[ "$1" == "--older-than" ]]; then
-                    has_older_than=1
+                if [[ "$1" == "--older-than" || "$1" == "--keep-last" ]]; then
+                    if [[ "$1" == "--older-than" ]]; then
+                        has_older_than=1
+                    else
+                        has_keep_last=1
+                    fi
                     [[ -n "${2:-}" ]] || {
                         base_clean_subcommand_usage >&2
-                        printf 'ERROR: Option '\''--older-than'\'' requires an argument.\n' >&2
+                        printf 'ERROR: Option '\''%s'\'' requires an argument.\n' "$1" >&2
                         return 2
                     }
                     args+=("$2")
@@ -52,6 +59,11 @@ base_clean_subcommand_main() {
                 args+=("$1")
                 shift
                 ;;
+            --keep-last=*)
+                has_keep_last=1
+                args+=("$1")
+                shift
+                ;;
             *)
                 args+=("$1")
                 shift
@@ -59,9 +71,9 @@ base_clean_subcommand_main() {
         esac
     done
 
-    if (( ! has_older_than )); then
+    if (( ! has_older_than && ! has_keep_last )); then
         base_clean_subcommand_usage >&2
-        printf 'ERROR: Option '\''--older-than'\'' is required.\n' >&2
+        printf 'ERROR: One of '\''--older-than'\'' or '\''--keep-last'\'' is required.\n' >&2
         return 2
     fi
 

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -24,7 +24,7 @@ run_basectl() {
     [[ "$output" == *"activate <project> [options]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [project] [options]"* ]]
-    [[ "$output" == *"clean --older-than <age> [options]"* ]]
+    [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
@@ -331,14 +331,14 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl clean --older-than <age> [options]"* ]]
+    [[ "$output" == *"basectl clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
 }
 
-@test "basectl clean reports missing age as a usage error" {
+@test "basectl clean reports missing cleanup criterion as a usage error" {
     run_basectl clean
 
     [ "$status" -eq 2 ]
-    [[ "$output" == *"ERROR: Option '--older-than' is required."* ]]
+    [[ "$output" == *"ERROR: One of '--older-than' or '--keep-last' is required."* ]]
     [[ "$output" != *"Traceback"* ]]
     [[ "$output" != *"FATAL"* ]]
 
@@ -346,6 +346,12 @@ EOF
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"ERROR: Option '--older-than' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl clean --keep-last
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--keep-last' requires an argument."* ]]
     [[ "$output" != *"FATAL"* ]]
 }
 

--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -31,38 +31,50 @@ def main(argv: list[str] | None = None) -> int:
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.option("--older-than", help="Remove runtime artifacts older than an age such as 30d.")
+@base_cli.option("--keep-last", help="Keep the newest N log files per CLI log directory.")
 @base_cli.option("--dry-run", is_flag=True, help="Print what would be removed without deleting anything.")
-def run(ctx: base_cli.Context, older_than: str | None, dry_run: bool) -> int:
-    if not older_than:
-        ctx.log.error("Option '--older-than' is required.")
+def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dry_run: bool) -> int:
+    if not older_than and not keep_last:
+        ctx.log.error("One of '--older-than' or '--keep-last' is required.")
         return 2
 
-    try:
-        threshold_seconds = parse_age(older_than)
-    except ValueError as exc:
-        ctx.log.error(str(exc))
-        return 2
-
-    cutoff = time.time() - threshold_seconds
     cache_root = base_cache_root()
     ctx.log.debug("Scanning Base cache root '%s'.", cache_root)
-    candidates = tuple(find_clean_candidates(cache_root, cutoff, ctx.log))
 
-    if not candidates:
-        ctx.log.info("No Base runtime artifacts older than %s were found.", older_than)
+    candidates: list[CleanCandidate] = []
+    if older_than:
+        try:
+            threshold_seconds = parse_age(older_than)
+        except ValueError as exc:
+            ctx.log.error(str(exc))
+            return 2
+        cutoff = time.time() - threshold_seconds
+        candidates.extend(find_clean_candidates(cache_root, cutoff, ctx.log))
+
+    if keep_last:
+        try:
+            keep_count = parse_keep_last(keep_last)
+        except ValueError as exc:
+            ctx.log.error(str(exc))
+            return 2
+        candidates.extend(find_log_retention_candidates(cache_root, keep_count, ctx.log))
+
+    unique_candidates = tuple(deduplicate_candidates(candidates))
+
+    if not unique_candidates:
+        ctx.log.info("No Base runtime artifacts matched the clean criteria.")
         return 0
 
-    for candidate in candidates:
+    for candidate in unique_candidates:
         action = "Would remove" if dry_run else "Removing"
         print(f"{action}\t{candidate.category}\t{candidate.path}")
         if not dry_run:
             remove_path(candidate.path)
 
     ctx.log.info(
-        "%s %s Base runtime artifact(s) older than %s.",
+        "%s %s Base runtime artifact(s).",
         "Would remove" if dry_run else "Removed",
-        len(candidates),
-        older_than,
+        len(unique_candidates),
     )
     return 0
 
@@ -88,6 +100,15 @@ def parse_age(value: str) -> int:
     return amount * units[unit]
 
 
+def parse_keep_last(value: str) -> int:
+    if not value.isdigit():
+        raise ValueError("Option '--keep-last' must be a positive integer.")
+    amount = int(value)
+    if amount <= 0:
+        raise ValueError("Option '--keep-last' must be greater than zero.")
+    return amount
+
+
 def find_clean_candidates(cache_root: Path, cutoff: float, logger: object | None = None) -> list[CleanCandidate]:
     cli_root = cache_root / "cli"
     if logger is not None:
@@ -103,6 +124,59 @@ def find_clean_candidates(cache_root: Path, cutoff: float, logger: object | None
         candidates.extend(find_category_candidates(cli_dir / "tmp", "temp", cutoff, logger))
         candidates.extend(find_category_candidates(cli_dir / "cache", "cache", cutoff, logger))
     return sorted(candidates, key=lambda candidate: str(candidate.path))
+
+
+def find_log_retention_candidates(
+    cache_root: Path,
+    keep_count: int,
+    logger: object | None = None,
+) -> list[CleanCandidate]:
+    cli_root = cache_root / "cli"
+    if logger is not None:
+        logger.debug("Scanning Base CLI log retention root '%s'.", cli_root)
+    if not cli_root.is_dir():
+        return []
+
+    candidates: list[CleanCandidate] = []
+    for cli_dir in sorted(cli_root.iterdir(), key=lambda path: path.name):
+        if not cli_dir.is_dir():
+            continue
+        candidates.extend(find_log_retention_candidates_for_dir(cli_dir / "logs", keep_count, logger))
+    return sorted(candidates, key=lambda candidate: str(candidate.path))
+
+
+def find_log_retention_candidates_for_dir(
+    logs_dir: Path,
+    keep_count: int,
+    logger: object | None = None,
+) -> list[CleanCandidate]:
+    if logger is not None:
+        logger.debug("Scanning log retention artifacts in '%s'.", logs_dir)
+    if not logs_dir.is_dir():
+        return []
+
+    log_files = []
+    for path in sorted(logs_dir.glob("*.log"), key=lambda item: item.name):
+        if not path.is_file():
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        log_files.append((path, stat.st_mtime))
+
+    retained = sorted(log_files, key=lambda item: (item[1], item[0].name), reverse=True)[:keep_count]
+    retained_paths = {path for path, _mtime in retained}
+    return [
+        CleanCandidate(path=path, category="log", age_seconds=int(time.time() - mtime))
+        for path, mtime in log_files
+        if path not in retained_paths
+    ]
+
+
+def deduplicate_candidates(candidates: list[CleanCandidate]) -> list[CleanCandidate]:
+    unique = {candidate.path: candidate for candidate in candidates}
+    return sorted(unique.values(), key=lambda candidate: str(candidate.path))
 
 
 def find_category_candidates(

--- a/cli/python/base_clean/tests/test_engine.py
+++ b/cli/python/base_clean/tests/test_engine.py
@@ -23,6 +23,15 @@ class BaseCleanTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     engine.parse_age(value)
 
+    def test_parse_keep_last_accepts_positive_integer(self) -> None:
+        self.assertEqual(engine.parse_keep_last("20"), 20)
+
+    def test_parse_keep_last_rejects_invalid_values(self) -> None:
+        for value in ("", "0", "-1", "ten", "1.5"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    engine.parse_keep_last(value)
+
     def test_find_clean_candidates_only_includes_old_runtime_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
@@ -77,6 +86,34 @@ class BaseCleanTests(unittest.TestCase):
             cache_root / "cli" / "demo" / "cache",
         )
 
+    def test_find_log_retention_candidates_keeps_newest_logs_per_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            demo_logs = cache_root / "cli" / "demo" / "logs"
+            other_logs = cache_root / "cli" / "other" / "logs"
+            demo_logs.mkdir(parents=True)
+            other_logs.mkdir(parents=True)
+            demo_old = demo_logs / "demo-1.log"
+            demo_middle = demo_logs / "demo-2.log"
+            demo_new = demo_logs / "demo-3.log"
+            demo_notes = demo_logs / "notes.txt"
+            other_old = other_logs / "other-1.log"
+            other_new = other_logs / "other-2.log"
+            for path in (demo_old, demo_middle, demo_new, demo_notes, other_old, other_new):
+                path.write_text("x", encoding="utf-8")
+
+            now = time.time()
+            for offset, path in enumerate((demo_old, demo_middle, demo_new, other_old, other_new), start=1):
+                timestamp = now - (10 - offset)
+                os.utime(path, (timestamp, timestamp))
+
+            candidates = engine.find_log_retention_candidates(cache_root, keep_count=1)
+
+        self.assertEqual(
+            [(candidate.category, candidate.path.name) for candidate in candidates],
+            [("log", "demo-1.log"), ("log", "demo-2.log"), ("log", "other-1.log")],
+        )
+
     def test_remove_path_removes_files_and_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -122,6 +159,41 @@ class BaseCleanTests(unittest.TestCase):
             self.assertEqual(result, 0)
             self.assertFalse(old_log.exists())
 
+    def test_clean_keep_last_removes_old_logs_but_keeps_latest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            logs_dir = cache_root / "cli" / "demo" / "logs"
+            logs_dir.mkdir(parents=True)
+            old_log = logs_dir / "old.log"
+            new_log = logs_dir / "new.log"
+            for path in (old_log, new_log):
+                path.write_text("x", encoding="utf-8")
+            now = time.time()
+            os.utime(old_log, (now - 10, now - 10))
+            os.utime(new_log, (now, now))
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                result = engine.main(["--keep-last", "1"])
+
+            self.assertEqual(result, 0)
+            self.assertFalse(old_log.exists())
+            self.assertTrue(new_log.exists())
+
+    def test_clean_deduplicates_age_and_retention_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
+            old_log.parent.mkdir(parents=True)
+            old_log.write_text("x", encoding="utf-8")
+            old_time = time.time() - 40 * 24 * 60 * 60
+            os.utime(old_log, (old_time, old_time))
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                result = engine.main(["--older-than", "30d", "--keep-last", "1"])
+
+            self.assertEqual(result, 0)
+            self.assertFalse(old_log.exists())
+
     def test_clean_invalid_older_than_returns_usage_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(Path(tmpdir) / "cache-root")}):
@@ -133,6 +205,13 @@ class BaseCleanTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(Path(tmpdir) / "cache-root")}):
                 result = engine.main([])
+
+        self.assertEqual(result, 2)
+
+    def test_clean_invalid_keep_last_returns_usage_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(Path(tmpdir) / "cache-root")}):
+                result = engine.main(["--keep-last", "many"])
 
         self.assertEqual(result, 2)
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -253,9 +253,11 @@ On Linux and other non-macOS platforms, the default is `~/.cache/base`. Use
 environments.
 
 `logs/` and `cache/` are runtime artifacts that can be pruned with
-`basectl clean --older-than <age>`. `tmp/<run-id>/` is deleted automatically
-after the command returns unless `--keep-temp` is set; retained temp entries can
-also be pruned by `basectl clean`.
+`basectl clean --older-than <age>`. Logs can also be pruned with
+`basectl clean --keep-last <count>`, which keeps the newest log files per CLI log
+directory. `tmp/<run-id>/` is deleted automatically after the command returns
+unless `--keep-temp` is set; retained temp entries can also be pruned by
+`basectl clean`.
 
 Use `ctx.on_cleanup()` for cleanup work that should happen even when helper code
 does not own the main command wrapper:


### PR DESCRIPTION
## Summary
- Add `basectl clean --keep-last <count>` to prune old `*.log` files while retaining the newest logs per CLI log directory.
- Allow `basectl clean` to run with either `--older-than`, `--keep-last`, or both, with duplicate candidates removed before deletion.
- Update Bash help, README docs, base_cli docs, and tests; remove the completed TODO.

## Tests
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_clean.tests.test_engine`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_clean/engine.py cli/python/base_clean/tests/test_engine.py`
- `bash -n cli/bash/commands/basectl/subcommands/clean.sh cli/bash/commands/basectl/basectl.sh`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bin/basectl clean --keep-last 20 --dry-run`
- `git diff --check`