### PR TITLE
Complete clean keep-last completions

### DIFF
--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1531,7 +1531,11 @@ EOF
             COMP_WORDS=(basectl onboard --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
-            printf "onboard_options=%s\n" "${COMPREPLY[*]}"'
+            printf "onboard_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl clean --); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "clean_options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
@@ -1542,6 +1546,7 @@ EOF
     [[ "$output" == *"check_options=--dev --format"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
+    [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
 }
 
 @test "Bash completion includes setup notification options" {

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -68,7 +68,7 @@ _base_basectl_completion() {
             _base_basectl_completion_project_or_options "--dev --format -v -h --help" "$cur"
             ;;
         clean)
-            _base_basectl_completion_compgen "--older-than --dry-run -v -h --help" "$cur"
+            _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"
             ;;
         config)
             if ((COMP_CWORD == 2)); then

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -70,7 +70,9 @@ _base_basectl_completion() {
             fi
             ;;
         clean)
-            _arguments '--older-than[Artifact age]:age:' '--dry-run[Log without removing files]' \
+            _arguments '--older-than[Artifact age]:age:' \
+                '--keep-last[Keep newest log files per CLI log directory]:count:' \
+                '--dry-run[Log without removing files]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         config)


### PR DESCRIPTION
## Summary

- add `--keep-last` to Bash `basectl clean` completion
- add `--keep-last` to Zsh `basectl clean` completion
- cover Bash clean option completion in tests

Fixes #217

## Tests

- `bash -n lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `bats --filter "completion" cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`