### PR TITLE
Add completion contract tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
             lib/bash/runtime/tests/runtime_bashrc.bats \
             lib/bash/std/tests/lib_std.bats \
             lib/bash/version/tests/lib_version.bats \
+            lib/shell/completions/tests/completions.bats \
             tests/install.bats
 
   integration:

--- a/bin/base-test
+++ b/bin/base-test
@@ -21,5 +21,6 @@ bats \
     lib/bash/runtime/tests/runtime_bashrc.bats \
     lib/bash/std/tests/lib_std.bats \
     lib/bash/version/tests/lib_version.bats \
+    lib/shell/completions/tests/completions.bats \
     tests/install.bats \
     tests/integration/base_workflows.bats

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load ../../../bash/tests/test_helper.sh
+bats_require_minimum_version 1.5.0
+
+setup() {
+    setup_test_tmpdir
+}
+
+basectl_help_commands() {
+    "$BASE_REPO_ROOT/bin/basectl" --help |
+        awk '
+            /^Commands:/ { in_commands = 1; next }
+            /^Options:/ { in_commands = 0 }
+            in_commands && /^  [a-z]/ {
+                command = $1
+                print command
+            }
+        ' |
+        sort -u
+}
+
+bash_completion_commands() {
+    sed -n 's/^[[:space:]]*local commands="\([^"]*\)".*/\1/p' \
+        "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.sh" |
+        tr ' ' '\n' |
+        sed '/^$/d' |
+        sort -u
+}
+
+zsh_completion_commands() {
+    awk '
+        /^[[:space:]]*commands=\(/ { in_commands = 1; next }
+        in_commands && /^[[:space:]]*\)/ { in_commands = 0 }
+        in_commands && /^[[:space:]]*'\''[^'\'']+:/ {
+            command = $1
+            sub(/^'\''/, "", command)
+            sub(/:.*/, "", command)
+            print command
+        }
+    ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh" |
+        sort -u
+}
+
+@test "Bash completion top-level commands match basectl help" {
+    local expected="$TEST_TMPDIR/help-commands"
+    local actual="$TEST_TMPDIR/bash-completion-commands"
+
+    basectl_help_commands > "$expected"
+    bash_completion_commands > "$actual"
+
+    bats_run diff -u "$expected" "$actual"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "Zsh completion top-level commands match basectl help" {
+    local expected="$TEST_TMPDIR/help-commands"
+    local actual="$TEST_TMPDIR/zsh-completion-commands"
+
+    basectl_help_commands > "$expected"
+    zsh_completion_commands > "$actual"
+
+    bats_run diff -u "$expected" "$actual"
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Add contract BATS tests that compare `basectl --help` top-level commands against Bash and Zsh completion command lists.
- Wire the completion test file into `bin/base-test` and the GitHub Actions BATS job.

## Validation

- `bats lib/shell/completions/tests/completions.bats`
- `./bin/base-test`
- `git diff --check`

Fixes #302