### PR TITLE
Make Python tests runnable with pytest

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -166,10 +166,7 @@ env PYTHONPATH=lib/python:cli/python \
 
 ```bash
 env PYTHONPATH=lib/python:cli/python \
-  ~/.base.d/base/.venv/bin/python -m unittest discover -s lib/python -p 'test*.py'
-
-env PYTHONPATH=lib/python:cli/python \
-  ~/.base.d/base/.venv/bin/python -m unittest discover -s cli/python -p 'test*.py'
+  ~/.base.d/base/.venv/bin/python -m pytest
 ```
 
 - Smoke validation:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --import-mode=importlib
+testpaths =
+    cli/python
+    lib/python


### PR DESCRIPTION
## Summary

- add pytest configuration that uses importlib import mode
- set Python test discovery roots for the CLI and shared Python library trees
- update AI context with the plain pytest validation command

Fixes #157

## Tests

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest`
- `git diff --check`