### PR TITLE
Extend basectl test options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Current implemented commands include:
 - `basectl update`
 - `basectl projects list`
 - `basectl activate <project>`
-- `basectl test <project>`
+- `basectl test [project]`
 - `basectl version`
 
 Planned commands include:
@@ -116,10 +116,16 @@ package to Base's hand-curated artifact registry.
 Future manifest fields should follow the same rule. A `mise` field causes Base
 to run `mise install` from the project root when a project chooses that
 substrate. A `test` field gives `basectl test` a single project-owned command
-to run. Later, `basectl test` can delegate task execution to `mise run` when
-declared. Base should not run arbitrary setup hooks until there is an
-explicit, reviewable contract for when they run, where they run, whether they
-are interactive, and how dry-run/check/doctor report them.
+to run. Projects that keep tasks in `mise` can declare `test.mise` instead:
+
+```yaml
+test:
+  mise: test
+```
+
+Base should not run arbitrary setup hooks until there is an explicit,
+reviewable contract for when they run, where they run, whether they are
+interactive, and how dry-run/check/doctor report them.
 
 The curated tool artifact registry lives in `cli/python/base_setup/registry.py`.
 It should stay small and Base-aware. `python-package` artifacts are pass-through
@@ -152,10 +158,18 @@ Run a discovered project's declared test command with:
 basectl test example
 ```
 
-Base runs the manifest `test.command` from the project root, exports
-`BASE_PROJECT`, `BASE_PROJECT_ROOT`, `BASE_PROJECT_MANIFEST`, and
+When the current directory is inside a Base-managed project, the project name
+can be omitted:
+
+```bash
+basectl test
+```
+
+Base runs the manifest `test.command` or `mise run <test.mise>` from the project
+root, exports `BASE_PROJECT`, `BASE_PROJECT_ROOT`, `BASE_PROJECT_MANIFEST`, and
 `BASE_PROJECT_VENV_DIR`, prepends the project virtual environment when it
-exists, and returns the command's exit status.
+exists, and returns the command's exit status. Use `--dry-run` to inspect the
+resolved command without running it.
 
 Once a project is discoverable, activate it with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -40,7 +40,7 @@ that delegate to `basectl`.
 
 ## Planned subcommands
 
-- Additional `test` delegation modes such as `mise run test`.
+- Additional `test` backends beyond manifest commands and `mise run`.
 
 ## Notes
 
@@ -65,8 +65,9 @@ that delegate to `basectl`.
 - `basectl onboard` guides first-run setup around existing setup, check,
   doctor, profile, and project-discovery primitives. See
   `docs/basectl-onboard.md`.
-- `basectl test <project>` runs the project's manifest `test.command` from the
-  project root with Base project environment variables exported.
+- `basectl test [project]` runs the project's manifest `test.command` or
+  `test.mise` from the project root with Base project environment variables
+  exported.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -15,7 +15,7 @@ Commands:
     Install and bootstrap the local Base CLI environment on macOS.
   check [project] [options]
     Verify the local Base CLI environment and optional project artifacts without making changes.
-  test <project> [options]
+  test [project] [options]
     Run a project's declared test command.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -7,10 +7,11 @@ readonly _base_test_subcommand_sourced
 base_test_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl test <project> [options]
+  basectl test [project] [options]
 
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  --dry-run           Print the resolved test command without running it.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
@@ -37,6 +38,7 @@ base_test_project_venv_dir() {
 
 base_test_subcommand_main() {
     local project="" wrapper resolve_output resolved_name project_root manifest_path test_command venv_dir
+    local dry_run=0 workspace_requested=0
     local args=()
 
     while (($#)); do
@@ -54,11 +56,17 @@ base_test_subcommand_main() {
                     base_test_usage_error "Option '--workspace' requires an argument."
                     return $?
                 }
+                workspace_requested=1
                 args+=(--workspace "$2")
                 shift 2
                 ;;
             --workspace=*)
+                workspace_requested=1
                 args+=("$1")
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
                 shift
                 ;;
             -*)
@@ -76,15 +84,17 @@ base_test_subcommand_main() {
         esac
     done
 
-    [[ -n "$project" ]] || {
-        base_test_usage_error "Project name is required."
+    [[ -n "$project" || "$workspace_requested" != "1" ]] || {
+        base_test_usage_error "Option '--workspace' requires an explicit project name."
         return $?
     }
 
     wrapper="$BASE_HOME/bin/base-wrapper"
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
-    resolve_output="$("$wrapper" --project base base_projects test-command "$project" "${args[@]}")" || return $?
+    local command_args=(test-command)
+    [[ -z "$project" ]] || command_args+=("$project")
+    resolve_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}")" || return $?
     IFS=$'\t' read -r resolved_name project_root manifest_path test_command <<<"$resolve_output"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$test_command" ]] || {
@@ -100,6 +110,11 @@ base_test_subcommand_main() {
     if [[ -d "$venv_dir/bin" ]]; then
         PATH="$venv_dir/bin:$PATH"
         export PATH
+    fi
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf '[DRY-RUN] Would run tests for project %q in %q: %s\n' "$resolved_name" "$project_root" "$test_command"
+        return 0
     fi
 
     log_info "Running tests for project '$resolved_name': $test_command"

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -26,7 +26,7 @@ run_basectl() {
     [[ "$output" == *"activate <project> [options]"* ]]
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [project] [options]"* ]]
-    [[ "$output" == *"test <project> [options]"* ]]
+    [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
@@ -827,23 +827,88 @@ EOF
     [[ "$(cat "$state_file")" == *"path=$TEST_HOME/.base.d/demo/.venv/bin:"* ]]
 }
 
+@test "basectl test dry-run prints resolved command without running it" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/test-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'touch "$BASE_TEST_TEST_STATE"; exit 7'
+    exit 0
+fi
+printf 'unexpected test python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ntest:\n  command: pytest tests/\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TEST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" test demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run tests for project demo"* ]]
+    [[ "$output" == *'touch "$BASE_TEST_TEST_STATE"; exit 7'* ]]
+    [ ! -e "$state_file" ]
+}
+
+@test "basectl test can resolve the current project when omitted" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && -z "${4:-}" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "current-project-test\n"'
+    exit 0
+fi
+printf 'unexpected test python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ntest:\n  command: pytest tests/\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        bash -c '
+            cd "$1"
+            shift
+            "$@"
+        ' bash "$workspace/demo" "$BASE_REPO_ROOT/bin/basectl" test
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"current-project-test"* ]]
+}
+
 @test "basectl test prints help without requiring the Base Python venv" {
     run_basectl test --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl test <project> [options]"* ]]
+    [[ "$output" == *"basectl test [project] [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--dry-run"* ]]
 }
 
 @test "basectl test reports invalid arguments as usage errors" {
-    run_basectl test
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"ERROR: Project name is required."* ]]
-
     run_basectl test --workspace
     [ "$status" -eq 2 ]
     [[ "$output" == *"ERROR: Option '--workspace' requires an argument."* ]]
+
+    run_basectl test --workspace "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--workspace' requires an explicit project name."* ]]
 
     run_basectl test --unknown demo
     [ "$status" -eq 2 ]

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1553,7 +1553,7 @@ EOF
     [[ "$output" == *"doctor_projects=base demo"* ]]
     [[ "$output" == *"test_projects=base demo"* ]]
     [[ "$output" == *"check_options=--dev --format"* ]]
-    [[ "$output" == *"test_options=--workspace"* ]]
+    [[ "$output" == *"test_options=--workspace --dry-run"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
 from base_cli.paths import discover_manifest
-from base_setup.manifest import ManifestError, read_manifest
+from base_setup.manifest import ManifestError, TestConfig, read_manifest
 
 
 app = base_cli.App(name="base_projects")
@@ -97,40 +98,53 @@ def resolve_project_command(ctx: base_cli.Context, project_name: str | None, wor
 
 
 def test_command_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
-    if not project_name:
-        ctx.log.error("Project name is required.")
-        return 2
-
     try:
-        workspace_root = resolve_workspace_root(ctx, workspace)
-        project = find_project(workspace_root, project_name)
+        if project_name:
+            workspace_root = resolve_workspace_root(ctx, workspace)
+            project = find_project(workspace_root, project_name)
+        else:
+            project = current_project()
         manifest = read_manifest(project.manifest_path)
     except (ProjectDiscoveryError, ManifestError) as exc:
         ctx.log.error(str(exc))
         return 1
 
     if manifest.test is None:
-        ctx.log.error("Project '%s' does not declare test.command in '%s'.", project.name, project.manifest_path)
+        ctx.log.error(
+            "Project '%s' does not declare test.command or test.mise in '%s'.",
+            project.name,
+            project.manifest_path,
+        )
         return 1
 
-    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{manifest.test.command}")
+    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{test_command(manifest.test)}")
     return 0
 
 
 def current_project_command(ctx: base_cli.Context) -> int:
-    manifest_path = discover_manifest(Path.cwd())
-    if manifest_path is None:
-        ctx.log.error("No base_manifest.yaml found from '%s' upward.", Path.cwd())
-        return 1
-
     try:
-        project = read_project(manifest_path)
+        project = current_project()
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return 1
 
     print(f"{project.name}\t{project.root}\t{project.manifest_path}")
     return 0
+
+
+def current_project() -> Project:
+    manifest_path = discover_manifest(Path.cwd())
+    if manifest_path is None:
+        raise ProjectDiscoveryError(f"No base_manifest.yaml found from '{Path.cwd()}' upward.")
+
+    return read_project(manifest_path)
+
+
+def test_command(test_config: TestConfig) -> str:
+    if test_config.command is not None:
+        return test_config.command
+    assert test_config.mise is not None
+    return shlex.join(["mise", "run", test_config.mise])
 
 
 def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -28,6 +28,14 @@ def write_test_manifest(project_root: Path, name: str, command: str) -> None:
     )
 
 
+def write_mise_test_manifest(project_root: Path, name: str, task: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\ntest:\n  mise: {task}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
 def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -135,6 +143,47 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
         )
 
+    def test_projects_test_command_prints_mise_task_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_mise_test_manifest(project_root, "demo", "unit")
+
+            status, stdout, stderr = run_engine(["test-command", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tmise run unit\n",
+        )
+
+    def test_projects_test_command_defaults_to_current_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            nested = project_root / "docs"
+            write_test_manifest(project_root, "demo", "pytest tests/")
+            nested.mkdir()
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(nested)
+                status, stdout, stderr = run_engine(["test-command"], base_home)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
+        )
+
     def test_projects_test_command_requires_manifest_test_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
@@ -145,7 +194,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             status, _stdout, stderr = run_engine(["test-command", "demo"], base_home)
 
         self.assertEqual(status, 1)
-        self.assertIn("does not declare test.command", stderr)
+        self.assertIn("does not declare test.command or test.mise", stderr)
 
     def test_projects_manifest_prints_project_details(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -36,7 +36,8 @@ class IdeConfig:
 
 @dataclass(frozen=True)
 class TestConfig:
-    command: str
+    command: str | None = None
+    mise: str | None = None
 
 
 @dataclass(frozen=True)
@@ -144,15 +145,26 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
     if not isinstance(test_data, dict):
         raise ManifestError(f"{path}: test must be a mapping when provided.")
 
-    allowed_keys = {"command"}
+    allowed_keys = {"command", "mise"}
     unknown_keys = sorted(set(test_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(f"{path}: test has unsupported keys: {', '.join(unknown_keys)}.")
 
     command = test_data.get("command")
-    if not isinstance(command, str) or not command.strip():
+    mise = test_data.get("mise")
+    if command is not None and (not isinstance(command, str) or not command.strip()):
         raise ManifestError(f"{path}: test.command must be a non-empty string when provided.")
-    return TestConfig(command=command.strip())
+    if mise is not None and (not isinstance(mise, str) or not mise.strip()):
+        raise ManifestError(f"{path}: test.mise must be a non-empty string when provided.")
+    if command is not None and mise is not None:
+        raise ManifestError(f"{path}: test must declare only one of command or mise.")
+    if command is None and mise is None:
+        raise ManifestError(f"{path}: test must declare command or mise.")
+
+    return TestConfig(
+        command=command.strip() if command is not None else None,
+        mise=mise.strip() if mise is not None else None,
+    )
 
 
 def _read_ide_config(path: Path, ide_name: str, config_data: Any) -> IdeConfig:

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -157,6 +157,29 @@ class ManifestTests(unittest.TestCase):
 
         self.assertIsNotNone(manifest.test)
         self.assertEqual(manifest.test.command, "pytest tests/")
+        self.assertIsNone(manifest.test.mise)
+
+    def test_reads_manifest_test_mise_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  mise: test",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.test)
+        self.assertIsNone(manifest.test.command)
+        self.assertEqual(manifest.test.mise, "test")
 
     def test_rejects_invalid_manifest_test_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -175,6 +198,26 @@ class ManifestTests(unittest.TestCase):
             )
 
             with self.assertRaisesRegex(ManifestError, "test.command must be a non-empty string"):
+                read_manifest(manifest_path)
+
+    def test_rejects_ambiguous_manifest_test_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  command: pytest",
+                        "  mise: test",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "test must declare only one of command or mise"):
                 read_manifest(manifest_path)
 
     def test_reads_ide_manifest_section(self) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -348,6 +348,8 @@ orchestration actions. The design rule is delegation-first:
   future tasks when a project opts into it. Base runs `mise install` during
   setup and does not reimplement mise's version management.
 - Use a project-owned `test` contract for `basectl test <project>` delegation.
+  Projects can declare either `test.command` for a shell command or `test.mise`
+  for a `mise run <task>` delegation.
 - Let Base own the project virtual environment and Base-aware package
   reconciliation.
 - Do not run arbitrary project setup hooks until Base has a clear safety

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -68,7 +68,7 @@ _base_basectl_completion() {
             _base_basectl_completion_project_or_options "--dev --format -v -h --help" "$cur"
             ;;
         test)
-            _base_basectl_completion_project_or_options "--workspace -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -72,6 +72,7 @@ _base_basectl_completion() {
             ;;
         test)
             _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--dry-run[Print the resolved test command without running it]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then


### PR DESCRIPTION
## Summary

- Add `basectl test --dry-run` to show the resolved project test command without executing it.
- Allow `basectl test` to default to the current Base project when run under a `base_manifest.yaml`.
- Add manifest support for `test.mise`, resolved as `mise run <task>` from the project root.
- Update Bash/Zsh completions and docs for the expanded command surface.

## Validation

- `bash -n cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/test.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_engine cli.python.base_projects.tests.test_engine`
- `bats cli/bash/commands/basectl/tests/basectl.bats cli/bash/commands/basectl/tests/setup.bats`
- `env PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest`
- `env PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 ~/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc`
- `bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/basectl.bats cli/bash/commands/caff/tests/caff.bats cli/bash/commands/sort-in-place/tests/sort-in-place.bats lib/bash/file/tests/lib_file.bats lib/bash/git/tests/lib_git.bats lib/bash/runtime/tests/runtime_bashrc.bats lib/bash/std/tests/lib_std.bats lib/bash/version/tests/lib_version.bats tests/install.bats`
- `git diff --check`

Fixes #238