### PR TITLE
Allow pass-through Python package artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,16 @@ Follow [STANDARDS.md](STANDARDS.md). In particular:
 
 ## Artifact Registry Changes
 
-Base's curated artifact registry lives in:
+Base's curated tool artifact registry lives in:
 
 ```text
 cli/python/base_setup/registry.py
 ```
 
-When adding or changing a built-in artifact:
+Python package artifacts are pass-through PyPI package names; they do not need
+registry entries unless Base needs special handling for them.
+
+When adding or changing a built-in tool artifact:
 
 - Add or update the registry entry.
 - Add tests for lookup and setup/check behavior.

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ single project-owned command to run. Base should not run arbitrary setup hooks
 until there is an explicit, reviewable contract for when they run, where they
 run, whether they are interactive, and how dry-run/check/doctor report them.
 
-The supported artifact registry lives in
-`cli/python/base_setup/registry.py`. It should stay small and Base-aware. Today,
-`python-package` artifacts install into the project virtual environment at
+The curated tool artifact registry lives in `cli/python/base_setup/registry.py`.
+It should stay small and Base-aware. `python-package` artifacts are pass-through
+PyPI package names and install into the project virtual environment at
 `~/.base.d/<project>/.venv`. Homebrew-managed `tool` artifacts currently support
 `version: latest`, but ordinary Homebrew tools should move toward Brewfile
 delegation. Pinned Homebrew versions fail clearly until Base grows explicit

--- a/cli/python/base_setup/registry.py
+++ b/cli/python/base_setup/registry.py
@@ -108,4 +108,17 @@ _ARTIFACTS = {
 
 
 def get_artifact_definition(artifact_type: str, name: str) -> ArtifactDefinition | None:
-    return _ARTIFACTS.get((artifact_type, name))
+    definition = _ARTIFACTS.get((artifact_type, name))
+    if definition is not None:
+        return definition
+
+    if artifact_type == "python-package":
+        return ArtifactDefinition(
+            name=name,
+            artifact_type=artifact_type,
+            manager="pip",
+            package=name,
+            target="project-venv",
+        )
+
+    return None

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -252,6 +252,19 @@ class ManifestTests(unittest.TestCase):
         self.assertIsNotNone(get_artifact_definition("python-package", "pylint"))
         self.assertIsNotNone(get_artifact_definition("python-package", "pytest"))
 
+    def test_python_package_artifacts_are_pass_through_pip_packages(self) -> None:
+        definition = get_artifact_definition("python-package", "rich")
+
+        self.assertIsNotNone(definition)
+        self.assertEqual(definition.name, "rich")
+        self.assertEqual(definition.artifact_type, "python-package")
+        self.assertEqual(definition.manager, "pip")
+        self.assertEqual(definition.package, "rich")
+        self.assertEqual(definition.target, "project-venv")
+
+    def test_unknown_tool_artifacts_remain_unsupported(self) -> None:
+        self.assertIsNone(get_artifact_definition("tool", "not-a-real-tool"))
+
     def test_base_dev_manifest_declares_supported_tools(self) -> None:
         manifest = read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
         tools = {(artifact.artifact_type, artifact.name) for artifact in manifest.artifacts}
@@ -295,6 +308,30 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 1)
         self.assertIn("Unsupported artifact 'not-a-real-artifact' of type 'tool'", stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_unknown_python_package_artifact_dry_run_uses_pip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts:",
+                        "  - type: python-package",
+                        "    name: rich",
+                        "    version: latest",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
+
+        self.assertEqual(status, 0)
+        self.assertIn("pip install rich", stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_known_homebrew_artifact_dry_run_does_not_require_brew(self) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,16 +356,17 @@ orchestration actions. The design rule is delegation-first:
   contract for execution timing, dry-run behavior, interactivity, and
   diagnostics.
 
-Base owns the artifact registry only for things it must manage directly. The
-current registry is `cli/python/base_setup/registry.py`.
+Base owns the curated tool artifact registry only for things it must manage
+directly. The current registry is `cli/python/base_setup/registry.py`.
 
 The optional top-level `brewfile` field delegates ordinary Homebrew dependencies
 to Homebrew's native `brew bundle` flow. The path is relative to the project root
 and must stay inside the project. Base runs `brew bundle --file=<path>` during
 setup before reconciling Base-managed artifacts.
 
-`python-package` artifacts install into the project virtual environment at
-`~/.base.d/<project>/.venv`. Base's own project venv is therefore
+`python-package` artifacts are pass-through PyPI package names and install into
+the project virtual environment at `~/.base.d/<project>/.venv`. Base's own
+project venv is therefore
 `~/.base.d/base/.venv`. The wrapper `bin/base-wrapper` runs Python packages
 through that project-scoped venv.
 


### PR DESCRIPTION
## Summary

- Allow arbitrary `python-package` artifact names to resolve as pip-managed project-venv artifacts.
- Keep unknown `tool` artifacts unsupported so Homebrew tool management remains curated.
- Update README, architecture docs, and contribution guidance to describe the new boundary.
- Add tests for pass-through Python package resolution, dry-run pip behavior, and unsupported tool behavior.

## Validation

- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`

Fixes #182