### PR TITLE
Cover base_config helper behavior

### DIFF
--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -54,11 +54,14 @@ def doctor_config_command() -> int:
     path = user_config_path()
     print("\nBase config doctor\n")
     print_finding("ok", "path", f"Config path: {path}")
-    if path.exists():
-        if path.is_symlink():
+    if path.is_symlink():
+        if path.exists():
             print_finding("ok", "symlink", f"Config path is a symlink to '{safe_resolve(path)}'.")
         else:
-            print_finding("ok", "file", "Config file exists.")
+            print_finding("warn", "symlink", f"Config path is a broken symlink to '{safe_resolve(path)}'.")
+            return 0
+    elif path.exists():
+        print_finding("ok", "file", "Config file exists.")
     else:
         print_finding("warn", "file", "Config file is missing; Base will use an empty user config.")
         return 0

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -14,6 +14,42 @@ from base_config import engine
 
 
 class BaseConfigCommandTests(unittest.TestCase):
+    def test_safe_resolve_returns_resolved_existing_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.yaml"
+            path.write_text("ide: {}\n", encoding="utf-8")
+
+            resolved = engine.safe_resolve(path)
+
+        self.assertEqual(resolved, path.resolve())
+
+    def test_safe_resolve_handles_missing_path_without_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "missing" / "config.yaml"
+
+            resolved = engine.safe_resolve(path)
+
+        self.assertEqual(resolved, path.resolve(strict=False))
+
+    def test_safe_resolve_resolves_symlink_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.yaml"
+            symlink = Path(tmpdir) / "config.yaml"
+            target.write_text("ide: {}\n", encoding="utf-8")
+            symlink.symlink_to(target)
+
+            resolved = engine.safe_resolve(symlink)
+
+        self.assertEqual(resolved, target.resolve())
+
+    def test_print_finding_formats_status_name_and_message(self) -> None:
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            engine.print_finding("warn", "file", "Config file is missing.")
+
+        self.assertEqual(stdout.getvalue(), "warn   file          Config file is missing.\n")
+
     def test_show_config_prints_empty_mapping_when_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch.dict(os.environ, {"HOME": tmpdir}):
@@ -75,6 +111,38 @@ class BaseConfigCommandTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("Config YAML is valid", output)
         self.assertIn("Config contains 1 top-level key", output)
+
+    def test_doctor_config_reports_broken_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(Path(tmpdir))
+                path.parent.mkdir(parents=True)
+                target = path.parent / "missing-config.yaml"
+                path.symlink_to(target)
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        output = stdout.getvalue()
+        self.assertEqual(status, 0)
+        self.assertIn("warn", output)
+        self.assertIn("broken symlink", output)
+        self.assertIn(str(target), output)
+
+    def test_doctor_config_reports_unexpected_top_level_keys_as_valid_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(Path(tmpdir))
+                path.parent.mkdir(parents=True)
+                path.write_text("unexpected: true\nide:\n  enabled: true\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        output = stdout.getvalue()
+        self.assertEqual(status, 0)
+        self.assertIn("Config YAML is valid", output)
+        self.assertIn("Config contains 2 top-level key", output)
 
     def test_doctor_config_reports_invalid_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Add direct tests for `safe_resolve` covering existing paths, missing paths, and symlink targets.
- Add direct `print_finding` output-format coverage.
- Make `base_config doctor` report broken config symlinks distinctly.
- Add doctor coverage for broken symlink configs and valid YAML with unexpected top-level keys.

## Validation

- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_config/tests/test_engine.py`
- `./bin/base-test`
- `git diff --check`

Fixes #304