### PR TITLE
Implement basectl test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ workspace that contains multiple project repositories.
 Current implemented commands include:
 
 - `basectl setup [project]`
+- `basectl test [project]`
 - `basectl check`
 - `basectl doctor`
 - `basectl clean --older-than <age>`
@@ -50,21 +51,15 @@ Current implemented commands include:
 - `basectl config path`
 - `basectl config show`
 - `basectl config doctor`
+- `basectl onboard`
 - `basectl update-profile`
 - `basectl update`
 - `basectl projects list`
 - `basectl activate <project>`
 - `basectl version`
 
-Planned commands include:
-
-- `basectl test`
-- `basectl test <project>`
-- `basectl onboard`
-
 The important idea is that the user should not need to memorize a different
-bootstrap story for every repository in the workspace. Planned commands are
-listed here to describe direction, not current availability.
+bootstrap story for every repository in the workspace.
 
 Base should be able to discover participating project repositories checked out
 next to it under a shared parent directory, for example:
@@ -98,7 +93,6 @@ artifacts:
     name: requests
     version: latest
 
-# Future contract for `basectl test example`.
 test:
   command: pytest tests/
 ```
@@ -117,11 +111,24 @@ package to Base's hand-curated artifact registry.
 
 Future manifest fields should follow the same rule. A `mise` field causes Base
 to run `mise install` from the project root when a project chooses that
-substrate. Later, `basectl test` can delegate task execution to `mise run` when
-declared. A `test` field should give `basectl test` a single project-owned
-command to run. Base should not run arbitrary setup hooks until there is an
-explicit, reviewable contract for when they run, where they run, whether they
-are interactive, and how dry-run/check/doctor report them.
+substrate. A `test` field gives `basectl test` a single project-owned command
+to run from the project root:
+
+```yaml
+test:
+  command: pytest tests/
+```
+
+Projects that keep tasks in `mise` can declare a mise task instead:
+
+```yaml
+test:
+  mise: test
+```
+
+Base should not run arbitrary setup hooks until there is an explicit,
+reviewable contract for when they run, where they run, whether they are
+interactive, and how dry-run/check/doctor report them.
 
 The curated tool artifact registry lives in `cli/python/base_setup/registry.py`.
 It should stay small and Base-aware. `python-package` artifacts are pass-through

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -13,6 +13,8 @@ Commands:
     Start an interactive Base runtime subshell for a project.
   setup [options]
     Install and bootstrap the local Base CLI environment on macOS.
+  test [project] [options]
+    Run a Base-managed project's declared test command.
   check [project] [options]
     Verify the local Base CLI environment and optional project artifacts without making changes.
   clean [--older-than <age>] [--keep-last <count>] [options]
@@ -146,6 +148,11 @@ basectl_source_subcommand_module() {
 basectl_do_setup() {
     basectl_source_subcommand_module setup || return 1
     base_setup_subcommand_main "$@"
+}
+
+basectl_do_test() {
+    basectl_source_subcommand_module test || return 1
+    base_test_subcommand_main "$@"
 }
 
 basectl_do_activate() {
@@ -302,6 +309,7 @@ basectl_main() {
         gh)               basectl_do_gh "$@" ;;
         onboard)          basectl_do_onboard "$@" ;;
         setup)            basectl_do_setup "$@" ;;
+        test)             basectl_do_test "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;
         update)           basectl_do_update "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -1,0 +1,43 @@
+[[ -n "${_base_test_subcommand_sourced:-}" ]] && return
+_base_test_subcommand_sourced=1
+readonly _base_test_subcommand_sourced
+
+base_test_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl test [project] [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  --dry-run           Print the project test command without running it.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Run a Base-managed project's declared test command from its project root.
+EOF
+}
+
+base_test_subcommand_main() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    while (($# > 0)); do
+        case "$1" in
+            -h|--help)
+                base_test_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_test "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -25,6 +25,7 @@ run_basectl() {
     [[ "$output" == *"Usage: basectl [options] <command> [args...]"* ]]
     [[ "$output" == *"activate <project> [options]"* ]]
     [[ "$output" == *"setup [options]"* ]]
+    [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
@@ -58,6 +59,7 @@ run_basectl() {
     grep -Fqx '  gh <area> <command> [options]' <<<"$output"
     grep -Fqx '  onboard [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
+    grep -Fqx '  test [project] [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
@@ -87,6 +89,39 @@ run_basectl() {
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl gh issue start <number>"* ]]
     [[ "$output" == *"<type>/<issue>-<YYYYMMDD>-<slug>"* ]]
+}
+
+@test "basectl test prints help" {
+    run_basectl test --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl test [project]"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "basectl test delegates to base_test through the Base wrapper" {
+    local fake_base_home="$TEST_TMPDIR/fake-base-home"
+
+    mkdir -p "$fake_base_home/bin"
+    cat > "$fake_base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*"
+EOF
+    chmod +x "$fake_base_home/bin/base-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$1/base_init.sh"
+            BASE_HOME="$2"
+            source "$1/cli/bash/commands/basectl/subcommands/test.sh"
+            base_test_subcommand_main demo --dry-run
+        ' bash "$BASE_REPO_ROOT" "$fake_base_home"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "--project base base_test demo --dry-run" ]
 }
 
 @test "basectl gh issue create applies type label" {

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -476,6 +476,7 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         artifacts=manifest.artifacts,
         ide=effective_ide_config(manifest.ide, user_config),
         mise=manifest.mise,
+        test=manifest.test,
     )
 
 

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -35,6 +35,12 @@ class IdeConfig:
 
 
 @dataclass(frozen=True)
+class TestConfig:
+    command: str | None = None
+    mise: str | None = None
+
+
+@dataclass(frozen=True)
 class BaseManifest:
     path: Path
     project_name: str
@@ -42,6 +48,7 @@ class BaseManifest:
     artifacts: tuple[ArtifactRequest, ...]
     ide: dict[str, IdeConfig] = field(default_factory=dict)
     mise: str | None = None
+    test: TestConfig | None = None
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -61,7 +68,7 @@ def read_manifest(path: Path) -> BaseManifest:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
-    allowed_top_level = {"project", "brewfile", "mise", "ide", "artifacts"}
+    allowed_top_level = {"project", "brewfile", "mise", "ide", "artifacts", "test"}
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
@@ -70,6 +77,7 @@ def read_manifest(path: Path) -> BaseManifest:
     brewfile = _read_brewfile(path, data.get("brewfile"))
     mise = _read_mise(path, data.get("mise"))
     ide = _read_ide(path, data.get("ide"))
+    test = _read_test(path, data.get("test"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -79,6 +87,7 @@ def read_manifest(path: Path) -> BaseManifest:
         artifacts=tuple(artifacts),
         ide=ide,
         mise=mise,
+        test=test,
     )
 
 
@@ -189,6 +198,34 @@ def _read_ide_settings(path: Path, ide_name: str, settings_data: Any) -> dict[st
             ) from exc
         settings[key] = value
     return settings
+
+
+def _read_test(path: Path, test_data: Any) -> TestConfig | None:
+    if test_data is None:
+        return None
+    if not isinstance(test_data, dict):
+        raise ManifestError(f"{path}: test must be a mapping when provided.")
+
+    allowed_keys = {"command", "mise"}
+    unknown_keys = sorted(set(test_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: test has unsupported keys: {', '.join(unknown_keys)}.")
+
+    command = test_data.get("command")
+    mise = test_data.get("mise")
+    if command is not None and (not isinstance(command, str) or not command.strip()):
+        raise ManifestError(f"{path}: test.command must be a non-empty string when provided.")
+    if mise is not None and (not isinstance(mise, str) or not mise.strip()):
+        raise ManifestError(f"{path}: test.mise must be a non-empty string when provided.")
+    if command is not None and mise is not None:
+        raise ManifestError(f"{path}: test must declare only one of command or mise.")
+    if command is None and mise is None:
+        raise ManifestError(f"{path}: test must declare command or mise.")
+
+    return TestConfig(
+        command=command.strip() if command is not None else None,
+        mise=mise.strip() if mise is not None else None,
+    )
 
 
 def _read_artifacts(path: Path, artifacts_data: Any) -> list[ArtifactRequest]:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -137,6 +137,70 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(manifest.mise, ".mise.toml")
 
+    def test_reads_manifest_test_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  command: pytest tests/",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.test)
+        self.assertEqual(manifest.test.command, "pytest tests/")
+        self.assertIsNone(manifest.test.mise)
+
+    def test_reads_manifest_test_mise_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  mise: test",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.test)
+        self.assertIsNone(manifest.test.command)
+        self.assertEqual(manifest.test.mise, "test")
+
+    def test_rejects_ambiguous_manifest_test_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  command: pytest",
+                        "  mise: test",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "test must declare only one of command or mise"):
+                read_manifest(manifest_path)
+
     def test_reads_ide_manifest_section(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"

--- a/cli/python/base_test/__init__.py
+++ b/cli/python/base_test/__init__.py
@@ -1,0 +1,2 @@
+"""Project test runner for basectl."""
+

--- a/cli/python/base_test/__main__.py
+++ b/cli/python/base_test/__main__.py
@@ -1,0 +1,6 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/cli/python/base_test/engine.py
+++ b/cli/python/base_test/engine.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import base_cli
+from base_cli.paths import discover_manifest
+from base_projects.engine import Project, ProjectDiscoveryError, find_project, read_project, resolve_workspace_root
+from base_setup.manifest import ManifestError, TestConfig, read_manifest
+
+
+app = base_cli.App(name="base_test")
+
+
+def main(argv: list[str] | None = None) -> int:
+    result = app.click_command.main(args=argv, standalone_mode=False)
+    return int(result or 0)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("project", required=False)
+@base_cli.option("--workspace", help="Workspace directory to scan. Defaults to BASE_HOME's parent.")
+@base_cli.option("--dry-run", is_flag=True, help="Print the test command without running it.")
+def run(ctx: base_cli.Context, project: str | None, workspace: str | None, dry_run: bool) -> int:
+    try:
+        resolved_project = resolve_project(ctx, project, workspace)
+        test_config = read_test_config(resolved_project)
+    except (ManifestError, ProjectDiscoveryError, TestRunnerError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    command = command_for_test(test_config)
+    display = format_command(command, shell=test_config.command is not None)
+
+    if dry_run:
+        print(f"[DRY-RUN] Would run in {resolved_project.root}: {display}")
+        return 0
+
+    ctx.log.info("Running tests for project '%s': %s", resolved_project.name, display)
+    return run_test_command(command, resolved_project.root, shell=test_config.command is not None)
+
+
+class TestRunnerError(RuntimeError):
+    pass
+
+
+def resolve_project(ctx: base_cli.Context, project: str | None, workspace: str | None) -> Project:
+    if project:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        return find_project(workspace_root, project)
+
+    manifest_path = discover_manifest(Path.cwd())
+    if manifest_path is None:
+        raise TestRunnerError("Project name is required when no base_manifest.yaml is found from the current directory.")
+    return read_project(manifest_path)
+
+
+def read_test_config(project: Project) -> TestConfig:
+    manifest = read_manifest(project.manifest_path)
+    if manifest.test is None:
+        raise TestRunnerError(
+            f"{project.manifest_path}: test is not configured. Add test.command or test.mise to base_manifest.yaml."
+        )
+    return manifest.test
+
+
+def command_for_test(test_config: TestConfig) -> str | list[str]:
+    if test_config.command is not None:
+        return test_config.command
+    if test_config.mise is not None:
+        return ["mise", "run", test_config.mise]
+    raise TestRunnerError("test is not configured.")
+
+
+def format_command(command: str | list[str], shell: bool) -> str:
+    if shell:
+        return str(command)
+    return shlex.join(command)
+
+
+def run_test_command(command: str | list[str], cwd: Path, shell: bool) -> int:
+    try:
+        completed = subprocess.run(command, cwd=cwd, shell=shell, check=False)
+    except FileNotFoundError as exc:
+        executable = command[0] if isinstance(command, list) else str(command)
+        raise TestRunnerError(f"Required test command '{executable}' was not found on PATH.") from exc
+    return completed.returncode

--- a/cli/python/base_test/tests/test_engine.py
+++ b/cli/python/base_test/tests/test_engine.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import io
+import importlib.util
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_test import engine
+
+
+def write_manifest(project_root: Path, name: str, test_section: str | None) -> None:
+    project_root.mkdir(parents=True)
+    manifest = [f"project:\n  name: {name}"]
+    if test_section is not None:
+        manifest.append(test_section)
+    manifest.append("artifacts: []")
+    (project_root / "base_manifest.yaml").write_text("\n".join(manifest) + "\n", encoding="utf-8")
+
+
+def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with tempfile.TemporaryDirectory() as home_dir:
+        with mock.patch.dict(os.environ, {"HOME": home_dir, "BASE_HOME": str(base_home)}):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+@unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+class BaseTestRunnerTests(unittest.TestCase):
+    def test_dry_run_prints_project_test_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_manifest(project_root, "demo", "test:\n  command: python -m unittest")
+
+            status, stdout, stderr = run_engine(["demo", "--dry-run"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"[DRY-RUN] Would run in {project_root.resolve()}: python -m unittest", stdout)
+
+    def test_runs_project_test_command_from_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            marker = project_root / "marker"
+            write_manifest(project_root, "demo", "test:\n  command: pwd > marker")
+
+            status, _stdout, _stderr = run_engine(["demo"], base_home)
+
+            self.assertEqual(status, 0)
+            self.assertEqual(marker.read_text(encoding="utf-8").strip(), str(project_root.resolve()))
+
+    def test_preserves_project_test_exit_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_manifest(project_root, "demo", "test:\n  command: exit 7")
+
+            status, _stdout, _stderr = run_engine(["demo"], base_home)
+
+        self.assertEqual(status, 7)
+
+    def test_mise_test_config_delegates_to_mise_run_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_manifest(project_root, "demo", "test:\n  mise: unit")
+
+            status, stdout, stderr = run_engine(["demo", "--dry-run"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("mise run unit", stdout)
+
+    def test_reports_missing_test_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo", None)
+
+            status, _stdout, stderr = run_engine(["demo"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("test is not configured", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -336,7 +336,6 @@ artifacts:
     name: requests
     version: latest
 
-# Future contract for `basectl test myproject`.
 test:
   command: pytest tests/
 ```
