### PR TITLE
Harden Python file discovery in CI

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           PYTHONPATH: lib/python:cli/python
         run: |
-          git ls-files '*.py' | xargs pylint --rcfile=.pylintrc
+          git ls-files -z '*.py' | xargs -0 pylint --rcfile=.pylintrc


### PR DESCRIPTION
## Summary

- switch the Pylint workflow to null-delimited Python file discovery
- avoid newline/word-splitting issues when passing tracked Python files to `xargs`

Fixes #129

## Tests

- `git ls-files -z '*.py' | xargs -0 ~/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc --errors-only`
- `git diff --check`