### PR TITLE
Preserve cwd for default basectl runtime shell

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -97,6 +97,9 @@ base-wrapper --project <project> base_setup ...
   `lib/python` and `cli/python` to `PYTHONPATH`, and executes package commands
   with `python -m <package>`.
 - Base itself uses project name `base`.
+- Invoking `basectl` with no arguments in an interactive terminal activates
+  the nearest project manifest above the current directory and preserves that
+  directory. It falls back to project `base` when no manifest is found.
 - End users normally invoke `basectl` or project `bin/` launchers rather than
   calling Python packages directly.
 

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -117,8 +117,9 @@ base-wrapper --project <project> base_setup ...
 - `basectl activate <project>` starts a runtime shell using
   `lib/bash/runtime/bashrc`; that runtime sources `base_init.sh`, loads the user
   shell config, activates the project venv, and owns the final runtime prompt.
-- Invoking `basectl` with no command in an interactive terminal is equivalent to
-  `basectl activate base`.
+- Invoking `basectl` with no command in an interactive terminal starts a Base
+  runtime shell with project `base`, but preserves the caller's current working
+  directory so the prompt Git segment reflects the current directory's repo.
 
 ## Useful Validation
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ Activation spawns a project-specific subshell, changes to the project root, sets
 virtual environment at `~/.base.d/<project>/.venv`. Exit that shell to return to
 the original environment.
 
-Invoking `basectl` with no arguments in a terminal is equivalent to
-`basectl activate base`, so the default interactive Base shell uses Base's own
-project virtual environment.
+Invoking `basectl` with no arguments in a terminal starts the default
+interactive Base shell. It uses Base's own project virtual environment while
+preserving the current directory, so the prompt's Git segment continues to
+describe the repository you were already in.
 
 Clean old Base CLI runtime logs, retained temp files, and cache entries with:
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ virtual environment at `~/.base.d/<project>/.venv`. Exit that shell to return to
 the original environment.
 
 Invoking `basectl` with no arguments in a terminal starts the default
-interactive Base shell. It uses Base's own project virtual environment while
-preserving the current directory, so the prompt's Git segment continues to
-describe the repository you were already in.
+interactive Base shell. It uses the nearest `base_manifest.yaml` above the
+current directory to choose the active project, then preserves the current
+directory. If no project manifest is found, it falls back to the `base` project.
 
 Clean old Base CLI runtime logs, retained temp files, and cache entries with:
 

--- a/bin/basectl
+++ b/bin/basectl
@@ -235,7 +235,7 @@ main() {
     fi
 
     if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
-        BASE_ACTIVATE_PRESERVE_CWD=1 basectl_run_control_command "$base_home" activate base
+        basectl_run_control_command "$base_home"
         return $?
     fi
 

--- a/bin/basectl
+++ b/bin/basectl
@@ -235,7 +235,7 @@ main() {
     fi
 
     if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
-        basectl_run_control_command "$base_home" activate base
+        BASE_ACTIVATE_PRESERVE_CWD=1 basectl_run_control_command "$base_home" activate base
         return $?
     fi
 

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -51,8 +51,9 @@ Notes:
   - `basectl setup` is the preferred entrypoint for machine bootstrap.
   - `basectl check` verifies the same local requirements without making changes.
     Pass a project name to include that project's manifest artifacts.
-  - Invoking `basectl` with no command starts a Base runtime shell with Base's
-    project virtual environment while preserving the current directory; in
+  - Invoking `basectl` with no command starts a Base runtime shell for the
+    nearest project manifest above the current directory, preserving that
+    directory. If no manifest is found, it falls back to project `base`. In
     non-interactive shells it prints this help text.
   - Use `-v` for command-level debug logs. Use `--debug-wrapper` when debugging
     startup before command dispatch or Base runtime initialization.
@@ -211,6 +212,23 @@ basectl_should_start_shell() {
     [[ -t 0 && -t 1 ]]
 }
 
+basectl_default_activate_project() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local resolve_output project_name
+
+    if [[ -x "$wrapper" ]]; then
+        if resolve_output="$("$wrapper" --project base base_projects current 2>/dev/null)"; then
+            IFS=$'\t' read -r project_name _ <<<"$resolve_output"
+            if [[ -n "$project_name" ]]; then
+                printf '%s\n' "$project_name"
+                return 0
+            fi
+        fi
+    fi
+
+    printf '%s\n' base
+}
+
 
 basectl_main() {
     local base_debug=0 command=""
@@ -283,7 +301,7 @@ basectl_main() {
         version)          basectl_do_version ;;
         "")
             if basectl_should_start_shell; then
-                BASE_ACTIVATE_PRESERVE_CWD=1 basectl_do_activate base
+                BASE_ACTIVATE_PRESERVE_CWD=1 basectl_do_activate "$(basectl_default_activate_project)"
             else
                 basectl_show_help
             fi

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -51,8 +51,9 @@ Notes:
   - `basectl setup` is the preferred entrypoint for machine bootstrap.
   - `basectl check` verifies the same local requirements without making changes.
     Pass a project name to include that project's manifest artifacts.
-  - Invoking `basectl` with no command is equivalent to `basectl activate base`
-    when attached to a terminal; otherwise it prints this help text.
+  - Invoking `basectl` with no command starts a Base runtime shell with Base's
+    project virtual environment while preserving the current directory; in
+    non-interactive shells it prints this help text.
   - Use `-v` for command-level debug logs. Use `--debug-wrapper` when debugging
     startup before command dispatch or Base runtime initialization.
 EOF
@@ -282,7 +283,7 @@ basectl_main() {
         version)          basectl_do_version ;;
         "")
             if basectl_should_start_shell; then
