### PR TITLE
Support configured workspace root discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ basectl update-profile
 exec "$SHELL" -l
 ```
 
+For Homebrew installs, Base itself lives under Homebrew's prefix rather than in
+your project workspace. If your repositories live under a shared directory such
+as `~/work`, set the workspace root in `~/.base.d/config.yaml`:
+
+```yaml
+workspace:
+  root: ~/work
+```
+
 Or install from the repository:
 
 ```bash
@@ -114,7 +123,7 @@ The important idea is that the user should not need to memorize a different
 bootstrap story for every repository in the workspace.
 
 Base should be able to discover participating project repositories checked out
-next to it under a shared parent directory, for example:
+under a shared workspace root, for example:
 
 ```text
 ~/work/
@@ -237,10 +246,12 @@ basectl projects list
 basectl projects list --format json
 ```
 
-By default this scans the parent directory of `BASE_HOME`, which matches the
-recommended sibling-repo workspace layout. Use `--workspace <path>` to inspect a
-different workspace root. Output is tab-separated as `<project-name><TAB><path>`.
-Use `--format json` for machine-readable output.
+By default this scans `workspace.root` from `~/.base.d/config.yaml` when that
+value is configured. If it is not configured, Base falls back to the parent
+directory of `BASE_HOME`, which matches the source-checkout sibling-repo layout.
+Use `--workspace <path>` to inspect a different workspace root for one command.
+Output is tab-separated as `<project-name><TAB><path>`. Use `--format json` for
+machine-readable output.
 
 Run a discovered project's declared test command with:
 
@@ -459,6 +470,17 @@ your shell startup path. When installed through Homebrew, update Base with:
 
 ```bash
 brew upgrade codeforester/base/base
+```
+
+When Base is installed through Homebrew, `BASE_HOME` points to the physical
+Homebrew install location. It does not point to your project workspace. Configure
+`workspace.root` in `~/.base.d/config.yaml` so commands such as
+`basectl projects list`, `basectl activate <project>`, and
+`basectl test <project>` can find your repositories:
+
+```yaml
+workspace:
+  root: ~/work
 ```
 
 The standalone installer is also available:

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -74,7 +74,9 @@ that delegate to `basectl`.
   to the delegated test command.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
-- `basectl projects list` scans a workspace for `base_manifest.yaml` files and prints discovered project names and paths.
+- `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`
+  when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
+  project names and paths.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -9,7 +9,7 @@ Usage:
   basectl activate <project> [options]
 
 Options:
-  --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --no-cd             Preserve the caller's current directory in the project shell.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.

--- a/cli/bash/commands/basectl/subcommands/projects.sh
+++ b/cli/bash/commands/basectl/subcommands/projects.sh
@@ -9,7 +9,7 @@ Usage:
   basectl projects list [options]
 
 Options:
-  --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --format <format>   Output format for list: text or json.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -10,7 +10,7 @@ Usage:
   basectl test [project] [options] [-- extra args...]
 
 Options:
-  --workspace <path>  Workspace directory to scan. Defaults to BASE_HOME's parent.
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --dry-run           Print the resolved test command without running it.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -4,7 +4,7 @@ import json
 import sys
 from pathlib import Path
 
-from base_cli.config import load_user_config, user_config_path
+from base_cli.config import load_user_config, read_user_config, user_config_path
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -74,6 +74,22 @@ def doctor_config_command() -> int:
 
     print_finding("ok", "yaml", "Config YAML is valid.")
     print_finding("ok", "mapping", f"Config contains {len(config)} top-level key(s).")
+    try:
+        user_config = read_user_config()
+    except (RuntimeError, ValueError) as exc:
+        print_finding("error", "schema", str(exc))
+        return 1
+
+    if user_config.workspace.root is None:
+        print_finding(
+            "warn",
+            "workspace",
+            "workspace.root is not configured; project discovery falls back to BASE_HOME's parent.",
+        )
+    elif user_config.workspace.root.is_dir():
+        print_finding("ok", "workspace", f"workspace.root points to '{user_config.workspace.root}'.")
+    else:
+        print_finding("warn", "workspace", f"workspace.root '{user_config.workspace.root}' is not a directory.")
     return 0
 
 

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -111,6 +111,39 @@ class BaseConfigCommandTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("Config YAML is valid", output)
         self.assertIn("Config contains 1 top-level key", output)