@@ -348,8 +347,9 @@ orchestration actions. The design rule is delegation-first:
 - Use `mise` for tool versions, language runtimes, environment variables, and
   future tasks when a project opts into it. Base runs `mise install` during
   setup and does not reimplement mise's version management.
-- Use a project-owned `test` contract for future `basectl test <project>`
-  delegation.
+- Use a project-owned `test` contract for `basectl test <project>` delegation.
+  The contract can declare either `test.command` for a project-owned shell
+  command or `test.mise` for a `mise run <task>` delegation.
 - Let Base own the project virtual environment and Base-aware package
   reconciliation.
 - Do not run arbitrary project setup hooks until Base has a clear safety

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check clean config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup test check clean config doctor gh onboard update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -63,6 +63,9 @@ _base_basectl_completion() {
             ;;
         setup)
             _base_basectl_completion_compgen "--dev --dry-run --manifest --notify --no-notify --recreate-venv -v -h --help" "$cur"
+            ;;
+        test)
+            _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
             ;;
         check)
             _base_basectl_completion_project_or_options "--dev --format -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -16,6 +16,7 @@ _base_basectl_completion() {
     commands=(
         'activate:Start an interactive Base runtime subshell for a project'
         'setup:Install and bootstrap the local Base CLI environment'
+        'test:Run a Base-managed project test command'
         'check:Verify the local Base CLI environment'
         'clean:Remove old Base CLI runtime artifacts'
         'config:Inspect Base machine-local user config'
@@ -59,6 +60,16 @@ _base_basectl_completion() {
                 '--no-notify[Disable setup completion notification]' \
                 '--recreate-venv[Recreate the Base venv]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        test)
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--dry-run[Print the test command without running it]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
             ;;
         check)
             _arguments '--dev[Include developer prerequisite checks]' '--format[Output format]:format:(text json)' \


### PR DESCRIPTION
Superseded by #233, which already landed `basectl test` and closed #119.

This branch overlapped with that merged implementation. It also explored follow-on ideas (`--dry-run`, `test.mise`, and a separate `base_test` Python runner), but those should be considered separately rather than merged as a duplicate/conflicting PR.