### PR TITLE
Implement basectl onboard

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -23,6 +23,8 @@ Commands:
     Diagnose the local Base CLI environment and optional project artifacts.
   gh <area> <command> [options]
     Manage GitHub issues, PRs, branches, and repository hygiene.
+  onboard [options]
+    Guide a user through the first Base setup checklist.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
   update [options]
@@ -176,6 +178,11 @@ basectl_do_gh() {
     base_gh_subcommand_main "$@"
 }
 
+basectl_do_onboard() {
+    basectl_source_subcommand_module onboard || return 1
+    base_onboard_subcommand_main "$@"
+}
+
 basectl_do_update_profile() {
     basectl_source_subcommand_module update_profile || return 1
     base_update_profile_subcommand_main "$@"
@@ -293,6 +300,7 @@ basectl_main() {
         config)           basectl_do_config "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;
         gh)               basectl_do_gh "$@" ;;
+        onboard)          basectl_do_onboard "$@" ;;
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_onboard_subcommand_sourced:-}" ]] && return
+_base_onboard_subcommand_sourced=1
+readonly _base_onboard_subcommand_sourced
+
+base_onboard_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl onboard [options]
+
+Options:
+  --dev         Include Base developer prerequisites.
+  --dry-run     Explain planned onboarding steps without making changes.
+  --yes         Accept default answers for setup and shell profile prompts.
+  --no-profile  Skip shell profile updates.
+  -v            Enable DEBUG logging for underlying commands.
+  -h, --help    Show this help text.
+
+Purpose:
+  Guide a user through the first Base setup by orchestrating check, setup,
+  update-profile, doctor, and project discovery commands.
+EOF
+}
+
+base_onboard_print_heading() {
+    printf '\n%s\n' "$1"
+    printf '%s\n' "----------------"
+}
+
+base_onboard_command_text() {
+    printf 'basectl'
+    printf ' %q' "$@"
+    printf '\n'
+}
+
+base_onboard_run_command() {
+    "$BASE_HOME/bin/basectl" "$@"
+}
+
+base_onboard_prompt() {
+    local prompt="$1"
+    local answer
+
+    printf '%s [y/N] ' "$prompt"
+    if ! IFS= read -r answer; then
+        printf '\n'
+        return 1
+    fi
+
+    case "$answer" in
+        y|Y|yes|YES|Yes)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+base_onboard_confirm() {
+    local yes="$1"
+    local prompt="$2"
+
+    if ((yes)); then
+        printf '%s [yes]\n' "$prompt"
+        return 0
+    fi
+
+    base_onboard_prompt "$prompt"
+}
+
+base_onboard_print_next() {
+    printf 'Next: '
+    base_onboard_command_text "$@"
+}
+
+base_onboard_execute() {
+    local dry_run="$1"
+    shift
+
+    base_onboard_print_next "$@"
+    if ((dry_run)); then
+        printf '[DRY-RUN] Would run '
+        base_onboard_command_text "$@"
+        return 0
+    fi
+
+    base_onboard_run_command "$@"
+}
+
+base_onboard_subcommand_main() {
+    local dev=0
+    local dry_run=0
+    local no_profile=0
+    local verbose=0
+    local yes=0
+    local check_status=0
+    local profile_status=0
+    local setup_status=0
+    local check_args=(check base)
+    local doctor_args=(doctor base)
+    local setup_args=(setup base)
+    local profile_args=(update-profile)
+    local projects_args=(projects list)
+
+    while (($#)); do
+        case "$1" in
+            --dev)
+                dev=1
+                ;;
+            --dry-run)
+                dry_run=1
+                ;;
+            --yes)
+                yes=1
+                ;;
+            --no-profile)
+                no_profile=1
+                ;;
+            -v)
+                verbose=1
+                ;;
+            -h|--help|help)
+                base_onboard_subcommand_usage
+                return 0
+                ;;
+            *)
+                print_error "Unknown option '$1'."
+                base_onboard_subcommand_usage >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    if ((dev)); then
+        check_args+=(--dev)
+        setup_args+=(--dev)
+        doctor_args+=(--dev)
+    fi
+    if ((verbose)); then
+        check_args+=(-v)
+        setup_args+=(-v)
+        doctor_args+=(-v)
+        profile_args+=(-v)
+        projects_args+=(-v)
+    fi
+    if ((dry_run)); then
+        setup_args+=(--dry-run)
+        profile_args+=(--dry-run)
+    fi
+
+    printf '%s\n' "Base onboard will verify project 'base' and guide the setup steps it can reconcile."
+
+    base_onboard_print_heading "Check"
+    printf '%s\n' "Base will check the current machine state before making changes."
+    if ((dry_run)); then
+        base_onboard_execute "$dry_run" "${check_args[@]}" || return $?
+    else
+        base_onboard_print_next "${check_args[@]}"
+        base_onboard_run_command "${check_args[@]}"
+        check_status=$?
+        if ((check_status != 0)); then
+            printf '%s\n' "Some checks did not pass. Setup can reconcile missing Base prerequisites."
+        fi
+    fi
+
+    base_onboard_print_heading "Setup"
+    printf '%s\n' "This installs or verifies Homebrew, Xcode Command Line Tools, Base Python, and Base-managed artifacts."
+    if ((dry_run)); then
+        base_onboard_execute "$dry_run" "${setup_args[@]}" || return $?
+    elif base_onboard_confirm "$yes" "Proceed with setup?"; then
+        base_onboard_print_next "${setup_args[@]}"
+        base_onboard_run_command "${setup_args[@]}"
+        setup_status=$?
+        if ((setup_status != 0)); then
+            printf '%s\n' "Setup failed. Running doctor can show the remaining issues."
+            base_onboard_print_next "${doctor_args[@]}"
+            base_onboard_run_command "${doctor_args[@]}" || true
+            return "$setup_status"
+        fi
+    else
+        printf '%s\n' "Setup skipped."
+        return 0
+    fi
+
+    base_onboard_print_heading "Shell Profile"
+    if ((no_profile)); then
+        printf '%s\n' "Shell profile updates skipped because --no-profile was set."
+    elif ((dry_run)); then
+        base_onboard_execute "$dry_run" "${profile_args[@]}" || return $?
+    elif base_onboard_confirm "$yes" "Update shell startup files for Base?"; then
+        base_onboard_print_next "${profile_args[@]}"
+        base_onboard_run_command "${profile_args[@]}"
+        profile_status=$?
+        if ((profile_status != 0)); then
+            printf '%s\n' "Shell profile update failed. You can retry with 'basectl update-profile'."
+            return "$profile_status"
+        fi
+    else
+        printf '%s\n' "Shell profile update skipped. You can run 'basectl update-profile' later."
+    fi
+
+    base_onboard_print_heading "Doctor"
+    base_onboard_execute "$dry_run" "${doctor_args[@]}" || return $?
+
+    base_onboard_print_heading "Projects"
+    if ((dry_run)); then
+        base_onboard_execute "$dry_run" "${projects_args[@]}" || return $?
+    else
+        base_onboard_print_next "${projects_args[@]}"
+        base_onboard_run_command "${projects_args[@]}" || printf '%s\n' "Project discovery is not available yet."
+    fi
+
+    base_onboard_print_heading "Next Steps"
+    printf '%s\n' "Run 'basectl' to enter the nearest Base project shell, or 'basectl activate base' to start with Base itself."
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -30,6 +30,7 @@ run_basectl() {
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"gh <area> <command> [options]"* ]]
+    [[ "$output" == *"onboard [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
@@ -55,6 +56,7 @@ run_basectl() {
     ! grep -Fqx '  shell' <<<"$output"
     grep -Fqx '  version' <<<"$output"
     grep -Fqx '  gh <area> <command> [options]' <<<"$output"
+    grep -Fqx '  onboard [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
@@ -237,6 +239,114 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *$'type:fix\tDetect outdated Xcode Command Line Tools in `basectl doctor`'* ]]
     [[ "$output" == *$'type:feat\tAdd first-class `mise` integration'* ]]
+}
+
+@test "basectl onboard prints help" {
+    run_basectl onboard --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl onboard [options]"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"--no-profile"* ]]
+}
+
+@test "basectl onboard dry-run shows planned commands without prompting" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() { printf "unexpected run: %s\n" "$*" >&2; return 99; }
+            base_onboard_subcommand_main --dry-run --dev
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run basectl check base --dev"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl setup base --dev --dry-run"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl update-profile --dry-run"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl doctor base --dev"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl projects list"* ]]
+    [[ "$output" != *"unexpected run"* ]]
+}
+
+@test "basectl onboard declines setup conservatively" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() { printf "RUN:%s\n" "$*"; return 0; }
+            printf "\n" | base_onboard_subcommand_main
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RUN:check base"* ]]
+    [[ "$output" == *"Proceed with setup? [y/N]"* ]]
+    [[ "$output" == *"Setup skipped."* ]]
+    [[ "$output" != *"RUN:setup base"* ]]
+}
+
+@test "basectl onboard accepted flow runs setup profile doctor and projects" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() { printf "RUN:%s\n" "$*"; return 0; }
+            printf "y\ny\n" | base_onboard_subcommand_main --dev
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RUN:check base --dev"* ]]
+    [[ "$output" == *"RUN:setup base --dev"* ]]
+    [[ "$output" == *"RUN:update-profile"* ]]
+    [[ "$output" == *"RUN:doctor base --dev"* ]]
+    [[ "$output" == *"RUN:projects list"* ]]
+}
+
+@test "basectl onboard --yes accepts setup and profile prompts" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() { printf "RUN:%s\n" "$*"; return 0; }
+            base_onboard_subcommand_main --yes --no-profile
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Proceed with setup? [yes]"* ]]
+    [[ "$output" == *"RUN:setup base"* ]]
+    [[ "$output" == *"Shell profile updates skipped because --no-profile was set."* ]]
+    [[ "$output" != *"RUN:update-profile"* ]]
+}
+
+@test "basectl onboard setup failure stops profile updates and returns setup status" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() {
+                printf "RUN:%s\n" "$*"
+                [[ "$1" == setup ]] && return 7
+                return 0
+            }
+            base_onboard_subcommand_main --yes
+        '
+
+    [ "$status" -eq 7 ]
+    [[ "$output" == *"RUN:check base"* ]]
+    [[ "$output" == *"RUN:setup base"* ]]
+    [[ "$output" == *"Setup failed. Running doctor can show the remaining issues."* ]]
+    [[ "$output" == *"RUN:doctor base"* ]]
+    [[ "$output" != *"RUN:update-profile"* ]]
 }
 
 @test "basectl update prints help" {


### PR DESCRIPTION
## Summary

Implements the v1 `basectl onboard` checklist flow from `docs/basectl-onboard.md`.

- adds a Bash `onboard` subcommand with `--dry-run`, prompted, `--yes`, `--dev`, `--no-profile`, `-v`, and help flows
- orchestrates existing `check`, `setup`, `update-profile`, `doctor`, and `projects list` commands without duplicating their internals
- wires `onboard` into top-level `basectl` help and dispatch
- adds BATS coverage for help, dry-run, declined setup, accepted setup, `--yes`, `--dev`, `--no-profile`, and setup failure behavior

Fixes #122

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/onboard.sh`
- `git diff --check`
- `./bin/basectl onboard --dry-run --dev --no-profile`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/basectl.bats cli/bash/commands/caff/tests/caff.bats cli/bash/commands/sort-in-place/tests/sort-in-place.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/runtime/tests/runtime_bashrc.bats lib/bash/std/tests/lib_std.bats lib/bash/version/tests/lib_version.bats tests/install.bats`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest`