### PR TITLE
Document initial Linux support plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ reference. The filename should answer "what is this about?"
   model, environment model, manifest shape, and repository conventions.
 - [Execution Model](execution-model.md) documents the current `basectl` runtime,
   dispatch order, public launchers, and runtime shell behavior.
+- [Linux Support](linux-support.md) defines the first Ubuntu/Debian runtime
+  support plan and bootstrap boundaries.
 - [Tool Boundaries](tool-boundaries.md) records ecosystem decisions for tools
   such as `mise`, `direnv`, Homebrew, IDEs, Docker, and dotfile managers.
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -1,0 +1,103 @@
+# Linux support plan
+
+Base is currently Mac-first. Linux support should be added deliberately, with
+Ubuntu/Debian as the first target because it covers GitHub Actions and a large
+share of developer machines.
+
+## Target Scope
+
+Start with Ubuntu/Debian runtime support:
+
+- Base Python CLIs run under Linux.
+- `base-wrapper` can select the project venv under `~/.base.d/<project>/.venv`.
+- `basectl projects list`, `check`, `doctor`, and future `ci` work when
+  prerequisites are already installed.
+- Setup gives clear guidance instead of invoking macOS-only installers.
+
+Full bootstrap support can come after runtime support is stable.
+
+## Platform Detection
+
+Use `/etc/os-release` for Linux distribution detection:
+
+```bash
+if [[ -r /etc/os-release ]]; then
+    source /etc/os-release
+fi
+```
+
+The setup layer should classify platforms into:
+
+- `macos`
+- `linux-debian`
+- `linux-unknown`
+- `unsupported`
+
+Unsupported platforms should fail with explicit guidance rather than falling
+through to macOS assumptions.
+
+## Package Manager Mapping
+
+Initial Ubuntu/Debian mappings:
+
+| Base prerequisite | macOS source | Ubuntu/Debian source |
+| --- | --- | --- |
+| Bash 4.2+ | Homebrew `bash` | `apt install bash` |
+| Python 3.13 | Homebrew `python@3.13` | documented manual install first |
+| BATS | Homebrew `bats-core` | `apt install bats` when available |
+| GitHub CLI | Homebrew `gh` | GitHub CLI apt repository |
+
+Python should be the conservative piece. Do not silently use arbitrary system
+Python for Base setup unless Linux support explicitly opts into that behavior.
+
+## Shell Startup
+
+Linux shell startup differs from macOS:
+
+- interactive Bash usually reads `~/.bashrc`
+- login Bash may read `~/.bash_profile`, `~/.bash_login`, or `~/.profile`
+- Zsh behavior is broadly portable but file locations remain user-specific
+
+The existing managed-section model should remain the abstraction. Platform
+support should change which dotfiles are touched, not the managed-section
+format.
+
+## Runtime Paths
+
+Existing path behavior already points in the right direction:
+
+- state and venvs: `~/.base.d`
+- runtime cache on Linux: `~/.cache/base`
+
+Linux support should preserve those defaults and continue to honor the existing
+environment overrides.
+
+## CI Relationship
+
+Linux support should make GitHub Actions a first-class validation target:
+
+```bash
+basectl ci check base --format json
+basectl ci doctor base --format json
+```
+
+The first CI-compatible milestone can document manual prerequisite setup in the
+workflow before invoking Base.
+
+## Implementation Phases
+
+1. Split macOS-only setup checks from portable runtime checks.
+2. Add Linux platform detection and explicit unsupported-platform messages.
+3. Make `basectl check` and `doctor` report Linux prerequisite status without
+   requiring Homebrew or Xcode.
+4. Add Ubuntu CI coverage for read-only commands.
+5. Add apt-backed setup for simple prerequisites.
+6. Revisit Python installation once the desired Linux Python distribution
+   strategy is clear.
+
+## Non-Goals
+
+- Do not support every Linux distribution in the first pass.
+- Do not add a second manifest format for Linux.
+- Do not use arbitrary `python3` silently to create Base-managed venvs.
+- Do not attempt GUI IDE installation on Linux until a real project needs it.


### PR DESCRIPTION
## Summary

- define Ubuntu/Debian as the first Linux support target
- document runtime support before full bootstrap support
- capture platform detection, package-manager mapping, shell startup, path, and CI boundaries

Fixes #125

## Tests

- `git diff --check`
- `rg -n "Linux support|Ubuntu|/etc/os-release|linux-support" docs`