### PR TITLE
Pin CI lint dependencies

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pylint click PyYAML pytest
+          python -m pip install -r requirements-dev.txt
 
       - name: Run Pylint
         env:
           PYTHONPATH: lib/python:cli/python
         run: |
-          pylint --rcfile=.pylintrc $(git ls-files '*.py')
+          git ls-files '*.py' | xargs pylint --rcfile=.pylintrc

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -159,6 +159,9 @@ env PYTHONPATH=lib/python:cli/python \
   cli/python/base_setup/engine.py cli/python/base_setup/tests/test_engine.py
 ```
 
+- CI installs Python lint dependencies from `requirements-dev.txt`; update that
+  file deliberately when changing the Pylint toolchain.
+
 - Broader Python validation:
 
 ```bash

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -583,7 +583,10 @@ def check_ide_extensions(manifest: BaseManifest) -> list[ArtifactCheck]:
         if not ide_config.extensions:
             continue
         definition = IDE_DEFINITIONS[ide_name]
-        checks.extend(check_ide_extension(manifest.project_name, definition, extension) for extension in ide_config.extensions)
+        checks.extend(
+            check_ide_extension(manifest.project_name, definition, extension)
+            for extension in ide_config.extensions
+        )
     return checks
 
 
@@ -592,8 +595,14 @@ def check_ide_extension(project: str, definition: IdeDefinition, extension: str)
         return ArtifactCheck(
             name=extension,
             ok=False,
-            message=f"Cannot check {definition.label} extension '{extension}' because CLI '{definition.cli}' is not on PATH.",
-            fix=f"Enable the '{definition.cli}' shell command from {definition.label}, then run 'basectl setup {project}'.",
+            message=(
+                f"Cannot check {definition.label} extension '{extension}' "
+                f"because CLI '{definition.cli}' is not on PATH."
+            ),
+            fix=(
+                f"Enable the '{definition.cli}' shell command from {definition.label}, "
+                f"then run 'basectl setup {project}'."
+            ),
         )
 
     try:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# pylint: disable=too-many-lines,too-many-public-methods
+
 import io
 import importlib.util
 import json

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# pylint: disable=too-many-public-methods
+
 import importlib.util
 import io
 import logging

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pylint==3.3.9
+click==8.4.1
+PyYAML==6.0.3
+pytest==9.0.3


### PR DESCRIPTION
## Summary

- install Python CI lint dependencies from a checked-in `requirements-dev.txt`
- pin the Pylint toolchain so unrelated PRs do not break when upstream Pylint changes behavior
- feed tracked Python files to Pylint through `xargs` instead of shell command substitution
- resolve the existing lint findings surfaced by the pinned CI run with targeted formatting and test-file suppressions

Fixes #154

## Tests

- `/private/tmp/base-ci-pylint-venv/bin/python -m pip install -r requirements-dev.txt`
- `git ls-files '*.py' | xargs /private/tmp/base-ci-pylint-venv/bin/pylint --rcfile=.pylintrc`
- `env PYTHONPATH=lib/python:cli/python /private/tmp/base-ci-pylint-venv/bin/python -m unittest cli.python.base_setup.tests.test_engine lib.python.base_cli.tests.test_base_cli`
- `git diff --check`