### PR TITLE
Document Base-managed demo project criteria

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,5 +37,7 @@ reference. The filename should answer "what is this about?"
   and its relationship to project installers.
 - [`basectl check` parallelism](check-parallelism.md) records the evaluation and
   implementation constraints for parallel check probes.
+- [Base-managed demo project](base-managed-demo-project.md) defines the proof
+  project criteria for showing Base's complete workspace workflow.
 - [base_cli Runtime Package](base-cli.md) describes the Python CLI foundation
   used by Base and Base-supported project CLIs.

--- a/docs/base-managed-demo-project.md
+++ b/docs/base-managed-demo-project.md
@@ -1,0 +1,68 @@
+# Base-managed demo project
+
+Base needs a real project that demonstrates the complete daily workflow without
+requiring a reader to infer how the pieces fit together. The demo should be a
+normal repository checked out next to Base, not synthetic fixtures inside the
+Base repo.
+
+## Candidate
+
+Use Banyanlabs when it is ready to be public enough for documentation. Until
+then, keep the demo plan project-neutral and avoid hard-coding private
+repository assumptions into Base.
+
+## Demo Goals
+
+The demo project should prove these commands end to end:
+
+```bash
+basectl projects list
+basectl setup <project>
+basectl check <project>
+basectl doctor <project>
+basectl activate <project>
+```
+
+When `basectl test <project>` exists, the same demo should add it to the flow.
+
+## Project Requirements
+
+The demo project should include:
+
+- `base_manifest.yaml` with the real project name.
+- a `Brewfile` if it needs Homebrew tools.
+- Python artifacts only when the project actually needs a Base-managed venv.
+- IDE settings or extensions only when they demonstrate a concrete workflow.
+- a README section titled "Base setup" with the exact commands above.
+
+The demo should avoid:
+
+- private credentials
+- cloud account assumptions
+- long-running service dependencies
+- project-specific installer logic inside Base
+
+## Acceptance Criteria
+
+A new developer should be able to:
+
+1. Clone Base.
+2. Run `basectl setup`.
+3. Clone the demo project next to Base.
+4. Run `basectl projects list` and see both repositories.
+5. Run `basectl setup <project>`.
+6. Run `basectl check <project>` and get a clean result.
+7. Run `basectl doctor <project>` and get no error findings.
+8. Run `basectl activate <project>` and land in a project shell with the
+   expected prompt and environment.
+
+## Documentation Placement
+
+Once the real project is selected, link it from:
+
+- Base's top-level README
+- the demo project's README
+- `docs/README.md`
+
+The Base README should show the demo as proof of the workflow, not as a second
+installation path.


### PR DESCRIPTION
## Summary

- define what a real Base-managed demo project should prove
- capture acceptance criteria for setup, discovery, check, doctor, and activate
- add the demo project plan to the docs map

Fixes #127

## Tests

- `git diff --check`
- `rg -n "Base-managed demo project|demo project" docs`