-                basectl_do_activate base
+                BASE_ACTIVATE_PRESERVE_CWD=1 basectl_do_activate base
             else
                 basectl_show_help
             fi

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -102,7 +102,9 @@ base_activate_subcommand_main() {
     export BASE_HOME
     export BASE_SHELL=1
 
-    cd "$project_root" || fatal_error "Unable to enter project root '$project_root'."
+    if [[ "${BASE_ACTIVATE_PRESERVE_CWD:-}" != "1" ]]; then
+        cd "$project_root" || fatal_error "Unable to enter project root '$project_root'."
+    fi
     activate_shell="${BASE_ACTIVATE_SHELL:-${BASH:-bash}}"
     exec "$activate_shell" --rcfile "$shell_rc"
 }

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -369,15 +369,57 @@ EOF
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
 }
 
-@test "basectl with no command activates the base project in an interactive shell" {
+@test "basectl with no command activates the current Base project in an interactive shell" {
+    local fake_base_home="$TEST_TMPDIR/fake-base-home"
+
+    mkdir -p "$fake_base_home/bin"
+    cat > "$fake_base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--project" && "${2:-}" == "base" && "${3:-}" == "base_projects" && "${4:-}" == "current" ]]; then
+    printf 'brew\t/tmp/work/brew\t/tmp/work/brew/base_manifest.yaml\n'
+    exit 0
+fi
+printf 'unexpected args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$fake_base_home/bin/base-wrapper"
+
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_FAKE_BASE_HOME="$fake_base_home" \
         bash -c '
             source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
             log_debug() { :; }
             basectl_should_start_shell() { return 0; }
