### PR TITLE
Cache project discovery metadata

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import shlex
+import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import base_cli
 from base_cli.config import read_user_config
+from base_cli.paths import base_cache_root
 from base_cli.paths import discover_manifest
 from base_setup.manifest import ManifestError, TestConfig, read_manifest
 
@@ -19,6 +24,13 @@ class Project:
     name: str
     root: Path
     manifest_path: Path
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    path: Path
+    mtime_ns: int
+    size: int
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -66,7 +78,7 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_f
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
-        projects = discover_projects(workspace_root)
+        projects = discover_projects_cached(ctx, workspace_root)
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return 1
@@ -187,32 +199,165 @@ def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: s
     if workspace is None and project_name == "base" and ctx.base_home is not None:
         return read_project(ctx.base_home / "base_manifest.yaml")
 
+    if workspace is None:
+        active_project = resolve_active_project(project_name)
+        if active_project is not None:
+            ctx.log.debug("Resolved active project '%s' from BASE_PROJECT_MANIFEST.", project_name)
+            return active_project
+
     workspace_root = resolve_workspace_root(ctx, workspace)
-    return find_project(workspace_root, project_name)
+    projects = discover_projects_cached(ctx, workspace_root)
+    return find_project_in_projects(projects, workspace_root, project_name)
 
 
 def discover_projects(workspace_root: Path) -> tuple[Project, ...]:
+    entries = workspace_manifest_entries(workspace_root)
+    projects = tuple(read_project(entry.path) for entry in entries)
+    return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def discover_projects_cached(ctx: base_cli.Context, workspace_root: Path) -> tuple[Project, ...]:
+    start = time.perf_counter()
+    entries = workspace_manifest_entries(workspace_root)
+    cached_projects = read_project_cache(workspace_root, entries)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    if cached_projects is not None:
+        ctx.log.debug(
+            "Project discovery cache hit for '%s': %d project(s) in %.1fms.",
+            workspace_root,
+            len(cached_projects),
+            elapsed_ms,
+        )
+        return cached_projects
+
+    projects = validate_unique_project_names(tuple(sorted(read_project(entry.path) for entry in entries)))
+    write_project_cache(workspace_root, entries, projects, ctx)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    ctx.log.debug(
+        "Project discovery scanned '%s': %d project(s) in %.1fms.",
+        workspace_root,
+        len(projects),
+        elapsed_ms,
+    )
+    return projects
+
+
+def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...]:
     if not workspace_root.is_dir():
         raise ProjectDiscoveryError(f"Workspace '{workspace_root}' is not a directory.")
 
-    projects = []
+    entries: list[ManifestEntry] = []
     for candidate in sorted(workspace_root.iterdir(), key=lambda path: path.name):
         if not candidate.is_dir():
             continue
         manifest_path = candidate / "base_manifest.yaml"
         if not manifest_path.is_file():
             continue
-        projects.append(read_project(manifest_path))
+        stat_result = manifest_path.stat()
+        entries.append(
+            ManifestEntry(
+                path=manifest_path,
+                mtime_ns=stat_result.st_mtime_ns,
+                size=stat_result.st_size,
+            )
+        )
 
-    return validate_unique_project_names(tuple(sorted(projects)))
+    return tuple(entries)
 
 
 def find_project(workspace_root: Path, project_name: str) -> Project:
     projects = discover_projects(workspace_root)
+    return find_project_in_projects(projects, workspace_root, project_name)
+
+
+def find_project_in_projects(projects: tuple[Project, ...], workspace_root: Path, project_name: str) -> Project:
     for project in projects:
         if project.name == project_name:
             return project
     raise ProjectDiscoveryError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
