### PR TITLE
Document Base GitHub workflow policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,32 +6,40 @@ opinionated, testable, and useful as a shared workspace control plane.
 ## Workflow
 
 1. Create or choose a GitHub issue before starting implementation work.
-2. Make sure the issue has one type label:
-   - `type:feat` for user-visible features or product capability.
-   - `type:fix` for bug fixes and correctness issues.
-   - `type:chore` for maintenance, CI, cleanup, or internal improvements.
-   - `type:docs` for documentation-only work.
+2. Make sure the issue has one primary GitHub-style category label:
+   - `bug` for defects, regressions, or correctness issues.
+   - `enhancement` for new capabilities, product improvements, refactors, and
+     most maintenance work.
+   - `documentation` for documentation-only work.
+   - `ci` for GitHub Actions, tests, release automation, or CI reliability.
+   - `security` for security hardening, dependency pinning, static analysis, or
+     permission tightening.
 3. Create a branch from the issue using this convention:
 
    ```text
-   <type>/<issue>-<YYYYMMDD>-<slug>
+   <category>/<issue>-<YYYYMMDD>-<slug>
    ```
 
    Example:
 
    ```text
-   feat/179-20260528-projects-list-json
+   enhancement/179-20260528-projects-list-json
    ```
 
-4. Prefer an isolated Git worktree for each pull request:
+4. Use an isolated Git worktree for each pull request:
 
    ```bash
-   git worktree add ../base-worktrees/<slug> -b <branch> master
+   git fetch origin master
+   git worktree add ../base-worktrees/<slug> -b <branch> origin/master
    ```
 
 5. Keep the PR scoped to the issue. Avoid unrelated refactors.
 6. Link the PR back to the issue with `Fixes #<issue>`.
-7. After merge, sync `master`, remove the worktree, and delete the local branch.
+7. After merge, sync `master`, remove the worktree, and delete the local and
+   remote branches.
+
+For the full policy, including milestone and GitHub Project guidance, see
+[GitHub Workflow](docs/github-workflow.md).
 
 ## Running Tests
 
@@ -87,7 +95,7 @@ When adding or changing a built-in tool artifact:
 
 Before opening a PR:
 
-- The branch name follows `<type>/<issue>-<YYYYMMDD>-<slug>`.
+- The branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
 - The PR is scoped to one issue.
 - The PR body explains what changed and how it was validated.
 - Relevant BATS and Python tests pass.

--- a/TODO.md
+++ b/TODO.md
@@ -4,12 +4,15 @@ Base product work is tracked in GitHub Issues.
 
 Use this file only for short-lived private scratch notes that are not ready to
 be public product work. Public bugs, enhancements, chores, and design tasks
-should be filed as GitHub Issues with a `type:*` label and implemented from a
+should be filed as GitHub Issues with a standard category label and implemented from a
 branch named:
 
 ```text
-<type>/<issue>-<YYYYMMDD>-<slug>
+<category>/<issue>-<YYYYMMDD>-<slug>
 ```
+
+See [docs/github-workflow.md](docs/github-workflow.md) for the current label,
+milestone, Project, issue assignment, branch, and worktree policy.
 
 The previous public TODO backlog was migrated to GitHub Issues on 2026-05-28:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@ is the documentation map.
 For contribution workflow, branch naming, tests, and PR expectations, see
 [CONTRIBUTING.md](../CONTRIBUTING.md).
 
+For GitHub labels, milestones, Projects, issue assignment, branch names, and
+worktree-based PR trains, see [GitHub Workflow](github-workflow.md).
+
 ## Naming Convention
 
 Use stable topic names for documentation files:
@@ -48,3 +51,5 @@ reference. The filename should answer "what is this about?"
   project criteria for showing Base's complete workspace workflow.
 - [base_cli Runtime Package](base-cli.md) describes the Python CLI foundation
   used by Base and Base-supported project CLIs.
