### PR TITLE
Document basectl gh dogfooding policy

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -63,7 +63,8 @@ that delegate to `basectl`.
 - `basectl gh` manages GitHub issues, pull requests, branch naming, and
   repository hygiene using Base's opinionated workflow. It uses standard
   GitHub-style issue categories such as `bug`, `enhancement`, `documentation`,
-  `ci`, and `security`, and derives branch names from those categories.
+  `ci`, and `security`, and derives branch names from those categories. Prefer
+  this command for Base repository GitHub workflows when it supports the task.
 - `basectl onboard` guides first-run setup around existing setup, check,
   doctor, profile, and project-discovery primitives. See
   `docs/basectl-onboard.md`.

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -34,6 +34,24 @@ assigned to `codeforester`.
 If assignment fails, the automation should mention that in its summary instead
 of silently leaving the issue unassigned.
 
+## Preferred GitHub Interface
+
+Use `basectl gh` as the preferred interface for Base repository GitHub
+workflows when it supports the operation.
+
+This keeps Base dogfooding its own workflow tool for common issue, branch, PR,
+and repository hygiene tasks. For example, prefer `basectl gh issue create`,
+`basectl gh issue start`, `basectl gh pr create`, and `basectl gh branch prune`
+over hand-written `gh` commands when those commands are available and local
+tooling is authenticated.
+
+Fallbacks are allowed when `basectl gh` does not support the needed operation,
+when local GitHub CLI authentication is unavailable, or when the GitHub
+connector provides a safer structured API for the task. In those cases, use the
+GitHub connector, raw `gh`, or `git` as appropriate and keep the resulting
+issue labels, branch names, assignments, and PR bodies aligned with this
+policy.
+
 ## Branch Names
 
 Branch names should be derived from the issue category:

--- a/skills.md
+++ b/skills.md
@@ -8,6 +8,11 @@ Coding standards live in `STANDARDS.md`.
 Use this workflow when creating GitHub issues, branches, worktrees, or pull
 requests for Base.
 
+- Prefer `basectl gh` for supported Base repository GitHub workflows so Base
+  dogfoods its own issue, branch, PR, and repository hygiene tool.
+- Fall back to the GitHub connector, raw `gh`, or `git` when `basectl gh` does
+  not support the needed operation or local `gh` authentication/tooling is not
+  available.
 - Assign Codex-created issues to `codeforester`.
 - Use GitHub default-style labels:
   - `bug` for defects.


### PR DESCRIPTION
## Summary
- document `basectl gh` as the preferred Base GitHub workflow interface when supported
- add Codex-facing guidance to dogfood `basectl gh` with explicit fallbacks
- clarify the `basectl gh` command README

## Tests
- `git diff --check`
- `rg -n 'dogfood|Preferred GitHub Interface|Prefer `basectl gh`|fallback|Fallback' docs/github-workflow.md skills.md cli/bash/commands/basectl/README.md`

Fixes #245.