### PR TITLE
Update README release status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated the README status section to match the current `0.2.0` release.
+
 ## [0.2.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -813,10 +813,10 @@ Base follows a few simple principles.
 
 ## Current Status
 
-Base has shipped a macOS-first `0.1.0` public baseline. The implemented command
-surface covers setup, checks, diagnostics, project discovery, project
-activation, project test execution, cleanup, updates, onboarding, and GitHub
-workflow helpers.
+Base `0.2.0` is the current release. The implemented command surface covers
+setup, checks, diagnostics, project discovery, project activation, project test
+execution, mise integration, cleanup, updates, onboarding, and GitHub workflow
+helpers.
 
 For the documentation map and naming convention, see
 [docs/README.md](docs/README.md). For the architecture and product direction,


### PR DESCRIPTION
## Summary
- Update the README Current Status section to identify 0.2.0 as the current release.
- Note the README status correction in the Unreleased changelog.

## Validation
- rg -n '0\\.1\\.0 public baseline|Base `0\\.2\\.0`|version-0\\.2\\.0|## \\[0\\.2\\.0\\]' README.md CHANGELOG.md VERSION\n- git diff --check\n\nCloses #329