### PR TITLE
Add standalone Base installer

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -9,6 +9,9 @@ debugging context changes.
 - Base is a macOS-first developer tooling foundation for multi-repo workspaces.
 - Current work is moving through `TODO.md`, which tracks May 2026 product-review
   follow-ups by priority.
+- The current in-flight branch is adding a standalone Base installer. Keep
+  `install.sh`, `tests/install.bats`, and the installer references in
+  `docs/project-installers.md` together in the same PR.
 - Public commands live in `bin/`; `bin/basectl` is the control-plane command.
 - Command implementations live under `cli/bash/commands/<command>/`.
 - Shared Bash libraries live under `lib/bash/`.
@@ -18,7 +21,23 @@ debugging context changes.
 - Durable Base state lives under `~/.base.d`; project virtual environments live
   at `~/.base.d/<project>/.venv`.
 - Runtime cache/log/temp data lives under the Base cache root, which defaults to
-  `~/Library/Caches/base` on macOS.
+  `~/Library/Caches/base` on macOS and can be overridden with `BASE_CACHE_DIR`.
+
+## Standalone Installer Model
+
+- `install.sh` is the user-facing installer for installing Base itself from a
+  fresh machine.
+- By default it installs into `~/work/base` from
+  `https://github.com/codeforester/base.git`.
+- Supported installer options are `--dir`, `--repo-url`, `--branch`,
+  `--no-profile`, and `--dry-run`.
+- The installer clones Base when the target directory is absent, updates it when
+  the target is an existing git checkout, rejects an existing non-git target, and
+  then runs `bin/basectl setup`.
+- Unless `--no-profile` is used, the installer also runs
+  `bin/basectl update-profile`.
+- Installer behavior is covered by `tests/install.bats`; include that file in
+  branch validation when touching installer logic.
 
 ## Artifact Setup Model
 
@@ -29,6 +48,7 @@ debugging context changes.
   `(type, name)` pairs to managers and errors on unknown artifacts.
 - Default project artifacts are declared in `lib/base/default_manifest.yaml`
   using the same manifest shape as project manifests.
+- Development-only Base artifacts are declared in `lib/base/dev_manifest.yaml`.
 - `click` and `PyYAML` are marked `bootstrap: true` in
   `lib/base/default_manifest.yaml`; they are the minimum Python packages needed
   before Base can run its Python CLI layer inside a project venv.
@@ -74,6 +94,7 @@ base-wrapper --project <project> base_setup ...
   reads optional defaults from `~/.base.d/profile.conf`, and sources
   `lib/shell/bash_defaults.sh` only when defaults are enabled.
 - `lib/shell/zshrc` mirrors the same integration model for Zsh.
+- Shell completions live under `lib/shell/completions/`.
 - `~/.baserc` is user-managed and may set startup-safe preferences such as
   `BASE_DEBUG=1`, but must not set Base-owned variables like `BASE_HOME` or
   `BASE_ENABLE_BASH_DEFAULTS`.
@@ -96,7 +117,8 @@ bats lib/bash/git/tests/lib_git.bats \
   cli/bash/commands/sort-in-place/tests/sort-in-place.bats \
   cli/bash/commands/basectl/tests/setup.bats \
   cli/bash/commands/basectl/tests/basectl.bats \
-  cli/bash/commands/caff/tests/caff.bats
+  cli/bash/commands/caff/tests/caff.bats \
+  tests/install.bats
 ```
 
 - Focused setup/control-plane validation:
@@ -117,9 +139,26 @@ env PYTHONPATH=lib/python:cli/python \
   cli/python/base_setup/engine.py cli/python/base_setup/tests/test_engine.py
 ```
 
+- Broader Python validation:
+
+```bash
+env PYTHONPATH=lib/python:cli/python \
+  ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python -p 'test*.py'
+
+env PYTHONPATH=lib/python:cli/python \
+  ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python -p 'test*.py'
+```
+
 - Smoke validation:
 
 ```bash
 bin/basectl check
 bin/basectl setup --dry-run
 ```
+
+## Open Design Notes
+
+- `docs/ide-bootstrapping.md` currently captures planned IDE support for
+  manifest-driven VS Code/Cursor extension and settings bootstrapping. If that
+  design is intended to move forward, commit it intentionally and keep this
+  context updated as the manifest shape becomes real.

--- a/README.md
+++ b/README.md
@@ -291,8 +291,35 @@ is requested on macOS, Base warns if `osascript` is not available.
 
 ## Quick Start
 
