### PR TITLE
Cover runtime bashrc startup behavior

### DIFF
--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -158,6 +158,11 @@ _base_runtime_set_prompt() {
 }
 
 _base_runtime_main() {
+    if [[ -n "${__base_runtime_bashrc_loaded__:-}" ]]; then
+        _base_runtime_debug "already loaded; skipping"
+        return 0
+    fi
+
     [[ -n "${BASE_HOME:-}" ]] || {
         _base_runtime_error "BASE_HOME is not set."
         return 1
@@ -181,6 +186,7 @@ _base_runtime_main() {
     _base_runtime_source_user_bashrc || return $?
     _base_runtime_activate_project_venv || return $?
     _base_runtime_set_prompt
+    __base_runtime_bashrc_loaded__=1
     _base_runtime_debug "complete"
 }
 

--- a/lib/bash/runtime/tests/runtime_bashrc.bats
+++ b/lib/bash/runtime/tests/runtime_bashrc.bats
@@ -8,6 +8,28 @@ setup() {
     mkdir -p "$TEST_HOME"
 }
 
+@test "non-interactive bash ignores runtime rcfile" {
+    cat > "$TEST_HOME/.bashrc" <<'EOF'
+touch "$HOME/user-bashrc-ran"
+EOF
+
+    run env -i \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -c '\
+            printf "BASE_SHELL=%s\n" "${BASE_SHELL:-}"; \
+            if [[ -f "$HOME/user-bashrc-ran" ]]; then \
+                printf "USER_BASHRC_RAN=1\n"; \
+            else \
+                printf "USER_BASHRC_RAN=0\n"; \
+            fi'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_SHELL="* ]]
+    [[ "$output" == *"USER_BASHRC_RAN=0"* ]]
+}
+
 @test "runtime bashrc sources base_init before user bashrc" {
     cat > "$TEST_HOME/.bashrc" <<'EOF'
 if declare -F import_base_lib >/dev/null 2>&1; then
@@ -43,4 +65,61 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_DEBUG runtime: sourced '$TEST_HOME/.baserc'"* ]]
     [[ "$output" == *"BASE_DEBUG runtime: complete"* ]]
+}
+
+@test "runtime bashrc handles a missing baserc without error" {
+    run env -i \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            printf "BASE_SHELL=%s\n" "${BASE_SHELL:-}"; \
+            printf "BASE_DEBUG=%s\n" "${BASE_DEBUG:-}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_SHELL=1"* ]]
+    [[ "$output" == *"BASE_DEBUG="* ]]
+    [[ "$output" != *"ERROR:"* ]]
+}
+
+@test "baserc debug setting enables full runtime trace" {
+    printf '%s\n' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
+
+    run env -i \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c 'printf "ok\n"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG runtime: sourced '$TEST_HOME/.baserc'"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: loading"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: sourcing '$BASE_REPO_ROOT/base_init.sh'"* ]]
+    [[ "$output" == *"BASE_DEBUG runtime: complete"* ]]
+}
+
+@test "runtime bashrc is idempotent when sourced twice" {
+    cat > "$TEST_HOME/.bashrc" <<'EOF'
+count_file="$HOME/user-bashrc-count"
+count=0
+if [[ -f "$count_file" ]]; then
+    count="$(cat "$count_file")"
+fi
+printf '%s\n' "$((count + 1))" > "$count_file"
+EOF
+    printf '%s\n' 'BASE_DEBUG=1' > "$TEST_HOME/.baserc"
+
+    run env -i \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            source "$BASE_HOME/lib/bash/runtime/bashrc"; \
+            printf "USER_BASHRC_COUNT=%s\n" "$(cat "$HOME/user-bashrc-count")"; \
+            printf "BASE_SHELL=%s\n" "${BASE_SHELL:-}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_DEBUG runtime: already loaded; skipping"* ]]
+    [[ "$output" == *"USER_BASHRC_COUNT=1"* ]]
+    [[ "$output" == *"BASE_SHELL=1"* ]]
 }


### PR DESCRIPTION
## Summary
- Add runtime bashrc tests for non-interactive rcfile handling, missing ~/.baserc behavior, full debug trace propagation from ~/.baserc, and repeated sourcing.
- Make runtime bashrc startup idempotent so sourcing the rcfile twice does not rerun user startup.

## Validation
- bats lib/bash/runtime/tests/runtime_bashrc.bats
- env HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test
- git diff --check

Closes #298