### PR TITLE
Add basectl gh workflow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,121 +1,28 @@
 # TODO
 
-Action items from the May 2026 Base product reviews.
+Base product work is tracked in GitHub Issues.
 
-Use this as a commit-by-commit work queue. Completed items are removed after
-they are merged.
+Use this file only for short-lived private scratch notes that are not ready to
+be public product work. Public bugs, enhancements, chores, and design tasks
+should be filed as GitHub Issues with a `type:*` label and implemented from a
+branch named:
 
-## P0 — Security And Correctness
+```text
+<type>/<issue>-<YYYYMMDD>-<slug>
+```
 
-## P1 — Product Core And Composability
+The previous public TODO backlog was migrated to GitHub Issues on 2026-05-28:
 
-- [ ] Add first-class `mise` integration.
-  - Goal: let Base orchestrate project tool versions and tasks without becoming
-    a version manager.
-  - Expected behavior: `basectl setup <project>` can run `mise install` when a
-    project opts in, and future `basectl test <project>` can delegate to
-    `mise run test` when declared.
-
-- [ ] Implement `basectl test [project]`.
-  - Goal: make Base the umbrella entry point for project test execution.
-  - Expected behavior: delegate to the project's declared test command, `mise`
-    task, or conventional runner while preserving Base logging and exit status.
-
-- [ ] Consider a structured `python:` manifest section.
-  - Goal: make Base-managed Python environments clearer than encoding every
-    package as an artifact entry.
-  - Expected design topics: default project venv location, optional venv path
-    override, package requirement syntax, relationship to `requirements.txt`,
-    and migration from existing `python-package` artifacts.
-
-- [ ] Decide whether setup hooks belong in the manifest.
-  - Goal: preserve Base's safety stance while allowing real projects to perform
-    necessary post-setup work when delegation targets are not enough.
-  - Expected behavior: either define a constrained hook contract with explicit
-    timing, dry-run, interactivity, and diagnostics semantics, or document why
-    project-owned installers remain the right layer for hooks.
-
-- [ ] Implement `basectl onboard`.
-  - Goal: provide the guided checklist-style Base setup experience described in
-    `docs/basectl-onboard.md`.
-  - Expected behavior: orchestrate existing setup, check, doctor, profile, and
-    project-discovery primitives without duplicating their logic.
-  - Starting point: implement the v1 Bash subcommand with dry-run, prompted,
-    `--yes`, `--dev`, and `--no-profile` flows.
-
-- [ ] Decide whether `basectl onboard <project>` belongs in Base or project installers.
-  - Goal: revisit the Round 5 recommendation for project-oriented onboarding
-    against Base's current boundary that project installers own
-    product-specific onboarding.
-  - Expected behavior: either extend the onboard design for project targets or
-    explicitly document why `<project>/install.sh` remains the preferred layer.
-
-- [ ] Implement future `docker-service` artifact support when a real project needs it.
-  - Goal: let Base orchestrate Docker Compose services without replacing Docker,
-    Docker Compose, or project-owned Compose files.
-  - Starting point: `docs/tool-boundaries.md` has the intended boundary and a
-    possible future manifest shape.
-  - Manifest design:
-    - Add a `docker-service` artifact type only after field names are finalized
-      against a real project.
-    - Require `compose-file` paths to be relative to the project root and to
-      stay inside that root.
-    - Start with one named `service` per artifact; add service groups later only
-      if needed.
-    - Decide whether `version` should be accepted for schema consistency or
-      omitted for this artifact type.
-  - Setup behavior:
-    - Validate Docker CLI availability and daemon reachability.
-    - Run `docker compose -f <file> pull <service>` when enabled.
-    - Run `docker compose -f <file> build <service>` when enabled.
-    - Keep setup idempotent and avoid starting long-lived services during setup.
-  - Check/doctor behavior:
-    - Report missing Docker, missing daemon, missing Compose file, and missing
-      service definitions as actionable findings.
-    - Give Colima-specific recovery guidance such as `colima start` when useful.
-    - Surface image/service status without hiding the underlying Docker command.
-  - Activate behavior:
-    - Optionally start opted-in services during `basectl activate <project>`.
-    - Keep startup visible in logs and make health-check failures easy to
-      understand.
-  - Tests:
-    - Cover manifest validation, dry-run command planning, daemon-check
-      failures, Compose command failures, and activate-time startup behavior.
-
-## P2 — Operational Excellence
-
-- [ ] Add initial Linux support plan.
-  - Goal: define the first supported Linux target, likely Ubuntu/Debian.
-  - Expected design topics: `/etc/os-release` detection, `apt` equivalents for
-    Homebrew-managed bootstrap dependencies, shell startup differences, and CI
-    implications.
-
-- [ ] Design `basectl ci`.
-  - Goal: make Base useful in non-interactive CI environments once Linux support
-    exists.
-  - Expected behavior: skip UI-only setup paths, avoid interactive prompts, and
-    emit structured output suitable for automation.
-
-- [ ] Add a real Base-managed project demonstration.
-  - Goal: use a project such as Banyanlabs to prove the complete workflow:
-    workspace discovery, `basectl setup <project>`, `basectl check <project>`,
-    `basectl doctor <project>`, `basectl activate <project>`, and future
-    `basectl test <project>`.
-
-## P3 — Performance And CI Hardening
-
-- [ ] Evaluate parallelizing independent `basectl check` probes.
-  - Goal: reduce check wall time by running independent probes concurrently.
-  - Expected behavior: preserve deterministic output order while collecting
-    Homebrew, Xcode, Python, venv, and package results in parallel.
-
-- [ ] Harden GitHub Actions Python file discovery.
-  - Problem: the pylint workflow uses unquoted command substitution with
-    `git ls-files '*.py'`.
-  - Goal: avoid word splitting issues in CI.
-  - Expected behavior: use a null-delimited or `xargs`-based invocation.
-
-- [ ] Pin CI development dependencies and add security scanners.
-  - Goal: make CI more reproducible and catch security issues earlier.
-  - Expected behavior: add a pinned dev requirements flow for CI and evaluate
-    adding Bandit for Python plus ShellCheck for Bash.
+- #118 Add first-class mise integration
+- #119 Implement basectl test project execution
+- #120 Consider a structured python manifest section
+- #121 Decide whether setup hooks belong in the manifest
+- #122 Implement basectl onboard
+- #123 Decide whether basectl onboard project belongs in Base or project installers
+- #124 Implement future docker-service artifact support when a real project needs it
+- #125 Add initial Linux support plan
+- #126 Design basectl ci
+- #127 Add a real Base-managed project demonstration
+- #128 Evaluate parallelizing independent basectl check probes
+- #129 Harden GitHub Actions Python file discovery
+- #130 Pin CI development dependencies and add security scanners

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -28,6 +28,7 @@ that delegate to `basectl`.
 - `check`
 - `clean`
 - `doctor`
