### PR TITLE
Use shutil.which for command lookup

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import tempfile
 import venv
@@ -1027,10 +1028,7 @@ def python_artifact_installed(python_bin: Path, package: str, version: str) -> b
 
 
 def command_exists(name: str) -> bool:
-    return any(
-        (Path(directory) / name).is_file() and os.access(Path(directory) / name, os.X_OK)
-        for directory in os.environ.get("PATH", "").split(os.pathsep)
-    )
+    return shutil.which(name) is not None
 
 
 def run_check(command: list[str]) -> bool:


### PR DESCRIPTION
## Summary

Replaces the hand-rolled PATH scan in `base_setup.engine.command_exists` with Python's standard `shutil.which`.

Fixes #184

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_engine.py`
- `bash -c 'export PYTHONPATH=lib/python:cli/python; /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc cli/python/base_setup/engine.py'`
- `git diff --check`