### PR TITLE
Cover git update failure paths

### DIFF
--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -40,12 +40,16 @@ load ./basectl_helpers.bash
             base_update_current_branch() { printf "%s\n" master; }
             base_update_default_branch() { printf "%s\n" master; }
             base_update_worktree_clean() { return 1; }
+            base_update_source_git_library() { printf "git library should not load\n"; return 99; }
+            git_update_repo() { printf "git update should not run\n"; return 99; }
             base_update_run_setup() { printf "setup should not run\n"; return 99; }
             base_update_subcommand_main
         '
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"Base repository has local changes."* ]]
+    [[ "$output" != *"git library should not load"* ]]
+    [[ "$output" != *"git update should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
 }
 

--- a/lib/bash/git/lib_git.sh
+++ b/lib/bash/git/lib_git.sh
@@ -91,7 +91,7 @@ _git_pull_with_retry() {
     local attempt=1
 
     while ((attempt <= max_attempts)); do
-        if git pull >"$git_log" 2>&1; then
+        if git pull --ff-only >"$git_log" 2>&1; then
             if ((attempt > 1)); then
                 log_debug "git pull succeeded on attempt $attempt."
             fi

--- a/lib/bash/git/tests/lib_git.bats
+++ b/lib/bash/git/tests/lib_git.bats
@@ -47,6 +47,68 @@ setup() {
     [[ "$output" == *"has local changes; skipping auto-update"* ]]
 }
 
+@test "git_update_repo fails clearly when origin remote is missing" {
+    local before_head
+    local repo="$TEST_TMPDIR/repo"
+
+    init_git_repo "$repo"
+    printf 'base\n' > "$repo/data.txt"
+    commit_all "$repo" "Initial commit"
+    before_head="$(git -C "$repo" rev-parse HEAD)"
+
+    bats_run git_update_repo "$repo" "" master
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"git pull failed on repo '$repo'"* ]]
+    [ "$(git -C "$repo" rev-parse HEAD)" = "$before_head" ]
+    [ "$(cat "$repo/data.txt")" = "base" ]
+    [ -z "$(git -C "$repo" status --porcelain)" ]
+}
+
+@test "git_update_repo fails clearly when origin remote is unreachable" {
+    local before_head
+    local remote="$TEST_TMPDIR/remote.git"
+    local repo="$TEST_TMPDIR/repo"
+
+    create_tracked_repo_with_upstream "$repo" "$remote" "data.txt" "base"
+    before_head="$(git -C "$repo" rev-parse HEAD)"
+    git -C "$repo" remote set-url origin "$TEST_TMPDIR/missing-remote.git"
+
+    bats_run git_update_repo "$repo" "" master
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"git pull failed on repo '$repo'"* ]]
+    [ "$(git -C "$repo" rev-parse HEAD)" = "$before_head" ]
+    [ "$(cat "$repo/data.txt")" = "base" ]
+    [ -z "$(git -C "$repo" status --porcelain)" ]
+}
+
+@test "git_update_repo fails on non-fast-forward updates without changing HEAD" {
+    local before_head
+    local other="$TEST_TMPDIR/other"
+    local remote="$TEST_TMPDIR/remote.git"
+    local repo="$TEST_TMPDIR/repo"
+
+    create_tracked_repo_with_upstream "$repo" "$remote" "data.txt" "base"
+    before_head="$(git -C "$repo" rev-parse HEAD)"
+
+    git clone "$remote" "$other" >/dev/null 2>&1
+    git -C "$other" config user.name "Bats Test"
+    git -C "$other" config user.email "bats@example.com"
+    printf 'rewritten remote\n' > "$other/data.txt"
+    git -C "$other" add data.txt
+    git -C "$other" commit --amend -m "Rewrite remote history" >/dev/null 2>&1
+    git -C "$other" push --force origin master >/dev/null 2>&1
+
+    bats_run git_update_repo "$repo" "" master
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"git pull failed on repo '$repo'"* ]]
+    [ "$(git -C "$repo" rev-parse HEAD)" = "$before_head" ]
+    [ "$(cat "$repo/data.txt")" = "base" ]
+    [ -z "$(git -C "$repo" status --porcelain)" ]
+}
+
 @test "git_update_repo accepts main as the detected update branch" {
     local repo="$TEST_TMPDIR/repo"
 


### PR DESCRIPTION
## Summary
- Add git_update_repo tests for missing origin, unreachable origin, and non-fast-forward remote history.
- Make git_update_repo pull with `--ff-only` so divergent histories fail without mutating the local checkout.
- Strengthen the basectl update dirty-worktree test to prove the git update path is not loaded or called.

## Validation
- bats lib/bash/git/tests/lib_git.bats
- bats cli/bash/commands/basectl/tests/update.bats
- bash -n lib/bash/git/lib_git.sh cli/bash/commands/basectl/tests/update.bats lib/bash/git/tests/lib_git.bats
- env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test
- git diff --check

Closes #333