### PR TITLE
Ignore Python test cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 # Ignore Python interpreter caches
 __pycache__/
 *.py[cod]
+
+# Ignore Python test caches and coverage output
+.pytest_cache/
+.coverage
+htmlcov/


### PR DESCRIPTION
## Summary

- ignore pytest cache directories
- ignore common Python coverage outputs

Fixes #162

## Tests

- `git diff --check`