### PR TITLE
Add basectl test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,11 @@ Current implemented commands include:
 - `basectl update`
 - `basectl projects list`
 - `basectl activate <project>`
+- `basectl test <project>`
 - `basectl version`
 
 Planned commands include:
 
-- `basectl test`
-- `basectl test <project>`
 - `basectl onboard`
 
 The important idea is that the user should not need to memorize a different
@@ -98,7 +97,6 @@ artifacts:
     name: requests
     version: latest
 
-# Future contract for `basectl test example`.
 test:
   command: pytest tests/
 ```
@@ -117,9 +115,9 @@ package to Base's hand-curated artifact registry.
 
 Future manifest fields should follow the same rule. A `mise` field causes Base
 to run `mise install` from the project root when a project chooses that
-substrate. Later, `basectl test` can delegate task execution to `mise run` when
-declared. A `test` field should give `basectl test` a single project-owned
-command to run. Base should not run arbitrary setup hooks until there is an
+substrate. A `test` field gives `basectl test` a single project-owned command
+to run. Later, `basectl test` can delegate task execution to `mise run` when
+declared. Base should not run arbitrary setup hooks until there is an
 explicit, reviewable contract for when they run, where they run, whether they
 are interactive, and how dry-run/check/doctor report them.
 
@@ -147,6 +145,17 @@ By default this scans the parent directory of `BASE_HOME`, which matches the
 recommended sibling-repo workspace layout. Use `--workspace <path>` to inspect a
 different workspace root. Output is tab-separated as `<project-name><TAB><path>`.
 Use `--format json` for machine-readable output.
+
+Run a discovered project's declared test command with:
+
+```bash
+basectl test example
+```
+
+Base runs the manifest `test.command` from the project root, exports
+`BASE_PROJECT`, `BASE_PROJECT_ROOT`, `BASE_PROJECT_MANIFEST`, and
+`BASE_PROJECT_VENV_DIR`, prepends the project virtual environment when it
+exists, and returns the command's exit status.
 
 Once a project is discoverable, activate it with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -30,6 +30,8 @@ that delegate to `basectl`.
 - `config`
 - `doctor`
 - `gh`
+- `onboard`
+- `test`
 - `update-profile`
 - `update`
 - `projects list`
@@ -38,7 +40,7 @@ that delegate to `basectl`.
 
 ## Planned subcommands
 
-- `onboard`
+- Additional `test` delegation modes such as `mise run test`.
 
 ## Notes
 
@@ -60,12 +62,14 @@ that delegate to `basectl`.
   provided, project manifest artifacts with suggested fixes.
 - `basectl gh` manages GitHub issues, pull requests, branch naming, and
   repository hygiene using Base's opinionated workflow.
+- `basectl onboard` guides first-run setup around existing setup, check,
+  doctor, profile, and project-discovery primitives. See
+  `docs/basectl-onboard.md`.
+- `basectl test <project>` runs the project's manifest `test.command` from the
+  project root with Base project environment variables exported.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
-- `basectl onboard` runs a guided first-run checklist around existing setup,
-  check, doctor, profile, and project-discovery primitives. See
-  `docs/basectl-onboard.md`.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -15,6 +15,8 @@ Commands:
     Install and bootstrap the local Base CLI environment on macOS.
   check [project] [options]
     Verify the local Base CLI environment and optional project artifacts without making changes.
+  test <project> [options]
+    Run a project's declared test command.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   config <path|show|doctor>
@@ -158,6 +160,11 @@ basectl_do_check() {
     base_check_subcommand_main "$@"
 }
 
+basectl_do_test() {
+    basectl_source_subcommand_module test || return 1
+    base_test_subcommand_main "$@"
+}
+
 basectl_do_clean() {
     basectl_source_subcommand_module clean || return 1
     base_clean_subcommand_main "$@"
@@ -296,6 +303,7 @@ basectl_main() {
     case "$command" in
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
+        test)             basectl_do_test "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         config)           basectl_do_config "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_test_subcommand_sourced:-}" ]] && return
+_base_test_subcommand_sourced=1
+readonly _base_test_subcommand_sourced
+
+base_test_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl test <project> [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Run a project's declared test command from its project root.
+EOF
+}
+
+base_test_usage_error() {
+    base_test_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_test_project_venv_dir() {
+    local project="$1"
+
+    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+        printf '%s\n' "$BASE_PROJECT_VENV_DIR"
+        return 0
+    fi
+
+    printf '%s\n' "$HOME/.base.d/$project/.venv"
+}
+
+base_test_subcommand_main() {
+    local project="" wrapper resolve_output resolved_name project_root manifest_path test_command venv_dir
+    local args=()
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_test_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --workspace)
+                [[ -n "${2:-}" ]] || {
+                    base_test_usage_error "Option '--workspace' requires an argument."
+                    return $?
+                }
+                args+=(--workspace "$2")
+                shift 2
+                ;;
+            --workspace=*)
+                args+=("$1")
+                shift
+                ;;
+            -*)
+                base_test_usage_error "Unknown test option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$project" ]]; then
+                    base_test_usage_error "The 'test' command accepts exactly one project name."
+                    return $?
+                fi
+                project="$1"
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$project" ]] || {
+        base_test_usage_error "Project name is required."
+        return $?
+    }
+
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    resolve_output="$("$wrapper" --project base base_projects test-command "$project" "${args[@]}")" || return $?
+    IFS=$'\t' read -r resolved_name project_root manifest_path test_command <<<"$resolve_output"
+
+    [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$test_command" ]] || {
+        fatal_error "Unable to resolve test command for project '$project'."
+    }
+
+    venv_dir="$(base_test_project_venv_dir "$resolved_name")"
+    export BASE_PROJECT="$resolved_name"
+    export BASE_PROJECT_ROOT="$project_root"
+    export BASE_PROJECT_MANIFEST="$manifest_path"
+    export BASE_PROJECT_VENV_DIR="$venv_dir"
+
+    if [[ -d "$venv_dir/bin" ]]; then
+        PATH="$venv_dir/bin:$PATH"
+        export PATH
+    fi
+
+    log_info "Running tests for project '$resolved_name': $test_command"
+    (cd "$project_root" && bash -c "$test_command")
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -26,6 +26,7 @@ run_basectl() {
     [[ "$output" == *"activate <project> [options]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [project] [options]"* ]]
+    [[ "$output" == *"test <project> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
@@ -788,6 +789,65 @@ EOF
     [ "$status" -eq 2 ]
     [[ "$output" == *"Unsupported output format 'xml'"* ]]
     [[ "$output" != *"Traceback"* ]]
+}
+
+@test "basectl test runs declared project test command from project root" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/test-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "project=%s\nroot=%s\nmanifest=%s\nvenv=%s\npwd=%s\npath=%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" "$PATH" > "$BASE_TEST_TEST_STATE"; exit 7'
+    exit 0
+fi
+printf 'unexpected test python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    touch "$TEST_HOME/.base.d/demo/.venv/bin/pytest"
+    printf 'project:\n  name: demo\ntest:\n  command: pytest tests/\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TEST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" test demo
+
+    [ "$status" -eq 7 ]
+    [[ "$(cat "$state_file")" == *"project=demo"* ]]
+    [[ "$(cat "$state_file")" == *"root=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"manifest=$workspace/demo/base_manifest.yaml"* ]]
+    [[ "$(cat "$state_file")" == *"venv=$TEST_HOME/.base.d/demo/.venv"* ]]
+    [[ "$(cat "$state_file")" == *"pwd=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"path=$TEST_HOME/.base.d/demo/.venv/bin:"* ]]
+}
+
+@test "basectl test prints help without requiring the Base Python venv" {
+    run_basectl test --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl test <project> [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+}
+
+@test "basectl test reports invalid arguments as usage errors" {
+    run_basectl test
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Project name is required."* ]]
+
+    run_basectl test --workspace
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--workspace' requires an argument."* ]]
+
+    run_basectl test --unknown demo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unknown test option '--unknown'."* ]]
 }
 
 @test "basectl clean delegates to the Python cleanup layer" {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1520,10 +1520,18 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "doctor_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl test ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "test_projects=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl check --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "check_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl test demo --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "test_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl projects list --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -1543,7 +1551,9 @@ EOF
     [[ "$output" == *"activate_options=--workspace --no-cd"* ]]
     [[ "$output" == *"check_projects=base demo"* ]]
     [[ "$output" == *"doctor_projects=base demo"* ]]
+    [[ "$output" == *"test_projects=base demo"* ]]
     [[ "$output" == *"check_options=--dev --format"* ]]
+    [[ "$output" == *"test_options=--workspace"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -44,8 +44,13 @@ def run(
         return manifest_project_command(ctx, project)
     if command == "resolve":
         return resolve_project_command(ctx, project, workspace)
+    if command == "test-command":
+        return test_command_project_command(ctx, project, workspace)
 
-    ctx.log.error("Unknown projects command '%s'. Supported commands: list, current, manifest, resolve.", command)
+    ctx.log.error(
+        "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, test-command.",
+        command,
+    )
     return 2
 
 
@@ -88,6 +93,27 @@ def resolve_project_command(ctx: base_cli.Context, project_name: str | None, wor
         return 1
 
     print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    return 0
+
+
+def test_command_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        project = find_project(workspace_root, project_name)
+        manifest = read_manifest(project.manifest_path)
+    except (ProjectDiscoveryError, ManifestError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    if manifest.test is None:
+        ctx.log.error("Project '%s' does not declare test.command in '%s'.", project.name, project.manifest_path)
+        return 1
+
+    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{manifest.test.command}")
     return 0
 
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -20,6 +20,14 @@ def write_manifest(project_root: Path, name: str) -> None:
     )
 
 
+def write_test_manifest(project_root: Path, name: str, command: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\ntest:\n  command: {command}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
 def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -109,6 +117,35 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
+
+    def test_projects_test_command_prints_project_details_and_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_test_manifest(project_root, "demo", "pytest tests/")
+
+            status, stdout, stderr = run_engine(["test-command", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
+        )
+
+    def test_projects_test_command_requires_manifest_test_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, _stdout, stderr = run_engine(["test-command", "demo"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("does not declare test.command", stderr)
 
     def test_projects_manifest_prints_project_details(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -476,6 +476,7 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         artifacts=manifest.artifacts,
         ide=effective_ide_config(manifest.ide, user_config),
         mise=manifest.mise,
+        test=manifest.test,
     )
 
 

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -35,6 +35,11 @@ class IdeConfig:
 
 
 @dataclass(frozen=True)
+class TestConfig:
+    command: str
+
+
+@dataclass(frozen=True)
 class BaseManifest:
     path: Path
     project_name: str
@@ -42,6 +47,7 @@ class BaseManifest:
     artifacts: tuple[ArtifactRequest, ...]
     ide: dict[str, IdeConfig] = field(default_factory=dict)
     mise: str | None = None
+    test: TestConfig | None = None
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -61,7 +67,7 @@ def read_manifest(path: Path) -> BaseManifest:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
-    allowed_top_level = {"project", "brewfile", "mise", "ide", "artifacts"}
+    allowed_top_level = {"project", "brewfile", "mise", "ide", "artifacts", "test"}
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
@@ -70,6 +76,7 @@ def read_manifest(path: Path) -> BaseManifest:
     brewfile = _read_brewfile(path, data.get("brewfile"))
     mise = _read_mise(path, data.get("mise"))
     ide = _read_ide(path, data.get("ide"))
+    test = _read_test(path, data.get("test"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -79,6 +86,7 @@ def read_manifest(path: Path) -> BaseManifest:
         artifacts=tuple(artifacts),
         ide=ide,
         mise=mise,
+        test=test,
     )
 
 
@@ -128,6 +136,23 @@ def _read_ide(path: Path, ide_data: Any) -> dict[str, IdeConfig]:
     for ide_name, config_data in ide_data.items():
         ide[ide_name] = _read_ide_config(path, ide_name, config_data)
     return ide
+
+
+def _read_test(path: Path, test_data: Any) -> TestConfig | None:
+    if test_data is None:
+        return None
+    if not isinstance(test_data, dict):
+        raise ManifestError(f"{path}: test must be a mapping when provided.")
+
+    allowed_keys = {"command"}
+    unknown_keys = sorted(set(test_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: test has unsupported keys: {', '.join(unknown_keys)}.")
+
+    command = test_data.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise ManifestError(f"{path}: test.command must be a non-empty string when provided.")
+    return TestConfig(command=command.strip())
 
 
 def _read_ide_config(path: Path, ide_name: str, config_data: Any) -> IdeConfig:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -137,6 +137,46 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(manifest.mise, ".mise.toml")
 
+    def test_reads_manifest_test_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  command: pytest tests/",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.test)
+        self.assertEqual(manifest.test.command, "pytest tests/")
+
+    def test_rejects_invalid_manifest_test_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  command: \"\"",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "test.command must be a non-empty string"):
+                read_manifest(manifest_path)
+
     def test_reads_ide_manifest_section(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ layers. This keeps the product name and the control-plane action separate:
 - `basectl update-profile`
 - `basectl projects list`
 - `basectl activate`
-- future commands such as `basectl test`
+- `basectl test`
 
 Shebang-based Bash scripts can also use:
 
@@ -336,7 +336,6 @@ artifacts:
     name: requests
     version: latest
 
-# Future contract for `basectl test myproject`.
 test:
   command: pytest tests/
 ```
