### PR TITLE
Use manifest project for Python artifacts

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -183,7 +183,7 @@ def reconcile_manifest(
     reconcile_ide_settings(ctx, effective_manifest, dry_run=dry_run)
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
-        reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
+        reconcile_artifact(ctx, definition, artifact.version, effective_manifest.project_name, dry_run=dry_run)
 
     ctx.log.info("Project '%s' setup is complete.", effective_manifest.project_name)
 
@@ -203,7 +203,7 @@ def reconcile_bootstrap_artifacts(
         return
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
-        reconcile_artifact(ctx, definition, artifact.version, dry_run=dry_run)
+        reconcile_artifact(ctx, definition, artifact.version, manifest.project_name, dry_run=dry_run)
 
 
 def check_manifest(
@@ -925,13 +925,14 @@ def reconcile_artifact(
     ctx: base_cli.Context,
     definition: ArtifactDefinition,
     version: str,
+    project: str,
     dry_run: bool,
 ) -> None:
     if definition.manager == "homebrew":
         reconcile_homebrew_artifact(ctx, definition, version, dry_run=dry_run)
         return
     if definition.manager == "pip":
-        reconcile_python_artifact(ctx, definition, version, dry_run=dry_run)
+        reconcile_python_artifact(ctx, definition, version, project, dry_run=dry_run)
         return
     raise ArtifactError(f"Artifact manager '{definition.manager}' is not implemented.")
 
@@ -978,9 +979,9 @@ def reconcile_python_artifact(
     ctx: base_cli.Context,
     definition: ArtifactDefinition,
     version: str,
+    project: str,
     dry_run: bool,
 ) -> None:
-    project = os.environ.get("BASE_PROJECT", "base")
     venv_dir = project_venv_dir(project)
     python_bin = venv_dir / "bin" / "python"
     requirement = f"{definition.package}=={version}" if version != "latest" else definition.package

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -401,9 +401,9 @@ class ManifestTests(unittest.TestCase):
             venv_dir = Path(tmpdir) / "custom-venv"
             with mock.patch.dict(
                 os.environ,
-                {"BASE_PROJECT": "demo", "BASE_PROJECT_VENV_DIR": str(venv_dir)},
+                {"BASE_PROJECT": "wrong-project", "BASE_PROJECT_VENV_DIR": str(venv_dir)},
             ), mock.patch("base_setup.engine.python_artifact_installed", return_value=False):
-                engine.reconcile_python_artifact(ctx, definition, "latest", dry_run=True)
+                engine.reconcile_python_artifact(ctx, definition, "latest", "demo", dry_run=True)
 
         info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
         self.assertIn(
@@ -414,6 +414,21 @@ class ManifestTests(unittest.TestCase):
             f"[DRY-RUN] Would run: {venv_dir}/bin/python -m pip install requests",
             info_messages,
         )
+
+    def test_python_artifact_uses_manifest_project_not_environment(self) -> None:
+        definition = get_artifact_definition("python-package", "requests")
+        self.assertIsNotNone(definition)
+        ctx = fake_context()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv_dir = Path(tmpdir) / "demo" / ".venv"
+            with mock.patch.dict(os.environ, {"BASE_PROJECT": "wrong-project"}), mock.patch(
+                "base_setup.engine.project_venv_dir",
+                return_value=venv_dir,
+            ) as project_venv_dir, mock.patch("base_setup.engine.python_artifact_installed", return_value=False):
+                engine.reconcile_python_artifact(ctx, definition, "latest", "demo", dry_run=True)
+
+        project_venv_dir.assert_called_once_with("demo")
 
     def test_run_command_includes_stderr_on_failure(self) -> None:
         ctx = fake_context()
@@ -526,6 +541,7 @@ class BootstrapManifestTests(unittest.TestCase):
 
         self.assertEqual(reconcile_artifact.call_count, 1)
         self.assertEqual(reconcile_artifact.call_args.args[1].name, "click")
+        self.assertEqual(reconcile_artifact.call_args.args[3], "demo")
 
     def test_merge_artifacts_preserves_default_bootstrap_marker(self) -> None:
         merged = merge_artifacts(


### PR DESCRIPTION
## Summary

- thread manifest project names through artifact reconciliation
- make Python artifact reconciliation use the supplied project instead of `BASE_PROJECT`
- cover the behavior with a regression test using a deliberately wrong environment value

Fixes #177

## Tests

- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine.ManifestTests.test_python_artifact_honors_project_venv_dir_override cli.python.base_setup.tests.test_engine.ManifestTests.test_python_artifact_uses_manifest_project_not_environment cli.python.base_setup.tests.test_engine.BootstrapManifestTests.test_reconcile_bootstrap_artifacts_uses_only_bootstrap_defaults`
- `~/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/engine.py cli/python/base_setup/tests/test_engine.py`
- `git diff --check`