### PR TITLE
Complete project completions for check and doctor

### DIFF
--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1505,11 +1505,26 @@ EOF
             COMP_WORDS=(basectl activate ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
-            printf "projects=%s\n" "${COMPREPLY[*]}"'
+            printf "activate_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl check ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "check_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl doctor ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "doctor_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl check --); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "check_options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
-    [[ "$output" == *"projects=base demo"* ]]
+    [[ "$output" == *"activate_projects=base demo"* ]]
+    [[ "$output" == *"check_projects=base demo"* ]]
+    [[ "$output" == *"doctor_projects=base demo"* ]]
+    [[ "$output" == *"check_options=--dev --format"* ]]
 }
 
 @test "Bash completion includes setup notification options" {

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -22,6 +22,17 @@ _base_basectl_completion_compgen() {
     done < <(compgen -W "$words" -- "$current")
 }
 
+_base_basectl_completion_project_or_options() {
+    local options="$1"
+    local current="$2"
+
+    if ((COMP_CWORD == 2)) && [[ "$current" != -* ]]; then
+        _base_basectl_completion_compgen "$(_base_basectl_completion_project_names)" "$current"
+    else
+        _base_basectl_completion_compgen "$options" "$current"
+    fi
+}
+
 _base_basectl_completion() {
     local command cur
     local commands="activate setup check clean config doctor gh update-profile update projects version help"
@@ -52,7 +63,7 @@ _base_basectl_completion() {
             _base_basectl_completion_compgen "--dev --dry-run --manifest --notify --no-notify --recreate-venv -v -h --help" "$cur"
             ;;
         check)
-            _base_basectl_completion_compgen "--dev --format -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options "--dev --format -v -h --help" "$cur"
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --dry-run -v -h --help" "$cur"
@@ -63,7 +74,7 @@ _base_basectl_completion() {
             fi
             ;;
         doctor)
-            _base_basectl_completion_compgen "--dev -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options "--dev -v -h --help" "$cur"
             ;;
         gh)
             case "${COMP_WORDS[2]:-}" in

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -11,6 +11,7 @@ _base_basectl_completion_project_names() {
 
 _base_basectl_completion() {
     local -a commands project_names
+    local state
 
     commands=(
         'activate:Start an interactive Base runtime subshell for a project'
@@ -55,7 +56,12 @@ _base_basectl_completion() {
             ;;
         check)
             _arguments '--dev[Include developer prerequisite checks]' '--format[Output format]:format:(text json)' \
-                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
             ;;
         clean)
             _arguments '--older-than[Artifact age]:age:' '--dry-run[Log without removing files]' \
@@ -66,7 +72,12 @@ _base_basectl_completion() {
             ;;
         doctor)
             _arguments '--dev[Include developer prerequisite checks]' '-v[Enable DEBUG logging]' \
-                '(-h --help)'{-h,--help}'[Show help text]'
+                '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
             ;;
         gh)
             case "${words[3]:-}" in


### PR DESCRIPTION
## Summary

- complete project names for `basectl check` and `basectl doctor`
- keep option completion available when the current token starts with `-`
- cover the Bash completion behavior in tests

Fixes #175

## Tests

- `bash -n lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `bats --filter "completion" cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`