-            basectl_get_base_home() { export BASE_HOME; }
+            basectl_get_base_home() { BASE_HOME="$BASE_TEST_FAKE_BASE_HOME"; export BASE_HOME; }
+            basectl_do_activate() { printf "activate=%s preserve=%s\n" "$*" "${BASE_ACTIVATE_PRESERVE_CWD:-}"; }
+            basectl_main
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "activate=brew preserve=1" ]
+}
+
+@test "basectl with no command falls back to base when current directory is not in a Base project" {
+    local fake_base_home="$TEST_TMPDIR/fake-base-home"
+
+    mkdir -p "$fake_base_home/bin"
+    cat > "$fake_base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$fake_base_home/bin/base-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_FAKE_BASE_HOME="$fake_base_home" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            log_debug() { :; }
+            basectl_should_start_shell() { return 0; }
+            basectl_get_base_home() { BASE_HOME="$BASE_TEST_FAKE_BASE_HOME"; export BASE_HOME; }
             basectl_do_activate() { printf "activate=%s preserve=%s\n" "$*" "${BASE_ACTIVATE_PRESERVE_CWD:-}"; }
             basectl_main
         '

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -32,7 +32,7 @@ run_basectl() {
     [[ "$output" == *"gh <area> <command> [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
-    [[ "$output" == *"Invoking \`basectl\` with no command is equivalent to \`basectl activate base\`"* ]]
+    [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
     [[ "$output" == *"--debug-wrapper"* ]]
@@ -378,12 +378,12 @@ EOF
             log_debug() { :; }
             basectl_should_start_shell() { return 0; }
             basectl_get_base_home() { export BASE_HOME; }
-            basectl_do_activate() { printf "activate=%s\n" "$*"; }
+            basectl_do_activate() { printf "activate=%s preserve=%s\n" "$*" "${BASE_ACTIVATE_PRESERVE_CWD:-}"; }
             basectl_main
         '
 
     [ "$status" -eq 0 ]
-    [ "$output" = "activate=base" ]
+    [ "$output" = "activate=base preserve=1" ]
 }
 
 @test "basectl prints version with --version and version" {
@@ -919,6 +919,50 @@ EOF
     [[ "$output" == *"BASE_PROJECT_MANIFEST=$workspace/demo/base_manifest.yaml"* ]]
     [[ "$output" == *"BASE_PROJECT_VENV_DIR=$TEST_HOME/.base.d/demo/.venv"* ]]
     [[ "$output" == *"PWD=$workspace/demo"* ]]
+}
+
+@test "basectl default runtime shell preserves caller working directory" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local project_activate="$TEST_HOME/.base.d/base/.venv/bin/activate"
+    local workspace="$TEST_TMPDIR/workspace"
+    local caller="$TEST_TMPDIR/caller"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    mkdir -p "$(dirname "$base_python")" "$workspace/base" "$caller"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "base" ]]; then
+    printf 'base\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'BASE_PROJECT_ROOT=%s\n' "$BASE_PROJECT_ROOT"
+printf 'PWD=%s\n' "$PWD"
+EOF
+    printf 'VIRTUAL_ENV=%s\nexport VIRTUAL_ENV\n' "$TEST_HOME/.base.d/base/.venv" > "$project_activate"
+    chmod +x "$base_python" "$fake_bash"
+    printf 'project:\n  name: base\nartifacts: []\n' > "$workspace/base/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+    caller="$(cd "$caller" && pwd -P)"
+
+    run bash -c 'cd "$1" || exit 1; shift; exec "$@"' _ "$caller" \
+        env \
+            HOME="$TEST_HOME" \
+            PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+            BASE_ACTIVATE_PRESERVE_CWD=1 \
+            BASE_ACTIVATE_SHELL="$fake_bash" \
+            BASE_TEST_PROJECT_ROOT="$workspace/base" \
+            "$BASE_REPO_ROOT/bin/basectl" activate base
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=base"* ]]
+    [[ "$output" == *"BASE_PROJECT_ROOT=$workspace/base"* ]]
+    [[ "$output" == *"PWD=$caller"* ]]
 }
 
 @test "basectl activate prints help without requiring the Base Python venv" {

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+from base_cli.paths import discover_manifest
 from base_setup.manifest import ManifestError, read_manifest
 
 
@@ -29,10 +30,12 @@ def main(argv: list[str] | None = None) -> int:
 def run(ctx: base_cli.Context, command: str | None, project: str | None, workspace: str | None) -> int:
     if command in (None, "list"):
         return list_projects_command(ctx, workspace)
+    if command == "current":
+        return current_project_command(ctx)
     if command == "resolve":
         return resolve_project_command(ctx, project, workspace)
 
-    ctx.log.error("Unknown projects command '%s'. Supported commands: list, resolve.", command)
+    ctx.log.error("Unknown projects command '%s'. Supported commands: list, current, resolve.", command)
     return 2
 
 
@@ -57,6 +60,22 @@ def resolve_project_command(ctx: base_cli.Context, project_name: str | None, wor
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
         project = find_project(workspace_root, project_name)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    return 0
+
+
+def current_project_command(ctx: base_cli.Context) -> int:
+    manifest_path = discover_manifest(Path.cwd())
+    if manifest_path is None:
+        ctx.log.error("No base_manifest.yaml found from '%s' upward.", Path.cwd())
+        return 1
+
+    try:
+        project = read_project(manifest_path)
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return 1

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -82,6 +82,45 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
 
+    def test_projects_current_prints_nearest_project_details(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            nested = project_root / "docs" / "notes"
+            write_manifest(project_root, "demo")
+            nested.mkdir(parents=True)
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(nested)
+                status, stdout, stderr = run_engine(["current"], base_home)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
+
+    def test_projects_current_reports_missing_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            outside = workspace / "outside"
+            outside.mkdir()
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(outside)
+                status, _stdout, stderr = run_engine(["current"], base_home)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(status, 1)
+        self.assertIn("No base_manifest.yaml found", stderr)
+
     def test_projects_resolve_reports_missing_project(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)

--- a/docs/design.md
+++ b/docs/design.md
@@ -249,9 +249,14 @@ The prompt shows three things, always:
 
 ### Project Name in Prompt
 
-`BASE_PROJECT` is set by `basectl activate`. Default value is `"base"`. It does not change
-based on directory. Once you activate a project, the project name shows consistently
-regardless of where you `cd` inside the subshell.
+`BASE_PROJECT` is set by `basectl activate`. When the user invokes `basectl`
+with no arguments in an interactive terminal, Base discovers the nearest
+`base_manifest.yaml` above the current directory and activates that project
+while preserving the current directory. If no manifest is found, it falls back
+to the `base` project.
+
+Once the subshell starts, `BASE_PROJECT` stays fixed until the shell exits. It
+does not change dynamically when the user later runs `cd`.
 
 ### Git Branch in Prompt
 
@@ -263,15 +268,17 @@ Implementation in PS1:
 
 ```bash
 _base_git_branch() {
-  git -C "$BASE_PROJECT_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo "detached"
+  git symbolic-ref --quiet --short HEAD 2>/dev/null ||
+    git rev-parse --short HEAD 2>/dev/null
 }
 
 PS1='[${BASE_PROJECT}: $(_base_git_branch)] \w $ '
 ```
 
-Key decision: the branch is always queried against `$BASE_PROJECT_ROOT` (the project's
-root directory), not the current working directory. This means even if you `cd /tmp`,
-the prompt shows the project's branch, not whatever git repo happens to be at `/tmp`.
+Key decision: the branch is queried from the current directory at prompt render
+time. This keeps the prompt honest when a Base runtime shell is started from a
+nested project directory or when the user moves between repositories inside the
+same shell.
 
 ### Why Not Show Python Venv in Prompt
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -159,7 +159,8 @@ availability.
 
 Applied when the user invokes `basectl`, `basectl activate <project>`, or
 `basectl /path/to/script.sh`. Invoking `basectl` with no arguments in a terminal
-is equivalent to `basectl activate base`.
+starts the Base project runtime while preserving the caller's current
+directory.
 
 Contains:
 - exported Base path contract such as `BASE_HOME`, `BASE_BIN_DIR`, and `BASE_BASH_LIB_DIR`

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -38,8 +38,8 @@ The Base home check validates the expected Base files instead of checking for a
 When `basectl` starts, it uses this dispatch order:
 
 1. If no arguments are provided and stdin/stdout are attached to a terminal,
-   behave like `basectl activate base` and start a Base-enabled interactive Bash
-   shell with Base's project virtual environment activated.
+   start a Base-enabled interactive Bash shell with Base's project virtual
+   environment activated, while preserving the caller's current directory.
 2. If the first argument is path-like or names an existing file, treat it as a
    Bash script path and run that script inside the Base runtime.
 3. If the first argument matches a Base command implementation by convention,
@@ -178,8 +178,8 @@ library cannot be found, so callers do not need to duplicate that check.
 
 Running `basectl activate <project>` starts an interactive Bash shell with the
 Base runtime loaded and the project virtual environment activated. Running
-`basectl` with no arguments in a terminal is equivalent to
-`basectl activate base`.
+`basectl` with no arguments in a terminal starts the Base project runtime while
+preserving the caller's current directory.
 
 That shell uses Base's runtime rcfile:
 

--- a/lib/bash/runtime/README.md
+++ b/lib/bash/runtime/README.md
@@ -2,8 +2,9 @@
 
 `lib/bash/runtime/bashrc` is the rcfile used by `basectl activate <project>`
 when it starts a Base-enabled interactive Bash shell. Invoking `basectl` with no
-arguments in a terminal starts the Base project runtime while preserving the
-caller directory.
+arguments in a terminal activates the nearest Base project for the caller
+directory, preserves that directory, and falls back to project `base` when no
+project manifest is found.
 
 ## What It Does
 

--- a/lib/bash/runtime/README.md
+++ b/lib/bash/runtime/README.md
@@ -2,7 +2,8 @@
 
 `lib/bash/runtime/bashrc` is the rcfile used by `basectl activate <project>`
 when it starts a Base-enabled interactive Bash shell. Invoking `basectl` with no
-arguments in a terminal is equivalent to `basectl activate base`.
+arguments in a terminal starts the Base project runtime while preserving the
+caller directory.
 
 ## What It Does
 


### PR DESCRIPTION
## Summary

- preserve the caller working directory for bare interactive `basectl`
- make bare `basectl` activate the nearest Base project for the current directory instead of hardcoding `base`
- keep explicit `basectl activate <project>` behavior unchanged: it still enters the project root
- document the default runtime shell behavior and add Bash/Python coverage

Fixes #152

## Tests

- `bash -n bin/basectl cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/activate.sh`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`