+
+
+def resolve_active_project(project_name: str) -> Project | None:
+    if os.environ.get("BASE_PROJECT") != project_name:
+        return None
+
+    manifest = os.environ.get("BASE_PROJECT_MANIFEST")
+    if not manifest:
+        return None
+
+    project = read_project(Path(manifest).expanduser().resolve())
+    if project.name != project_name:
+        raise ProjectDiscoveryError(
+            f"BASE_PROJECT is '{project_name}' but BASE_PROJECT_MANIFEST points to project '{project.name}'."
+        )
+    return project
+
+
+def project_cache_path(workspace_root: Path) -> Path:
+    workspace_key = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[:24]
+    return base_cache_root() / "projects" / f"{workspace_key}.json"
+
+
+def read_project_cache(workspace_root: Path, entries: tuple[ManifestEntry, ...]) -> tuple[Project, ...] | None:
+    cache_path = project_cache_path(workspace_root)
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if data.get("version") != 1 or data.get("workspace") != str(workspace_root):
+        return None
+    if data.get("manifests") != [manifest_entry_to_json(entry) for entry in entries]:
+        return None
+
+    try:
+        projects = tuple(
+            Project(
+                name=project["name"],
+                root=Path(project["root"]),
+                manifest_path=Path(project["manifest_path"]),
+            )
+            for project in data["projects"]
+        )
+    except (KeyError, TypeError):
+        return None
+    return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def write_project_cache(
+    workspace_root: Path,
+    entries: tuple[ManifestEntry, ...],
+    projects: tuple[Project, ...],
+    ctx: base_cli.Context,
+) -> None:
+    cache_path = project_cache_path(workspace_root)
+    data = {
+        "version": 1,
+        "workspace": str(workspace_root),
+        "manifests": [manifest_entry_to_json(entry) for entry in entries],
+        "projects": [project_to_json(project) for project in projects],
+    }
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
+    except OSError as exc:
+        ctx.log.debug("Unable to write project discovery cache '%s': %s", cache_path, exc)
+
+
+def manifest_entry_to_json(entry: ManifestEntry) -> dict[str, Any]:
+    return {
+        "path": str(entry.path),
+        "mtime_ns": entry.mtime_ns,
+        "size": entry.size,
+    }
+
+
+def project_to_json(project: Project) -> dict[str, str]:
+    return {
+        "name": project.name,
+        "root": str(project.root),
+        "manifest_path": str(project.manifest_path),
+    }
 
 
 def read_project(manifest_path: Path) -> Project:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -38,17 +38,49 @@ def write_mise_test_manifest(project_root: Path, name: str, task: str) -> None:
     )
 
 
-def run_engine(args: list[str], base_home: Path, user_config: str | None = None) -> tuple[int, str, str]:
+def invoke_engine(
+    args: list[str],
+    base_home: Path,
+    home: Path,
+    user_config: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
+    if user_config is not None:
+        config_path = home / ".base.d" / "config.yaml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(user_config, encoding="utf-8")
+    env = {
+        "HOME": str(home),
+        "BASE_HOME": str(base_home),
+        "BASE_PROJECT": "",
+        "BASE_PROJECT_MANIFEST": "",
+    }
+    if extra_env is not None:
+        env.update(extra_env)
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+def run_engine(
+    args: list[str],
+    base_home: Path,
+    user_config: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
     with tempfile.TemporaryDirectory() as home_dir:
-        if user_config is not None:
-            config_path = Path(home_dir) / ".base.d" / "config.yaml"
-            config_path.parent.mkdir(parents=True)
-            config_path.write_text(user_config, encoding="utf-8")
-        with mock.patch.dict(os.environ, {"HOME": home_dir, "BASE_HOME": str(base_home)}):
-            with redirect_stdout(stdout), redirect_stderr(stderr):
-                status = engine.main(args)
+        return invoke_engine(args, base_home, Path(home_dir), user_config=user_config, extra_env=extra_env)
+
+
+def run_engine_with_home(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_HOME": str(base_home)}):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
     return status, stdout.getvalue(), stderr.getvalue()
 
 
@@ -145,6 +177,57 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(json.loads(stdout), [{"name": "demo", "path": str((workspace / "demo").resolve())}])
 
+    def test_projects_list_reuses_project_cache_when_manifests_are_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            with mock.patch("base_projects.engine.read_project", wraps=engine.read_project) as read_project_mock:
+                status, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace)], base_home, home)
+                self.assertEqual(status, 0)
+                self.assertEqual(stderr, "")
+                self.assertEqual(stdout, f"demo\t{(workspace / 'demo').resolve()}\n")
+
+                status, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{(workspace / 'demo').resolve()}\n")
+        self.assertEqual(read_project_mock.call_count, 1)
+
+    def test_projects_list_invalidates_project_cache_when_manifest_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_manifest(project_root, "demo")
+
+            with mock.patch("base_projects.engine.read_project", wraps=engine.read_project) as read_project_mock:
+                status, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace)], base_home, home)
+                self.assertEqual(status, 0)
+                self.assertEqual(stderr, "")
+                self.assertEqual(stdout, f"demo\t{project_root.resolve()}\n")
+
+                manifest = project_root / "base_manifest.yaml"
+                manifest.write_text("project:\n  name: renamed\nartifacts: []\n", encoding="utf-8")
+                stat_result = manifest.stat()
+                os.utime(manifest, ns=(stat_result.st_atime_ns, stat_result.st_mtime_ns + 1_000_000_000))
+                status, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"renamed\t{project_root.resolve()}\n")
+        self.assertEqual(read_project_mock.call_count, 2)
+
     def test_projects_list_rejects_unknown_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
