### PR TITLE
Install supported IDEs from manifest

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -34,6 +34,20 @@ class ManifestAction:
     output_format: str
 
 
+@dataclass(frozen=True)
+class IdeDefinition:
+    name: str
+    label: str
+    cli: str
+    cask: str
+
+
+IDE_DEFINITIONS = {
+    "vscode": IdeDefinition(name="vscode", label="VS Code", cli="code", cask="visual-studio-code"),
+    "cursor": IdeDefinition(name="cursor", label="Cursor", cli="cursor", cask="cursor"),
+}
+
+
 def main(argv: list[str] | None = None) -> int:
     result = app.click_command.main(args=argv, standalone_mode=False)
     return int(result or 0)
@@ -141,6 +155,7 @@ def reconcile_manifest(
             ctx.log.info("Project '%s' has no artifacts to install.", manifest.project_name)
 
     reconcile_brewfile(ctx, manifest, dry_run=dry_run)
+    reconcile_ide_installs(ctx, manifest, dry_run=dry_run)
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
         reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
@@ -218,6 +233,8 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
 
     if manifest.brewfile is not None:
         checks.append(check_brewfile(manifest))
+
+    checks.extend(check_ide_installs(manifest))
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
         checks.append(check_artifact(manifest.project_name, artifact, definition))
@@ -451,6 +468,83 @@ def resolve_brewfile_path(manifest: BaseManifest) -> Path:
     if not brewfile_path.is_file():
         raise ArtifactError(f"{manifest.path}: brewfile '{manifest.brewfile}' does not exist.")
     return brewfile_path
+
+
+def reconcile_ide_installs(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
+    for ide_name, ide_config in manifest.ide.items():
+        definition = IDE_DEFINITIONS[ide_name]
+        if not ide_config.install:
+            ctx.log.debug("IDE '%s' does not request installation; skipping cask install.", ide_name)
+            continue
+        reconcile_ide_install(ctx, definition, dry_run=dry_run)
+
+
+def reconcile_ide_install(ctx: base_cli.Context, definition: IdeDefinition, dry_run: bool) -> None:
+    command = ["brew", "install", "--cask", definition.cask]
+    if dry_run:
+        dry_run_command(ctx, command)
+        return
+
+    if not command_exists("brew"):
+        raise ArtifactError(f"Homebrew is required to install {definition.label}.")
+
+    if run_check(["brew", "list", "--cask", definition.cask]):
+        ctx.log.info("%s is already installed via Homebrew cask '%s'.", definition.label, definition.cask)
+    else:
+        ctx.log.info("Installing %s via Homebrew cask '%s'.", definition.label, definition.cask)
+        run_command(ctx, command)
+
+    if command_exists(definition.cli):
+        ctx.log.info("%s CLI '%s' is available on PATH.", definition.label, definition.cli)
+    else:
+        ctx.log.warning(
+            "%s is installed, but CLI '%s' is not on PATH. Enable the IDE shell command before extension setup.",
+            definition.label,
+            definition.cli,
+        )
+
+
+def check_ide_installs(manifest: BaseManifest) -> list[ArtifactCheck]:
+    checks: list[ArtifactCheck] = []
+    for ide_name, ide_config in manifest.ide.items():
+        definition = IDE_DEFINITIONS[ide_name]
+        if ide_config.install:
+            checks.append(check_ide_install(manifest.project_name, definition))
+    return checks
+
+
+def check_ide_install(project: str, definition: IdeDefinition) -> ArtifactCheck:
+    if not command_exists("brew"):
+        return ArtifactCheck(
+            name=f"{definition.label} app",
+            ok=False,
+            message=f"Homebrew is required to check {definition.label} installation.",
+            fix="basectl setup",
+        )
+
+    cask_installed = run_check(["brew", "list", "--cask", definition.cask])
+    cli_available = command_exists(definition.cli)
+
+    if cask_installed and cli_available:
+        return ArtifactCheck(
+            name=f"{definition.label} app",
+            ok=True,
+            message=f"{definition.label} is installed and CLI '{definition.cli}' is on PATH.",
+            fix="",
+        )
+    if not cask_installed:
+        return ArtifactCheck(
+            name=f"{definition.label} app",
+            ok=False,
+            message=f"{definition.label} is not installed via Homebrew cask '{definition.cask}'.",
+            fix=f"basectl setup {project}",
+        )
+    return ArtifactCheck(
+        name=f"{definition.label} CLI",
+        ok=False,
+        message=f"{definition.label} is installed, but CLI '{definition.cli}' is not on PATH.",
+        fix=f"Enable the '{definition.cli}' shell command from {definition.label}.",
+    )
 
 
 def reconcile_artifact(

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 from base_setup import engine
 from base_setup.engine import ArtifactError, format_command, main, merge_artifacts
-from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError
+from base_setup.manifest import ArtifactRequest, BaseManifest, IdeConfig, ManifestError
 from base_setup.manifest import read_manifest
 from base_setup.registry import get_artifact_definition
 
@@ -783,6 +783,129 @@ class BrewfileTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ArtifactError, "must stay inside the project root"):
                 engine.resolve_brewfile_path(manifest)
+
+
+class IdeInstallTests(unittest.TestCase):
+    def test_ide_install_dry_run_invokes_homebrew_cask_install(self) -> None:
+        ctx = fake_context()
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(install=True, extensions=(), settings={}),
+                "cursor": IdeConfig(install=False, extensions=(), settings={}),
+            },
+        )
+
+        engine.reconcile_ide_installs(ctx, manifest, dry_run=True)
+
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertIn("[DRY-RUN] Would run: brew install --cask visual-studio-code", info_messages)
+        self.assertEqual(len(info_messages), 1)
+
+    def test_ide_install_skips_existing_cask_and_reports_available_cli(self) -> None:
+        ctx = fake_context()
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.run_check",
+            return_value=True,
+        ), mock.patch("base_setup.engine.run_command") as run_command:
+            engine.reconcile_ide_install(ctx, definition, dry_run=False)
+
+        run_command.assert_not_called()
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertIn("VS Code is already installed via Homebrew cask 'visual-studio-code'.", info_messages)
+        self.assertIn("VS Code CLI 'code' is available on PATH.", info_messages)
+
+    def test_ide_install_installs_missing_cask(self) -> None:
+        ctx = fake_context()
+        definition = engine.IDE_DEFINITIONS["cursor"]
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.run_check",
+            return_value=False,
+        ), mock.patch("base_setup.engine.run_command") as run_command:
+            engine.reconcile_ide_install(ctx, definition, dry_run=False)
+
+        run_command.assert_called_once_with(ctx, ["brew", "install", "--cask", "cursor"])
+
+    def test_ide_install_warns_when_cli_is_missing_after_install(self) -> None:
+        ctx = fake_context()
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        def command_exists(name: str) -> bool:
+            return name == "brew"
+
+        with mock.patch("base_setup.engine.command_exists", side_effect=command_exists), mock.patch(
+            "base_setup.engine.run_check",
+            return_value=True,
+        ):
+            engine.reconcile_ide_install(ctx, definition, dry_run=False)
+
+        warning_messages = [call.args[0] % call.args[1:] for call in ctx.log.warning.call_args_list]
+        self.assertIn(
+            "VS Code is installed, but CLI 'code' is not on PATH. Enable the IDE shell command before extension setup.",
+            warning_messages,
+        )
+
+    def test_check_ide_install_reports_missing_cask(self) -> None:
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.run_check",
+            return_value=False,
+        ):
+            check = engine.check_ide_install("demo", definition)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.name, "VS Code app")
+        self.assertIn("Homebrew cask 'visual-studio-code'", check.message)
+        self.assertEqual(check.fix, "basectl setup demo")
+
+    def test_check_ide_install_reports_missing_cli(self) -> None:
+        definition = engine.IDE_DEFINITIONS["cursor"]
+
+        def command_exists(name: str) -> bool:
+            return name == "brew"
+
+        with mock.patch("base_setup.engine.command_exists", side_effect=command_exists), mock.patch(
+            "base_setup.engine.run_check",
+            return_value=True,
+        ):
+            check = engine.check_ide_install("demo", definition)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.name, "Cursor CLI")
+        self.assertIn("CLI 'cursor' is not on PATH", check.message)
+        self.assertIn("Enable the 'cursor' shell command", check.fix)
+
+    def test_manifest_checks_include_requested_ide_installs(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={"vscode": IdeConfig(install=True, extensions=(), settings={})},
+        )
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.run_check",
+            return_value=True,
+        ):
+            checks = engine.manifest_checks(default_manifest, manifest)
+
+        self.assertEqual(len(checks), 1)
+        self.assertEqual(checks[0].name, "VS Code app")
+        self.assertTrue(checks[0].ok)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the setup/check foundation for IDE app installation from the `ide:` manifest section.

- defines supported IDE metadata for VS Code and Cursor
- installs opted-in IDEs through Homebrew casks during setup
- treats IDE installation as opt-in via `install: true`
- reports missing Homebrew, missing casks, and missing IDE CLIs through manifest checks
- keeps extension install and settings merge for follow-up issues

Fixes #133

## Validation

- `PYTHONPATH=cli/python:lib/python python3 -m unittest cli.python.base_setup.tests.test_engine`
- `python3 -m py_compile cli/python/base_setup/engine.py cli/python/base_setup/manifest.py`