### PR TITLE
Demote project doctor plumbing logs

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -647,7 +647,11 @@ setup_run_project_artifact_layer() {
         IFS=$'\t' read -r resolved_name resolved_root manifest_path <<<"$resolve_output"
         project="$resolved_name"
         if [[ "$output_format" != json ]]; then
-            log_info "Resolved project '$project' at '$resolved_root'."
+            if [[ "$action" == setup ]]; then
+                log_info "Resolved project '$project' at '$resolved_root'."
+            else
+                log_debug "Resolved project '$project' at '$resolved_root'."
+            fi
         fi
     else
         if [[ -z "$project" ]]; then
@@ -667,7 +671,11 @@ setup_run_project_artifact_layer() {
     args+=("$project")
 
     if [[ "$output_format" != json ]]; then
-        log_info "Running Python project $action layer."
+        if [[ "$action" == setup ]]; then
+            log_info "Running Python project $action layer."
+        else
+            log_debug "Running Python project $action layer."
+        fi
     fi
 
     if [[ "$action" == setup ]]; then

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -1224,7 +1224,8 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Base doctor for project 'demo'"* ]]
-    [[ "$output" == *"Running Python project doctor layer."* ]]
+    [[ "$output" != *"Resolved project 'demo' at '$workspace/demo'."* ]]
+    [[ "$output" != *"Running Python project doctor layer."* ]]
     [[ "$output" == *"ok"*"demo-artifact"*"Project artifact check passed."* ]]
     [[ "$output" == *"Base doctor found no blocking issues for project 'demo'."* ]]
 }

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1234,8 +1234,8 @@ EOF
     run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Resolved project 'demo' at '$workspace/demo'."* ]]
-    [[ "$output" == *"Running Python project check layer."* ]]
+    [[ "$output" != *"Resolved project 'demo' at '$workspace/demo'."* ]]
+    [[ "$output" != *"Running Python project check layer."* ]]
     [[ "$output" == *"Project artifact check passed."* ]]
     [[ "$output" == *"Base CLI environment and project 'demo' check passed."* ]]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]


### PR DESCRIPTION
## Summary

- Demote project resolution logs for `check`/`doctor` to DEBUG while keeping setup-visible output.
- Demote `Running Python project check/doctor layer.` to DEBUG.
- Update BATS coverage so normal text output stays quiet for project check/doctor.

Fixes #249

## Tests

- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/basectl.bats`
- `./bin/basectl doctor brew`