### PR TITLE
Document Homebrew tap install path

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -10,7 +10,7 @@ debugging context changes.
 - Current work is moving through `TODO.md`, which tracks May 2026 product-review
   follow-ups by priority.
 - Base has a public Homebrew tap at `codeforester/homebrew-base`, exposed to
-  users as `brew install codeforester/base/basectl`.
+  users as `brew install codeforester/base/base`.
 - Public commands live in `bin/`; `bin/basectl` is the control-plane command.
 - Command implementations live under `cli/bash/commands/<command>/`.
 - Shared Bash libraries live under `lib/bash/`.
@@ -45,13 +45,13 @@ debugging context changes.
 - The user-facing install command is:
 
 ```bash
-brew install codeforester/base/basectl
+brew install codeforester/base/base
 ```
 
 - The formula installs Base files and users still finish setup with
   `basectl setup` and `basectl update-profile`.
 - When installed through Homebrew, Base should be updated with
-  `brew upgrade basectl` rather than `basectl update`.
+  `brew upgrade codeforester/base/base` rather than `basectl update`.
 - The initial formula follows Base's `master` branch. Once Base publishes
   release tarballs, the formula should move to a versioned URL plus SHA256.
 

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -9,9 +9,8 @@ debugging context changes.
 - Base is a macOS-first developer tooling foundation for multi-repo workspaces.
 - Current work is moving through `TODO.md`, which tracks May 2026 product-review
   follow-ups by priority.
-- The current in-flight branch is adding a standalone Base installer. Keep
-  `install.sh`, `tests/install.bats`, and the installer references in
-  `docs/project-installers.md` together in the same PR.
+- Base has a public Homebrew tap at `codeforester/homebrew-base`, exposed to
+  users as `brew install codeforester/base/basectl`.
 - Public commands live in `bin/`; `bin/basectl` is the control-plane command.
 - Command implementations live under `cli/bash/commands/<command>/`.
 - Shared Bash libraries live under `lib/bash/`.
@@ -38,6 +37,23 @@ debugging context changes.
   `bin/basectl update-profile`.
 - Installer behavior is covered by `tests/install.bats`; include that file in
   branch validation when touching installer logic.
+
+## Homebrew Tap Model
+
+- The Homebrew tap repository is `https://github.com/codeforester/homebrew-base`.
+- The formula lives at `Formula/basectl.rb` in that repository.
+- The user-facing install command is:
+
+```bash
+brew install codeforester/base/basectl
+```
+
+- The formula installs Base files and users still finish setup with
+  `basectl setup` and `basectl update-profile`.
+- When installed through Homebrew, Base should be updated with
+  `brew upgrade basectl` rather than `basectl update`.
+- The initial formula follows Base's `master` branch. Once Base publishes
+  release tarballs, the formula should move to a versioned URL plus SHA256.
 
 ## Artifact Setup Model
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ is requested on macOS, Base warns if `osascript` is not available.
 Base can be installed through its Homebrew tap:
 
 ```bash
-brew install codeforester/base/basectl
+brew install codeforester/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
@@ -305,7 +305,7 @@ runtime under `~/.base.d/base/.venv`, and `basectl update-profile` adds Base to
 your shell startup path. When installed through Homebrew, update Base with:
 
 ```bash
-brew upgrade basectl
+brew upgrade codeforester/base/base
 ```
 
 The standalone installer is also available:

--- a/README.md
+++ b/README.md
@@ -291,8 +291,24 @@ is requested on macOS, Base warns if `osascript` is not available.
 
 ## Quick Start
 
-Base is designed to be checked out once per workspace. The quickest install path
-is:
+Base can be installed through its Homebrew tap:
+
+```bash
+brew install codeforester/base/basectl
+basectl setup
+basectl update-profile
+exec "$SHELL" -l
+```
+
+Homebrew installs the Base files. `basectl setup` still prepares the local Base
+runtime under `~/.base.d/base/.venv`, and `basectl update-profile` adds Base to
+your shell startup path. When installed through Homebrew, update Base with:
+
+```bash
+brew upgrade basectl
+```
+
+The standalone installer is also available:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh | bash

--- a/TODO.md
+++ b/TODO.md
@@ -84,11 +84,6 @@ they are merged.
 
 ## P2 — Operational Excellence
 
-- [ ] Package Base as a Homebrew formula or tap.
-  - Goal: make Base installation feel native on macOS.
-  - Expected behavior: support an install path such as
-    `brew install codeforester/base/basectl`.
-
 - [ ] Add initial Linux support plan.
   - Goal: define the first supported Linux target, likely Ubuntu/Debian.
   - Expected design topics: `/etc/os-release` detection, `apt` equivalents for


### PR DESCRIPTION
## Summary
- Document `brew install codeforester/base/base` in the README quick start.
- Record the live `codeforester/homebrew-base` tap model in `AI_CONTEXT.md`.
- Remove the completed Homebrew packaging TODO.

## Validation
- `git diff --check`
- Verified the tap locally with `brew tap codeforester/base`.
- Verified formula metadata with `brew info codeforester/base/base`.
- Verified that Homebrew does not resolve the two-part `brew info codeforester/base`; Homebrew exposes this formula as `codeforester/base/base`.

## Note
`brew audit --formula Formula/base.rb` in the tap repo is currently blocked locally because Homebrew reports the installed Xcode Command Line Tools are too outdated and asks for Command Line Tools for Xcode 26.3.