### PR TITLE
Add JSON output for projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,13 @@ You can inspect the projects Base can see with:
 
 ```bash
 basectl projects list
+basectl projects list --format json
 ```
 
 By default this scans the parent directory of `BASE_HOME`, which matches the
 recommended sibling-repo workspace layout. Use `--workspace <path>` to inspect a
 different workspace root. Output is tab-separated as `<project-name><TAB><path>`.
+Use `--format json` for machine-readable output.
 
 Once a project is discoverable, activate it with:
 

--- a/cli/bash/commands/basectl/subcommands/projects.sh
+++ b/cli/bash/commands/basectl/subcommands/projects.sh
@@ -9,6 +9,7 @@ Usage:
 
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  --format <format>   Output format for list: text or json.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -725,12 +725,44 @@ EOF
     [ "$(cat "$TEST_TMPDIR/projects-list-state")" = "BASE_PROJECT=base" ]
 }
 
+@test "basectl projects list forwards json format option" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_TEST_PROJECTS_LIST_STATE:?}"
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
+    printf '[{"name":"base","path":"%s"}]\n' "${BASE_TEST_WORKSPACE:?}/base"
+    exit 0
+fi
+printf 'unexpected projects list python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: base\nartifacts: []\n' > "$workspace/base/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECTS_LIST_STATE="$TEST_TMPDIR/projects-list-state" \
+        BASE_TEST_WORKSPACE="$workspace" \
+        "$BASE_REPO_ROOT/bin/basectl" projects list --workspace "$workspace" --format json
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "[{\"name\":\"base\",\"path\":\"$workspace/base\"}]" ]
+    [ "$(cat "$TEST_TMPDIR/projects-list-state")" = "-m base_projects list --workspace $workspace --format json" ]
+}
+
 @test "basectl projects list prints help without requiring the Base Python venv" {
     run_basectl projects list --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl projects list [options]"* ]]
+    [[ "$output" == *"--format <format>"* ]]
 }
 
 @test "basectl clean delegates to the Python cleanup layer" {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1523,7 +1523,11 @@ EOF
             COMP_WORDS=(basectl check --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
-            printf "check_options=%s\n" "${COMPREPLY[*]}"'
+            printf "check_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl projects list --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "projects_options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
@@ -1532,6 +1536,7 @@ EOF
     [[ "$output" == *"check_projects=base demo"* ]]
     [[ "$output" == *"doctor_projects=base demo"* ]]
     [[ "$output" == *"check_options=--dev --format"* ]]
+    [[ "$output" == *"projects_options=--workspace --format"* ]]
 }
 
 @test "Bash completion includes setup notification options" {

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,9 +28,16 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.argument("command", required=False)
 @base_cli.argument("project", required=False)
 @base_cli.option("--workspace", help="Workspace directory to scan. Defaults to BASE_HOME's parent.")
-def run(ctx: base_cli.Context, command: str | None, project: str | None, workspace: str | None) -> int:
+@base_cli.option("--format", "output_format", default="text", help="Output format for list: text or json.")
+def run(
+    ctx: base_cli.Context,
+    command: str | None,
+    project: str | None,
+    workspace: str | None,
+    output_format: str,
+) -> int:
     if command in (None, "list"):
-        return list_projects_command(ctx, workspace)
+        return list_projects_command(ctx, workspace, output_format)
     if command == "current":
         return current_project_command(ctx)
     if command == "manifest":
@@ -41,13 +49,26 @@ def run(ctx: base_cli.Context, command: str | None, project: str | None, workspa
     return 2
 
 
-def list_projects_command(ctx: base_cli.Context, workspace: str | None) -> int:
+def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
+    if output_format not in ("text", "json"):
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+        return 2
+
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
         projects = discover_projects(workspace_root)
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return 1
+
+    if output_format == "json":
+        print(
+            json.dumps(
+                [{"name": project.name, "path": str(project.root)} for project in projects],
+                separators=(",", ":"),
+            )
+        )
+        return 0
 
     for project in projects:
         print(f"{project.name}\t{project.root}")

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 import os
 import tempfile
 import unittest
@@ -67,6 +68,33 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{(workspace / 'demo').resolve()}\n")
+
+    def test_projects_list_supports_json_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "custom"
+            base_home = Path(tmpdir) / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(
+                ["list", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(json.loads(stdout), [{"name": "demo", "path": str((workspace / "demo").resolve())}])
+
+    def test_projects_list_rejects_unknown_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+
+            status, _stdout, stderr = run_engine(["list", "--format", "xml"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertIn("Unsupported output format 'xml'", stderr)
 
     def test_projects_resolve_prints_project_details(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -57,6 +57,8 @@ _base_basectl_completion() {
         projects)
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "list" "$cur"
+            else
+                _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
             fi
             ;;
         setup)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -46,7 +46,10 @@ _base_basectl_completion() {
             fi
             ;;
         projects)
-            _arguments '1:projects command:(list)'
+            _arguments '1:projects command:(list)' \
+                '--workspace[Workspace directory to scan]:path:_files' \
+                '--format[Output format]:format:(text json)' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         setup)
             _arguments '--dev[Install developer prerequisites]' '--dry-run[Log without making changes]' \


### PR DESCRIPTION
## Summary

- Add `basectl projects list --format json` for machine-readable project discovery.
- Keep the existing tab-separated text output as the default.
- Document and complete `--format` for Bash and Zsh.
- Add Python and Bash coverage for JSON output, invalid formats, forwarding, help, and completion.

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/projects.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_engine`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`

Fixes #179