### PR TITLE
Document IDE bootstrap workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ users who want a checklist-style first Base setup. Its design is captured in
 [docs/basectl-onboard.md](docs/basectl-onboard.md). Product-specific onboarding
 should still live in project installers that call Base internally.
 
+Base can also bootstrap supported IDEs for participating projects through the
+optional `ide:` manifest section. It currently supports VS Code and Cursor app
+installation, extension installation, additive user settings, and check/doctor
+diagnostics. See [docs/ide-bootstrapping.md](docs/ide-bootstrapping.md).
+
 ### 2. Shell Environment Management
 
 Base should manage shell environments at two levels:

--- a/docs/ide-bootstrapping.md
+++ b/docs/ide-bootstrapping.md
@@ -1,0 +1,157 @@
+# IDE Bootstrapping
+
+Base can bootstrap supported IDEs for Base-managed projects on macOS. This is
+part of Base's workstation setup responsibility: a fresh machine should be able
+to install the tools a project expects, validate that they are present, and
+surface clear recovery guidance through `basectl check` and `basectl doctor`.
+
+Base does not try to become a general IDE preference manager. It orchestrates
+IDE readiness for project work.
+
+## Scope
+
+Base owns:
+
+- installing supported IDEs through Homebrew casks when a project opts in
+- installing declared IDE extensions through the IDE CLI
+- adding missing user-level IDE settings required by a project
+- resolving Base-owned paths such as the project virtual environment Python
+- reporting IDE app, CLI, extension, and settings state through check/doctor
+
+Base does not own:
+
+- every personal editor preference
+- extension version pinning
+- workspace `.vscode/settings.json` generation
+- JetBrains IDE configuration
+- generic dotfile synchronization
+- user-local IDE preference layering
+
+## Manifest Schema
+
+Projects opt in through `base_manifest.yaml`:
+
+```yaml
+project:
+  name: example
+
+ide:
+  vscode:
+    install: true
+    extensions:
+      - ms-python.python
+      - ms-python.pylint
+      - github.vscode-pull-request-github
+    settings:
+      python.defaultInterpreterPath: auto
+      editor.formatOnSave: true
+
+  cursor:
+    install: true
+    extensions:
+      - ms-python.python
+    settings:
+      python.defaultInterpreterPath: auto
+```
+
+Supported IDE keys:
+
+- `vscode`
+- `cursor`
+
+Supported fields:
+
+- `install`: optional boolean. When true, `basectl setup` installs the IDE with
+  Homebrew cask.
+- `extensions`: optional list of extension IDs.
+- `settings`: optional mapping of user-level IDE settings.
+
+The only supported special setting value today is:
+
+```yaml
+python.defaultInterpreterPath: auto
+```
+
+Base resolves that to:
+
+```text
+~/.base.d/<project>/.venv/bin/python
+```
+
+or to `$BASE_PROJECT_VENV_DIR/bin/python` when that override is set.
+
+## Setup Behavior
+
+`basectl setup <project>` performs IDE work in this order:
+
+1. Install opted-in IDE apps through Homebrew casks.
+2. Install missing declared extensions through the IDE CLI.
+3. Add missing declared user-level settings.
+
+VS Code uses:
+
+```text
+brew install --cask visual-studio-code
+code --install-extension <extension>
+~/Library/Application Support/Code/User/settings.json
+```
+
+Cursor uses:
+
+```text
+brew install --cask cursor
+cursor --install-extension <extension>
+~/Library/Application Support/Cursor/User/settings.json
+```
+
+If an IDE app is installed but its CLI is not available on `PATH`, Base reports
+that state. Extension setup is skipped until the CLI is available.
+
+## Additive Settings
+
+IDE settings are additive-only.
+
+If a setting key is absent, Base writes the project-requested value. If the user
+already has that key with a different value, Base leaves the user value intact
+and reports the divergence through check/doctor.
+
+To accept the Base value, remove the key from the IDE `settings.json` and rerun:
+
+```bash
+basectl setup <project>
+```
+
+Settings writes are atomic: Base writes a temporary JSON file in the same
+directory and then replaces `settings.json`.
+
+## Validation
+
+Use:
+
+```bash
+basectl check <project>
+basectl doctor <project>
+```
+
+IDE checks include:
+
+- requested IDE app installed through Homebrew cask
+- IDE CLI available on `PATH`
+- declared extensions installed
+- declared settings present and matching
+
+`doctor` provides human-oriented fix guidance for missing or divergent state.
+
+## Future Work
+
+Future IDE-related work should remain inside Base's boundary: workstation
+bootstrap and diagnostics for Base-managed projects.
+
+Candidate future work:
+
+- user-local IDE preference config under `~/.base.d`
+- workspace `.vscode` settings if a real project needs shared editor settings
+- Windsurf support if its CLI and settings surface match the VS Code family
+- JetBrains support only after a clean, scriptable configuration surface is
+  identified
+- extension pinning only if Base adopts a deliberate VSIX management strategy

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -52,6 +52,7 @@ Base gets weaker when it drifts into becoming any of these:
 | `Brewfile` / `brew bundle` | declarative Homebrew bootstrap | Yes, by orchestration rather than replacement | Yes, strongly | High |
 | Docker / Docker Compose / Colima | containers, Compose-defined local services | Partially, as orchestration only | Yes, strongly | High |
 | `mise` tasks | project-local task running inside `mise` | No | Yes, strongly | Medium |
+| VS Code / Cursor | IDE app, extensions, and user editor settings | Partially, as workstation bootstrap only | Yes, strongly | High |
 
 ## Tool-by-Tool Decisions
 
@@ -258,6 +259,37 @@ How Base should coexist:
 - Base should provide the workspace-wide orchestration and selection layer
 
 Current stance: strong coexistence, borrow the explicit-command philosophy.
+
+### VS Code / Cursor
+
+What they do well:
+
+- provide the main editing environment for project work
+- install language/tooling extensions through a scriptable CLI
+- store user-level settings in a known macOS location
+
+What Base should borrow:
+
+- the idea that project development ergonomics should be declared and checked
+- the ability to install extensions through the IDE's own CLI
+
+What Base should not do:
+
+- become a general IDE preference manager
+- overwrite personal user settings
+- manage every editor or fork before a real project needs it
+- pin extension versions without a deliberate VSIX strategy
+
+How Base should coexist:
+
+- let projects declare supported IDE requirements through `base_manifest.yaml`
+- install VS Code/Cursor through Homebrew casks when opted in
+- install declared extensions through `code` or `cursor`
+- add missing user-level settings without overwriting user values
+- report missing app, CLI, extension, and settings state through check/doctor
+
+Current stance: strong coexistence, Base as IDE-readiness orchestrator rather
+than IDE owner.
 
 ### `Brewfile` / `brew bundle`
 


### PR DESCRIPTION
## Summary

Documents Base's IDE bootstrap scope and workflow.

- adds `docs/ide-bootstrapping.md` as the canonical IDE bootstrap guide
- documents supported IDEs, manifest schema, setup behavior, additive settings, validation, and future work
- links the guide from README
- records VS Code/Cursor boundaries in the ecosystem boundaries doc

Fixes #137

## Validation

- docs-only change; reviewed rendered Markdown source locally