### PR TITLE
Clean up check JSON dead branch

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -1020,8 +1020,6 @@ setup_run_check_json() {
     fi
     if [[ -n "$project" ]]; then
         setup_print_json_property_value "project_checks" "$project_json"
-    else
-        :
     fi
     printf '}\n'
 


### PR DESCRIPTION
## Summary
- remove the no-op `else :` branch from `setup_run_check_json`
- keep JSON output behavior unchanged

## Tests
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bats --filter "check --format json" cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`

Fixes #221.