### PR TITLE
Use platform IDE settings paths

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -768,9 +768,10 @@ def resolve_ide_settings(project: str, settings: dict[str, object]) -> dict[str,
 
 
 def ide_settings_file(definition: IdeDefinition) -> Path:
+    home = Path(os.environ.get("HOME") or Path.home()).expanduser()
     if sys.platform == "darwin":
-        return Path.home() / "Library" / "Application Support" / definition.settings_app_dir / "User" / "settings.json"
-    config_home = Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config").expanduser()
+        return home / "Library" / "Application Support" / definition.settings_app_dir / "User" / "settings.json"
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME") or home / ".config").expanduser()
     return config_home / definition.settings_app_dir / "User" / "settings.json"
 
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -7,6 +7,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 import venv
 from dataclasses import dataclass
@@ -767,7 +768,10 @@ def resolve_ide_settings(project: str, settings: dict[str, object]) -> dict[str,
 
 
 def ide_settings_file(definition: IdeDefinition) -> Path:
-    return Path.home() / "Library" / "Application Support" / definition.settings_app_dir / "User" / "settings.json"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / definition.settings_app_dir / "User" / "settings.json"
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config").expanduser()
+    return config_home / definition.settings_app_dir / "User" / "settings.json"
 
 
 def read_ide_settings(definition: IdeDefinition) -> dict[str, object]:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -1176,7 +1176,7 @@ class IdeSettingsTests(unittest.TestCase):
         definition = engine.IDE_DEFINITIONS["vscode"]
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 engine.merge_ide_settings(
                     ctx,
                     definition,
@@ -1193,7 +1193,7 @@ class IdeSettingsTests(unittest.TestCase):
         definition = engine.IDE_DEFINITIONS["cursor"]
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 settings_file = engine.ide_settings_file(definition)
                 settings_file.parent.mkdir(parents=True)
                 settings_file.write_text(
@@ -1219,7 +1219,7 @@ class IdeSettingsTests(unittest.TestCase):
         definition = engine.IDE_DEFINITIONS["vscode"]
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 engine.merge_ide_settings(
                     ctx,
                     definition,
@@ -1265,7 +1265,7 @@ class IdeSettingsTests(unittest.TestCase):
         definition = engine.IDE_DEFINITIONS["vscode"]
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 check = engine.check_ide_setting("demo", definition, "editor.formatOnSave", True)
 
         self.assertFalse(check.ok)
@@ -1276,7 +1276,7 @@ class IdeSettingsTests(unittest.TestCase):
         definition = engine.IDE_DEFINITIONS["vscode"]
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 settings_file = engine.ide_settings_file(definition)
                 settings_file.parent.mkdir(parents=True)
                 settings_file.write_text(json.dumps({"editor.formatOnSave": True}), encoding="utf-8")
@@ -1289,7 +1289,7 @@ class IdeSettingsTests(unittest.TestCase):
         definition = engine.IDE_DEFINITIONS["cursor"]
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 settings_file = engine.ide_settings_file(definition)
                 settings_file.parent.mkdir(parents=True)
                 settings_file.write_text(json.dumps({"editor.formatOnSave": False}), encoding="utf-8")
@@ -1315,7 +1315,7 @@ class IdeSettingsTests(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 settings_file = engine.ide_settings_file(engine.IDE_DEFINITIONS["vscode"])
                 settings_file.parent.mkdir(parents=True)
                 settings_file.write_text(json.dumps({"editor.formatOnSave": True}), encoding="utf-8")
@@ -1550,7 +1550,7 @@ class UserIdePreferenceMergeTests(unittest.TestCase):
                 "ide:\n  vscode:\n    settings:\n      editor.formatOnSave: false\n",
                 encoding="utf-8",
             )
-            with mock.patch.dict(os.environ, {"HOME": home_dir}):
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}):
                 settings_file = engine.ide_settings_file(engine.IDE_DEFINITIONS["vscode"])
                 settings_file.parent.mkdir(parents=True)
                 settings_file.write_text(json.dumps({"editor.formatOnSave": True}), encoding="utf-8")
@@ -1593,7 +1593,7 @@ class IdeDiagnosticsTests(unittest.TestCase):
             ), mock.patch(
                 "base_setup.engine.list_ide_extensions",
                 return_value={"ms-python.python"},
-            ), mock.patch.dict(os.environ, {"HOME": tmpdir}):
+            ), mock.patch.dict(os.environ, {"HOME": tmpdir, "XDG_CONFIG_HOME": ""}):
                 settings_file = engine.ide_settings_file(engine.IDE_DEFINITIONS["vscode"])
                 settings_file.parent.mkdir(parents=True)
                 settings_file.write_text(json.dumps({"editor.formatOnSave": True}), encoding="utf-8")
@@ -1631,7 +1631,7 @@ class IdeDiagnosticsTests(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir}), mock.patch(
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}), mock.patch(
                 "base_setup.engine.command_exists",
                 return_value=False,
             ):

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -1130,6 +1130,47 @@ class IdeSettingsTests(unittest.TestCase):
         self.assertEqual(settings["python.defaultInterpreterPath"], str(venv_dir / "bin" / "python"))
         self.assertTrue(settings["editor.formatOnSave"])
 
