### PR TITLE
Infer setup project from explicit manifest

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -540,8 +540,18 @@ setup_resolve_project_manifest() {
     local resolve_output resolved_manifest resolved_name resolved_root
 
     if [[ -n "${BASE_SETUP_MANIFEST:-}" ]]; then
+        if [[ -z "$project" ]]; then
+            setup_ensure_cached_paths
+            env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+                "$python_bin" -m base_projects manifest "$BASE_SETUP_MANIFEST"
+            return $?
+        fi
         printf '%s\n' "$BASE_SETUP_MANIFEST"
         return 0
+    fi
+
+    if [[ -z "$project" ]]; then
+        project=base
     fi
 
     if [[ "$project" == base ]]; then
@@ -558,7 +568,7 @@ setup_resolve_project_manifest() {
     IFS=$'\t' read -r resolved_name resolved_root resolved_manifest <<<"$resolve_output"
     [[ "$resolved_name" == "$project" && -n "$resolved_root" && -n "$resolved_manifest" ]] || return 1
 
-    printf '%s\t%s\n' "$resolved_root" "$resolved_manifest"
+    printf '%s\t%s\t%s\n' "$resolved_name" "$resolved_root" "$resolved_manifest"
 }
 
 setup_project_venv_dir() {
@@ -616,7 +626,7 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path project python_bin resolved_root resolve_output venv_dir
+    local exit_code manifest_path project python_bin resolved_name resolved_root resolve_output venv_dir
     local args=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
@@ -624,7 +634,7 @@ setup_run_project_artifact_layer() {
         return 0
     fi
 
-    project="${BASE_SETUP_PROJECT_NAME:-base}"
+    project="${BASE_SETUP_PROJECT_NAME:-}"
     setup_ensure_cached_paths
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
@@ -634,11 +644,15 @@ setup_run_project_artifact_layer() {
         return 1
     }
     if [[ "$resolve_output" == *$'\t'* ]]; then
-        IFS=$'\t' read -r resolved_root manifest_path <<<"$resolve_output"
+        IFS=$'\t' read -r resolved_name resolved_root manifest_path <<<"$resolve_output"
+        project="$resolved_name"
         if [[ "$output_format" != json ]]; then
             log_info "Resolved project '$project' at '$resolved_root'."
         fi
     else
+        if [[ -z "$project" ]]; then
+            project=base
+        fi
         manifest_path="$resolve_output"
     fi
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -503,6 +503,17 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" ]
     printf 'Project not found: %s\n' "$project" >&2
     exit 1
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "manifest" ]]; then
+    manifest_path="${4:-}"
+    if [[ -f "$manifest_path" ]]; then
+        project="$(awk '/^[[:space:]]*name:/ { print $2; exit }' "$manifest_path")"
+        project_root="$(cd -- "$(dirname -- "$manifest_path")" && pwd -P)"
+        printf '%s\t%s\t%s\n' "$project" "$project_root" "$manifest_path"
+        exit 0
+    fi
+    printf 'Manifest not found: %s\n' "$manifest_path" >&2
+    exit 1
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
     [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
     exit $?
@@ -803,6 +814,34 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Running Python project setup layer."* ]]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]
+}
+
+@test "basectl setup infers project name from explicit manifest" {
+    local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local demo_venv_dir="$TEST_HOME/.base.d/demo/.venv"
+    local project_root="$TEST_TMPDIR/demo"
+    local resolved_project_root
+    local manifest_path="$project_root/base_manifest.yaml"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$project_root"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_project_setup_venv_stub "$base_venv_dir"
+    create_project_setup_venv_stub "$demo_venv_dir"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest_path"
+    resolved_project_root="$(cd "$project_root" && pwd -P)"
+
+    run_base_command setup --dry-run --manifest "$manifest_path"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Resolved project 'demo' at '$resolved_project_root'."* ]]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -32,10 +32,12 @@ def run(ctx: base_cli.Context, command: str | None, project: str | None, workspa
         return list_projects_command(ctx, workspace)
     if command == "current":
         return current_project_command(ctx)
+    if command == "manifest":
+        return manifest_project_command(ctx, project)
     if command == "resolve":
         return resolve_project_command(ctx, project, workspace)
 
-    ctx.log.error("Unknown projects command '%s'. Supported commands: list, current, resolve.", command)
+    ctx.log.error("Unknown projects command '%s'. Supported commands: list, current, manifest, resolve.", command)
     return 2
 
 
@@ -76,6 +78,21 @@ def current_project_command(ctx: base_cli.Context) -> int:
 
     try:
         project = read_project(manifest_path)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    return 0
+
+
+def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:
+    if not manifest:
+        ctx.log.error("Manifest path is required.")
+        return 2
+
+    try:
+        project = read_project(Path(manifest).expanduser().resolve())
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return 1

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -82,6 +82,31 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
 
+    def test_projects_manifest_prints_project_details(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            manifest_path = project_root / "base_manifest.yaml"
+            write_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["manifest", str(manifest_path)], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{manifest_path.resolve()}\n")
+
+    def test_projects_manifest_requires_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_home = Path(tmpdir) / "base"
+            base_home.mkdir()
+
+            status, _stdout, stderr = run_engine(["manifest"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertIn("Manifest path is required", stderr)
+
     def test_projects_current_prints_nearest_project_details(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)


### PR DESCRIPTION
## Summary

- add a `base_projects manifest` helper that reads a manifest and prints project details
- make `basectl setup --manifest <path>` infer the project name when no project argument is supplied
- keep explicit project validation in the Python setup layer when a project argument is supplied

Fixes #159

## Tests

- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py`
- `git diff --check`