### PR TITLE
Add user IDE preference schema

### DIFF
--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -1,10 +1,35 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import os
+import json
 from pathlib import Path
 from typing import Any
 
 from .paths import base_state_root
+
+
+SUPPORTED_IDES = {"vscode", "cursor"}
+
+
+@dataclass(frozen=True)
+class UserIdePreference:
+    enabled: bool | None
+    install: bool | None
+    extra_extensions: tuple[str, ...]
+    settings: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class UserIdeConfig:
+    enabled: bool | None
+    preferences: dict[str, UserIdePreference]
+
+
+@dataclass(frozen=True)
+class UserConfig:
+    raw: dict[str, Any]
+    ide: UserIdeConfig
 
 
 def user_config_path(home: Path | None = None) -> Path:
@@ -33,6 +58,96 @@ def load_yaml_file(path: Path) -> dict[str, Any]:
 
 def load_user_config(home: Path | None = None) -> dict[str, Any]:
     return load_yaml_file(user_config_path(home))
+
+
+def read_user_config(home: Path | None = None) -> UserConfig:
+    raw = load_user_config(home)
+    return UserConfig(raw=raw, ide=_read_user_ide_config(user_config_path(home), raw.get("ide")))
+
+
+def _read_user_ide_config(path: Path, ide_data: Any) -> UserIdeConfig:
+    if ide_data is None:
+        return UserIdeConfig(enabled=None, preferences={})
+    if not isinstance(ide_data, dict):
+        raise ValueError(f"{path}: ide must be a mapping when provided.")
+
+    allowed_keys = SUPPORTED_IDES | {"enabled"}
+    unknown_keys = sorted(set(ide_data) - allowed_keys)
+    if unknown_keys:
+        raise ValueError(f"{path}: unsupported ide keys: {', '.join(unknown_keys)}.")
+
+    enabled = _optional_bool(path, "ide.enabled", ide_data.get("enabled"))
+    preferences = {
+        ide_name: _read_user_ide_preference(path, ide_name, ide_data.get(ide_name))
+        for ide_name in sorted(SUPPORTED_IDES)
+        if ide_name in ide_data
+    }
+    return UserIdeConfig(enabled=enabled, preferences=preferences)
+
+
+def _read_user_ide_preference(path: Path, ide_name: str, preference_data: Any) -> UserIdePreference:
+    if preference_data is None:
+        preference_data = {}
+    if not isinstance(preference_data, dict):
+        raise ValueError(f"{path}: ide.{ide_name} must be a mapping when provided.")
+
+    allowed_keys = {"enabled", "install", "extra_extensions", "settings"}
+    unknown_keys = sorted(set(preference_data) - allowed_keys)
+    if unknown_keys:
+        raise ValueError(f"{path}: ide.{ide_name} has unsupported keys: {', '.join(unknown_keys)}.")
+
+    enabled = _optional_bool(path, f"ide.{ide_name}.enabled", preference_data.get("enabled"))
+    install = _optional_bool(path, f"ide.{ide_name}.install", preference_data.get("install"))
+    extra_extensions = _read_extra_extensions(path, ide_name, preference_data.get("extra_extensions", []))
+    settings = _read_user_ide_settings(path, ide_name, preference_data.get("settings", {}))
+    return UserIdePreference(
+        enabled=enabled,
+        install=install,
+        extra_extensions=extra_extensions,
+        settings=settings,
+    )
+
+
+def _optional_bool(path: Path, key: str, value: Any) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ValueError(f"{path}: {key} must be a boolean when provided.")
+    return value
+
+
+def _read_extra_extensions(path: Path, ide_name: str, extensions_data: Any) -> tuple[str, ...]:
+    if extensions_data is None:
+        return ()
+    if not isinstance(extensions_data, list):
+        raise ValueError(f"{path}: ide.{ide_name}.extra_extensions must be a list when provided.")
+
+    extensions: list[str] = []
+    for index, extension in enumerate(extensions_data, start=1):
+        if not isinstance(extension, str) or not extension.strip():
+            raise ValueError(
+                f"{path}: ide.{ide_name}.extra_extensions[{index}] must be a non-empty string."
+            )
+        extensions.append(extension.strip())
+    return tuple(extensions)
+
+
+def _read_user_ide_settings(path: Path, ide_name: str, settings_data: Any) -> dict[str, Any]:
+    if settings_data is None:
+        return {}
+    if not isinstance(settings_data, dict):
+        raise ValueError(f"{path}: ide.{ide_name}.settings must be a mapping when provided.")
+
+    settings: dict[str, Any] = {}
+    for key, value in settings_data.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"{path}: ide.{ide_name}.settings keys must be non-empty strings.")
+        try:
+            json.dumps(value)
+        except TypeError as exc:
+            raise ValueError(f"{path}: ide.{ide_name}.settings.{key} must be JSON-serializable.") from exc
+        settings[key] = value
+    return settings
 
 
 def merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 import base_cli
 from base_cli import config as config_module
