### PR TITLE
Escape DEL in setup JSON output

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -961,7 +961,9 @@ setup_json_escape() {
                 ;;
             *)
                 printf -v code '%d' "'$char"
-                if ((code < 32)); then
+                # JSON requires escaping C0 controls and DEL. C1 controls are
+                # valid UTF-8 codepoints and are intentionally left as-is here.
+                if ((code < 32 || code == 127)); then
                     printf -v escaped '\\u%04x' "$code"
                     output+="$escaped"
                 else

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -178,11 +178,11 @@ load ./setup_helpers.bash
     [ "${stderr:-}" = "" ]
 }
 
-@test "basectl check --format json escapes all C0 control characters in strings" {
+@test "basectl check --format json escapes C0 control characters and DEL in strings" {
     local control_package
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
-    control_package=$'Py\vYAML'
+    control_package=$'Py\vYAML\177'
     create_brew_stub
     create_xcode_stubs
     touch "$TEST_STATE_DIR/xcode-installed"
@@ -206,7 +206,7 @@ load ./setup_helpers.bash
         "$BASE_REPO_ROOT/bin/basectl" check --format json
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Py\\u000bYAML"* ]]
+    [[ "$output" == *"Py\\u000bYAML\\u007f"* ]]
     [[ "$output" != *"$control_package"* ]]
     [ "${stderr:-}" = "" ]
 }


### PR DESCRIPTION
## Summary
- Escape the DEL character (`0x7F`) in `setup_json_escape` so Base JSON output remains spec-compliant.
- Document the intentional C1 control-character behavior in the escape helper.
- Extend the basectl JSON escaping test to cover both a C0 control and DEL.

## Validation
- bats cli/bash/commands/basectl/tests/check.bats
- env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test
- git diff --check

Closes #335