### PR TITLE
Fix gh issue category completions

### DIFF
--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -1467,13 +1467,13 @@ EOF
     [[ "$(cat "$TEST_HOME/.bash_profile")" == *"source $BASE_REPO_ROOT/lib/shell/bash_profile"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" == *"# --- BEGIN base bashrc MANAGED SECTION - DO NOT EDIT ---"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" == *"source $BASE_REPO_ROOT/lib/shell/bashrc"* ]]
-    [[ "$(cat "$TEST_HOME/.bashrc")" != *"completion"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" != *"basectl_completion"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" != *"PATH="* ]]
     [[ "$(cat "$TEST_HOME/.zprofile")" == *"# --- BEGIN base zprofile MANAGED SECTION - DO NOT EDIT ---"* ]]
     [[ "$(cat "$TEST_HOME/.zprofile")" == *"source $BASE_REPO_ROOT/lib/shell/zprofile"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" == *"# --- BEGIN base zshrc MANAGED SECTION - DO NOT EDIT ---"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" == *"source $BASE_REPO_ROOT/lib/shell/zshrc"* ]]
-    [[ "$(cat "$TEST_HOME/.zshrc")" != *"completion"* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" != *"basectl_completion"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" != *"PATH="* ]]
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_PROFILE_VERSION=1"* ]]
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_BASH_DEFAULTS=false"* ]]
@@ -1572,6 +1572,23 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"--notify"* ]]
     [[ "$output" == *"--no-notify"* ]]
+}
+
+@test "Bash completion uses gh issue category options" {
+    run env \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '\
+            source "$BASE_HOME/lib/shell/completions/basectl_completion.sh"; \
+            COMP_WORDS=(basectl gh issue create --); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "reply=%s\n" "${COMPREPLY[*]}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--category"* ]]
+    [[ "$output" == *"--title"* ]]
+    [[ "$output" == *"--body"* ]]
+    [[ "$output" != *"--type"* ]]
 }
 
 @test "basectl update-profile preserves non-Base dotfile content and is idempotent" {

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -90,7 +90,7 @@ _base_basectl_completion() {
                     if ((COMP_CWORD == 3)); then
                         _base_basectl_completion_compgen "list create start" "$cur"
                     else
-                        _base_basectl_completion_compgen "--type --title --body -h --help" "$cur"
+                        _base_basectl_completion_compgen "--category --title --body -h --help" "$cur"
                     fi
                     ;;
                 pr)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -103,7 +103,7 @@ _base_basectl_completion() {
                 issue)
                     _arguments '1:gh area:(issue pr branch todo)' \
                         '2:issue command:(list create start)' \
-                        '--type[Issue or branch type]:type:(feat fix chore docs)' \
+                        '--category[Issue category]:category:(bug enhancement documentation ci security)' \
                         '--title[Issue title]:title:' \
                         '--body[Issue body]:body:' \
                         '(-h --help)'{-h,--help}'[Show help text]'

--- a/skills.md
+++ b/skills.md
@@ -41,7 +41,8 @@ Use this workflow when adding or changing a `basectl <command>` feature.
 - Tests: `cli/bash/commands/basectl/tests/`
 - Update completions: `lib/shell/completions/basectl_completion.sh` and
   `lib/shell/completions/basectl_completion.zsh` — add the new command to the
-  top-level command list and add a case block for its options.
+  top-level command list, add a case block for its options, and keep changed
+  flags synchronized.
 - Follow shell standards in `STANDARDS.md`.
 - Validate focused command behavior with:
 


### PR DESCRIPTION
## Summary

- Update Bash and Zsh completions for `basectl gh issue` from `--type` to `--category`.
- Use the current issue category values: `bug`, `enhancement`, `documentation`, `ci`, and `security`.
- Add a Bash completion regression test and tighten a dotfile assertion that was sensitive to worktree path names.
- Update `skills.md` to remind contributors to keep changed flags synchronized with completions.

## Validation

```bash
HOME=/private/tmp/base-review-home bats cli/bash/commands/basectl/tests/setup.bats
git diff --check
```

Closes #251