### PR TITLE
Clarify mise check limitations

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -343,9 +343,13 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
 
     return ArtifactCheck(
         name="mise",
-        ok=True,
-        message=f"mise config '{mise_path}' is present and the mise CLI is available.",
-        fix="",
+        ok=False,
+        message=(
+            f"mise config '{mise_path}' is present and the mise CLI is available, "
+            "but installed mise tools are not verified."
+        ),
+        fix=f"Run 'basectl setup {manifest.project_name}' to install declared mise tools.",
+        status="warn",
     )
 
 

--- a/cli/python/base_setup/tests/test_engine.py
+++ b/cli/python/base_setup/tests/test_engine.py
@@ -1035,7 +1035,11 @@ class BrewfileTests(unittest.TestCase):
                 checks = engine.manifest_checks(default_manifest, manifest)
 
         self.assertIn("mise", [check.name for check in checks])
-        self.assertTrue(next(check for check in checks if check.name == "mise").ok)
+        mise_check = next(check for check in checks if check.name == "mise")
+        self.assertFalse(mise_check.ok)
+        self.assertEqual(mise_check.status, "warn")
+        self.assertIn("installed mise tools are not verified", mise_check.message)
+        self.assertEqual(mise_check.fix, "Run 'basectl setup demo' to install declared mise tools.")
 
 
 class IdeInstallTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Change the mise manifest check from a green `ok` to a warning when Base has only verified the config file and the `mise` CLI.
- Tell users that installed mise tools are not verified by the check and point them to `basectl setup <project>`.
- Update tests to assert the warning status and message.

## Validation

```bash
HOME=/private/tmp/base-review-home PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_engine.py
BASE_CACHE_DIR=/private/tmp/base-review-cache bin/basectl test base --dry-run
git diff --check
```

Closes #254