-Base is currently designed to be checked out once per workspace. Until a
-standalone installer exists, the explicit bootstrap path is:
+Base is designed to be checked out once per workspace. The quickest install path
+is:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh | bash
+exec "$SHELL" -l
+```
+
+This runs a shell script from GitHub, so review the script first if you do not
+already trust this repository:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh
+```
+
+By default, the installer clones or updates Base at `~/work/base`, runs
+`~/work/base/bin/basectl setup`, and then runs
+`~/work/base/bin/basectl update-profile`. Set `BASE_INSTALL_DIR` or pass
+`--dir <path>` to install somewhere else. When using the piped form, pass
+installer options with `bash -s --`, for example:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh | bash -s -- --dir ~/work/base --no-profile
+```
+
+Use `--no-profile` to skip shell startup integration and `--dry-run` to print
+planned actions.
+
+The explicit manual bootstrap path is:
 
 ```bash
 git clone https://github.com/codeforester/base.git ~/work/base

--- a/TODO.md
+++ b/TODO.md
@@ -84,15 +84,6 @@ they are merged.
 
 ## P2 — Operational Excellence
 
-- [ ] Add a standalone installer script.
-  - Goal: make first-time Base adoption easier than manually cloning the repo.
-  - Expected behavior: provide an install path such as
-    `curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh | bash`
-    that clones or updates Base, runs `basectl setup`, and optionally runs
-    `basectl update-profile`.
-  - Security note: document the trust implications of `curl | bash` and align
-    with the Homebrew installer trust decision.
-
 - [ ] Package Base as a Homebrew formula or tap.
   - Goal: make Base installation feel native on macOS.
   - Expected behavior: support an install path such as

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -55,7 +55,7 @@ project_dir="${workspace_dir}/${project_name}"
 mkdir -p "$workspace_dir"
 
 if [[ ! -d "$base_dir/.git" ]]; then
-    git clone https://github.com/codeforester/base.git "$base_dir"
+    curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh | BASE_INSTALL_DIR="$base_dir" bash
 else
     git -C "$base_dir" pull --ff-only
 fi
@@ -72,6 +72,11 @@ fi
 
 This is only a sketch. A real installer should add friendlier output, better
 error handling, and project-specific next steps.