+    def test_ide_settings_file_uses_macos_application_support(self) -> None:
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            with mock.patch.dict(os.environ, {"HOME": home_dir}, clear=False), mock.patch(
+                "base_setup.engine.sys.platform", "darwin"
+            ):
+                settings_file = engine.ide_settings_file(definition)
+
+        self.assertEqual(
+            settings_file,
+            Path(home_dir) / "Library" / "Application Support" / "Code" / "User" / "settings.json",
+        )
+
+    def test_ide_settings_file_uses_xdg_config_home_off_macos(self) -> None:
+        definition = engine.IDE_DEFINITIONS["cursor"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home_dir = Path(tmpdir) / "home"
+            config_home = Path(tmpdir) / "xdg-config"
+            home_dir.mkdir()
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": str(home_dir), "XDG_CONFIG_HOME": str(config_home)},
+                clear=False,
+            ), mock.patch("base_setup.engine.sys.platform", "linux"):
+                settings_file = engine.ide_settings_file(definition)
+
+        self.assertEqual(settings_file, config_home / "Cursor" / "User" / "settings.json")
+
+    def test_ide_settings_file_defaults_to_home_config_off_macos(self) -> None:
+        definition = engine.IDE_DEFINITIONS["vscode"]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}, clear=False), mock.patch(
+                "base_setup.engine.sys.platform", "linux"
+            ):
+                settings_file = engine.ide_settings_file(definition)
+
+        self.assertEqual(settings_file, Path(home_dir) / ".config" / "Code" / "User" / "settings.json")
+
     def test_merge_ide_settings_writes_missing_keys(self) -> None:
         ctx = fake_context()
         definition = engine.IDE_DEFINITIONS["vscode"]


### PR DESCRIPTION
## Summary

Isolates IDE user settings file locations behind a platform-aware helper.

- keeps macOS on `$HOME/Library/Application Support/<app>/User/settings.json`
- uses `$XDG_CONFIG_HOME/<app>/User/settings.json` off macOS when set
- falls back to `$HOME/.config/<app>/User/settings.json` off macOS
- honors explicit `HOME` values so controlled setup environments do not leak into the runner/user's real home when XDG is not set
- clears `XDG_CONFIG_HOME` in temp-home tests that assert isolated IDE settings paths
- adds direct tests for all three path modes

Fixes #185

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_engine.py`
- `bash -c 'export PYTHONPATH=lib/python:cli/python; /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc cli/python/base_setup/engine.py cli/python/base_setup/tests/test_engine.py'`
- `git diff --check`