### PR TITLE
[codex] Add skills documentation workflow

### DIFF
--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -1,0 +1,175 @@
+name: Skills Document
+
+on:
+  pull_request:
+    paths:
+      - "skills.md"
+      - ".github/workflows/skills.yml"
+  push:
+    paths:
+      - "skills.md"
+      - ".github/workflows/skills.yml"
+  workflow_dispatch:
+    inputs:
+      create_pr:
+        description: "Create a pull request when skills.md is missing"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate skills.md
+    if: github.event_name != 'workflow_dispatch' || inputs.create_pr != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check required sections
+        run: |
+          test -f skills.md
+          grep -q '^# Skills$' skills.md
+          grep -q '^## Add a basectl subcommand$' skills.md
+          grep -q '^## Add a Bash command$' skills.md
+          grep -q '^## Add a Bash library$' skills.md
+          grep -q '^## Add a Python CLI feature$' skills.md
+          grep -q '^## Add or change artifact setup$' skills.md
+          grep -q '^## Change shell startup behavior$' skills.md
+          grep -q '^## Release or Homebrew-facing changes$' skills.md
+
+  create:
+    name: Create skills.md PR
+    if: github.event_name == 'workflow_dispatch' && inputs.create_pr == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create starter skills.md when missing
+        run: |
+          if [ -f skills.md ]; then
+            echo "skills.md already exists; nothing to create."
+            exit 0
+          fi
+
+          cat > skills.md <<'EOF'
+          # Skills
+
+          This file documents repeatable AI-assisted development workflows for Base.
+          General project context lives in `AI_CONTEXT.md`; coding standards live in
+          `STANDARDS.md`.
+
+          ## Add a basectl subcommand
+
+          Use this workflow when adding or changing a `basectl <command>` feature.
+
+          - Public entrypoint: `bin/basectl`
+          - Command implementation: `cli/bash/commands/basectl/`
+          - Subcommands: `cli/bash/commands/basectl/subcommands/`
+          - Tests: `cli/bash/commands/basectl/tests/`
+          - Follow shell standards in `STANDARDS.md`.
+
+          ## Add a Bash command
+
+          Use this workflow when adding a public Base-owned Bash command.
+
+          - Add the public launcher under `bin/`.
+          - Put implementation code under `cli/bash/commands/<command>/`.
+          - Keep command tests under `cli/bash/commands/<command>/tests/`.
+
+          ## Add a Bash library
+
+          Use this workflow when adding shared Bash behavior.
+
+          - Library path: `lib/bash/<name>/lib_<name>.sh`
+          - Module README: `lib/bash/<name>/README.md`
+          - Tests: `lib/bash/<name>/tests/`
+
+          ## Add a Python CLI feature
+
+          Use this workflow when adding or changing Python-backed Base behavior.
+
+          - Shared framework: `lib/python/base_cli/`
+          - Command packages: `cli/python/`
+          - Command execution wrapper: `bin/base-wrapper`
+
+          ## Add or change artifact setup
+
+          Use this workflow when changing `base_manifest.yaml`, default artifacts, or
+          setup behavior.
+
+          - Project manifest: `base_manifest.yaml`
+          - Default artifacts: `lib/base/default_manifest.yaml`
+          - Development artifacts: `lib/base/dev_manifest.yaml`
+          - Artifact registry: `cli/python/base_setup/registry.py`
+
+          ## Change shell startup behavior
+
+          Use this workflow when changing profile, rc, completion, or activation behavior.
+
+          - Startup snippets: `lib/shell/`
+          - Runtime shell entrypoint: `lib/bash/runtime/bashrc`
+          - Profile updater: `cli/bash/commands/basectl/subcommands/update_profile.sh`
+
+          ## Release or Homebrew-facing changes
+
+          Use this workflow when changing installation, update, or public package
+          behavior.
+
+          - Standalone installer: `install.sh`
+          - User-facing install test coverage: `tests/install.bats`
+          EOF
+
+          sed -i 's/^          //' skills.md
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet -- skills.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push starter file
+        if: steps.changes.outputs.changed == 'true'
+        id: commit
+        run: |
+          branch="codex/create-skills-md-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add skills.md
+          git commit -m "Add skills.md"
+          git push origin "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > pr-body.md <<'EOF'
+          Add a root `skills.md` file with starter AI-assisted development
+          workflows for Base.
+
+          This PR was generated by the Skills Document workflow.
+          EOF
+          sed -i 's/^          //' pr-body.md
+
+          gh pr create \
+            --draft \
+            --base "${GITHUB_REF_NAME}" \
+            --head "${{ steps.commit.outputs.branch }}" \
+            --title "[codex] Add skills.md" \
+            --body-file pr-body.md

