### PR TITLE
Update onboard docs after shipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,11 @@ basectl check example
 basectl doctor example
 ```
 
-`basectl onboard` is a planned guided setup experience for technically-adjacent
-users who want a checklist-style first Base setup. Its design is captured in
-[docs/basectl-onboard.md](docs/basectl-onboard.md). Product-specific onboarding
-should still live in project installers that call Base internally.
+`basectl onboard` provides a guided checklist for technically-adjacent users who
+want a first Base setup flow around check, setup, profile refresh, doctor, and
+project discovery. Product-specific onboarding should still live in project
+installers that call Base internally. See
+[docs/basectl-onboard.md](docs/basectl-onboard.md).
 
 Base can also bootstrap supported IDEs for participating projects through the
 optional `ide:` manifest section. It currently supports VS Code and Cursor app

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -64,8 +64,8 @@ that delegate to `basectl`.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
-- `basectl onboard` is planned as a guided first-run checklist around existing
-  setup, check, doctor, profile, and project-discovery primitives. See
+- `basectl onboard` runs a guided first-run checklist around existing setup,
+  check, doctor, profile, and project-discovery primitives. See
   `docs/basectl-onboard.md`.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/docs/basectl-onboard.md
+++ b/docs/basectl-onboard.md
@@ -1,8 +1,8 @@
 # `basectl onboard` Design
 
-`basectl onboard` is a future guided setup experience for Base itself.
+`basectl onboard` is the guided setup experience for Base itself.
 
-It should help technically-adjacent users through the first Base setup without
+It helps technically-adjacent users through the first Base setup without
 turning `basectl setup` into an interactive, hand-holding command. The setup
 command should remain the direct, scriptable reconciler. The onboard command can
 be slower, friendlier, and more explanatory because that is its purpose.


### PR DESCRIPTION
## Summary

- update the README to describe `basectl onboard` as shipped
- update the basectl command README to remove planned/future wording
- refresh the onboard design doc opening language

Fixes #218

## Tests

- `rg -n "onboard.*planned|planned.*onboard|future guided setup experience" README.md cli/bash/commands/basectl/README.md docs`
- `git diff --check`