### PR TITLE
Warn when basectl test lacks project venv

### DIFF
--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -110,6 +110,8 @@ base_test_subcommand_main() {
     if [[ -d "$venv_dir/bin" ]]; then
         PATH="$venv_dir/bin:$PATH"
         export PATH
+    elif [[ "$dry_run" != "1" ]]; then
+        log_warn "Project virtual environment was not found at '$venv_dir'. Run 'basectl setup $resolved_name' first."
     fi
 
     if [[ "$dry_run" == "1" ]]; then

--- a/cli/bash/commands/basectl/tests/basectl.bats
+++ b/cli/bash/commands/basectl/tests/basectl.bats
@@ -860,6 +860,36 @@ EOF
     [ ! -e "$state_file" ]
 }
 
+@test "basectl test warns when project venv is missing" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "ran-test\n"'
+    exit 0
+fi
+printf 'unexpected test python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ntest:\n  command: pytest tests/\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" test demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Project virtual environment was not found at '$TEST_HOME/.base.d/demo/.venv'"* ]]
+    [[ "$output" == *"Run 'basectl setup demo' first."* ]]
+    [[ "$output" == *"ran-test"* ]]
+}
+
 @test "basectl test can resolve the current project when omitted" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"


### PR DESCRIPTION
## Summary

- Emit a clear warning when `basectl test` is about to run without the project's Base-managed venv on `PATH`.
- Keep the existing warn-and-continue behavior so project-owned test commands can still run.
- Add a BATS regression covering the missing-venv warning.

## Validation

```bash
HOME=/private/tmp/base-review-home bats cli/bash/commands/basectl/tests/basectl.bats
git diff --check
```

Closes #253