### PR TITLE
Add basectl activate --no-cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Activation spawns a project-specific subshell, changes to the project root, sets
 virtual environment at `~/.base.d/<project>/.venv`. Exit that shell to return to
 the original environment.
 
+Use `basectl activate example --no-cd` to keep the caller's current directory
+while still loading the selected project's Base runtime environment.
+
 Invoking `basectl` with no arguments in a terminal starts the default
 interactive Base shell. It uses the nearest `base_manifest.yaml` above the
 current directory to choose the active project, then preserves the current

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -9,6 +9,7 @@ Usage:
 
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  --no-cd             Preserve the caller's current directory in the project shell.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
@@ -44,6 +45,7 @@ base_activate_project_venv_dir() {
 base_activate_subcommand_main() {
     local project="" wrapper resolve_output activate_shell
     local resolved_name project_root manifest_path venv_dir shell_rc
+    local preserve_cwd="${BASE_ACTIVATE_PRESERVE_CWD:-0}"
     local args=()
 
     while (($# > 0)); do
@@ -66,6 +68,10 @@ base_activate_subcommand_main() {
                 ;;
             --workspace=*)
                 args+=("$1")
+                shift
+                ;;
+            --no-cd)
+                preserve_cwd=1
                 shift
                 ;;
             -*)
@@ -113,7 +119,7 @@ base_activate_subcommand_main() {
     export BASE_HOME
     export BASE_SHELL=1
 
-    if [[ "${BASE_ACTIVATE_PRESERVE_CWD:-}" != "1" ]]; then
+    if [[ "$preserve_cwd" != "1" ]]; then
         cd "$project_root" || fatal_error "Unable to enter project root '$project_root'."
     fi
     activate_shell="${BASE_ACTIVATE_SHELL:-${BASH:-bash}}"

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -1256,12 +1256,58 @@ EOF
     [[ "$output" == *"PWD=$caller"* ]]
 }
 
+@test "basectl activate --no-cd preserves caller working directory" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local project_python="$TEST_HOME/.base.d/demo/.venv/bin/python"
+    local project_activate="$TEST_HOME/.base.d/demo/.venv/bin/activate"
+    local workspace="$TEST_TMPDIR/workspace"
+    local caller="$TEST_TMPDIR/caller"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo" "$caller"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'BASE_PROJECT_ROOT=%s\n' "$BASE_PROJECT_ROOT"
+printf 'PWD=%s\n' "$PWD"
+EOF
+    printf 'VIRTUAL_ENV=%s\nexport VIRTUAL_ENV\n' "$TEST_HOME/.base.d/demo/.venv" > "$project_activate"
+    printf '#!/usr/bin/env bash\n' > "$project_python"
+    chmod +x "$base_python" "$project_python" "$fake_bash"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+    caller="$(cd "$caller" && pwd -P)"
+
+    run bash -c 'cd "$1" || exit 1; shift; exec "$@"' _ "$caller" \
+        env \
+            HOME="$TEST_HOME" \
+            PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+            BASE_ACTIVATE_SHELL="$fake_bash" \
+            BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+            "$BASE_REPO_ROOT/bin/basectl" activate demo --no-cd
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"BASE_PROJECT_ROOT=$workspace/demo"* ]]
+    [[ "$output" == *"PWD=$caller"* ]]
+}
+
 @test "basectl activate prints help without requiring the Base Python venv" {
     run_basectl activate --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl activate <project> [options]"* ]]
+    [[ "$output" == *"--no-cd"* ]]
 }
 
 @test "basectl activate reports missing project as a usage error" {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1508,6 +1508,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "activate_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl activate demo --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "activate_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl check ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -1524,6 +1528,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
     [[ "$output" == *"activate_projects=base demo"* ]]
+    [[ "$output" == *"activate_options=--workspace --no-cd"* ]]
     [[ "$output" == *"check_projects=base demo"* ]]
     [[ "$output" == *"doctor_projects=base demo"* ]]
     [[ "$output" == *"check_options=--dev --format"* ]]

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -51,7 +51,7 @@ _base_basectl_completion() {
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "$(_base_basectl_completion_project_names)" "$cur"
             else
-                _base_basectl_completion_compgen "--workspace -v -h --help" "$cur"
+                _base_basectl_completion_compgen "--workspace --no-cd -v -h --help" "$cur"
             fi
             ;;
         projects)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -39,7 +39,9 @@ _base_basectl_completion() {
                 project_names=("${(@f)$(_base_basectl_completion_project_names)}")
                 _describe -t projects 'Base project' project_names
             else
-                _arguments '--workspace[Workspace directory to scan]:path:_files' '-v[Enable DEBUG logging]' \
+                _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                    '--no-cd[Preserve the caller current directory]' \
+                    '-v[Enable DEBUG logging]' \
                     '(-h --help)'{-h,--help}'[Show help text]'
             fi
             ;;


### PR DESCRIPTION
## Summary

- Add `basectl activate <project> --no-cd` as a first-class option for preserving the caller's current directory.
- Preserve `BASE_ACTIVATE_PRESERVE_CWD` as the internal/advanced override used by default runtime shell dispatch.
- Add Bash and Zsh completion entries for `--no-cd`.
- Document the flag in README and activate help.

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/activate.sh lib/shell/completions/basectl_completion.sh`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`

Fixes #180