+
+If a project installer uses Base's standalone installer, it should still avoid
+reimplementing Base setup. Use `BASE_INSTALL_DIR` or `install.sh --dir <path>` to
+choose the Base checkout location, and use `--no-profile` if the project
+installer wants to defer shell startup integration until later.
 
 ## User Experience Guidelines
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+install_usage() {
+    cat <<'EOF'
+Usage:
+  install.sh [options]
+
+Options:
+  --dir <path>       Install or update Base at this path. Defaults to ~/work/base.
+  --repo-url <url>   Git repository URL to clone. Defaults to https://github.com/codeforester/base.git.
+  --branch <name>    Clone a specific branch when installing into a new directory.
+  --no-profile       Skip basectl update-profile after setup.
+  --dry-run          Print planned actions without making changes.
+  -h, --help         Show this help text.
+
+Install or update Base, run basectl setup, and optionally update shell startup files.
+EOF
+}
+
+install_log() {
+    printf '%s\n' "$*"
+}
+
+install_die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+install_expand_path() {
+    local path="$1"
+    case "$path" in
+        "~") printf '%s\n' "$HOME" ;;
+        "~/"*) printf '%s/%s\n' "$HOME" "${path#"~/"}" ;;
+        *) printf '%s\n' "$path" ;;
+    esac
+}
+
+install_run() {
+    if [[ "${BASE_INSTALL_DRY_RUN:-false}" == "true" ]]; then
+        printf '[DRY-RUN] Would run:'
+        printf ' %q' "$@"
+        printf '\n'
+        return 0
+    fi
+    "$@"
+}
+
+install_clone_or_update() {
+    local repo_url="$1"
+    local install_dir="$2"
+    local branch="$3"
+
+    if [[ "${BASE_INSTALL_DRY_RUN:-false}" != "true" ]] && ! command -v git >/dev/null 2>&1; then
+        install_die "Git is required to install Base."
+    fi
+
+    if [[ -d "$install_dir/.git" ]]; then
+        install_log "Updating existing Base checkout at '$install_dir'."
+        install_run git -C "$install_dir" pull --ff-only
+        return 0
+    fi
+
+    if [[ -e "$install_dir" ]]; then
+        install_die "Install path '$install_dir' exists but is not a Git checkout."
+    fi
+
+    install_log "Cloning Base into '$install_dir'."
+    install_run mkdir -p "$(dirname "$install_dir")"
+    if [[ -n "$branch" ]]; then
+        install_run git clone --branch "$branch" "$repo_url" "$install_dir"
+    else
+        install_run git clone "$repo_url" "$install_dir"
+    fi
+}
+
+install_run_base_setup() {
+    local install_dir="$1"
+
+    install_log "Running basectl setup."
+    install_run "$install_dir/bin/basectl" setup
+}
+
+install_run_update_profile() {
+    local install_dir="$1"
+
+    install_log "Updating shell startup files."
+    install_run "$install_dir/bin/basectl" update-profile
+}
+
+install_main() {
+    local repo_url="${BASE_INSTALL_REPO_URL:-https://github.com/codeforester/base.git}"
+    local install_dir="${BASE_INSTALL_DIR:-$HOME/work/base}"
+    local branch="${BASE_INSTALL_BRANCH:-}"
+    local update_profile="${BASE_INSTALL_UPDATE_PROFILE:-true}"
+    BASE_INSTALL_DRY_RUN="${BASE_INSTALL_DRY_RUN:-false}"
+
+    while (($# > 0)); do
+        case "$1" in
+            -h|--help)
+                install_usage
+                return 0
+                ;;
+            --dir)
+                [[ -n "${2:-}" ]] || install_die "Option '--dir' requires an argument."
+                install_dir="$2"
+                shift 2
+                ;;
+            --repo-url)
+                [[ -n "${2:-}" ]] || install_die "Option '--repo-url' requires an argument."
+                repo_url="$2"
+                shift 2
+                ;;
+            --branch)
+                [[ -n "${2:-}" ]] || install_die "Option '--branch' requires an argument."
+                branch="$2"
+                shift 2
+                ;;
+            --no-profile)
+                update_profile=false
+                shift
+                ;;
+            --dry-run)
+                BASE_INSTALL_DRY_RUN=true
+                shift
+                ;;
+            *)
+                install_usage >&2
+                install_die "Unknown option '$1'."
+                ;;
+        esac
+    done
+
+    install_dir="$(install_expand_path "$install_dir")"
+
+    install_log "Base installer"
+    install_log "Repository: $repo_url"
+    install_log "Install path: $install_dir"
+
+    install_clone_or_update "$repo_url" "$install_dir" "$branch"
+    install_run_base_setup "$install_dir"
+    if [[ "$update_profile" == "true" ]]; then
+        install_run_update_profile "$install_dir"
+    fi
+
+    install_log "Base installation is complete."
+    if [[ "$update_profile" == "true" ]]; then
+        install_log "Restart your shell with: exec \"\$SHELL\" -l"
+    fi
+}
+
+if [[ "${BASE_INSTALL_TESTING:-false}" != "true" ]]; then
+    install_main "$@"
+fi

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+load ../lib/bash/tests/test_helper.sh
+bats_require_minimum_version 1.5.0
+
+setup() {
+    setup_test_tmpdir
+    TEST_HOME="$TEST_TMPDIR/home"
+    mkdir -p "$TEST_HOME"
+}
+
+run_installer() {
+    run env \
+        HOME="$TEST_HOME" \
+        "$BASE_REPO_ROOT/install.sh" "$@"
+}
+
+@test "installer prints planned actions in dry-run mode" {
+    run_installer --dry-run --dir "$TEST_HOME/work/base" --repo-url https://example.test/base.git --no-profile
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base installer"* ]]
+    [[ "$output" == *"Repository: https://example.test/base.git"* ]]
+    [[ "$output" == *"Install path: $TEST_HOME/work/base"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: mkdir -p $TEST_HOME/work"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: git clone https://example.test/base.git $TEST_HOME/work/base"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: $TEST_HOME/work/base/bin/basectl setup"* ]]
+    [[ "$output" != *"update-profile"* ]]
+}
+
+@test "installer expands tilde install paths" {
+    run_installer --dry-run --dir "~/custom/base" --no-profile
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Install path: $TEST_HOME/custom/base"* ]]
+}
+
+@test "installer includes update-profile by default" {
+    run_installer --dry-run --dir "$TEST_HOME/work/base"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run: $TEST_HOME/work/base/bin/basectl update-profile"* ]]
+    [[ "$output" == *"Restart your shell with: exec \"\$SHELL\" -l"* ]]
+}
+
+@test "installer rejects an existing non-git install path" {
+    mkdir -p "$TEST_HOME/work/base"
+
+    run_installer --dir "$TEST_HOME/work/base"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"exists but is not a Git checkout"* ]]
+}


### PR DESCRIPTION
## Summary
- Add a root `install.sh` that clones or updates Base, runs `basectl setup`, and runs `basectl update-profile` by default.
- Support installer options for `--dir`, `--repo-url`, `--branch`, `--no-profile`, and `--dry-run`.
- Document the `curl | bash` quick start, review-first trust boundary, project-installer usage, and remove the completed TODO.

## Tests
- `bash -n install.sh`
- `bats tests/install.bats`
- `./install.sh --dry-run --dir /private/tmp/base-installer-smoke --no-profile`
- `git diff --check`