### PR TITLE
Reorganize documentation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,20 @@ Project-specific onboarding should live in project installers that call Base
 internally. See [Project Installers](docs/project-installers.md) for the
 recommended boundary between Base and scripts such as `banyanlabs/install.sh`.
 
+## Documentation
+
+The top-level README is the product overview and first-run guide. The
+[docs README](docs/README.md) is the map for architecture, runtime behavior,
+feature designs, and ecosystem boundary decisions.
+
+Key starting points:
+
+- [Architecture](docs/architecture.md)
+- [Execution Model](docs/execution-model.md)
+- [Tool Boundaries](docs/tool-boundaries.md)
+- [IDE Bootstrapping](docs/ide-bootstrapping.md)
+- [Local Config](docs/local-config.md)
+
 ## Compatibility
 
 Base is currently macOS-first. The implemented and tested support contract is
@@ -674,10 +688,12 @@ The current contents include useful shell-oriented building blocks from the
 older version of Base. The goal now is to evolve those foundations into a more
 general multi-project workspace tool.
 
-For the evolving architecture and product-direction notes behind that refactor,
-see [docs/design.md](docs/design.md). For the current `basectl` runtime and
-dispatch contract, see [docs/execution-model.md](docs/execution-model.md). For
-ecosystem boundary and integration decisions, see
+For the documentation map and naming convention, see
+[docs/README.md](docs/README.md). For the evolving architecture and
+product-direction notes behind that refactor, see
+[docs/architecture.md](docs/architecture.md). For the current `basectl` runtime
+and dispatch contract, see [docs/execution-model.md](docs/execution-model.md).
+For ecosystem boundary and integration decisions, see
 [docs/tool-boundaries.md](docs/tool-boundaries.md).
 
 The first migration pass has already started: the Base CLI, runtime bootstrap,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Base Documentation
+
+This directory holds design, architecture, and operational documentation for
+Base. The top-level [README](../README.md) is the product front door; this page
+is the documentation map.
+
+## Naming Convention
+
+Use stable topic names for documentation files:
+
+- `architecture.md` for the broad product and system architecture.
+- `<feature>.md` for focused feature designs such as `ide-bootstrapping.md`.
+- `<domain>-<topic>.md` when a shorter topic name would be ambiguous.
+- Avoid generic names such as `design.md` once the subject is known.
+
+Document titles can still say whether a page is a design, model, boundary, or
+reference. The filename should answer "what is this about?"
+
+## Core Documents
+
+- [Architecture](architecture.md) describes Base's product direction, command
+  model, environment model, manifest shape, and repository conventions.
+- [Execution Model](execution-model.md) documents the current `basectl` runtime,
+  dispatch order, public launchers, and runtime shell behavior.
+- [Tool Boundaries](tool-boundaries.md) records ecosystem decisions for tools
+  such as `mise`, `direnv`, Homebrew, IDEs, Docker, and dotfile managers.
+
+## Feature And Boundary Documents
+
+- [IDE Bootstrapping](ide-bootstrapping.md) covers project IDE manifests,
+  supported IDEs, extensions, additive settings, and diagnostics.
+- [Local Config](local-config.md) covers user-local Base config, precedence,
+  sync guidance, and the user/project boundary.
+- [Project Installers](project-installers.md) defines how project-owned
+  installers should use Base without moving product-specific logic into Base.
+- [`basectl onboard`](basectl-onboard.md) captures the guided setup experience
+  and its relationship to project installers.
+- [base_cli Runtime Package](base-cli.md) describes the Python CLI foundation
+  used by Base and Base-supported project CLIs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Base — Design Document
+# Base Architecture
 
 ## Overview
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -1,4 +1,4 @@
-# base_cli Design
+# base_cli Runtime Package
 
 `base_cli` is the Python CLI foundation for Base and Base-supported projects.
 It wraps Click with Base conventions for runtime context, logging, run-scoped


### PR DESCRIPTION
## Summary

- Add `docs/README.md` as the documentation map and naming convention.
- Rename the generic `docs/design.md` to `docs/architecture.md`.
- Rename `docs/base-cli-design.md` to `docs/base-cli.md`.
- Add a top-level README `Documentation` section and update stale links.

## Validation

- `rg` checked markdown references for stale `design.md` / `base-cli-design.md` links.
- `git diff --check`

Fixes #203