### PR TITLE
Complete setup notification flags

### DIFF
--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1512,6 +1512,21 @@ EOF
     [[ "$output" == *"projects=base demo"* ]]
 }
 
+@test "Bash completion includes setup notification options" {
+    run env \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '\
+            source "$BASE_HOME/lib/shell/completions/basectl_completion.sh"; \
+            COMP_WORDS=(basectl setup --no); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "reply=%s\n" "${COMPREPLY[*]}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--notify"* ]]
+    [[ "$output" == *"--no-notify"* ]]
+}
+
 @test "basectl update-profile preserves non-Base dotfile content and is idempotent" {
     printf '%s
 ' 'user line before' > "$TEST_HOME/.bashrc"

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -49,7 +49,7 @@ _base_basectl_completion() {
             fi
             ;;
         setup)
-            _base_basectl_completion_compgen "--dev --dry-run --manifest --recreate-venv -v -h --help" "$cur"
+            _base_basectl_completion_compgen "--dev --dry-run --manifest --notify --no-notify --recreate-venv -v -h --help" "$cur"
             ;;
         check)
             _base_basectl_completion_compgen "--dev --format -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -47,7 +47,10 @@ _base_basectl_completion() {
             ;;
         setup)
             _arguments '--dev[Install developer prerequisites]' '--dry-run[Log without making changes]' \
-                '--manifest[Use a specific manifest]:path:_files' '--recreate-venv[Recreate the Base venv]' \
+                '--manifest[Use a specific manifest]:path:_files' \
+                '--notify[Force a setup completion notification]' \
+                '--no-notify[Disable setup completion notification]' \
+                '--recreate-venv[Recreate the Base venv]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         check)


### PR DESCRIPTION
## Summary

- add `--notify` and `--no-notify` to Bash basectl setup completions
- add the same notification flags to Zsh completions
- cover Bash completion output for the notification options

Fixes #174

## Tests

- `bash -n lib/shell/completions/basectl_completion.sh`
- `bats --filter "completion" cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`