### PR TITLE
Report ShellCheck warnings in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,3 +112,13 @@ jobs:
             'install.sh' \
             'bin/*' \
             | xargs -0 shellcheck --severity=error
+
+      - name: Run ShellCheck warnings
+        continue-on-error: true
+        run: |
+          git ls-files -z \
+            '*.sh' \
+            'base_init.sh' \
+            'install.sh' \
+            'bin/*' \
+            | xargs -0 shellcheck --severity=warning --format=tty


### PR DESCRIPTION
## Summary
- Keep the existing ShellCheck error gate as a blocking CI step.
- Add a second non-blocking ShellCheck run at warning severity so warnings are visible in GitHub Actions.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml")'\n- git diff --check\n\nNote: local `shellcheck` is not installed here; the GitHub Actions security job installs and runs it.\n\nCloses #332