### PR TITLE
Avoid default cache writes for dry-run CLIs

### DIFF
--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -58,7 +58,7 @@ class App:
         @functools.wraps(func)
         def wrapper(**kwargs: Any):
             standard = _pop_standard_options(kwargs)
-            context = self._create_context(standard, sensitive_options)
+            context = self._create_context(standard, sensitive_options, dry_run=bool(kwargs.get("dry_run")))
             token = set_current_context(context)
             try:
                 log_invocation(context.log, sys.argv, sensitive_options)
@@ -79,7 +79,7 @@ class App:
         wrapper = _decorate_standard_options(click, wrapper, self.version)
         return click.command(*self._command_args, **self._command_kwargs)(wrapper)
 
-    def _create_context(self, standard: dict[str, Any], sensitive_options: set[str]) -> Context:
+    def _create_context(self, standard: dict[str, Any], sensitive_options: set[str], dry_run: bool = False) -> Context:
         del sensitive_options
         run_id = make_run_id()
         manifest_path = discover_manifest(Path.cwd())
@@ -95,11 +95,17 @@ class App:
         log_dir = state_dir / "logs"
         cache_dir = state_dir / "cache"
         temp_dir = state_dir / "tmp" / run_id
-        for directory in (log_dir, cache_dir, temp_dir):
-            directory.mkdir(parents=True, exist_ok=True)
 
-        log_file = Path(standard["log_file"]).expanduser() if standard.get("log_file") else log_dir / f"{run_id}.log"
-        log_file.parent.mkdir(parents=True, exist_ok=True)
+        log_file = Path(standard["log_file"]).expanduser() if standard.get("log_file") else None
+        if dry_run:
+            if log_file is not None:
+                log_file.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            for directory in (log_dir, cache_dir, temp_dir):
+                directory.mkdir(parents=True, exist_ok=True)
+            if log_file is None:
+                log_file = log_dir / f"{run_id}.log"
+            log_file.parent.mkdir(parents=True, exist_ok=True)
         logger = configure_logger(self.name, log_file, debug)
         logger.debug("cli=%s run_id=%s environment=%s", self.name, run_id, environment)
 

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -22,7 +22,7 @@ class Context:
     log_dir: Path
     cache_dir: Path
     temp_dir: Path
-    log_file: Path
+    log_file: Path | None
     config: dict
     environment: str
     debug: bool

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -12,7 +12,7 @@ from .redaction import redact_argv
 
 def configure_logger(
     cli_name: str,
-    log_file: Path,
+    log_file: Path | None,
     debug: bool,
 ) -> logging.Logger:
     logger = logging.getLogger(f"base_cli.{cli_name}")
@@ -27,11 +27,12 @@ def configure_logger(
     user_handler.setFormatter(BaseCliFormatter())
     logger.addHandler(user_handler)
 
-    file_handler = logging.FileHandler(log_file, encoding="utf-8")
-    secure_log_file_permissions(log_file)
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(BaseCliFormatter())
-    logger.addHandler(file_handler)
+    if log_file is not None:
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        secure_log_file_permissions(log_file)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(BaseCliFormatter())
+        logger.addHandler(file_handler)
     return logger
 
 

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -370,6 +370,69 @@ class BaseCliTests(unittest.TestCase):
             self.assertIn("hello Ada", result.stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_dry_run_avoids_default_cache_writes(self) -> None:
+        app = base_cli.App(name="dry-run-demo", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        @base_cli.option("--dry-run", is_flag=True)
+        def main(ctx: base_cli.Context, dry_run: bool) -> None:
+            seen["dry_run"] = dry_run
+            seen["temp_dir"] = ctx.temp_dir
+            seen["cache_dir"] = ctx.cache_dir
+            seen["log_dir"] = ctx.log_dir
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("dry run")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
+                from base_cli.testing import invoke
+
+                result = invoke(app, ["--dry-run"], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(seen["dry_run"])
+            self.assertIsNone(seen["log_file"])
+            self.assertFalse(seen["temp_dir"].exists())
+            self.assertFalse(seen["cache_dir"].exists())
+            self.assertFalse(seen["log_dir"].exists())
+            self.assertFalse((home / "Library" / "Caches" / "base").exists())
+            self.assertIn("dry run", result.stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_dry_run_honors_explicit_log_file_without_cache_dirs(self) -> None:
+        app = base_cli.App(name="dry-run-log-demo", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        @base_cli.option("--dry-run", is_flag=True)
+        def main(ctx: base_cli.Context, dry_run: bool) -> None:
+            seen["dry_run"] = dry_run
+            seen["temp_dir"] = ctx.temp_dir
+            seen["cache_dir"] = ctx.cache_dir
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("dry run with log")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_file = home / "logs" / "dry-run.log"
+            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
+                from base_cli.testing import invoke
+
+                result = invoke(app, ["--dry-run", "--log-file", str(log_file)], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(seen["dry_run"])
+            self.assertEqual(seen["log_file"], log_file)
+            self.assertTrue(log_file.is_file())
+            self.assertEqual(log_file.stat().st_mode & 0o777, 0o600)
+            self.assertFalse(seen["temp_dir"].exists())
+            self.assertFalse(seen["cache_dir"].exists())
+            self.assertFalse((home / "Library" / "Caches" / "base").exists())
+            self.assertIn("dry run with log", log_file.read_text(encoding="utf-8"))
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_testing_invoke_captures_stderr_separately(self) -> None:
         app = base_cli.App(name="streams", version="0.1.0")
 


### PR DESCRIPTION
## Summary

- let base_cli detect command-level `dry_run` options before context creation
- skip default log/cache/temp directory creation for dry-run commands unless `--log-file` is explicitly provided
- allow stream-only logging when no persistent dry-run log file is needed
- add coverage for default dry-run no-write behavior and explicit log-file behavior

Fixes #160

## Tests

- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli`
- `git diff --check`