@@ -169,6 +252,79 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
+
+    def test_projects_resolve_uses_active_project_manifest_without_workspace_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            base_home = root / "base"
+            base_home.mkdir()
+            project_root = root / "active" / "demo"
+            manifest_path = project_root / "base_manifest.yaml"
+            write_manifest(project_root, "demo")
+
+            with mock.patch(
+                "base_projects.engine.discover_projects_cached",
+                side_effect=AssertionError("workspace scan should not run"),
+            ):
+                status, stdout, stderr = run_engine(
+                    ["resolve", "demo"],
+                    base_home,
+                    extra_env={
+                        "BASE_PROJECT": "demo",
+                        "BASE_PROJECT_MANIFEST": str(manifest_path),
+                    },
+                )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{manifest_path.resolve()}\n")
+
+    def test_projects_resolve_explicit_workspace_wins_over_active_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            base_home = root / "base"
+            base_home.mkdir()
+            active_root = root / "active" / "demo"
+            explicit_workspace = root / "explicit"
+            explicit_root = explicit_workspace / "demo"
+            write_manifest(active_root, "demo")
+            write_manifest(explicit_root, "demo")
+
+            status, stdout, stderr = run_engine(
+                ["resolve", "demo", "--workspace", str(explicit_workspace)],
+                base_home,
+                extra_env={
+                    "BASE_PROJECT": "demo",
+                    "BASE_PROJECT_MANIFEST": str(active_root / "base_manifest.yaml"),
+                },
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{explicit_root.resolve()}\t{(explicit_root / 'base_manifest.yaml').resolve()}\n",
+        )
+
+    def test_projects_resolve_rejects_active_project_manifest_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            base_home = root / "base"
+            base_home.mkdir()
+            project_root = root / "active" / "demo"
+            write_manifest(project_root, "other")
+
+            status, _stdout, stderr = run_engine(
+                ["resolve", "demo"],
+                base_home,
+                extra_env={
+                    "BASE_PROJECT": "demo",
+                    "BASE_PROJECT_MANIFEST": str(project_root / "base_manifest.yaml"),
+                },
+            )
+
+        self.assertEqual(status, 1)
+        self.assertIn("BASE_PROJECT is 'demo' but BASE_PROJECT_MANIFEST points to project 'other'", stderr)
 
     def test_projects_resolve_prefers_configured_workspace_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -410,7 +566,6 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
             with self.assertRaisesRegex(engine.ProjectDiscoveryError, "Duplicate project names"):
                 engine.discover_projects(workspace)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -457,13 +457,20 @@ parent manifest rather than auto-discovering everything.
 
 ### Caching project definitions
 
-A cache for discovered project metadata is premature optimization. The current
-flat workspace scan is a single `readdir` call. Cache invalidation for filesystem
-state — what invalidates the entry: a manifest edit, a new checkout, a `git
-pull` — is harder than the problem it solves. Base already has a cache root
-(`~/Library/Caches/base`) for runtime artifacts; revisit this only after tree
-traversal creates a measured performance problem and a concrete invalidation
-strategy is available.
+Base keeps project discovery flat: it scans direct children of the workspace
+root for `base_manifest.yaml` files instead of traversing repository trees. That
+keeps discovery predictable, but repeated YAML parsing still shows up in
+project-aware commands and shell completion.
+
+The implemented cache is intentionally narrow. Base stores discovered project
+metadata under the runtime cache root in `projects/`, keyed by the resolved
+workspace path. On each discovery run it still checks the immediate workspace
+children, but it reuses cached project names and paths when the manifest path,
+mtime, and size set is unchanged. A new checkout, manifest edit, or manifest
+removal changes that key data and forces a fresh parse.
+
+This cache is an optimization, not an authority. The manifest files remain the
+source of truth, and corrupt or unwritable cache files are ignored.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a lightweight project discovery cache keyed by workspace root and manifest path/mtime/size metadata.
- Reuse cached project names and manifest paths when the workspace manifest set is unchanged, avoiding repeated YAML parsing for project-aware commands and completions.
- Add an activated-shell fast path that resolves the active project directly from `BASE_PROJECT_MANIFEST` when no explicit workspace override is requested.
- Update architecture docs to reflect the narrow cache contract.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_projects/engine.py cli/python/base_projects/tests/test_engine.py`
- `bats cli/bash/commands/basectl/tests/projects.bats cli/bash/commands/basectl/tests/activate.bats cli/bash/commands/basectl/tests/test.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Fixes #334