### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-30
+
 ### Added
 
 - Added documentation for the no-hooks manifest boundary and future setup hook


### PR DESCRIPTION
## Summary
- Move the current changelog entries from Unreleased into v0.2.0 dated 2026-05-30.
- Leave a fresh Unreleased section for v0.3.0 work.

## Validation
- git diff --check

Fixes #317