### PR TITLE
Add contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to Base
+
+Base is a developer tooling repository. Contributions should keep the project
+opinionated, testable, and useful as a shared workspace control plane.
+
+## Workflow
+
+1. Create or choose a GitHub issue before starting implementation work.
+2. Make sure the issue has one type label:
+   - `type:feat` for user-visible features or product capability.
+   - `type:fix` for bug fixes and correctness issues.
+   - `type:chore` for maintenance, CI, cleanup, or internal improvements.
+   - `type:docs` for documentation-only work.
+3. Create a branch from the issue using this convention:
+
+   ```text
+   <type>/<issue>-<YYYYMMDD>-<slug>
+   ```
+
+   Example:
+
+   ```text
+   feat/179-20260528-projects-list-json
+   ```
+
+4. Prefer an isolated Git worktree for each pull request:
+
+   ```bash
+   git worktree add ../base-worktrees/<slug> -b <branch> master
+   ```
+
+5. Keep the PR scoped to the issue. Avoid unrelated refactors.
+6. Link the PR back to the issue with `Fixes #<issue>`.
+7. After merge, sync `master`, remove the worktree, and delete the local branch.
+
+## Running Tests
+
+Run the narrowest relevant checks first, then broaden when the change touches
+shared behavior.
+
+Common checks:
+
+```bash
+bats cli/bash/commands/basectl/tests/basectl.bats
+bats cli/bash/commands/basectl/tests/setup.bats
+PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover cli/python
+git diff --check
+```
+
+Use `basectl setup --dev` to install developer prerequisites such as BATS and
+the GitHub CLI. Use `basectl check --dev` or `basectl doctor --dev` to diagnose
+missing developer tools.
+
+Shell files should pass ShellCheck. Python changes should pass the existing
+Python tests and lint workflows.
+
+## Code Standards
+
+Follow [STANDARDS.md](STANDARDS.md). In particular:
+
+- Keep Bash control flow explicit. Do not rely on `set -e`.
+- Keep command implementations under `cli/bash/commands/<command>/`.
+- Keep Python package code under `cli/python/` or `lib/python/` as appropriate.
+- Put tests next to the command, library, or package they validate.
+- Keep public command launchers in `bin/` thin.
+
+## Artifact Registry Changes
+
+Base's curated artifact registry lives in:
+
+```text
+cli/python/base_setup/registry.py
+```
+
+When adding or changing a built-in artifact:
+
+- Add or update the registry entry.
+- Add tests for lookup and setup/check behavior.
+- Keep ordinary Homebrew tools in project `Brewfile` delegation when Base does
+  not need to manage the artifact directly.
+- Keep project-specific setup logic in the project repository, not in Base.
+
+## Pull Request Checklist
+
+Before opening a PR:
+
+- The branch name follows `<type>/<issue>-<YYYYMMDD>-<slug>`.
+- The PR is scoped to one issue.
+- The PR body explains what changed and how it was validated.
+- Relevant BATS and Python tests pass.
+- Documentation is updated when behavior or user-facing commands change.
+- The PR includes `Fixes #<issue>` when it should close the issue.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A developer may need:
 
 Base exists to provide that missing common layer.
 
+Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Top Goals
 
 Base is being refactored around three primary goals.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@ This directory holds design, architecture, and operational documentation for
 Base. The top-level [README](../README.md) is the product front door; this page
 is the documentation map.
 
+For contribution workflow, branch naming, tests, and PR expectations, see
+[CONTRIBUTING.md](../CONTRIBUTING.md).
+
 ## Naming Convention
 
 Use stable topic names for documentation files:


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` covering issue-first workflow, type labels, branch naming, worktree PR flow, tests, standards, artifact registry changes, and PR checklist.
- Link the contribution guide from the top-level README and docs map.

## Validation

- `git diff --check`
- `rg -n "CONTRIBUTING|type:feat|worktree|Fixes #|STANDARDS|registry.py" CONTRIBUTING.md README.md docs/README.md`

Fixes #181