### PR TITLE
Document local config sync boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ to `~/Library/Caches/base` on macOS. Set `BASE_CACHE_DIR` to override it. Durabl
 state such as `~/.base.d/config.yaml` and project virtual environments under
 `~/.base.d/<project>/.venv` are outside this scope.
 
+Inspect machine-local Base config with:
+
+```bash
+basectl config path
+basectl config show
+basectl config doctor
+```
+
+Base owns the meaning of `~/.base.d/config.yaml`, but users own how that file is
+edited, backed up, or synced. See [docs/local-config.md](docs/local-config.md).
+
 Use `--keep-last <count>` to retain the newest log files per CLI log directory
 while pruning older logs. This retention mode applies only to `*.log` files;
 temp and cache artifacts continue to use `--older-than`.

--- a/docs/ide-bootstrapping.md
+++ b/docs/ide-bootstrapping.md
@@ -25,7 +25,6 @@ Base does not own:
 - workspace `.vscode/settings.json` generation
 - JetBrains IDE configuration
 - generic dotfile synchronization
-- user-local IDE preference layering
 
 ## Manifest Schema
 
@@ -149,9 +148,11 @@ bootstrap and diagnostics for Base-managed projects.
 
 Candidate future work:
 
-- user-local IDE preference config under `~/.base.d`
 - workspace `.vscode` settings if a real project needs shared editor settings
 - Windsurf support if its CLI and settings surface match the VS Code family
 - JetBrains support only after a clean, scriptable configuration surface is
   identified
 - extension pinning only if Base adopts a deliberate VSIX management strategy
+
+Machine-local IDE preferences live in `~/.base.d/config.yaml`. See
+[local-config.md](local-config.md) for the user config schema and sync boundary.

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -1,0 +1,113 @@
+# Local Config
+
+Base reads machine-local user configuration from:
+
+```text
+~/.base.d/config.yaml
+```
+
+This file is optional. When it is missing, Base behaves as though the user
+config is an empty YAML mapping.
+
+Inspect it with:
+
+```bash
+basectl config path
+basectl config show
+basectl config doctor
+```
+
+`basectl config path` prints the default path without requiring the Base Python
+environment. `show` prints the parsed config as JSON. `doctor` reports whether
+the file exists, whether it is valid YAML, whether it is a mapping, and whether
+the path is a symlink.
+
+## Ownership Boundary
+
+Base owns the meaning of `~/.base.d/config.yaml`.
+
+The user owns how that file is edited, backed up, copied, or synced.
+
+Base does not edit the file for the user, and Base does not automate iCloud,
+dotfile, or backup setup. Developers can edit the YAML directly.
+
+Good ways to keep this file across machines include:
+
+- iCloud Drive, if the user chooses to keep a symlink there
+- chezmoi or another dotfile manager
+- a private dotfiles repository
+- Time Machine
+- manual copy during machine setup
+
+Base should tolerate ordinary filesystem choices such as symlinks, but it should
+not assume a specific sync provider. Work machines, personal machines, and
+managed corporate environments can have very different policies around iCloud
+and cloud sync.
+
+## Config Precedence
+
+For Python commands built on `base_cli.App`, configuration is loaded in this
+order:
+
+1. user config: `~/.base.d/config.yaml`
+2. project config: `<project>/.base/config.yaml`
+3. explicit config from `--config`
+4. recognized environment variables
+5. direct command-line standard options
+
+Later layers override earlier layers for the same key.
+
+Recognized environment variables include:
+
+- `BASE_CLI_ENVIRONMENT`
+- `BASE_CLI_LOG_LEVEL`
+- `BASE_CLI_KEEP_TEMP`
+
+`BASE_CACHE_DIR` separately controls the runtime cache/log/temp root; it is not
+stored in the user config.
+
+## IDE Preferences
+
+User-local IDE preferences can add machine-specific IDE behavior without
+changing a project's `base_manifest.yaml`:
+
+```yaml
+ide:
+  enabled: true
+
+  vscode:
+    enabled: true
+    install: false
+    extra_extensions:
+      - eamodio.gitlens
+    settings:
+      editor.fontSize: 14
+
+  cursor:
+    enabled: false
+```
+
+The project manifest remains authoritative for project requirements. User
+settings are additive:
+
+- user `extra_extensions` are appended to project extensions
+- user settings are applied only when the project does not declare the same key
+- project settings win when both layers declare the same setting
+- users can disable IDE handling for one machine with `ide.enabled: false` or
+  `ide.<name>.enabled: false`
+
+If a user setting conflicts with a project setting, Base reports a warning and
+uses the project setting.
+
+## Sync Guidance
+
+iCloud can be useful for a single developer's multi-Mac setup, but it is not a
+Base feature. Base should not create iCloud folders, move config into iCloud, or
+automatically symlink config into iCloud Drive.
+
+Users who want iCloud sync can create their own symlink from
+`~/.base.d/config.yaml` to a file in iCloud Drive. `basectl config doctor` will
+surface that the config path is a symlink.
+
+This boundary keeps Base focused on workstation bootstrap and project
+orchestration rather than backup, sync, or dotfile management.

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -223,6 +223,11 @@ Environment variables currently recognized by the config layer:
 Command-line standard options are applied after config is loaded. For example,
 `--environment prod` overrides `environment: dev` from config.
 
+The user config file is machine-local by default. Base owns the semantics of
+`~/.base.d/config.yaml`, while users own backup and sync choices such as iCloud,
+chezmoi, dotfiles repositories, Time Machine, or manual copy. See
+`docs/local-config.md` for the product-level boundary.
+
 ## Project Discovery
 
 When a command runs, `base_cli` walks upward from the current working directory


### PR DESCRIPTION
## Summary

Documents Base's machine-local config model and sync boundary.

- adds `docs/local-config.md`
- documents `~/.base.d/config.yaml` and `basectl config path/show/doctor`
- explains config precedence and IDE preference behavior
- clarifies that Base owns config semantics, while users own backup/sync choices
- explicitly keeps iCloud automation outside Base while allowing user-managed symlinks
- links the new doc from README, IDE docs, and `base_cli` docs

Fixes #148

## Validation

- docs-only change; reviewed markdown source locally
- `basectl gh issue start 148 --type feat --title "Document local Base config and sync boundary"`
- tried `./bin/basectl gh pr create --title "Document local config sync boundary"`; local `gh` still failed with API connectivity/auth, tracked by #151