-from base_cli.config import load_config, load_user_config, user_config_path
+from base_cli.config import load_config, load_user_config, read_user_config, user_config_path
 from base_cli.logging import BaseCliFormatter
 from base_cli.paths import base_cache_root, base_state_root, discover_manifest, normalize_cli_name
 from base_cli.redaction import redact_argv
@@ -193,6 +193,137 @@ class BaseCliTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "contains invalid YAML"):
                 load_user_config(home)
+
+    def test_read_user_config_missing_file_returns_empty_ide_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = read_user_config(Path(tmpdir))
+
+        self.assertEqual(config.raw, {})
+        self.assertIsNone(config.ide.enabled)
+        self.assertEqual(config.ide.preferences, {})
+
+    def test_read_user_config_parses_ide_preferences(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "\n".join(
+                    [
+                        "ide:",
+                        "  enabled: true",
+                        "  vscode:",
+                        "    enabled: true",
+                        "    install: false",
+                        "    extra_extensions:",
+                        "      - eamodio.gitlens",
+                        "      - github.copilot",
+                        "    settings:",
+                        "      editor.fontSize: 14",
+                        "      editor.minimap.enabled: false",
+                        "  cursor:",
+                        "    enabled: false",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            config = read_user_config(home)
+
+        self.assertTrue(config.ide.enabled)
+        vscode = config.ide.preferences["vscode"]
+        self.assertTrue(vscode.enabled)
+        self.assertFalse(vscode.install)
+        self.assertEqual(vscode.extra_extensions, ("eamodio.gitlens", "github.copilot"))
+        self.assertEqual(
+            vscode.settings,
+            {
+                "editor.fontSize": 14,
+                "editor.minimap.enabled": False,
+            },
+        )
+        self.assertFalse(config.ide.preferences["cursor"].enabled)
+        self.assertIsNone(config.ide.preferences["cursor"].install)
+
+    def test_read_user_config_rejects_non_mapping_ide(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("ide: true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "ide must be a mapping"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_unknown_ide_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "\n".join(
+                    [
+                        "ide:",
+                        "  windswept:",
+                        "    enabled: true",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "unsupported ide keys: windswept"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_non_boolean_ide_enabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("ide:\n  enabled: sometimes\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "ide.enabled must be a boolean"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_non_boolean_per_ide_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("ide:\n  vscode:\n    install: maybe\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "ide.vscode.install must be a boolean"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_invalid_extra_extension(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "\n".join(
+                    [
+                        "ide:",
+                        "  cursor:",
+                        "    extra_extensions:",
+                        "      - github.copilot",
+                        "      - 17",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, r"ide.cursor.extra_extensions\[2\]"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_non_mapping_ide_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("ide:\n  vscode:\n    settings: true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "ide.vscode.settings must be a mapping"):
+                read_user_config(home)
 
     def test_log_debug_enables_python_debug_logging(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Adds typed parsing and validation for user-local IDE preferences in `~/.base.d/config.yaml`.

- adds `UserConfig`, `UserIdeConfig`, and `UserIdePreference` models
- parses global `ide.enabled`
- parses per-IDE `enabled`, `install`, `extra_extensions`, and `settings`
- validates supported IDE keys, booleans, extension lists, and settings mappings
- keeps this slice parser-only; project manifest merge and setup/check/doctor behavior are left for #147

Fixes #146

## Validation

- `PYTHONPATH=lib/python:cli/python python3 -m unittest lib.python.base_cli.tests.test_base_cli cli.python.base_config.tests.test_engine`
- `python3 -m py_compile lib/python/base_cli/config.py`