### PR TITLE
Clarify gh branch prune dry-run behavior

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -28,7 +28,7 @@ Branch naming:
 
 Notes:
   - This command requires the GitHub CLI (`gh`) for GitHub operations.
-  - Branch pruning is dry-run unless --yes is passed.
+  - Branch pruning is dry-run by default and applies only when --yes is passed.
   - TODO import is currently a dry-run planning command.
 EOF
 }
@@ -331,7 +331,7 @@ base_gh_branch_stale() {
 }
 
 base_gh_branch_prune() {
-    local dry_run=1 yes=0 remote=0 default_branch current_branch branch
+    local dry_run=1 remote=0 default_branch current_branch branch
 
     while (($#)); do
         case "$1" in
@@ -340,7 +340,6 @@ base_gh_branch_prune() {
                 ;;
             --yes)
                 dry_run=0
-                yes=1
                 ;;
             --remote)
                 remote=1
@@ -363,9 +362,6 @@ base_gh_branch_prune() {
 
     if ((dry_run)); then
         printf '[DRY-RUN] Local branches merged into %s that would be deleted:\n' "$default_branch"
-    elif ((yes == 0)); then
-        base_gh_error "Refusing to prune without --yes."
-        return 1
     fi
 
     while read -r branch; do

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -172,6 +172,55 @@ EOF
     [[ "$output" == "chore/117-"*"-prune-merged-branches" ]]
 }
 
+@test "basectl gh branch prune defaults to dry-run" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" branch merged-work
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Local branches merged into"* ]]
+    [[ "$output" == *"merged-work"* ]]
+    git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
+}
+
+@test "basectl gh branch prune applies only with yes" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" branch merged-work
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Deleted branch merged-work"* ]]
+    ! git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
+}
+
 @test "basectl gh pr create links current branch issue" {
     local repo
 


### PR DESCRIPTION
## Summary

- simplify `basectl gh branch prune` so dry-run remains the default and `--yes` applies pruning
- remove the unreachable confirmation branch from prune handling
- add tests for default dry-run and explicit `--yes` deletion behavior

Fixes #178

## Tests

- `bash -n cli/bash/commands/basectl/subcommands/gh.sh`
- `bats --filter "branch prune" cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`