### PR TITLE
Add onboard shell completions

### DIFF
--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1527,7 +1527,11 @@ EOF
             COMP_WORDS=(basectl projects list --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
-            printf "projects_options=%s\n" "${COMPREPLY[*]}"'
+            printf "projects_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl onboard --); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "onboard_options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
@@ -1537,6 +1541,7 @@ EOF
     [[ "$output" == *"doctor_projects=base demo"* ]]
     [[ "$output" == *"check_options=--dev --format"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
+    [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
 }
 
 @test "Bash completion includes setup notification options" {

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check clean config doctor gh update-profile update projects version help"
+    local commands="activate setup check clean config doctor gh onboard update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -110,6 +110,9 @@ _base_basectl_completion() {
                     fi
                     ;;
             esac
+            ;;
+        onboard)
+            _base_basectl_completion_compgen "--dev --dry-run --yes --no-profile -v -h --help" "$cur"
             ;;
         update-profile)
             _base_basectl_completion_compgen "--defaults --no-defaults --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -21,6 +21,7 @@ _base_basectl_completion() {
         'config:Inspect Base machine-local user config'
         'doctor:Diagnose the local Base environment'
         'gh:Manage GitHub issues, pull requests, branches, and hygiene'
+        'onboard:Guide a user through first Base setup'
         'update-profile:Refresh Base-managed shell startup sections'
         'update:Update Base and rerun setup'
         'projects:List Base-managed projects'
@@ -118,6 +119,14 @@ _base_basectl_completion() {
                     _arguments '1:gh area:(issue pr branch todo)'
                     ;;
             esac
+            ;;
+        onboard)
+            _arguments '--dev[Include Base developer prerequisites]' \
+                '--dry-run[Explain planned onboarding steps without making changes]' \
+                '--yes[Accept default answers for setup and shell profile prompts]' \
+                '--no-profile[Skip shell profile updates]' \
+                '-v[Enable DEBUG logging]' \
+                '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         update-profile)
             _arguments '--defaults[Enable shell defaults]' '--no-defaults[Disable shell defaults]' \


### PR DESCRIPTION
## Summary

- add `onboard` to Bash and Zsh basectl command completions
- complete onboard flags in both shells
- cover Bash onboard option completion in the existing completion test

Fixes #216

## Tests

- `bash -n lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `bats --filter "completion" cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`