### PR TITLE
Add Base user config inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Current implemented commands include:
 - `basectl doctor`
 - `basectl clean --older-than <age>`
 - `basectl clean --keep-last <count>`
+- `basectl config path`
+- `basectl config show`
+- `basectl config doctor`
 - `basectl update-profile`
 - `basectl update`
 - `basectl projects list`

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -27,6 +27,7 @@ that delegate to `basectl`.
 - `setup`
 - `check`
 - `clean`
+- `config`
 - `doctor`
 - `gh`
 - `update-profile`
@@ -54,6 +55,7 @@ that delegate to `basectl`.
   manage developer prerequisites through `lib/base/dev_manifest.yaml`.
 - `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
 - `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
+- `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.
 - `basectl gh` manages GitHub issues, pull requests, branch naming, and

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -17,6 +17,8 @@ Commands:
     Verify the local Base CLI environment and optional project artifacts without making changes.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
+  config <path|show|doctor>
+    Inspect Base's machine-local user config.
   doctor [project] [options]
     Diagnose the local Base CLI environment and optional project artifacts.
   gh <area> <command> [options]
@@ -157,6 +159,11 @@ basectl_do_clean() {
     base_clean_subcommand_main "$@"
 }
 
+basectl_do_config() {
+    basectl_source_subcommand_module config || return 1
+    base_config_subcommand_main "$@"
+}
+
 basectl_do_doctor() {
     basectl_source_subcommand_module doctor || return 1
     base_doctor_subcommand_main "$@"
@@ -264,6 +271,7 @@ basectl_main() {
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
         clean)            basectl_do_clean "$@" ;;
+        config)           basectl_do_config "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;
         gh)               basectl_do_gh "$@" ;;
         setup)            basectl_do_setup "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/config.sh
+++ b/cli/bash/commands/basectl/subcommands/config.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_config_subcommand_sourced:-}" ]] && return
+_base_config_subcommand_sourced=1
+readonly _base_config_subcommand_sourced
+
+base_config_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl config path
+  basectl config show
+  basectl config doctor
+
+Purpose:
+  Inspect Base's machine-local user config.
+
+Notes:
+  - The default config path is ~/.base.d/config.yaml.
+  - Missing config is treated as an empty config.
+  - Base does not edit or sync this file.
+EOF
+}
+
+base_config_path() {
+    [[ -n "${HOME:-}" ]] || fatal_error "Environment variable 'HOME' is not set."
+    printf '%s\n' "$HOME/.base.d/config.yaml"
+}
+
+base_config_subcommand_main() {
+    local config_command="${1:-}"
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+
+    case "$config_command" in
+        ""|-h|--help|help)
+            base_config_subcommand_usage
+            return 0
+            ;;
+        path)
+            shift
+            if (($#)); then
+                base_config_subcommand_usage >&2
+                fatal_error "config path does not accept arguments."
+            fi
+            base_config_path
+            ;;
+        show|doctor)
+            shift
+            if (($#)); then
+                base_config_subcommand_usage >&2
+                fatal_error "config $config_command does not accept arguments."
+            fi
+            [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+            "$wrapper" --project base base_config "$config_command"
+            ;;
+        *)
+            base_config_subcommand_usage >&2
+            fatal_error "Unknown config command '$config_command'."
+            ;;
+    esac
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -27,6 +27,7 @@ run_basectl() {
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
+    [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"gh <area> <command> [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
@@ -54,9 +55,27 @@ run_basectl() {
     ! grep -Fqx '  shell' <<<"$output"
     grep -Fqx '  version' <<<"$output"
     grep -Fqx '  gh <area> <command> [options]' <<<"$output"
+    grep -Fqx '  config <path|show|doctor>' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
+}
+
+@test "basectl config prints help" {
+    run_basectl config --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl config path"* ]]
+    [[ "$output" == *"basectl config show"* ]]
+    [[ "$output" == *"basectl config doctor"* ]]
+}
+
+@test "basectl config path prints default user config path without Python venv" {
+    run_basectl config path
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_HOME/.base.d/config.yaml" ]
 }
 
 @test "basectl gh prints help" {

--- a/cli/python/base_config/__init__.py
+++ b/cli/python/base_config/__init__.py
@@ -1,0 +1,1 @@
+"""Base user config inspection command."""

--- a/cli/python/base_config/__main__.py
+++ b/cli/python/base_config/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from base_cli.config import load_user_config, user_config_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    command = args[0] if args else "show"
+    if command in ("-h", "--help", "help"):
+        print_usage()
+        return 0
+    if len(args) > 1:
+        print_usage(file=sys.stderr)
+        print(f"ERROR: config {command} does not accept arguments.", file=sys.stderr)
+        return 2
+    if command == "show":
+        return show_config_command()
+    if command == "doctor":
+        return doctor_config_command()
+
+    print_usage(file=sys.stderr)
+    print(f"ERROR: Unknown config command '{command}'. Supported commands: show, doctor.", file=sys.stderr)
+    return 2
+
+
+def print_usage(file=sys.stdout) -> None:
+    print(
+        """Usage:
+  base_config show
+  base_config doctor
+
+Purpose:
+  Inspect Base's machine-local user config.""",
+        file=file,
+    )
+
+
+def show_config_command() -> int:
+    try:
+        config = load_user_config()
+    except (RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(config, indent=2, sort_keys=True))
+    return 0
+
+
+def doctor_config_command() -> int:
+    path = user_config_path()
+    print("\nBase config doctor\n")
+    print_finding("ok", "path", f"Config path: {path}")
+    if path.exists():
+        if path.is_symlink():
+            print_finding("ok", "symlink", f"Config path is a symlink to '{safe_resolve(path)}'.")
+        else:
+            print_finding("ok", "file", "Config file exists.")
+    else:
+        print_finding("warn", "file", "Config file is missing; Base will use an empty user config.")
+        return 0
+
+    try:
+        config = load_user_config()
+    except (RuntimeError, ValueError) as exc:
+        print_finding("error", "yaml", str(exc))
+        return 1
+
+    print_finding("ok", "yaml", "Config YAML is valid.")
+    print_finding("ok", "mapping", f"Config contains {len(config)} top-level key(s).")
+    return 0
+
+
+def safe_resolve(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except OSError:
+        return path
+
+
+def print_finding(status: str, name: str, message: str) -> None:
+    print(f"{status:<5}  {name:<12}  {message}")

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_cli.config import user_config_path
+from base_config import engine
+
+
+class BaseConfigCommandTests(unittest.TestCase):
+    def test_show_config_prints_empty_mapping_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.show_config_command()
+
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(stdout.getvalue()), {})
+
+    def test_show_config_prints_parsed_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(Path(tmpdir))
+                path.parent.mkdir(parents=True)
+                path.write_text("ide:\n  enabled: true\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.show_config_command()
+
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(stdout.getvalue()), {"ide": {"enabled": True}})
+
+    def test_show_config_reports_invalid_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(Path(tmpdir))
+                path.parent.mkdir(parents=True)
+                path.write_text("ide: [unterminated\n", encoding="utf-8")
+                with redirect_stderr(io.StringIO()):
+                    status = engine.show_config_command()
+
+        self.assertEqual(status, 1)
+
+    def test_doctor_config_reports_missing_file_as_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        output = stdout.getvalue()
+        self.assertEqual(status, 0)
+        self.assertIn("Base config doctor", output)
+        self.assertIn("warn", output)
+        self.assertIn("Config file is missing", output)
+
+    def test_doctor_config_reports_valid_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(Path(tmpdir))
+                path.parent.mkdir(parents=True)
+                path.write_text("ide:\n  enabled: true\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        output = stdout.getvalue()
+        self.assertEqual(status, 0)
+        self.assertIn("Config YAML is valid", output)
+        self.assertIn("Config contains 1 top-level key", output)
+
+    def test_doctor_config_reports_invalid_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(Path(tmpdir))
+                path.parent.mkdir(parents=True)
+                path.write_text("ide: [unterminated\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        self.assertEqual(status, 1)
+        self.assertIn("error", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -4,6 +4,12 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .paths import base_state_root
+
+
+def user_config_path(home: Path | None = None) -> Path:
+    return base_state_root(home) / "config.yaml"
+
 
 def load_yaml_file(path: Path) -> dict[str, Any]:
     if not path.is_file():
@@ -14,12 +20,19 @@ def load_yaml_file(path: Path) -> dict[str, Any]:
     except ImportError as exc:
         raise RuntimeError("PyYAML is required to load base_cli configuration.") from exc
 
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Config file '{path}' contains invalid YAML: {exc}") from exc
     if data is None:
         return {}
     if not isinstance(data, dict):
         raise ValueError(f"Config file '{path}' must contain a YAML mapping.")
     return data
+
+
+def load_user_config(home: Path | None = None) -> dict[str, Any]:
+    return load_yaml_file(user_config_path(home))
 
 
 def merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
@@ -39,7 +52,7 @@ def load_config(
 ) -> dict[str, Any]:
     root = home or Path.home()
     config: dict[str, Any] = {}
-    config = merge_dicts(config, load_yaml_file(root / ".base.d" / "config.yaml"))
+    config = merge_dicts(config, load_user_config(root))
     if project_root is not None:
         config = merge_dicts(config, load_yaml_file(project_root / ".base" / "config.yaml"))
     if explicit_config is not None:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 import base_cli
 from base_cli import config as config_module
-from base_cli.config import load_config
+from base_cli.config import load_config, load_user_config, user_config_path
 from base_cli.logging import BaseCliFormatter
 from base_cli.paths import base_cache_root, base_state_root, discover_manifest, normalize_cli_name
 from base_cli.redaction import redact_argv
@@ -150,6 +150,49 @@ class BaseCliTests(unittest.TestCase):
 
         self.assertEqual(config["environment"], "env")
         self.assertEqual(config["log_level"], "warning")
+
+    def test_user_config_path_defaults_to_base_state_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            self.assertEqual(user_config_path(home), home / ".base.d" / "config.yaml")
+
+    def test_load_user_config_missing_file_returns_empty_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = load_user_config(Path(tmpdir))
+
+        self.assertEqual(config, {})
+
+    def test_load_user_config_reads_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("ide:\n  enabled: true\n", encoding="utf-8")
+
+            config = load_user_config(home)
+
+        self.assertEqual(config, {"ide": {"enabled": True}})
+
+    def test_load_user_config_rejects_non_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("- not\n- mapping\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "must contain a YAML mapping"):
+                load_user_config(home)
+
+    def test_load_user_config_rejects_invalid_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("ide: [unterminated\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "contains invalid YAML"):
+                load_user_config(home)
 
     def test_log_debug_enables_python_debug_logging(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -24,7 +24,7 @@ _base_basectl_completion_compgen() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check clean doctor gh update-profile update projects version help"
+    local commands="activate setup check clean config doctor gh update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -56,6 +56,11 @@ _base_basectl_completion() {
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --dry-run -v -h --help" "$cur"
+            ;;
+        config)
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "path show doctor" "$cur"
+            fi
             ;;
         doctor)
             _base_basectl_completion_compgen "--dev -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -17,6 +17,7 @@ _base_basectl_completion() {
         'setup:Install and bootstrap the local Base CLI environment'
         'check:Verify the local Base CLI environment'
         'clean:Remove old Base CLI runtime artifacts'
+        'config:Inspect Base machine-local user config'
         'doctor:Diagnose the local Base environment'
         'gh:Manage GitHub issues, pull requests, branches, and hygiene'
         'update-profile:Refresh Base-managed shell startup sections'
@@ -56,6 +57,9 @@ _base_basectl_completion() {
         clean)
             _arguments '--older-than[Artifact age]:age:' '--dry-run[Log without removing files]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        config)
+            _arguments '1:config command:(path show doctor)'
             ;;
         doctor)
             _arguments '--dev[Include developer prerequisite checks]' '-v[Enable DEBUG logging]' \


### PR DESCRIPTION
## Summary

Adds the first machine-local Base config surface at `~/.base.d/config.yaml` with read-only inspection commands.

- adds reusable `base_cli.config.user_config_path()` and `load_user_config()` helpers
- treats missing user config as `{}` and reports invalid YAML/non-mapping config cleanly
- adds `basectl config path`, `basectl config show`, and `basectl config doctor`
- implements `base_config` without the standard Base app context so broken config can still be diagnosed
- updates help, completions, and command docs

Fixes #145

## Validation

- `PYTHONPATH=lib/python:cli/python python3 -m unittest lib.python.base_cli.tests.test_base_cli cli.python.base_config.tests.test_engine`
- `python3 -m py_compile lib/python/base_cli/config.py cli/python/base_config/engine.py cli/python/base_config/__main__.py`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `BASE_CACHE_DIR=/private/tmp/base-cache ./bin/basectl config doctor`
- `BASE_CACHE_DIR=/private/tmp/base-cache ./bin/basectl config show`