### PR TITLE
Dogfood basectl test for Base

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,7 @@ shared behavior.
 Common checks:
 
 ```bash
-bats cli/bash/commands/basectl/tests/basectl.bats
-bats cli/bash/commands/basectl/tests/setup.bats
-PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest
+basectl test base
 git diff --check
 ```
 

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -3,6 +3,9 @@ project:
   # environment at ~/.base.d/<project>/.venv.
   name: base
 
+test:
+  command: ./bin/base-test
+
 # Optional relative path to a Homebrew Brewfile for ordinary macOS tools.
 # Base runs `brew bundle --file=<path>` during setup when this is set.
 # Keep Base-specific managed dependencies in `artifacts`; use Brewfile for

--- a/bin/base-test
+++ b/bin/base-test
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_test_python="${BASE_TEST_PYTHON:-$HOME/.base.d/base/.venv/bin/python}"
+
+if [[ ! -x "$base_test_python" ]]; then
+    printf 'ERROR: Base test Python was not found at %s. Run basectl setup base first.\n' "$base_test_python" >&2
+    exit 1
+fi
+
+PYTHONPATH="${BASE_HOME:-$(pwd)}/lib/python:${BASE_HOME:-$(pwd)}/cli/python${PYTHONPATH:+:$PYTHONPATH}" \
+    "$base_test_python" -m pytest
+
+bats \
+    cli/bash/commands/basectl/tests/setup.bats \
+    cli/bash/commands/basectl/tests/basectl.bats \
+    cli/bash/commands/caff/tests/caff.bats \
+    cli/bash/commands/sort-in-place/tests/sort-in-place.bats \
+    lib/bash/file/tests/lib_file.bats \
+    lib/bash/git/tests/lib_git.bats \
+    lib/bash/runtime/tests/runtime_bashrc.bats \
+    lib/bash/std/tests/lib_std.bats \
+    lib/bash/version/tests/lib_version.bats \
+    tests/install.bats

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -87,8 +87,7 @@ def resolve_project_command(ctx: base_cli.Context, project_name: str | None, wor
         return 2
 
     try:
-        workspace_root = resolve_workspace_root(ctx, workspace)
-        project = find_project(workspace_root, project_name)
+        project = resolve_named_project(ctx, project_name, workspace)
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return 1
@@ -100,8 +99,7 @@ def resolve_project_command(ctx: base_cli.Context, project_name: str | None, wor
 def test_command_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
     try:
         if project_name:
-            workspace_root = resolve_workspace_root(ctx, workspace)
-            project = find_project(workspace_root, project_name)
+            project = resolve_named_project(ctx, project_name, workspace)
         else:
             project = current_project()
         manifest = read_manifest(project.manifest_path)
@@ -173,6 +171,14 @@ def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path
     if ctx.base_home is None:
         raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
     return ctx.base_home.parent.resolve()
+
+
+def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: str | None) -> Project:
+    if workspace is None and project_name == "base" and ctx.base_home is not None:
+        return read_project(ctx.base_home / "base_manifest.yaml")
+
+    workspace_root = resolve_workspace_root(ctx, workspace)
+    return find_project(workspace_root, project_name)
 
 
 def discover_projects(workspace_root: Path) -> tuple[Project, ...]:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -126,6 +126,20 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
 
+    def test_projects_resolve_base_uses_base_home_without_workspace_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            other_base = workspace / "base-worktree"
+            write_manifest(base_home, "base")
+            write_manifest(other_base, "base")
+
+            status, stdout, stderr = run_engine(["resolve", "base"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}\n")
+
     def test_projects_test_command_prints_project_details_and_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
@@ -141,6 +155,23 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
+        )
+
+    def test_projects_test_command_for_base_uses_base_home_without_workspace_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            other_base = workspace / "base-worktree"
+            write_test_manifest(base_home, "base", "./bin/base-test")
+            write_test_manifest(other_base, "base", "false")
+
+            status, stdout, stderr = run_engine(["test-command", "base"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}\t./bin/base-test\n",
         )
 
     def test_projects_test_command_prints_mise_task_command(self) -> None:


### PR DESCRIPTION
## Summary

- Add `bin/base-test` as Base's repo-owned full local test runner.
- Declare `test.command: ./bin/base-test` in `base_manifest.yaml` so `basectl test base` works.
- Resolve explicit project `base` through `BASE_HOME` to avoid duplicate Base worktrees during project lookup.
- Point contributor docs at `basectl test base` as the common broad validation command.

## Validation

```bash
HOME=/private/tmp/base-review-home PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py
BASE_CACHE_DIR=/private/tmp/base-review-cache bin/basectl test base --dry-run
BASE_CACHE_DIR=/private/tmp/base-review-cache ./bin/base-test
git diff --check
```

Closes #259