### PR TITLE
Add base_init bootstrap smoke tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
             lib/bash/std/tests/lib_std.bats \
             lib/bash/version/tests/lib_version.bats \
             lib/shell/completions/tests/completions.bats \
+            tests/base_init.bats \
             tests/install.bats
 
   integration:

--- a/base_init.sh
+++ b/base_init.sh
@@ -92,17 +92,28 @@ base_init_resolve_home() {
 }
 
 base_init_export_contract() {
-    local base_home base_os base_host
+    local base_home base_os base_host uname_os
 
     base_home="$(base_init_resolve_home)" || return 1
-    base_os="$(uname -s)" || {
+    uname_os="$(uname -s)" || {
         base_init_error "Unable to determine BASE_OS with uname."
         return 1
     }
-    [[ -n "$base_os" ]] || {
+    [[ -n "$uname_os" ]] || {
         base_init_error "Unable to determine BASE_OS with uname."
         return 1
     }
+    case "$uname_os" in
+        Darwin)
+            base_os=macos
+            ;;
+        Linux)
+            base_os=linux
+            ;;
+        *)
+            base_os="$(printf '%s\n' "$uname_os" | tr '[:upper:]' '[:lower:]')"
+            ;;
+    esac
     base_host="$(hostname -s)" || {
         base_init_error "Unable to determine BASE_HOST with hostname."
         return 1
@@ -122,8 +133,9 @@ base_init_export_contract() {
     BASE_SHELL_DIR="$BASE_LIB_DIR/shell"
     BASE_OS="$base_os"
     BASE_HOST="$base_host"
+    BASE_SHELL="${BASE_SHELL:-bash}"
     export BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_BASH_DIR BASE_BASH_COMMANDS_DIR
-    export BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_HOST
+    export BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_HOST BASE_SHELL
 }
 
 base_init_source_stdlib() {

--- a/bin/base-test
+++ b/bin/base-test
@@ -22,5 +22,6 @@ bats \
     lib/bash/std/tests/lib_std.bats \
     lib/bash/version/tests/lib_version.bats \
     lib/shell/completions/tests/completions.bats \
+    tests/base_init.bats \
     tests/install.bats \
     tests/integration/base_workflows.bats

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+load ../lib/bash/tests/test_helper.sh
+bats_require_minimum_version 1.5.0
+
+setup() {
+    setup_test_tmpdir
+    TEST_BASE_HOME="$TEST_TMPDIR/base"
+    mkdir -p "$TEST_BASE_HOME"
+    TEST_BASE_HOME="$(cd "$TEST_BASE_HOME" && pwd -P)"
+    create_minimal_base_home "$TEST_BASE_HOME"
+}
+
+create_minimal_base_home() {
+    local base_home="$1"
+
+    mkdir -p \
+        "$base_home/bin" \
+        "$base_home/cli/bash/commands" \
+        "$base_home/lib/bash/file" \
+        "$base_home/lib/bash/std" \
+        "$base_home/lib/shell"
+
+    cp "$BASE_REPO_ROOT/base_init.sh" "$base_home/base_init.sh"
+    cp "$BASE_REPO_ROOT/lib/bash/std/lib_std.sh" "$base_home/lib/bash/std/lib_std.sh"
+    cp "$BASE_REPO_ROOT/lib/bash/file/lib_file.sh" "$base_home/lib/bash/file/lib_file.sh"
+}
+
+run_base_init_script() {
+    local script="$1"
+
+    run env \
+        -u BASE_HOME \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        bash -c "$script" bash "$TEST_BASE_HOME"
+}
+
+@test "base_init exports the Base runtime path contract" {
+    run_base_init_script '
+        base_home="$1"
+        source "$base_home/base_init.sh"
+        printf "BASE_HOME=%s\n" "$BASE_HOME"
+        printf "BASE_BIN_DIR=%s\n" "$BASE_BIN_DIR"
+        printf "BASE_CLI_DIR=%s\n" "$BASE_CLI_DIR"
+        printf "BASE_BASH_DIR=%s\n" "$BASE_BASH_DIR"
+        printf "BASE_BASH_COMMANDS_DIR=%s\n" "$BASE_BASH_COMMANDS_DIR"
+        printf "BASE_LIB_DIR=%s\n" "$BASE_LIB_DIR"
+        printf "BASE_BASH_LIB_DIR=%s\n" "$BASE_BASH_LIB_DIR"
+        printf "BASE_SHELL_DIR=%s\n" "$BASE_SHELL_DIR"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_HOME=$TEST_BASE_HOME"* ]]
+    [[ "$output" == *"BASE_BIN_DIR=$TEST_BASE_HOME/bin"* ]]
+    [[ "$output" == *"BASE_CLI_DIR=$TEST_BASE_HOME/cli"* ]]
+    [[ "$output" == *"BASE_BASH_DIR=$TEST_BASE_HOME/cli/bash"* ]]
+    [[ "$output" == *"BASE_BASH_COMMANDS_DIR=$TEST_BASE_HOME/cli/bash/commands"* ]]
+    [[ "$output" == *"BASE_LIB_DIR=$TEST_BASE_HOME/lib"* ]]
+    [[ "$output" == *"BASE_BASH_LIB_DIR=$TEST_BASE_HOME/lib/bash"* ]]
+    [[ "$output" == *"BASE_SHELL_DIR=$TEST_BASE_HOME/lib/shell"* ]]
+}
+
+@test "base_init exports host operating system and shell metadata" {
+    run_base_init_script '
+        base_home="$1"
+        source "$base_home/base_init.sh"
+        printf "BASE_OS=%s\n" "$BASE_OS"
+        printf "BASE_HOST=%s\n" "$BASE_HOST"
+        printf "BASE_SHELL=%s\n" "$BASE_SHELL"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_HOST="* ]]
+    [[ "$output" == *"BASE_SHELL=bash"* ]]
+    [[ "$output" == *"BASE_OS=linux"* || "$output" == *"BASE_OS=macos"* ]]
+}
+
+@test "base_init is idempotent when sourced twice" {
+    run_base_init_script '
+        base_home="$1"
+        source "$base_home/base_init.sh"
+        source "$base_home/base_init.sh"
+        print_path | grep -Fxc "$BASE_BIN_DIR"
+    '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "1" ]
+}
+
+@test "base_init import_base_lib resolves libraries relative to BASE_HOME" {
+    run_base_init_script '
+        base_home="$1"
+        source "$base_home/base_init.sh"
+        import_base_lib file/lib_file.sh
+        declare -F safe_touch >/dev/null
+    '
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Add dedicated BATS smoke tests for the `base_init.sh` runtime path, host, OS, shell, idempotency, and `import_base_lib` contracts.
- Normalize `BASE_OS` to Base contract values such as `macos` and `linux`.
- Export `BASE_SHELL=bash` when `base_init.sh` is sourced outside an already-marked runtime shell, while preserving the existing runtime-shell sentinel.
- Wire `tests/base_init.bats` into `bin/base-test` and CI.

## Validation

- `bats tests/base_init.bats`
- `bats lib/bash/runtime/tests/runtime_bashrc.bats`
- `./bin/base-test`
- `git diff --check`

Fixes #303