+- `gh`
 - `update-profile`
 - `update`
 - `projects list`
@@ -55,6 +56,8 @@ that delegate to `basectl`.
 - `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.
+- `basectl gh` manages GitHub issues, pull requests, branch naming, and
+  repository hygiene using Base's opinionated workflow.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -19,6 +19,8 @@ Commands:
     Remove old Base CLI runtime logs, temp files, and cache entries.
   doctor [project] [options]
     Diagnose the local Base CLI environment and optional project artifacts.
+  gh <area> <command> [options]
+    Manage GitHub issues, PRs, branches, and repository hygiene.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
   update [options]
@@ -160,6 +162,11 @@ basectl_do_doctor() {
     base_doctor_subcommand_main "$@"
 }
 
+basectl_do_gh() {
+    basectl_source_subcommand_module gh || return 1
+    base_gh_subcommand_main "$@"
+}
+
 basectl_do_update_profile() {
     basectl_source_subcommand_module update_profile || return 1
     base_update_profile_subcommand_main "$@"
@@ -258,6 +265,7 @@ basectl_main() {
         check)            basectl_do_check "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;
+        gh)               basectl_do_gh "$@" ;;
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -1,0 +1,505 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_gh_subcommand_sourced:-}" ]] && return
+_base_gh_subcommand_sourced=1
+readonly _base_gh_subcommand_sourced
+
+base_gh_usage() {
+    cat <<'EOF'
+Usage:
+  basectl gh issue list [gh options...]
+  basectl gh issue create --type <feat|fix|chore|docs> --title <title> [--body <body>]
+  basectl gh issue start <number> [--type <feat|fix|chore|docs>] [--title <title>]
+  basectl gh pr create [gh options...]
+  basectl gh pr status [gh options...]
+  basectl gh pr checks [gh options...]
+  basectl gh pr ready [gh options...]
+  basectl gh pr merge [gh options...]
+  basectl gh branch stale [--days <days>]
+  basectl gh branch prune [--dry-run] [--yes] [--remote]
+  basectl gh todo import [--dry-run] [--file <path>]
+
+Purpose:
+  Manage GitHub issues, pull requests, branch naming, and repository hygiene
+  using Base's opinionated workflow.
+
+Branch naming:
+  <type>/<issue>-<YYYYMMDD>-<slug>
+
+Notes:
+  - This command requires the GitHub CLI (`gh`) for GitHub operations.
+  - Branch pruning is dry-run unless --yes is passed.
+  - TODO import is currently a dry-run planning command.
+EOF
+}
+
+base_gh_error() {
+    print_error "$*"
+}
+
+base_gh_require_command() {
+    local command="$1"
+
+    command -v "$command" >/dev/null 2>&1 || {
+        base_gh_error "Required command '$command' was not found on PATH."
+        return 1
+    }
+}
+
+base_gh_require_git_repo() {
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+        base_gh_error "Current directory is not inside a Git worktree."
+        return 1
+    }
+}
+
+base_gh_default_branch() {
+    local default_branch
+
+    if default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+        default_branch="${default_branch#origin/}"
+        [[ -n "$default_branch" ]] && {
+            printf '%s\n' "$default_branch"
+            return 0
+        }
+    fi
+
+    if git show-ref --verify --quiet refs/heads/main; then
+        printf '%s\n' main
+        return 0
+    fi
+
+    if git show-ref --verify --quiet refs/heads/master; then
+        printf '%s\n' master
+        return 0
+    fi
+
+    printf '%s\n' master
+}
+
+base_gh_validate_type() {
+    case "$1" in
+        feat|fix|chore|docs) return 0 ;;
+        *)
+            base_gh_error "Invalid type '$1'. Expected one of: feat, fix, chore, docs."
+            return 1
+            ;;
+    esac
+}
+
+base_gh_slug() {
+    local input="$1"
+    local slug
+
+    slug="$(printf '%s\n' "$input" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+    if [[ -z "$slug" ]]; then
+        slug="work"
+    fi
+    printf '%.60s\n' "$slug" | sed -E 's/-+$//'
+}
+
+base_gh_issue_type_from_labels() {
+    local issue="$1"
+    local issue_type
+
+    issue_type="$(gh issue view "$issue" --json labels --jq '.labels[].name | select(startswith("type:")) | sub("^type:"; "")' 2>/dev/null | head -n 1)"
+    if [[ -z "$issue_type" ]]; then
+        issue_type="feat"
+    fi
+    base_gh_validate_type "$issue_type" || return 1
+    printf '%s\n' "$issue_type"
+}
+
+base_gh_issue_title() {
+    local issue="$1"
+    gh issue view "$issue" --json title --jq '.title'
+}
+
+base_gh_current_issue_from_branch() {
+    local branch
+
+    branch="$(git branch --show-current 2>/dev/null)" || return 1
+    [[ "$branch" =~ ^[^/]+/([0-9]+)- ]] || return 1
+    printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+base_gh_do_issue() {
+    local command="${1:-}"
+    shift || true
+
+    case "$command" in
+        list)
+            base_gh_require_command gh || return 1
+            gh issue list "$@"
+            ;;
+        create)
+            base_gh_issue_create "$@"
+            ;;
+        start)
+            base_gh_issue_start "$@"
+            ;;
+        -h|--help|help|"")
+            base_gh_usage
+            ;;
+        *)
+            base_gh_error "Unknown gh issue command '$command'."
+            base_gh_usage >&2
+            return 1
+            ;;
+    esac
+}
+
+base_gh_issue_create() {
+    local issue_type="" title="" body=""
+
+    while (($#)); do
+        case "$1" in
+            --type)
+                issue_type="${2:-}"
+                shift
+                ;;
+            --title)
+                title="${2:-}"
+                shift
+                ;;
+            --body)
+                body="${2:-}"
+                shift
+                ;;
+            -h|--help)
+                base_gh_usage
+                return 0
+                ;;
+            *)
+                base_gh_error "Unknown option '$1'."
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    [[ -n "$title" ]] || {
+        base_gh_error "Missing required --title."
+        return 1
+    }
+    issue_type="${issue_type:-feat}"
+    base_gh_validate_type "$issue_type" || return 1
+    base_gh_require_command gh || return 1
+
+    if [[ -n "$body" ]]; then
+        gh issue create --title "$title" --body "$body" --label "type:$issue_type"
+    else
+        gh issue create --title "$title" --label "type:$issue_type"
+    fi
+}
+
+base_gh_issue_start() {
+    local issue="${1:-}" issue_type="" title="" slug branch today
+
+    [[ -n "$issue" ]] || {
+        base_gh_error "Missing issue number."
+        return 1
+    }
+    shift
+
+    while (($#)); do
+        case "$1" in
+            --type)
+                issue_type="${2:-}"
+                shift
+                ;;
+            --title)
+                title="${2:-}"
+                shift
+                ;;
+            -h|--help)
+                base_gh_usage
+                return 0
+                ;;
+            *)
+                base_gh_error "Unknown option '$1'."
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    base_gh_require_git_repo || return 1
+    if [[ -z "$issue_type" || -z "$title" ]]; then
+        base_gh_require_command gh || return 1
+    fi
+    if [[ -z "$issue_type" ]]; then
+        issue_type="$(base_gh_issue_type_from_labels "$issue")" || return 1
+    fi
+    base_gh_validate_type "$issue_type" || return 1
+    if [[ -z "$title" ]]; then
+        title="$(base_gh_issue_title "$issue")" || return 1
+    fi
+
+    slug="$(base_gh_slug "$title")"
+    today="$(date +%Y%m%d)"
+    branch="$issue_type/$issue-$today-$slug"
+
+    git switch --quiet -c "$branch"
+    printf '%s\n' "$branch"
+}
+
+base_gh_do_pr() {
+    local command="${1:-}"
+    local issue body_file status
+    shift || true
+
+    case "$command" in
+        create)
+            base_gh_require_command gh || return 1
+            base_gh_require_git_repo || return 1
+            issue="$(base_gh_current_issue_from_branch || true)"
+            if [[ -n "$issue" ]]; then
+                body_file="$(mktemp "${TMPDIR:-/tmp}/basectl-gh-pr.XXXXXX")" || return 1
+                printf 'Fixes #%s\n' "$issue" > "$body_file"
+                gh pr create --fill --body-file "$body_file" "$@"
+                status=$?
+                rm -f "$body_file"
+                return "$status"
+            fi
+            gh pr create --fill "$@"
+            ;;
+        status)
+            base_gh_require_command gh || return 1
+            gh pr status "$@"
+            ;;
+        checks)
+            base_gh_require_command gh || return 1
+            gh pr checks "$@"
+            ;;
+        ready)
+            base_gh_require_command gh || return 1
+            gh pr ready "$@"
+            ;;
+        merge)
+            base_gh_require_command gh || return 1
+            gh pr merge "$@"
+            ;;
+        -h|--help|help|"")
+            base_gh_usage
+            ;;
+        *)
+            base_gh_error "Unknown gh pr command '$command'."
+            base_gh_usage >&2
+            return 1
+            ;;
+    esac
+}
+
+base_gh_branch_stale() {
+    local days=30 now ref name timestamp age
+
+    while (($#)); do
+        case "$1" in
+            --days)
+                days="${2:-}"
+                shift
+                ;;
+            -h|--help)
+                base_gh_usage
+                return 0
+                ;;
+            *)
+                base_gh_error "Unknown option '$1'."
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    [[ "$days" =~ ^[0-9]+$ ]] || {
+        base_gh_error "--days must be a positive integer."
+        return 1
+    }
+    base_gh_require_git_repo || return 1
+
+    now="$(date +%s)"
+    printf 'age_days\tlast_commit\tbranch\n'
+    while read -r timestamp ref; do
+        age=$(((now - timestamp) / 86400))
+        if ((age >= days)); then
+            name="${ref#refs/heads/}"
+            name="${name#refs/remotes/}"
+            printf '%s\t%s\t%s\n' "$age" "$(date -r "$timestamp" +%Y-%m-%d 2>/dev/null || date -d "@$timestamp" +%Y-%m-%d)" "$name"
+        fi
+    done < <(git for-each-ref --format='%(committerdate:unix) %(refname)' refs/heads refs/remotes/origin | grep -v ' refs/remotes/origin/HEAD$')
+}
+
+base_gh_branch_prune() {
+    local dry_run=1 yes=0 remote=0 default_branch current_branch branch
+
+    while (($#)); do
+        case "$1" in
+            --dry-run)
+                dry_run=1
+                ;;
+            --yes)
+                dry_run=0
+                yes=1
+                ;;
+            --remote)
+                remote=1
+                ;;
+            -h|--help)
+                base_gh_usage
+                return 0
+                ;;
+            *)
+                base_gh_error "Unknown option '$1'."
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    base_gh_require_git_repo || return 1
+    default_branch="$(base_gh_default_branch)"
+    current_branch="$(git branch --show-current)"
+
+    if ((dry_run)); then
+        printf '[DRY-RUN] Local branches merged into %s that would be deleted:\n' "$default_branch"
+    elif ((yes == 0)); then
+        base_gh_error "Refusing to prune without --yes."
+        return 1
+    fi
+
+    while read -r branch; do
+        branch="${branch#\* }"
+        branch="${branch## }"
+        [[ -z "$branch" || "$branch" == "$default_branch" || "$branch" == "$current_branch" ]] && continue
+        if ((dry_run)); then
+            printf '%s\n' "$branch"
+        else
+            git branch -d "$branch"
+        fi
+    done < <(git branch --merged "$default_branch" --format='%(refname:short)')
+
+    if ((remote)); then
+        if ((dry_run)); then
+            printf '[DRY-RUN] Remote pruning would run: git remote prune origin\n'
+        else
+            git remote prune origin
+        fi
+    fi
+}
+
+base_gh_do_branch() {
+    local command="${1:-}"
+    shift || true
+
+    case "$command" in
+        stale) base_gh_branch_stale "$@" ;;
+        prune) base_gh_branch_prune "$@" ;;
+        -h|--help|help|"") base_gh_usage ;;
+        *)
+            base_gh_error "Unknown gh branch command '$command'."
+            base_gh_usage >&2
+            return 1
+            ;;
+    esac
+}
+
+base_gh_todo_infer_type() {
+    local section="$1"
+    local title="${2:-}"
+
+    case "$title" in
+        Harden*|Fix*|Repair*) printf '%s\n' fix; return 0 ;;
+    esac
+
+    case "$section" in
+        *Security*|*Correctness*) printf '%s\n' fix ;;
+        *Product*|*Core*|*Composability*) printf '%s\n' feat ;;
+        *Documentation*|*Docs*) printf '%s\n' docs ;;
+        *) printf '%s\n' chore ;;
+    esac
+}
+
+base_gh_todo_import() {
+    local file="$BASE_HOME/TODO.md" dry_run=1 line section="" title issue_type
+
+    while (($#)); do
+        case "$1" in
+            --dry-run)
+                dry_run=1
+                ;;
+            --file)
+                file="${2:-}"
+                shift
+                ;;
+            -h|--help)
+                base_gh_usage
+                return 0
+                ;;
+            *)
+                base_gh_error "Unknown option '$1'."
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    [[ -f "$file" ]] || {
+        base_gh_error "TODO file '$file' was not found."
+        return 1
+    }
+
+    if ((dry_run)); then
+        printf '[DRY-RUN] Issues that would be created from %s:\n' "$file"
+    else
+        base_gh_error "TODO import creation is not enabled yet; run with --dry-run."
+        return 1
+    fi
+
+    while IFS= read -r line; do
+        case "$line" in
+            "## "*)
+                section="${line#'## '}"
+                ;;
+            "- [ ] "*)
+                title="${line#'- [ ] '}"
+                title="${title%.}"
+                issue_type="$(base_gh_todo_infer_type "$section" "$title")"
+                printf 'type:%s\t%s\n' "$issue_type" "$title"
+                ;;
+        esac
+    done < "$file"
+}
+
+base_gh_do_todo() {
+    local command="${1:-}"
+    shift || true
+
+    case "$command" in
+        import) base_gh_todo_import "$@" ;;
+        -h|--help|help|"") base_gh_usage ;;
+        *)
+            base_gh_error "Unknown gh todo command '$command'."
+            base_gh_usage >&2
+            return 1
+            ;;
+    esac
+}
+
+base_gh_subcommand_main() {
+    local area="${1:-}"
+    shift || true
+
+    case "$area" in
+        issue) base_gh_do_issue "$@" ;;
+        pr) base_gh_do_pr "$@" ;;
+        branch) base_gh_do_branch "$@" ;;
+        todo) base_gh_do_todo "$@" ;;
+        -h|--help|help|"") base_gh_usage ;;
+        *)
+            base_gh_error "Unknown gh area '$area'."
+            base_gh_usage >&2
+            return 1
+            ;;
+    esac
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -6,7 +6,9 @@ bats_require_minimum_version 1.5.0
 setup() {
     setup_test_tmpdir
     TEST_HOME="$TEST_TMPDIR/home"
-    mkdir -p "$TEST_HOME"
+    TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
+    TEST_STATE_DIR="$TEST_TMPDIR/state"
+    mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
 }
 
 run_basectl() {
@@ -26,6 +28,7 @@ run_basectl() {
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
+    [[ "$output" == *"gh <area> <command> [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command is equivalent to \`basectl activate base\`"* ]]
@@ -50,9 +53,171 @@ run_basectl() {
     ! grep -Fqx '  install' <<<"$output"
     ! grep -Fqx '  shell' <<<"$output"
     grep -Fqx '  version' <<<"$output"
+    grep -Fqx '  gh <area> <command> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
+}
+
+@test "basectl gh prints help" {
+    run_basectl gh --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl gh issue start <number>"* ]]
+    [[ "$output" == *"<type>/<issue>-<YYYYMMDD>-<slug>"* ]]
+}
+
+@test "basectl gh issue create applies type label" {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue create --type fix --title "Repair branch pruning"
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Repair branch pruning --label type:fix" ]
+}
+
+@test "basectl gh issue start creates convention branch from issue metadata" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "issue view 117 --json labels --jq .labels[].name | select(startswith(\"type:\")) | sub(\"^type:\"; \"\")" ]]; then
+    printf 'feat\n'
+    exit 0
+fi
+if [[ "$*" == "issue view 117 --json title --jq .title" ]]; then
+    printf 'Add basectl gh workflow for issues\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue start 117
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == "feat/117-"*"-add-basectl-gh-workflow-for-issues" ]]
+    [ "$(git -C "$repo" branch --show-current)" = "$output" ]
+}
+
+@test "basectl gh issue start accepts explicit type and title without gh" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue start 117 --type chore --title "Prune merged branches"
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == "chore/117-"*"-prune-merged-branches" ]]
+}
+
+@test "basectl gh pr create links current branch issue" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c "feat/117-20260528-basectl-gh-workflow" >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+body_file=""
+while (($#)); do
+    if [[ "$1" == "--body-file" ]]; then
+        body_file="$2"
+        break
+    fi
+    shift
+done
+[[ -n "$body_file" ]] && cat "$body_file" > "${BASE_GH_TEST_STATE_DIR:?}/body"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main pr create
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$TEST_STATE_DIR/gh-args")" == pr\ create\ --fill\ --body-file* ]]
+    [ "$(cat "$TEST_STATE_DIR/body")" = "Fixes #117" ]
+}
+
+@test "basectl gh todo import dry-run classifies TODO items" {
+    local todo_file
+
+    todo_file="$TEST_TMPDIR/TODO.md"
+    cat > "$todo_file" <<'EOF'
+## P0 — Security And Correctness
+
+- [ ] Detect outdated Xcode Command Line Tools in `basectl doctor`.
+
+## P1 — Product Core And Composability
+
+- [ ] Add first-class `mise` integration.
+EOF
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main todo import --dry-run --file "$1"
+        ' bash "$todo_file"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'type:fix\tDetect outdated Xcode Command Line Tools in `basectl doctor`'* ]]
+    [[ "$output" == *$'type:feat\tAdd first-class `mise` integration'* ]]
 }
 
 @test "basectl update prints help" {

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -24,7 +24,7 @@ _base_basectl_completion_compgen() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check clean doctor update-profile update projects version help"
+    local commands="activate setup check clean doctor gh update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -59,6 +59,39 @@ _base_basectl_completion() {
             ;;
         doctor)
             _base_basectl_completion_compgen "--dev -v -h --help" "$cur"
+            ;;
+        gh)
+            case "${COMP_WORDS[2]:-}" in
+                "")
+                    _base_basectl_completion_compgen "issue pr branch todo" "$cur"
+                    ;;
+                issue)
+                    if ((COMP_CWORD == 3)); then
+                        _base_basectl_completion_compgen "list create start" "$cur"
+                    else
+                        _base_basectl_completion_compgen "--type --title --body -h --help" "$cur"
+                    fi
+                    ;;
+                pr)
+                    if ((COMP_CWORD == 3)); then
+                        _base_basectl_completion_compgen "create status checks ready merge" "$cur"
+                    fi
+                    ;;
+                branch)
+                    if ((COMP_CWORD == 3)); then
+                        _base_basectl_completion_compgen "stale prune" "$cur"
+                    else
+                        _base_basectl_completion_compgen "--days --dry-run --yes --remote -h --help" "$cur"
+                    fi
+                    ;;
+                todo)
+                    if ((COMP_CWORD == 3)); then
+                        _base_basectl_completion_compgen "import" "$cur"
+                    else
+                        _base_basectl_completion_compgen "--dry-run --file -h --help" "$cur"
+                    fi
+                    ;;
+            esac
             ;;
         update-profile)
             _base_basectl_completion_compgen "--defaults --no-defaults --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -18,6 +18,7 @@ _base_basectl_completion() {
         'check:Verify the local Base CLI environment'
         'clean:Remove old Base CLI runtime artifacts'
         'doctor:Diagnose the local Base environment'
+        'gh:Manage GitHub issues, pull requests, branches, and hygiene'
         'update-profile:Refresh Base-managed shell startup sections'
         'update:Update Base and rerun setup'
         'projects:List Base-managed projects'
@@ -59,6 +60,41 @@ _base_basectl_completion() {
         doctor)
             _arguments '--dev[Include developer prerequisite checks]' '-v[Enable DEBUG logging]' \
                 '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        gh)
+            case "${words[3]:-}" in
+                issue)
+                    _arguments '1:gh area:(issue pr branch todo)' \
+                        '2:issue command:(list create start)' \
+                        '--type[Issue or branch type]:type:(feat fix chore docs)' \
+                        '--title[Issue title]:title:' \
+                        '--body[Issue body]:body:' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                pr)
+                    _arguments '1:gh area:(issue pr branch todo)' \
+                        '2:pr command:(create status checks ready merge)'
+                    ;;
+                branch)
+                    _arguments '1:gh area:(issue pr branch todo)' \
+                        '2:branch command:(stale prune)' \
+                        '--days[Stale threshold in days]:days:' \
+                        '--dry-run[Show planned deletions]' \
+                        '--yes[Apply branch pruning]' \
+                        '--remote[Prune stale remote tracking refs]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                todo)
+                    _arguments '1:gh area:(issue pr branch todo)' \
+                        '2:todo command:(import)' \
+                        '--dry-run[Show planned issues]' \
+                        '--file[TODO file]:path:_files' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                *)
+                    _arguments '1:gh area:(issue pr branch todo)'
+                    ;;
+            esac
             ;;
         update-profile)
             _arguments '--defaults[Enable shell defaults]' '--no-defaults[Disable shell defaults]' \


### PR DESCRIPTION
## Summary

Adds a first-class `basectl gh` command family for Base's GitHub workflow:

- issue helpers for listing, creating typed issues, and starting convention-named branches
- PR helpers for create/status/checks/ready/merge, with `Fixes #<issue>` inferred from branch names
- branch hygiene helpers for stale branch reporting and dry-run/default-safe pruning
- TODO migration dry-run classification by `type:*`
- shell completion and help updates

Also migrates the current public `TODO.md` backlog into GitHub Issues and rewrites `TODO.md` as scratch-note guidance.

Fixes #117

## Validation

- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bash -n cli/bash/commands/basectl/subcommands/gh.sh`