### PR TITLE
Update README setup project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ workspace that contains multiple project repositories.
 
 Current implemented commands include:
 
-- `basectl setup`
+- `basectl setup [project]`
 - `basectl check`
 - `basectl doctor`
 - `basectl clean --older-than <age>`
@@ -51,7 +51,6 @@ Current implemented commands include:
 
 Planned commands include:
 
-- `basectl setup <project>`
 - `basectl test`
 - `basectl test <project>`
 - `basectl onboard`


### PR DESCRIPTION
## Summary

- move `basectl setup [project]` into the implemented command list
- remove `basectl setup <project>` from the planned command list

Fixes #163

## Tests

- `git diff --check`
- inspected README command-status section with `rg`