--- a/skills.md
+++ b/skills.md
@@ -1,0 +1,105 @@
+# Skills
+
+This file documents repeatable AI-assisted development workflows for Base.
+General project context lives in `AI_CONTEXT.md`; coding standards live in
+`STANDARDS.md`.
+
+## Add a basectl subcommand
+
+Use this workflow when adding or changing a `basectl <command>` feature.
+
+- Public entrypoint: `bin/basectl`
+- Command implementation: `cli/bash/commands/basectl/`
+- Subcommands: `cli/bash/commands/basectl/subcommands/`
+- Tests: `cli/bash/commands/basectl/tests/`
+- Follow shell standards in `STANDARDS.md`.
+- Validate focused command behavior with:
+
+```bash
+bats cli/bash/commands/basectl/tests/basectl.bats
+bats cli/bash/commands/basectl/tests/setup.bats
+```
+
+## Add a Bash command
+
+Use this workflow when adding a public Base-owned Bash command.
+
+- Add the public launcher under `bin/`.
+- Put implementation code under `cli/bash/commands/<command>/`.
+- Keep command tests under `cli/bash/commands/<command>/tests/`.
+- Prefer a launcher that delegates through `basectl` so the Base runtime owns
+  path setup and library loading.
+- Add or update the command README when user-facing behavior changes.
+
+## Add a Bash library
+
+Use this workflow when adding shared Bash behavior.
+
+- Library path: `lib/bash/<name>/lib_<name>.sh`
+- Module README: `lib/bash/<name>/README.md`
+- Tests: `lib/bash/<name>/tests/`
+- Use `import_base_lib` from Base runtime scripts.
+- Do not use `set -e`; use explicit error handling.
+- Validate the module's BATS tests directly before running the broader suite.
+
+## Add a Python CLI feature
+
+Use this workflow when adding or changing Python-backed Base behavior.
+
+- Shared framework: `lib/python/base_cli/`
+- Command packages: `cli/python/`
+- Command execution wrapper: `bin/base-wrapper`
+- Keep package tests next to the package under `tests/`.
+- Run Python commands with `PYTHONPATH=lib/python:cli/python`.
+- Validate with:
+
+```bash
+env PYTHONPATH=lib/python:cli/python python -m pytest
+```
+
+## Add or change artifact setup
+
+Use this workflow when changing `base_manifest.yaml`, default artifacts, or
+setup behavior.
+
+- Project manifest: `base_manifest.yaml`
+- Default artifacts: `lib/base/default_manifest.yaml`
+- Development artifacts: `lib/base/dev_manifest.yaml`
+- Artifact registry: `cli/python/base_setup/registry.py`
+- Prefer delegation to mature tools over expanding Base-owned setup logic.
+- Keep `basectl check` and `basectl doctor` non-mutating.
+- Include `tests/install.bats` when installer behavior or setup bootstrap
+  behavior changes.
+
+## Change shell startup behavior
+
+Use this workflow when changing profile, rc, completion, or activation behavior.
+
+- Startup snippets: `lib/shell/`
+- Runtime shell entrypoint: `lib/bash/runtime/bashrc`
+- Profile updater: `cli/bash/commands/basectl/subcommands/update_profile.sh`
+- Managed login and interactive snippets must not source `base_init.sh`.
+- Validate startup behavior with:
+
+```bash
+bats lib/bash/runtime/tests/runtime_bashrc.bats
+bats cli/bash/commands/basectl/tests/setup.bats
+```
+
+## Release or Homebrew-facing changes
+
+Use this workflow when changing installation, update, or public package
+behavior.
+
+- Standalone installer: `install.sh`
+- User-facing install test coverage: `tests/install.bats`
+- Homebrew install path is documented in `AI_CONTEXT.md`.
+- Keep Homebrew users on `brew upgrade codeforester/base/base` rather than
+  `basectl update`.
+- Validate with:
+
+```bash
+bats tests/install.bats
+bin/basectl check
+bin/basectl setup --dry-run
+```


### PR DESCRIPTION
Add a root `skills.md` file with repeatable AI-assisted development workflows for Base.

Also add a GitHub Actions workflow that validates the required `skills.md` sections on push and pull request, and can be manually dispatched to create a starter `skills.md` PR if the file is missing.

Validation run locally:
- `test -f skills.md && grep ...` for required sections
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/skills.yml"); puts "ok"'`