### PR TITLE
Centralize supported IDE schema definitions

### DIFF
--- a/cli/python/base_setup/ide.py
+++ b/cli/python/base_setup/ide.py
@@ -5,44 +5,18 @@ import os
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
 from base_cli.config import UserConfig
+from base_cli.ide_schema import IDE_DEFINITIONS
+from base_cli.ide_schema import IdeDefinition
 
 from . import artifacts
 from . import process
 from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest, IdeConfig
-
-
-@dataclass(frozen=True)
-class IdeDefinition:
-    name: str
-    label: str
-    cli: str
-    cask: str
-    settings_app_dir: str
-
-
-IDE_DEFINITIONS = {
-    "vscode": IdeDefinition(
-        name="vscode",
-        label="VS Code",
-        cli="code",
-        cask="visual-studio-code",
-        settings_app_dir="Code",
-    ),
-    "cursor": IdeDefinition(
-        name="cursor",
-        label="Cursor",
-        cli="cursor",
-        cask="cursor",
-        settings_app_dir="Cursor",
-    ),
-}
 
 
 def effective_ide_config(project_ide: dict[str, IdeConfig], user_config: UserConfig) -> dict[str, IdeConfig]:

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
-import json
 from pathlib import Path
 from typing import Any
+
+from base_cli.ide_schema import PROJECT_AUTO_SETTING_KEYS
+from base_cli.ide_schema import SUPPORTED_IDES
+from base_cli.ide_schema import parse_ide_extensions
+from base_cli.ide_schema import parse_ide_settings
 
 try:
     import yaml
@@ -128,8 +132,7 @@ def _read_ide(path: Path, ide_data: Any) -> dict[str, IdeConfig]:
     if not isinstance(ide_data, dict):
         raise ManifestError(f"{path}: ide must be a mapping when provided.")
 
-    allowed_ide_names = {"vscode", "cursor"}
-    unknown_ide_names = sorted(set(ide_data) - allowed_ide_names)
+    unknown_ide_names = sorted(set(ide_data) - SUPPORTED_IDES)
     if unknown_ide_names:
         raise ManifestError(f"{path}: unsupported IDE names: {', '.join(unknown_ide_names)}.")
 
@@ -189,43 +192,21 @@ def _read_ide_config(path: Path, ide_name: str, config_data: Any) -> IdeConfig:
 
 
 def _read_ide_extensions(path: Path, ide_name: str, extensions_data: Any) -> tuple[str, ...]:
-    if extensions_data is None:
-        return ()
-    if not isinstance(extensions_data, list):
-        raise ManifestError(f"{path}: ide.{ide_name}.extensions must be a list when provided.")
-
-    extensions: list[str] = []
-    for index, extension in enumerate(extensions_data, start=1):
-        if not isinstance(extension, str) or not extension.strip():
-            raise ManifestError(
-                f"{path}: ide.{ide_name}.extensions[{index}] must be a non-empty string."
-            )
-        extensions.append(extension.strip())
-    return tuple(extensions)
+    try:
+        return parse_ide_extensions(f"{path}: ide.{ide_name}.extensions", extensions_data)
+    except ValueError as exc:
+        raise ManifestError(str(exc)) from exc
 
 
 def _read_ide_settings(path: Path, ide_name: str, settings_data: Any) -> dict[str, Any]:
-    if settings_data is None:
-        return {}
-    if not isinstance(settings_data, dict):
-        raise ManifestError(f"{path}: ide.{ide_name}.settings must be a mapping when provided.")
-
-    settings: dict[str, Any] = {}
-    for key, value in settings_data.items():
-        if not isinstance(key, str) or not key:
-            raise ManifestError(f"{path}: ide.{ide_name}.settings keys must be non-empty strings.")
-        if value == "auto" and key != "python.defaultInterpreterPath":
-            raise ManifestError(
-                f"{path}: ide.{ide_name}.settings.{key} does not support the special value 'auto'."
-            )
-        try:
-            json.dumps(value)
-        except TypeError as exc:
-            raise ManifestError(
-                f"{path}: ide.{ide_name}.settings.{key} must be JSON-serializable."
-            ) from exc
-        settings[key] = value
-    return settings
+    try:
+        return parse_ide_settings(
+            f"{path}: ide.{ide_name}.settings",
+            settings_data,
+            auto_setting_keys=PROJECT_AUTO_SETTING_KEYS,
+        )
+    except ValueError as exc:
+        raise ManifestError(str(exc)) from exc
 
 
 def _read_artifacts(path: Path, artifacts_data: Any) -> list[ArtifactRequest]:

