### PR TITLE
Replace test command assert with explicit error

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -143,8 +143,9 @@ def current_project() -> Project:
 def test_command(test_config: TestConfig) -> str:
     if test_config.command is not None:
         return test_config.command
-    assert test_config.mise is not None
-    return shlex.join(["mise", "run", test_config.mise])
+    if test_config.mise is not None:
+        return shlex.join(["mise", "run", test_config.mise])
+    raise ValueError("TestConfig must have command or mise set.")
 
 
 def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -160,6 +160,10 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tmise run unit\n",
         )
 
+    def test_test_command_rejects_invalid_config_without_assert(self) -> None:
+        with self.assertRaisesRegex(ValueError, "TestConfig must have command or mise set"):
+            engine.test_command(engine.TestConfig())
+
     def test_projects_test_command_defaults_to_current_project(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Replace the `assert` in `base_projects.test_command()` with an explicit `ValueError` invariant.
- Add a unit test covering the invalid `TestConfig` path so behavior is stable under `python -O`.

## Validation

```bash
HOME=/private/tmp/base-review-home PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py
```

Closes #258