### PR TITLE
Harden basectl gh auth checks

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -46,6 +46,16 @@ base_gh_require_command() {
     }
 }
 
+base_gh_require_auth() {
+    base_gh_require_command gh || return 1
+
+    gh auth status >/dev/null 2>&1 || {
+        base_gh_error "GitHub CLI authentication is not ready."
+        base_gh_error "Run 'gh auth login -h github.com' and retry."
+        return 1
+    }
+}
+
 base_gh_require_git_repo() {
     git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
         base_gh_error "Current directory is not inside a Git worktree."
@@ -129,7 +139,7 @@ base_gh_do_issue() {
 
     case "$command" in
         list)
-            base_gh_require_command gh || return 1
+            base_gh_require_auth || return 1
             gh issue list "$@"
             ;;
         create)
@@ -184,7 +194,7 @@ base_gh_issue_create() {
     }
     issue_type="${issue_type:-feat}"
     base_gh_validate_type "$issue_type" || return 1
-    base_gh_require_command gh || return 1
+    base_gh_require_auth || return 1
 
     if [[ -n "$body" ]]; then
         gh issue create --title "$title" --body "$body" --label "type:$issue_type"
@@ -226,7 +236,7 @@ base_gh_issue_start() {
 
     base_gh_require_git_repo || return 1
     if [[ -z "$issue_type" || -z "$title" ]]; then
-        base_gh_require_command gh || return 1
+        base_gh_require_auth || return 1
     fi
     if [[ -z "$issue_type" ]]; then
         issue_type="$(base_gh_issue_type_from_labels "$issue")" || return 1
@@ -251,7 +261,7 @@ base_gh_do_pr() {
 
     case "$command" in
         create)
-            base_gh_require_command gh || return 1
+            base_gh_require_auth || return 1
             base_gh_require_git_repo || return 1
             issue="$(base_gh_current_issue_from_branch || true)"
             if [[ -n "$issue" ]]; then
@@ -265,19 +275,19 @@ base_gh_do_pr() {
             gh pr create --fill "$@"
             ;;
         status)
-            base_gh_require_command gh || return 1
+            base_gh_require_auth || return 1
             gh pr status "$@"
             ;;
         checks)
-            base_gh_require_command gh || return 1
+            base_gh_require_auth || return 1
             gh pr checks "$@"
             ;;
         ready)
-            base_gh_require_command gh || return 1
+            base_gh_require_auth || return 1
             gh pr ready "$@"
             ;;
         merge)
-            base_gh_require_command gh || return 1
+            base_gh_require_auth || return 1
             gh pr merge "$@"
             ;;
         -h|--help|help|"")

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -92,6 +92,9 @@ run_basectl() {
 @test "basectl gh issue create applies type label" {
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
+if [[ "$*" == "auth status" ]]; then
+    exit 0
+fi
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
 EOF
     chmod +x "$TEST_MOCKBIN/gh"
@@ -111,6 +114,33 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Repair branch pruning --label type:fix" ]
 }
 
+@test "basectl gh issue list reports missing gh authentication clearly" {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status" ]]; then
+    exit 1
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 99
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue list
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"GitHub CLI authentication is not ready."* ]]
+    [[ "$output" == *"gh auth login -h github.com"* ]]
+    [[ "$output" != *"unexpected gh args"* ]]
+}
+
 @test "basectl gh issue start creates convention branch from issue metadata" {
     local repo
 
@@ -121,6 +151,9 @@ EOF
 
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
+if [[ "$*" == "auth status" ]]; then
+    exit 0
+fi
 if [[ "$*" == "issue view 117 --json labels --jq .labels[].name | select(startswith(\"type:\")) | sub(\"^type:\"; \"\")" ]]; then
     printf 'feat\n'
     exit 0
@@ -232,6 +265,9 @@ EOF
 
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
+if [[ "$*" == "auth status" ]]; then
+    exit 0
+fi
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
 body_file=""
 while (($#)); do


### PR DESCRIPTION
## Summary

- Add a shared `basectl gh` authentication preflight for GitHub API-backed issue and PR commands.
- Preserve the local-only `issue start --type --title` branch creation path without requiring `gh` authentication.
- Add BATS coverage for the auth failure path and update existing `gh` stubs to model `gh auth status`.

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/gh.sh`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- Dogfooded `./bin/basectl gh pr create --title "Harden basectl gh auth checks"`; local `gh` auth is not ready, and the command now reports the new Base guidance.

Fixes #151