--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
-import json
 from pathlib import Path
 from typing import Any
 
+from .ide_schema import SUPPORTED_IDES
+from .ide_schema import parse_ide_extensions
+from .ide_schema import parse_ide_settings
 from .paths import base_state_root
-
-
-SUPPORTED_IDES = {"vscode", "cursor"}
 
 
 @dataclass(frozen=True)
@@ -117,37 +116,11 @@ def _optional_bool(path: Path, key: str, value: Any) -> bool | None:
 
 
 def _read_extra_extensions(path: Path, ide_name: str, extensions_data: Any) -> tuple[str, ...]:
-    if extensions_data is None:
-        return ()
-    if not isinstance(extensions_data, list):
-        raise ValueError(f"{path}: ide.{ide_name}.extra_extensions must be a list when provided.")
-
-    extensions: list[str] = []
-    for index, extension in enumerate(extensions_data, start=1):
-        if not isinstance(extension, str) or not extension.strip():
-            raise ValueError(
-                f"{path}: ide.{ide_name}.extra_extensions[{index}] must be a non-empty string."
-            )
-        extensions.append(extension.strip())
-    return tuple(extensions)
+    return parse_ide_extensions(f"{path}: ide.{ide_name}.extra_extensions", extensions_data)
 
 
 def _read_user_ide_settings(path: Path, ide_name: str, settings_data: Any) -> dict[str, Any]:
-    if settings_data is None:
-        return {}
-    if not isinstance(settings_data, dict):
-        raise ValueError(f"{path}: ide.{ide_name}.settings must be a mapping when provided.")
-
-    settings: dict[str, Any] = {}
-    for key, value in settings_data.items():
-        if not isinstance(key, str) or not key:
-            raise ValueError(f"{path}: ide.{ide_name}.settings keys must be non-empty strings.")
-        try:
-            json.dumps(value)
-        except TypeError as exc:
-            raise ValueError(f"{path}: ide.{ide_name}.settings.{key} must be JSON-serializable.") from exc
-        settings[key] = value
-    return settings
+    return parse_ide_settings(f"{path}: ide.{ide_name}.settings", settings_data)
 
 
 def merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/lib/python/base_cli/ide_schema.py
+++ b/lib/python/base_cli/ide_schema.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+
+@dataclass(frozen=True)
+class IdeDefinition:
+    name: str
+    label: str
+    cli: str
+    cask: str
+    settings_app_dir: str
+
+
+IDE_DEFINITIONS = {
+    "vscode": IdeDefinition(
+        name="vscode",
+        label="VS Code",
+        cli="code",
+        cask="visual-studio-code",
+        settings_app_dir="Code",
+    ),
+    "cursor": IdeDefinition(
+        name="cursor",
+        label="Cursor",
+        cli="cursor",
+        cask="cursor",
+        settings_app_dir="Cursor",
+    ),
+}
+
+SUPPORTED_IDES = frozenset(IDE_DEFINITIONS)
+PROJECT_AUTO_SETTING_KEYS = frozenset({"python.defaultInterpreterPath"})
+
+
+def parse_ide_extensions(context: str, extensions_data: Any) -> tuple[str, ...]:
+    if extensions_data is None:
+        return ()
+    if not isinstance(extensions_data, list):
+        raise ValueError(f"{context} must be a list when provided.")
+
+    extensions: list[str] = []
+    for index, extension in enumerate(extensions_data, start=1):
+        if not isinstance(extension, str) or not extension.strip():
+            raise ValueError(f"{context}[{index}] must be a non-empty string.")
+        extensions.append(extension.strip())
+    return tuple(extensions)
+
+
+def parse_ide_settings(
+    context: str,
+    settings_data: Any,
+    *,
+    auto_setting_keys: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    if settings_data is None:
+        return {}
+    if not isinstance(settings_data, dict):
+        raise ValueError(f"{context} must be a mapping when provided.")
+
+    settings: dict[str, Any] = {}
+    for key, value in settings_data.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"{context} keys must be non-empty strings.")
+        if auto_setting_keys is not None and value == "auto" and key not in auto_setting_keys:
+            raise ValueError(f"{context}.{key} does not support the special value 'auto'.")
+        try:
+            json.dumps(value)
+        except TypeError as exc:
+            raise ValueError(f"{context}.{key} must be JSON-serializable.") from exc
+        settings[key] = value
+    return settings

