### PR TITLE
Honor activate venv override

### DIFF
--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -27,7 +27,18 @@ base_activate_resolve_project() {
     local wrapper="$2"
     shift 2
 
-    "$wrapper" --project base base_projects resolve "$project" "$@"
+    env -u BASE_PROJECT_VENV_DIR "$wrapper" --project base base_projects resolve "$project" "$@"
+}
+
+base_activate_project_venv_dir() {
+    local project="$1"
+
+    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+        printf '%s\n' "$BASE_PROJECT_VENV_DIR"
+        return 0
+    fi
+
+    printf '%s\n' "$HOME/.base.d/$project/.venv"
 }
 
 base_activate_subcommand_main() {
@@ -87,7 +98,7 @@ base_activate_subcommand_main() {
         fatal_error "Unable to resolve project '$project'."
     }
 
-    venv_dir="$HOME/.base.d/$resolved_name/.venv"
+    venv_dir="$(base_activate_project_venv_dir "$resolved_name")"
     [[ -x "$venv_dir/bin/python" ]] || {
         fatal_error "Project virtual environment Python was not found at '$venv_dir/bin/python'. Run 'basectl setup $resolved_name' first."
     }

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -1073,6 +1073,45 @@ EOF
     [[ "$output" == *"PWD=$workspace/demo"* ]]
 }
 
+@test "basectl activate honors BASE_PROJECT_VENV_DIR override" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local project_python="$TEST_TMPDIR/custom-venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'BASE_PROJECT_VENV_DIR=%s\n' "$BASE_PROJECT_VENV_DIR"
+EOF
+    printf '#!/usr/bin/env bash\n' > "$project_python"
+    chmod +x "$base_python" "$project_python" "$fake_bash"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_ACTIVATE_SHELL="$fake_bash" \
+        BASE_PROJECT_VENV_DIR="$TEST_TMPDIR/custom-venv" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"BASE_PROJECT_VENV_DIR=$TEST_TMPDIR/custom-venv"* ]]
+}
+
 @test "basectl default runtime shell preserves caller working directory" {
     local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local project_activate="$TEST_HOME/.base.d/base/.venv/bin/activate"


### PR DESCRIPTION
## Summary

- make `basectl activate` use `BASE_PROJECT_VENV_DIR` for the target project venv when provided
- keep project resolution on Base's own venv by clearing the override for the resolver call
- add activation coverage for a custom project venv path

Fixes #173

## Tests

- `bash -n cli/bash/commands/basectl/subcommands/activate.sh`
- `bats --filter "activate" cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`