### PR TITLE
Add IDE diagnostics coverage

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -176,7 +176,7 @@ def reconcile_manifest(
     for artifact, definition in zip(artifacts, definitions, strict=True):
         reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
 
-    ctx.log.info("Project '%s' artifact setup is complete.", manifest.project_name)
+    ctx.log.info("Project '%s' setup is complete.", manifest.project_name)
 
 
 def reconcile_bootstrap_artifacts(
@@ -207,7 +207,7 @@ def check_manifest(
     if output_format == "json":
         print(json.dumps([check_to_json(check) for check in checks], indent=2))
     elif output_format == "text":
-        ctx.log.info("Checking project '%s' artifacts.", manifest.project_name)
+        ctx.log.info("Checking project '%s' manifest requirements.", manifest.project_name)
         for check in checks:
             if check.ok:
                 ctx.log.info(check.message)

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -1265,5 +1265,94 @@ class IdeSettingsTests(unittest.TestCase):
         self.assertTrue(checks[0].ok)
 
 
+class IdeDiagnosticsTests(unittest.TestCase):
+    def test_check_json_reports_ide_app_extension_and_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "ide:",
+                        "  vscode:",
+                        "    install: true",
+                        "    extensions:",
+                        "      - ms-python.python",
+                        "    settings:",
+                        "      editor.formatOnSave: true",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            default_manifest = BaseManifest(
+                path=Path("default_manifest.yaml"),
+                project_name="base-defaults",
+                brewfile=None,
+                artifacts=(),
+            )
+            manifest = read_manifest(manifest_path)
+            with mock.patch("base_setup.engine.command_exists", return_value=True), mock.patch(
+                "base_setup.engine.run_check",
+                return_value=True,
+            ), mock.patch(
+                "base_setup.engine.list_ide_extensions",
+                return_value={"ms-python.python"},
+            ), mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                settings_file = engine.ide_settings_file(engine.IDE_DEFINITIONS["vscode"])
+                settings_file.parent.mkdir(parents=True)
+                settings_file.write_text(json.dumps({"editor.formatOnSave": True}), encoding="utf-8")
+                stdout_buffer = io.StringIO()
+                with redirect_stdout(stdout_buffer):
+                    status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+
+        checks = json.loads(stdout_buffer.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(
+            [check["name"] for check in checks],
+            ["VS Code app", "ms-python.python", "VS Code setting: editor.formatOnSave"],
+        )
+        self.assertTrue(all(check["ok"] for check in checks))
+
+    def test_doctor_text_reports_ide_fix_guidance(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "cursor": IdeConfig(
+                    install=True,
+                    extensions=("github.copilot",),
+                    settings={"editor.formatOnSave": True},
+                )
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            with mock.patch.dict(os.environ, {"HOME": home_dir}), mock.patch(
+                "base_setup.engine.command_exists",
+                return_value=False,
+            ):
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
+
+        output = stdout.getvalue()
+        self.assertGreater(status, 0)
+        self.assertIn("Project doctor: demo", output)
+        self.assertIn("Cursor app", output)
+        self.assertIn("github.copilot", output)
+        self.assertIn("Cursor setting: editor.formatOnSave", output)
+        self.assertIn("Fix:", output)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Tightens `check` and `doctor` behavior around IDE manifest requirements.

- updates setup/check wording from artifact-only to manifest requirements
- adds JSON check coverage for IDE app, extension, and setting diagnostics
- adds doctor text coverage for IDE app, extension, setting, and fix guidance

Fixes #136

## Validation

- `PYTHONPATH=cli/python:lib/python python3 -m unittest cli.python.base_setup.tests.test_engine`
- `python3 -m py_compile cli/python/base_setup/engine.py cli/python/base_setup/manifest.py`