### PR TITLE
Avoid duplicate onboard dry-run commands

### DIFF
--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -79,13 +79,13 @@ base_onboard_execute() {
     local dry_run="$1"
     shift
 
-    base_onboard_print_next "$@"
     if ((dry_run)); then
         printf '[DRY-RUN] Would run '
         base_onboard_command_text "$@"
         return 0
     fi
 
+    base_onboard_print_next "$@"
     base_onboard_run_command "$@"
 }
 

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -353,6 +353,9 @@ EOF
     [[ "$output" == *"[DRY-RUN] Would run basectl update-profile --dry-run"* ]]
     [[ "$output" == *"[DRY-RUN] Would run basectl doctor base --dev"* ]]
     [[ "$output" == *"[DRY-RUN] Would run basectl projects list"* ]]
+    [[ "$output" != *"Next: basectl check base --dev"* ]]
+    [[ "$output" != *"Next: basectl setup base --dev --dry-run"* ]]
+    [[ "$output" != *"Next: basectl update-profile --dry-run"* ]]
     [[ "$output" != *"unexpected run"* ]]
 }
 


### PR DESCRIPTION
## Summary

- make `base_onboard_execute` print only the dry-run command in dry-run mode
- keep `Next:` output for commands that will actually execute
- add a regression assertion for dry-run output

Fixes #219

## Tests

- `bash -n cli/bash/commands/basectl/subcommands/onboard.sh`
- `bats --filter "onboard dry-run" cli/bash/commands/basectl/tests/basectl.bats`
- `git diff --check`