### PR TITLE
Fix README version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Tests](https://github.com/codeforester/base/actions/workflows/tests.yml/badge.svg)
 ![Lint](https://github.com/codeforester/base/actions/workflows/pylint.yml/badge.svg)
 ![Platform: macOS](https://img.shields.io/badge/platform-macOS-lightgrey)
-![Version](https://img.shields.io/github/v/tag/codeforester/base?label=version)
+![Version](https://img.shields.io/badge/version-0.1.0-blue)
 
 Base is a foundational developer tooling repo for a multi-project workspace.
 

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -637,6 +637,15 @@ EOF
     [ "$output" = "basectl $expected_version" ]
 }
 
+@test "README version badge matches VERSION" {
+    local expected_version expected_badge
+
+    expected_version="$(head -n 1 "$BASE_REPO_ROOT/VERSION")"
+    expected_badge="![Version](https://img.shields.io/badge/version-$expected_version-blue)"
+
+    grep -Fqx "$expected_badge" "$BASE_REPO_ROOT/README.md"
+}
+
 @test "basectl re-execs through an installed supported Bash when current Bash is too old" {
     local fake_bash="$TEST_TMPDIR/fake-bash"
 


### PR DESCRIPTION
## Summary

- Replace the GitHub tag-backed README version badge with a stable Shields badge for the current `VERSION` value.
- Add a BATS guard that checks the README version badge matches the top-level `VERSION` file.

## Notes

GitHub Markdown cannot interpolate `VERSION` directly into an image URL at render time, so the README badge remains static markdown. The test makes `VERSION` the source of truth by failing if the badge is not updated when `VERSION` changes.

## Validation

- `git diff --check`
- `bats cli/bash/commands/basectl/tests/basectl.bats`

Fixes #205