### PR TITLE
Add CI security scanners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,3 +53,35 @@ jobs:
             lib/bash/std/tests/lib_std.bats \
             lib/bash/version/tests/lib_version.bats \
             tests/install.bats
+
+  security:
+    name: Security scanners
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run Bandit
+        run: |
+          bandit -q -r cli/python lib/python -x '*/tests/*' --severity-level medium
+
+      - name: Run ShellCheck
+        run: |
+          git ls-files -z \
+            '*.sh' \
+            'base_init.sh' \
+            'install.sh' \
+            'bin/*' \
+            | xargs -0 shellcheck --severity=error

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pylint==3.3.9
 click==8.4.1
 PyYAML==6.0.3
 pytest==9.0.3
+bandit==1.9.4


### PR DESCRIPTION
## Summary

- add Bandit as a pinned development dependency
- add a CI security scanner job for Bandit and ShellCheck
- run Bandit at medium-or-higher severity to avoid blocking on existing low-risk subprocess noise

Fixes #130

## Tests

- `PYTHONPATH=/private/tmp/base-bandit /Users/rameshhp/.base.d/base/.venv/bin/python -m bandit -q -r cli/python lib/python -x '*/tests/*' --severity-level medium`
- `~/.base.d/base/.venv/bin/python -m pip install --dry-run -r requirements-dev.txt`
- `git diff --check`

Note: ShellCheck is installed by the CI job through apt; it is not installed locally on this machine.