### PR TITLE
Require Bash 4.2 in stdlib version check

### DIFF
--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -86,7 +86,7 @@ is_interactive() {
 #
 # check_bash_version - Verifies the Bash version without prompting or installing anything.
 #
-# This function checks if the running Bash interpreter is version 4.0 or higher and returns
+# This function checks if the running Bash interpreter is version 4.2 or higher and returns
 # non-zero when it is not. Base entrypoints should enforce the supported runtime before
 # sourcing this library; this helper is intentionally passive so sourcing lib_std.sh never
 # prompts, installs packages, or re-execs the caller.
@@ -94,9 +94,11 @@ is_interactive() {
 # Note: This function is called before logging is initialized, so it uses `echo` to stderr.
 #
 check_bash_version() {
-    local -r major_version=${BASH_VERSINFO[0]}
-    if ((major_version < 4)); then
-        echo "Error: This script requires Bash 4.0 or higher." >&2
+    local current_version
+
+    current_version="${BASE_TEST_BASH_VERSION:-${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}}"
+    if ((current_version < 42)); then
+        echo "Error: This script requires Bash 4.2 or higher." >&2
         echo "Your version ($BASH_VERSION) is not compatible." >&2
         return 1
     fi

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -138,6 +138,21 @@ EOF
     [ "$?" -eq 0 ]
 }
 
+@test "stdlib passive bash version check requires Bash 4.2 or newer" {
+    local script="$TEST_TMPDIR/bash-version.sh"
+
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+source "$STDLIB_PATH"
+BASE_TEST_BASH_VERSION=41 check_bash_version
+EOF
+
+    bats_run "$script"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"requires Bash 4.2 or higher"* ]]
+}
+
 @test "color initialization honors tty mode when --color is passed" {
     local script="$TEST_TMPDIR/tty-colors.sh"
     local normalized


### PR DESCRIPTION
## Summary

- update `check_bash_version` to enforce Base's Bash 4.2+ requirement
- refresh the helper documentation and error message
- add test coverage for rejecting Bash 4.1

Fixes #172

## Tests

- `bash -n lib/bash/std/lib_std.sh`
- `bats --filter "bash version" lib/bash/std/tests/lib_std.bats`
- `git diff --check`