### PR TITLE
Use pytest in contributing test docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Common checks:
 ```bash
 bats cli/bash/commands/basectl/tests/basectl.bats
 bats cli/bash/commands/basectl/tests/setup.bats
-PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m unittest discover cli/python
+PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest
 git diff --check
 ```
 


### PR DESCRIPTION
## Summary

- Replace the stale `unittest discover` command in `CONTRIBUTING.md` with the repo's current `pytest` command.
- Keep the documented command aligned with `.github/workflows/tests.yml` and `pytest.ini`.

## Validation

```bash
git diff --check
```

Closes #252