### PR TITLE
Cover projects list format errors

### DIFF
--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -768,6 +768,28 @@ EOF
     [[ "$output" == *"--format <format>"* ]]
 }
 
+@test "basectl projects list reports invalid format as a usage error" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
+    printf 'ERROR: Unsupported output format '\''xml'\''. Expected one of: text, json.\n' >&2
+    exit 2
+fi
+printf 'unexpected projects list python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl projects list --format xml
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unsupported output format 'xml'"* ]]
+    [[ "$output" != *"Traceback"* ]]
+}
+
 @test "basectl clean delegates to the Python cleanup layer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
 


### PR DESCRIPTION
## Summary

- add a `basectl projects list --format xml` regression test
- verify invalid formats fail as usage errors without tracebacks
- keep coverage around the already-shipped `--format json` path

Fixes #220

## Tests

- `bats --filter "projects list" cli/bash/commands/basectl/tests/basectl.bats`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_engine.ProjectDiscoveryTests.test_projects_list_supports_json_format cli.python.base_projects.tests.test_engine.ProjectDiscoveryTests.test_projects_list_rejects_unknown_format`
- `git diff --check`