### PR TITLE
Install IDE extensions from manifest

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -156,6 +156,7 @@ def reconcile_manifest(
 
     reconcile_brewfile(ctx, manifest, dry_run=dry_run)
     reconcile_ide_installs(ctx, manifest, dry_run=dry_run)
+    reconcile_ide_extensions(ctx, manifest, dry_run=dry_run)
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
         reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
@@ -235,6 +236,7 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
         checks.append(check_brewfile(manifest))
 
     checks.extend(check_ide_installs(manifest))
+    checks.extend(check_ide_extensions(manifest))
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
         checks.append(check_artifact(manifest.project_name, artifact, definition))
@@ -511,6 +513,96 @@ def check_ide_installs(manifest: BaseManifest) -> list[ArtifactCheck]:
         if ide_config.install:
             checks.append(check_ide_install(manifest.project_name, definition))
     return checks
+
+
+def reconcile_ide_extensions(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
+    for ide_name, ide_config in manifest.ide.items():
+        if not ide_config.extensions:
+            continue
+        definition = IDE_DEFINITIONS[ide_name]
+        if dry_run:
+            for extension in ide_config.extensions:
+                dry_run_command(ctx, [definition.cli, "--install-extension", extension])
+            continue
+        if not command_exists(definition.cli):
+            ctx.log.warning(
+                "%s CLI '%s' is not on PATH; skipping extension setup.",
+                definition.label,
+                definition.cli,
+            )
+            continue
+        installed_extensions = list_ide_extensions(definition)
+        for extension in ide_config.extensions:
+            if extension in installed_extensions:
+                ctx.log.debug(
+                    "%s extension '%s' is already installed.",
+                    definition.label,
+                    extension,
+                )
+                continue
+            ctx.log.info("Installing %s extension '%s'.", definition.label, extension)
+            run_command(ctx, [definition.cli, "--install-extension", extension])
+
+
+def list_ide_extensions(definition: IdeDefinition) -> set[str]:
+    completed = subprocess.run(
+        [definition.cli, "--list-extensions"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode:
+        stderr = (completed.stderr or "").strip()
+        message = f"Unable to list {definition.label} extensions with '{definition.cli} --list-extensions'."
+        if stderr:
+            message = f"{message}\n{stderr}"
+        raise ArtifactError(message)
+    return {line.strip() for line in completed.stdout.splitlines() if line.strip()}
+
+
+def check_ide_extensions(manifest: BaseManifest) -> list[ArtifactCheck]:
+    checks: list[ArtifactCheck] = []
+    for ide_name, ide_config in manifest.ide.items():
+        if not ide_config.extensions:
+            continue
+        definition = IDE_DEFINITIONS[ide_name]
+        checks.extend(check_ide_extension(manifest.project_name, definition, extension) for extension in ide_config.extensions)
+    return checks
+
+
+def check_ide_extension(project: str, definition: IdeDefinition, extension: str) -> ArtifactCheck:
+    if not command_exists(definition.cli):
+        return ArtifactCheck(
+            name=extension,
+            ok=False,
+            message=f"Cannot check {definition.label} extension '{extension}' because CLI '{definition.cli}' is not on PATH.",
+            fix=f"Enable the '{definition.cli}' shell command from {definition.label}, then run 'basectl setup {project}'.",
+        )
+
+    try:
+        installed_extensions = list_ide_extensions(definition)
+    except ArtifactError as exc:
+        return ArtifactCheck(
+            name=extension,
+            ok=False,
+            message=str(exc),
+            fix=f"basectl setup {project}",
+        )
+
+    if extension in installed_extensions:
+        return ArtifactCheck(
+            name=extension,
+            ok=True,
+            message=f"{definition.label} extension '{extension}' is installed.",
+            fix="",
+        )
+    return ArtifactCheck(
+        name=extension,
+        ok=False,
+        message=f"{definition.label} extension '{extension}' is not installed.",
+        fix=f"basectl setup {project}",
+    )
 
 
 def check_ide_install(project: str, definition: IdeDefinition) -> ArtifactCheck:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -908,5 +908,192 @@ class IdeInstallTests(unittest.TestCase):
         self.assertTrue(checks[0].ok)
 
 
+class IdeExtensionTests(unittest.TestCase):
+    def test_ide_extensions_dry_run_prints_install_commands(self) -> None:
+        ctx = fake_context()
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=False,
+                    extensions=("ms-python.python", "github.copilot"),
+                    settings={},
+                )
+            },
+        )
+
+        engine.reconcile_ide_extensions(ctx, manifest, dry_run=True)
+
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertEqual(
+            info_messages,
+            [
+                "[DRY-RUN] Would run: code --install-extension ms-python.python",
+                "[DRY-RUN] Would run: code --install-extension github.copilot",
+            ],
+        )
+
+    def test_ide_extensions_skip_installed_extensions(self) -> None:
+        ctx = fake_context()
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=False,
+                    extensions=("ms-python.python", "github.copilot"),
+                    settings={},
+                )
+            },
+        )
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.list_ide_extensions",
+            return_value={"ms-python.python", "github.copilot"},
+        ), mock.patch("base_setup.engine.run_command") as run_command:
+            engine.reconcile_ide_extensions(ctx, manifest, dry_run=False)
+
+        run_command.assert_not_called()
+
+    def test_ide_extensions_install_missing_extensions(self) -> None:
+        ctx = fake_context()
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "cursor": IdeConfig(
+                    install=False,
+                    extensions=("ms-python.python", "github.copilot"),
+                    settings={},
+                )
+            },
+        )
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.list_ide_extensions",
+            return_value={"ms-python.python"},
+        ), mock.patch("base_setup.engine.run_command") as run_command:
+            engine.reconcile_ide_extensions(ctx, manifest, dry_run=False)
+
+        run_command.assert_called_once_with(ctx, ["cursor", "--install-extension", "github.copilot"])
+
+    def test_ide_extensions_warn_when_cli_is_missing(self) -> None:
+        ctx = fake_context()
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=False,
+                    extensions=("ms-python.python",),
+                    settings={},
+                )
+            },
+        )
+
+        with mock.patch("base_setup.engine.command_exists", return_value=False):
+            engine.reconcile_ide_extensions(ctx, manifest, dry_run=False)
+
+        warning_messages = [call.args[0] % call.args[1:] for call in ctx.log.warning.call_args_list]
+        self.assertIn("VS Code CLI 'code' is not on PATH; skipping extension setup.", warning_messages)
+
+    def test_list_ide_extensions_returns_installed_extension_ids(self) -> None:
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        with mock.patch(
+            "base_setup.engine.subprocess.run",
+            return_value=mock.Mock(returncode=0, stdout="ms-python.python\n\ngithub.copilot\n", stderr=""),
+        ):
+            extensions = engine.list_ide_extensions(definition)
+
+        self.assertEqual(extensions, {"ms-python.python", "github.copilot"})
+
+    def test_list_ide_extensions_includes_stderr_on_failure(self) -> None:
+        definition = engine.IDE_DEFINITIONS["cursor"]
+
+        with mock.patch(
+            "base_setup.engine.subprocess.run",
+            return_value=mock.Mock(returncode=1, stdout="", stderr="extensions unavailable\n"),
+        ):
+            with self.assertRaisesRegex(ArtifactError, "extensions unavailable"):
+                engine.list_ide_extensions(definition)
+
+    def test_check_ide_extension_reports_installed_extension(self) -> None:
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.list_ide_extensions",
+            return_value={"ms-python.python"},
+        ):
+            check = engine.check_ide_extension("demo", definition, "ms-python.python")
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.name, "ms-python.python")
+        self.assertIn("is installed", check.message)
+
+    def test_check_ide_extension_reports_missing_extension(self) -> None:
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.list_ide_extensions",
+            return_value=set(),
+        ):
+            check = engine.check_ide_extension("demo", definition, "ms-python.python")
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.fix, "basectl setup demo")
+        self.assertIn("is not installed", check.message)
+
+    def test_check_ide_extension_reports_missing_cli(self) -> None:
+        definition = engine.IDE_DEFINITIONS["cursor"]
+
+        with mock.patch("base_setup.engine.command_exists", return_value=False):
+            check = engine.check_ide_extension("demo", definition, "github.copilot")
+
+        self.assertFalse(check.ok)
+        self.assertIn("CLI 'cursor' is not on PATH", check.message)
+        self.assertIn("basectl setup demo", check.fix)
+
+    def test_manifest_checks_include_ide_extensions(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=False,
+                    extensions=("ms-python.python",),
+                    settings={},
+                )
+            },
+        )
+
+        with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+            "base_setup.engine.list_ide_extensions",
+            return_value={"ms-python.python"},
+        ):
+            checks = engine.manifest_checks(default_manifest, manifest)
+
+        self.assertEqual(len(checks), 1)
+        self.assertEqual(checks[0].name, "ms-python.python")
+        self.assertTrue(checks[0].ok)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds IDE extension setup/check support for the `ide:` manifest section.

- installs declared extensions with `code --install-extension` or `cursor --install-extension`
- lists installed extensions through the IDE CLI and skips already installed extensions
- supports dry-run extension install output
- warns and skips setup when the IDE CLI is missing
- reports installed, missing, and uncheckable extensions through manifest checks

Fixes #134

## Validation

- `PYTHONPATH=cli/python:lib/python python3 -m unittest cli.python.base_setup.tests.test_engine`
- `python3 -m py_compile cli/python/base_setup/engine.py cli/python/base_setup/manifest.py`