+        self.assertIn("workspace.root is not configured", output)
+
+    def test_doctor_config_reports_configured_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workspace = root / "work"
+            workspace.mkdir()
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(root)
+                path.parent.mkdir(parents=True)
+                path.write_text(f"workspace:\n  root: {workspace}\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        output = stdout.getvalue()
+        self.assertEqual(status, 0)
+        self.assertIn("workspace.root points to", output)
+        self.assertIn(str(workspace), output)
+
+    def test_doctor_config_reports_invalid_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(root)
+                path.parent.mkdir(parents=True)
+                path.write_text("workspace:\n  root: work\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        self.assertEqual(status, 1)
+        self.assertIn("workspace.root must be an absolute path", stdout.getvalue())
 
     def test_doctor_config_reports_broken_symlink(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+from base_cli.config import read_user_config
 from base_cli.paths import discover_manifest
 from base_setup.manifest import ManifestError, TestConfig, read_manifest
 
@@ -28,7 +29,10 @@ def main(argv: list[str] | None = None) -> int:
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.argument("command", required=False)
 @base_cli.argument("project", required=False)
-@base_cli.option("--workspace", help="Workspace directory to scan. Defaults to BASE_HOME's parent.")
+@base_cli.option(
+    "--workspace",
+    help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
+)
 @base_cli.option("--format", "output_format", default="text", help="Output format for list: text or json.")
 def run(
     ctx: base_cli.Context,
@@ -168,6 +172,12 @@ class ProjectDiscoveryError(RuntimeError):
 def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path:
     if workspace:
         return Path(workspace).expanduser().resolve()
+    try:
+        workspace_root = read_user_config().workspace.root
+    except (RuntimeError, ValueError) as exc:
+        raise ProjectDiscoveryError(str(exc)) from exc
+    if workspace_root is not None:
+        return workspace_root
     if ctx.base_home is None:
         raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
     return ctx.base_home.parent.resolve()

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# pylint: disable=too-many-public-methods
+
 import io
 import json
 import os
@@ -36,10 +38,14 @@ def write_mise_test_manifest(project_root: Path, name: str, task: str) -> None:
     )
 
 
-def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
+def run_engine(args: list[str], base_home: Path, user_config: str | None = None) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
     with tempfile.TemporaryDirectory() as home_dir:
+        if user_config is not None:
+            config_path = Path(home_dir) / ".base.d" / "config.yaml"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(user_config, encoding="utf-8")
         with mock.patch.dict(os.environ, {"HOME": home_dir, "BASE_HOME": str(base_home)}):
             with redirect_stdout(stdout), redirect_stderr(stderr):
                 status = engine.main(args)
@@ -85,6 +91,44 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{(workspace / 'demo').resolve()}\n")
 
+    def test_projects_list_prefers_configured_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workspace = root / "configured-workspace"
+            base_home = root / "homebrew" / "base" / "libexec"
+            base_home.mkdir(parents=True)
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(
+                ["list"],
+                base_home,
+                user_config=f"workspace:\n  root: {workspace}\n",
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{(workspace / 'demo').resolve()}\n")
+
+    def test_projects_list_workspace_override_wins_over_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            configured_workspace = root / "configured"
+            explicit_workspace = root / "explicit"
+            base_home = root / "homebrew" / "base" / "libexec"
+            base_home.mkdir(parents=True)
+            write_manifest(configured_workspace / "configured-demo", "configured-demo")
+            write_manifest(explicit_workspace / "explicit-demo", "explicit-demo")
+
+            status, stdout, stderr = run_engine(
+                ["list", "--workspace", str(explicit_workspace)],
+                base_home,
+                user_config=f"workspace:\n  root: {configured_workspace}\n",
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"explicit-demo\t{(explicit_workspace / 'explicit-demo').resolve()}\n")
+
     def test_projects_list_supports_json_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir) / "custom"
@@ -126,6 +170,25 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
 
+    def test_projects_resolve_prefers_configured_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workspace = root / "configured-workspace"
+            base_home = root / "homebrew" / "base" / "libexec"
+            base_home.mkdir(parents=True)
+            project_root = workspace / "demo"
+            write_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(
+                ["resolve", "demo"],
+                base_home,
+                user_config=f"workspace:\n  root: {workspace}\n",
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
+
     def test_projects_resolve_base_uses_base_home_without_workspace_scan(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
@@ -135,6 +198,25 @@ class ProjectDiscoveryTests(unittest.TestCase):
             write_manifest(other_base, "base")
 
             status, stdout, stderr = run_engine(["resolve", "base"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}\n")
+
+    def test_projects_resolve_base_uses_base_home_with_configured_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workspace = root / "configured-workspace"
+            base_home = root / "homebrew" / "base" / "libexec"
+            other_base = workspace / "base"
+            write_manifest(base_home, "base")
+            write_manifest(other_base, "base")
+
+            status, stdout, stderr = run_engine(
+                ["resolve", "base"],
+                base_home,
+                user_config=f"workspace:\n  root: {workspace}\n",
+            )
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,7 @@ command can validate the target and launch the configured subshell.
 ```
 basectl activate myproject
   ↓
-1. Look up BASE_HOME, scan known projects
+1. Look up BASE_HOME, resolve the workspace root, and scan known projects
 2. Validate myproject exists and has a valid manifest
 3. Set BASE_PROJECT=myproject
 4. Spawn a new subshell
@@ -130,7 +130,8 @@ basectl activate myproject
 
 - Takes a project name as argument (not a directory path)
 - Works from any current directory — the user does not need to be in the project folder
-- Base looks in `$BASE_HOME` to locate and validate the project
+- Base locates projects from explicit `--workspace`, configured `workspace.root`,
+  or the parent of `$BASE_HOME` as a source-checkout fallback
 - Validates that the target is a recognized Base project with a valid manifest
 
 ---

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -30,6 +30,12 @@ does not require `$BASE_HOME` to be the root of a Git repository. That keeps the
 same runtime model usable when Base is checked out as its own repo or embedded
 inside a larger repository.
 
+`BASE_HOME` is always the physical Base installation root. It is not the
+developer workspace root, and it is not changed by `~/.base.d/config.yaml`.
+Project-discovery commands use the configured `workspace.root` from
+`~/.base.d/config.yaml` when present, then fall back to `BASE_HOME`'s parent for
+source-checkout layouts.
+
 The Base home check validates the expected Base files instead of checking for a
 `.git` directory.
 

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -66,6 +66,34 @@ Recognized environment variables include:
 `BASE_CACHE_DIR` separately controls the runtime cache/log/temp root; it is not
 stored in the user config.
 
+## Workspace Root
+
+`workspace.root` tells Base where to discover project repositories when a command
+needs a workspace scan:
+
+```yaml
+workspace:
+  root: ~/work
+```
+
+Project discovery uses this order:
+
+1. explicit `--workspace <path>` for the current command
+2. `workspace.root` from `~/.base.d/config.yaml`
+3. the parent directory of `BASE_HOME`
+
+This distinction matters for Homebrew installs. In a source checkout,
+`BASE_HOME` is usually the `base` repository inside a shared directory such as
+`~/work/base`, so `BASE_HOME`'s parent is a reasonable fallback. In a Homebrew
+install, `BASE_HOME` points to the physical Homebrew install location, not the
+developer's workspace. Set `workspace.root` to make commands such as
+`basectl projects list`, `basectl activate <project>`, and
+`basectl test <project>` independent of how Base itself was installed.
+
+`workspace.root` must be an absolute path or start with `~`. Base does not
+create the directory automatically; `basectl config doctor` reports whether the
+configured path exists.
+
 ## IDE Preferences
 
 User-local IDE preferences can add machine-specific IDE behavior without

--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -26,9 +26,15 @@ class UserIdeConfig:
 
 
 @dataclass(frozen=True)
+class UserWorkspaceConfig:
+    root: Path | None
+
+
+@dataclass(frozen=True)
 class UserConfig:
     raw: dict[str, Any]
     ide: UserIdeConfig
+    workspace: UserWorkspaceConfig = UserWorkspaceConfig(root=None)
 
 
 def user_config_path(home: Path | None = None) -> Path:
@@ -61,7 +67,38 @@ def load_user_config(home: Path | None = None) -> dict[str, Any]:
 
 def read_user_config(home: Path | None = None) -> UserConfig:
     raw = load_user_config(home)
-    return UserConfig(raw=raw, ide=_read_user_ide_config(user_config_path(home), raw.get("ide")))
+    path = user_config_path(home)
+    return UserConfig(
+        raw=raw,
+        workspace=_read_user_workspace_config(path, raw.get("workspace")),
+        ide=_read_user_ide_config(path, raw.get("ide")),
+    )
+
+
+def _read_user_workspace_config(path: Path, workspace_data: Any) -> UserWorkspaceConfig:
+    if workspace_data is None:
+        return UserWorkspaceConfig(root=None)
+    if not isinstance(workspace_data, dict):
+        raise ValueError(f"{path}: workspace must be a mapping when provided.")
+
+    allowed_keys = {"root"}
+    unknown_keys = sorted(set(workspace_data) - allowed_keys)
+    if unknown_keys:
+        raise ValueError(f"{path}: workspace has unsupported keys: {', '.join(unknown_keys)}.")
+
+    return UserWorkspaceConfig(root=_optional_path(path, "workspace.root", workspace_data.get("root")))
+
+
+def _optional_path(path: Path, key: str, value: Any) -> Path | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path}: {key} must be a non-empty string when provided.")
+
+    candidate = Path(value).expanduser()
+    if not candidate.is_absolute():
+        raise ValueError(f"{path}: {key} must be an absolute path or start with '~'.")
+    return candidate.resolve(strict=False)
 
 
 def _read_user_ide_config(path: Path, ide_data: Any) -> UserIdeConfig:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -207,8 +207,41 @@ class BaseCliTests(unittest.TestCase):
             config = read_user_config(Path(tmpdir))
 
         self.assertEqual(config.raw, {})
+        self.assertIsNone(config.workspace.root)
         self.assertIsNone(config.ide.enabled)
         self.assertEqual(config.ide.preferences, {})
+
+    def test_read_user_config_parses_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            workspace = home / "work"
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(f"workspace:\n  root: {workspace}\n", encoding="utf-8")
+
+            config = read_user_config(home)
+
+        self.assertEqual(config.workspace.root, workspace.resolve(strict=False))
+
+    def test_read_user_config_rejects_non_mapping_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("workspace: true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "workspace must be a mapping"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_relative_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("workspace:\n  root: work\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "workspace.root must be an absolute path"):
+                read_user_config(home)
 
     def test_read_user_config_parses_ide_preferences(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Add `workspace.root` parsing to the user config contract so project discovery can use a durable workspace root independent of `BASE_HOME`.
- Make `basectl projects list`, project resolution, activation, and test lookup prefer explicit `--workspace`, then configured `workspace.root`, then the old `BASE_HOME` parent fallback.
- Extend `basectl config doctor` and docs to explain Homebrew install behavior, `BASE_HOME`, and workspace-root configuration.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py cli/python/base_projects/tests/test_engine.py cli/python/base_config/tests/test_engine.py`
- `bats cli/bash/commands/basectl/tests/projects.bats cli/bash/commands/basectl/tests/activate.bats cli/bash/commands/basectl/tests/test.bats`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/config.py cli/python/base_projects/engine.py cli/python/base_config/engine.py lib/python/base_cli/tests/test_base_cli.py cli/python/base_projects/tests/test_engine.py cli/python/base_config/tests/test_engine.py`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Fixes #282