--- a/lib/python/base_cli/tests/test_ide_schema.py
+++ b/lib/python/base_cli/tests/test_ide_schema.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import unittest
+
+from base_cli.ide_schema import IDE_DEFINITIONS
+from base_cli.ide_schema import PROJECT_AUTO_SETTING_KEYS
+from base_cli.ide_schema import SUPPORTED_IDES
+from base_cli.ide_schema import parse_ide_extensions
+from base_cli.ide_schema import parse_ide_settings
+
+
+class IdeSchemaTests(unittest.TestCase):
+    def test_supported_ide_names_are_derived_from_definitions(self) -> None:
+        self.assertEqual(SUPPORTED_IDES, frozenset(IDE_DEFINITIONS))
+        self.assertEqual(IDE_DEFINITIONS["vscode"].cli, "code")
+        self.assertEqual(IDE_DEFINITIONS["cursor"].settings_app_dir, "Cursor")
+
+    def test_parse_ide_extensions_trims_and_rejects_empty_values(self) -> None:
+        self.assertEqual(
+            parse_ide_extensions("ide.vscode.extensions", [" ms-python.python "]),
+            ("ms-python.python",),
+        )
+
+        with self.assertRaisesRegex(ValueError, r"ide.vscode.extensions\[1\]"):
+            parse_ide_extensions("ide.vscode.extensions", [""])
+
+    def test_parse_ide_settings_allows_auto_as_literal_by_default(self) -> None:
+        self.assertEqual(
+            parse_ide_settings("ide.vscode.settings", {"editor.defaultFormatter": "auto"}),
+            {"editor.defaultFormatter": "auto"},
+        )
+
+    def test_parse_ide_settings_can_restrict_project_auto_values(self) -> None:
+        self.assertEqual(
+            parse_ide_settings(
+                "ide.vscode.settings",
+                {"python.defaultInterpreterPath": "auto"},
+                auto_setting_keys=PROJECT_AUTO_SETTING_KEYS,
+            ),
+            {"python.defaultInterpreterPath": "auto"},
+        )
+
+        with self.assertRaisesRegex(ValueError, "does not support the special value 'auto'"):
+            parse_ide_settings(
+                "ide.vscode.settings",
+                {"editor.defaultFormatter": "auto"},
+                auto_setting_keys=PROJECT_AUTO_SETTING_KEYS,
+            )


### PR DESCRIPTION
## Summary
- Add `base_cli.ide_schema` as the single source for supported IDE names, IDE metadata, and shared IDE value validation.
- Update user config and project manifest parsing to share extension/settings validators while preserving their different `auto` policies.
- Update setup IDE behavior to use the centralized IDE definitions.
- Add focused schema tests for metadata derivation, extension parsing, and `auto` policy handling.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests cli/python/base_setup/tests`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest`
- `git ls-files -z '*.py' | xargs -0 env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`
- `git diff --check`

Closes #291