+- [GitHub Workflow](github-workflow.md) documents how Base uses GitHub Issues,
+  labels, milestones, Projects, worktrees, and PR trains.

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -1,0 +1,149 @@
+# GitHub Workflow
+
+Base uses GitHub Issues as the public product backlog and Git worktrees for
+parallel pull request trains. This page captures the repository workflow so
+humans and AI-assisted development agents follow the same rules.
+
+## Labels
+
+Base uses GitHub default-style labels instead of `type:*` labels.
+
+Use one primary category label on each issue:
+
+- `bug`
+  Unexpected behavior, correctness issues, regressions, and defects.
+- `enhancement`
+  New capabilities, product improvements, refactors, and most maintenance work.
+- `documentation`
+  Documentation-only changes.
+- `ci`
+  GitHub Actions, test automation, release automation, and CI reliability.
+- `security`
+  Security hardening, dependency pinning, static analysis, and permission
+  tightening.
+
+Avoid creating new `type:*` labels. Older issues may still carry historical
+`type:fix`, `type:feat`, `type:chore`, or `type:docs` labels, but new work
+should use the labels above.
+
+## Issue Assignment
+
+Issues created by Codex or other automation for the Base repository should be
+assigned to `codeforester`.
+
+If assignment fails, the automation should mention that in its summary instead
+of silently leaving the issue unassigned.
+
+## Branch Names
+
+Branch names should be derived from the issue category:
+
+```text
+<category>/<issue>-<YYYYMMDD>-<slug>
+```
+
+Examples:
+
+```text
+bug/245-20260529-fix-profile-project-prompt
+enhancement/222-20260529-add-changelog
+documentation/241-20260529-document-github-workflow
+ci/246-20260529-pin-shellcheck-version
+security/247-20260529-restrict-log-permissions
+```
+
+Use `enhancement/` for maintenance work unless the issue is more specifically
+`documentation`, `ci`, or `security`.
+
+## Worktrees
+
+All pull request implementation work should happen in a dedicated worktree.
+
+The main checkout can stay as the user's active working copy:
+
+```text
+~/work/base
+```
+
+Issue work should use:
+
+```text
+~/work/base-worktrees/<slug>
+```
+
+Create a worktree from current `origin/master`:
+
+```bash
+git fetch origin master
+git worktree add -b documentation/241-20260529-document-github-workflow \
+  ~/work/base-worktrees/documentation-241-github-workflow origin/master
+```
+
+After a pull request is merged:
+
+```bash
+git -C ~/work/base pull --ff-only origin master
+git -C ~/work/base worktree remove ~/work/base-worktrees/<slug>
+git -C ~/work/base branch -d <branch>
+git -C ~/work/base push origin --delete <branch>
+```
+
+Delete remote branches after merge unless there is a specific reason to keep
+one around.
+
+## Pull Requests
+
+Keep each PR scoped to one issue.
+
+PR bodies should include:
+
+- a short summary of the change
+- the validation commands that were run
+- `Fixes #<issue>` or `Closes #<issue>` when the merge should close the issue
+
+Prefer small PR trains over large mixed PRs. A train may contain several
+worktrees and PRs, but each PR should still close one issue cleanly.
+
+## Milestones
+
+Milestones represent release intent, not workflow state.
+
+Suggested Base milestones:
+
+- `v0.1.0 - Public baseline`
+  Current public baseline for Base's first installable product shape.
+- `v0.2.0 - Adoption polish`
+  Installer, Homebrew, README, changelog, issue templates, and workflow polish.
+- `v0.3.0 - Project orchestration`
+  Project test execution, mise integration, manifest refinement, and a real
+  Base-managed demo project.
+- `v0.4.0 - CI and Linux foundation`
+  Linux runtime support, CI-oriented behavior, and `basectl ci` planning.
+- `v1.0.0 - Stable public release`
+  Stable manifest contracts, compatibility expectations, and upgrade policy.
+
+Every issue does not need a milestone. Use milestones when the issue contributes
+to a concrete release goal.
+
+## Projects
+
+Use one GitHub Project first: `Base Roadmap`.
+
+Recommended fields:
+
+- `Status`: Triage, Backlog, Ready, In Progress, In Review, Done
+- `Priority`: P0, P1, P2, P3
+- `Area`: CLI, Setup, Manifest, Shell, Python, Docs, CI, Packaging, Security,
+  Product
+- `Size`: S, M, L
+- `PR Train`: optional text field for batch work
+
+Useful views:
+
+- Board by status
+- Priority view
+- Release view grouped by milestone
+- Bugs and CI
+- Ready for PR train
+
+Projects show workflow and prioritization. Milestones show release grouping.

--- a/skills.md
+++ b/skills.md
@@ -3,6 +3,29 @@
 This file documents repeatable AI-assisted development workflows for Base.
 Coding standards live in `STANDARDS.md`.
 
+## GitHub Issue And PR Workflow
+
+Use this workflow when creating GitHub issues, branches, worktrees, or pull
+requests for Base.
+
+- Assign Codex-created issues to `codeforester`.
+- Use GitHub default-style labels:
+  - `bug` for defects.
+  - `enhancement` for features, refactors, and most maintenance.
+  - `documentation` for docs-only changes.
+  - `ci` for GitHub Actions, tests, and release automation.
+  - `security` for hardening, dependency pinning, and static analysis.
+- Do not create new `type:*` labels.
+- Name branches as `<category>/<issue>-<YYYYMMDD>-<slug>`, for example
+  `bug/245-20260529-fix-profile-project-prompt`.
+- Do all pull request implementation work in a dedicated worktree under
+  `~/work/base-worktrees/<slug>`.
+- After merge, sync `master`, remove the worktree, and delete local and remote
+  branches.
+- Link PRs to issues with `Fixes #<issue>` or `Closes #<issue>`.
+- See `docs/github-workflow.md` for the full policy, including milestones and
+  GitHub Projects.
+
 ## Add a basectl subcommand
 
 Use this workflow when adding or changing a `basectl <command>` feature.


### PR DESCRIPTION
## Summary
- document Base's GitHub label, issue assignment, branch, worktree, PR train, milestone, and Project conventions
- update CONTRIBUTING and TODO to use standard GitHub-style category labels instead of `type:*`
- add AI-assisted workflow reminders to `skills.md`

## Tests
- `git diff --check`
- `rg -n "type:fix|type:feat|type:chore|type:\\*|<type>" CONTRIBUTING.md TODO.md docs skills.md`

Fixes #241.