@@ -348,8 +347,7 @@ orchestration actions. The design rule is delegation-first:
 - Use `mise` for tool versions, language runtimes, environment variables, and
   future tasks when a project opts into it. Base runs `mise install` during
   setup and does not reimplement mise's version management.
-- Use a project-owned `test` contract for future `basectl test <project>`
-  delegation.
+- Use a project-owned `test` contract for `basectl test <project>` delegation.
 - Let Base own the project virtual environment and Base-aware package
   reconciliation.
 - Do not run arbitrary project setup hooks until Base has a clear safety

--- a/docs/base-managed-demo-project.md
+++ b/docs/base-managed-demo-project.md
@@ -23,7 +23,8 @@ basectl doctor <project>
 basectl activate <project>
 ```
 
-When `basectl test <project>` exists, the same demo should add it to the flow.
+The same demo should include `basectl test <project>` once it declares a
+manifest `test.command`.
 
 ## Project Requirements
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -119,6 +119,7 @@ It owns the current Base subcommands:
 - `clean`
 - `doctor`
 - `activate`
+- `test`
 - `projects list`
 - `update-profile`
 - `version`

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check clean config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup check test clean config doctor gh onboard update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -66,6 +66,9 @@ _base_basectl_completion() {
             ;;
         check)
             _base_basectl_completion_project_or_options "--dev --format -v -h --help" "$cur"
+            ;;
+        test)
+            _base_basectl_completion_project_or_options "--workspace -v -h --help" "$cur"
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -17,6 +17,7 @@ _base_basectl_completion() {
         'activate:Start an interactive Base runtime subshell for a project'
         'setup:Install and bootstrap the local Base CLI environment'
         'check:Verify the local Base CLI environment'
+        'test:Run a project test command'
         'clean:Remove old Base CLI runtime artifacts'
         'config:Inspect Base machine-local user config'
         'doctor:Diagnose the local Base environment'
@@ -62,6 +63,15 @@ _base_basectl_completion() {
             ;;
         check)
             _arguments '--dev[Include developer prerequisite checks]' '--format[Output format]:format:(text json)' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
+            ;;
+        test)
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then


### PR DESCRIPTION
## Summary
- Add manifest parsing for `test.command` and expose a `base_projects test-command` resolver.
- Add `basectl test <project>` to run the declared command from the project root with Base project environment variables and project venv PATH.
- Update Bash/Zsh completions, docs, and focused Python/BATS coverage.

## Validation
- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest`
- `bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/basectl.bats cli/bash/commands/caff/tests/caff.bats cli/bash/commands/sort-in-place/tests/sort-in-place.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/runtime/tests/runtime_bashrc.bats lib/bash/std/tests/lib_std.bats lib/bash/version/tests/lib_version.bats tests/install.bats`
- `PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 "$HOME/.base.d/base/.venv/bin/pylint" --rcfile=.pylintrc`
- `bash -n cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/test.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `git diff --check`

Fixes #119