### PR TITLE
Batch Python artifact installs

### DIFF
--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -151,6 +151,31 @@ def reconcile_artifact(
     raise ArtifactError(f"Artifact manager '{definition.manager}' is not implemented.")
 
 
+def reconcile_artifacts(
+    ctx: base_cli.Context,
+    artifacts: tuple[ArtifactRequest, ...],
+    definitions: tuple[ArtifactDefinition, ...],
+    project: str,
+    dry_run: bool,
+) -> None:
+    pending_python_artifacts: list[tuple[ArtifactDefinition, str]] = []
+
+    def flush_python_artifacts() -> None:
+        nonlocal pending_python_artifacts
+        if not pending_python_artifacts:
+            return
+        reconcile_python_artifacts(ctx, tuple(pending_python_artifacts), project, dry_run=dry_run)
+        pending_python_artifacts = []
+
+    for artifact, definition in zip(artifacts, definitions, strict=True):
+        if definition.manager == "pip":
+            pending_python_artifacts.append((definition, artifact.version))
+            continue
+        flush_python_artifacts()
+        reconcile_artifact(ctx, definition, artifact.version, project, dry_run=dry_run)
+    flush_python_artifacts()
+
+
 def reconcile_homebrew_artifact(
     ctx: base_cli.Context,
     definition: ArtifactDefinition,
@@ -196,26 +221,74 @@ def reconcile_python_artifact(
     project: str,
     dry_run: bool,
 ) -> None:
+    reconcile_python_artifacts(ctx, ((definition, version),), project, dry_run=dry_run)
+
+
+def reconcile_python_artifacts(
+    ctx: base_cli.Context,
+    artifact_definitions: tuple[tuple[ArtifactDefinition, str], ...],
+    project: str,
+    dry_run: bool,
+) -> None:
     venv_dir = project_venv_dir(project)
     python_bin = venv_dir / "bin" / "python"
-    requirement = f"{definition.package}=={version}" if version != "latest" else definition.package
+    missing = []
 
-    if python_artifact_installed(python_bin, definition.package, version):
-        ctx.log.info("Python artifact '%s' is already installed in the project virtual environment.", definition.name)
+    for definition, version in artifact_definitions:
+        if python_artifact_installed(python_bin, definition.package, version):
+            ctx.log.info(
+                "Python artifact '%s' is already installed in the project virtual environment.",
+                definition.name,
+            )
+            continue
+        missing.append((definition, version, python_requirement(definition, version)))
+
+    if not missing:
         return
+
+    requirements = [requirement for _definition, _version, requirement in missing]
 
     if dry_run:
         if not python_bin.exists():
             ctx.log.info("[DRY-RUN] Would create project virtual environment at '%s'.", venv_dir)
-        process.dry_run_command(ctx, [str(python_bin), "-m", "pip", "install", requirement])
+        process.dry_run_command(ctx, [str(python_bin), "-m", "pip", "install", *requirements])
         return
 
     if not python_bin.exists():
         ctx.log.info("Creating project virtual environment at '%s'.", venv_dir)
         venv.create(venv_dir, with_pip=True)
 
-    ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
-    process.run_command(ctx, [str(python_bin), "-m", "pip", "install", requirement])
+    names = ", ".join(definition.name for definition, _version, _requirement in missing)
+    ctx.log.info("Installing Python artifacts into project virtual environment: %s.", names)
+    command = [str(python_bin), "-m", "pip", "install", *requirements]
+    try:
+        process.run_command(ctx, command)
+    except ArtifactError as exc:
+        if len(missing) == 1:
+            raise
+        ctx.log.warning("Batch Python artifact install failed; retrying one artifact at a time.")
+        ctx.log.debug("Batch Python artifact install failed: %s", exc)
+        reconcile_python_artifacts_sequential(ctx, python_bin, missing)
+
+
+def reconcile_python_artifacts_sequential(
+    ctx: base_cli.Context,
+    python_bin: Path,
+    missing: list[tuple[ArtifactDefinition, str, str]],
+) -> None:
+    for definition, version, requirement in missing:
+        if python_artifact_installed(python_bin, definition.package, version):
+            ctx.log.info(
+                "Python artifact '%s' is already installed in the project virtual environment.",
+                definition.name,
+            )
+            continue
+        ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
+        process.run_command(ctx, [str(python_bin), "-m", "pip", "install", requirement])
+
+
+def python_requirement(definition: ArtifactDefinition, version: str) -> str:
+    return f"{definition.package}=={version}" if version != "latest" else definition.package
 
 
 def project_venv_dir(project: str) -> Path:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -10,7 +10,7 @@ from base_cli.paths import discover_manifest
 
 from .artifacts import check_artifact
 from .artifacts import merge_artifacts
-from .artifacts import reconcile_artifact
+from .artifacts import reconcile_artifacts
 from .artifacts import resolve_artifact_definitions
 from .checks import ArtifactCheck
 from .checks import check_to_doctor_json
@@ -158,8 +158,7 @@ def reconcile_manifest(
     reconcile_ide_extensions(ctx, effective_manifest, dry_run=dry_run)
     reconcile_ide_settings(ctx, effective_manifest, dry_run=dry_run)
 
-    for artifact, definition in zip(artifacts, definitions, strict=True):
-        reconcile_artifact(ctx, definition, artifact.version, effective_manifest.project_name, dry_run=dry_run)
+    reconcile_artifacts(ctx, artifacts, definitions, effective_manifest.project_name, dry_run=dry_run)
 
     ctx.log.info("Project '%s' setup is complete.", effective_manifest.project_name)
 
@@ -178,8 +177,7 @@ def reconcile_bootstrap_artifacts(
         ctx.log.info("Base default manifest declares no bootstrap artifacts.")
         return
 
-    for artifact, definition in zip(artifacts, definitions, strict=True):
-        reconcile_artifact(ctx, definition, artifact.version, manifest.project_name, dry_run=dry_run)
+    reconcile_artifacts(ctx, artifacts, definitions, manifest.project_name, dry_run=dry_run)
 
 
 def check_manifest(

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -156,7 +156,7 @@ class ArtifactReconcileTests(unittest.TestCase):
             status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
 
         self.assertEqual(status, 0)
-        self.assertIn("pip install rich", stderr)
+        self.assertIn("pip install click==8.4.1 PyYAML==6.0.3 rich", stderr)
 
 
 
@@ -279,6 +279,82 @@ class ArtifactReconcileTests(unittest.TestCase):
                 artifacts.reconcile_python_artifact(ctx, definition, "latest", "demo", dry_run=True)
 
         project_venv_dir.assert_called_once_with("demo")
+
+    def test_reconcile_artifacts_batches_python_installs(self) -> None:
+        click = get_artifact_definition("python-package", "click")
+        requests = get_artifact_definition("python-package", "requests")
+        self.assertIsNotNone(click)
+        self.assertIsNotNone(requests)
+        ctx = fake_context()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv_dir = Path(tmpdir) / "venv"
+            python_bin = venv_dir / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.touch()
+            with mock.patch(
+                "base_setup.artifacts.project_venv_dir",
+                return_value=venv_dir,
+            ), mock.patch("base_setup.artifacts.python_artifact_installed", return_value=False), mock.patch(
+                "base_setup.process.run_command"
+            ) as run_command:
+                artifacts.reconcile_artifacts(
+                    ctx,
+                    (
+                        ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1"),
+                        ArtifactRequest(artifact_type="python-package", name="requests", version="latest"),
+                    ),
+                    (click, requests),
+                    "demo",
+                    dry_run=False,
+                )
+
+        run_command.assert_called_once_with(
+            ctx,
+            [str(python_bin), "-m", "pip", "install", "click==8.4.1", "requests"],
+        )
+
+    def test_reconcile_artifacts_retries_python_installs_sequentially_after_batch_failure(self) -> None:
+        click = get_artifact_definition("python-package", "click")
+        requests = get_artifact_definition("python-package", "requests")
+        self.assertIsNotNone(click)
+        self.assertIsNotNone(requests)
+        ctx = fake_context()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv_dir = Path(tmpdir) / "venv"
+            python_bin = venv_dir / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.touch()
+            with mock.patch(
+                "base_setup.artifacts.project_venv_dir",
+                return_value=venv_dir,
+            ), mock.patch("base_setup.artifacts.python_artifact_installed", return_value=False), mock.patch(
+                "base_setup.process.run_command",
+                side_effect=[ArtifactError("batch failed"), None, None],
+            ) as run_command:
+                artifacts.reconcile_artifacts(
+                    ctx,
+                    (
+                        ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1"),
+                        ArtifactRequest(artifact_type="python-package", name="requests", version="latest"),
+                    ),
+                    (click, requests),
+                    "demo",
+                    dry_run=False,
+                )
+
+        self.assertEqual(
+            run_command.call_args_list,
+            [
+                mock.call(ctx, [str(python_bin), "-m", "pip", "install", "click==8.4.1", "requests"]),
+                mock.call(ctx, [str(python_bin), "-m", "pip", "install", "click==8.4.1"]),
+                mock.call(ctx, [str(python_bin), "-m", "pip", "install", "requests"]),
+            ],
+        )
+        ctx.log.warning.assert_called_once_with(
+            "Batch Python artifact install failed; retrying one artifact at a time."
+        )
 
 
 

--- a/cli/python/base_setup/tests/test_bootstrap.py
+++ b/cli/python/base_setup/tests/test_bootstrap.py
@@ -30,12 +30,12 @@ class BootstrapManifestTests(unittest.TestCase):
             artifacts=(),
         )
 
-        with mock.patch("base_setup.engine.reconcile_artifact") as reconcile_artifact:
+        with mock.patch("base_setup.engine.reconcile_artifacts") as reconcile_artifacts:
             engine.reconcile_bootstrap_artifacts(ctx, default_manifest, manifest, dry_run=True)
 
-        self.assertEqual(reconcile_artifact.call_count, 1)
-        self.assertEqual(reconcile_artifact.call_args.args[1].name, "click")
-        self.assertEqual(reconcile_artifact.call_args.args[3], "demo")
+        reconcile_artifacts.assert_called_once()
+        self.assertEqual(reconcile_artifacts.call_args.args[1][0].name, "click")
+        self.assertEqual(reconcile_artifacts.call_args.args[3], "demo")
 
 
 


### PR DESCRIPTION
## Summary
- Add a batch artifact reconciler that groups consecutive `python-package` artifacts into a single `pip install` command.
- Keep existing per-artifact installed checks and already-installed logging.
- Retry one artifact at a time when a multi-package pip install fails so failure output remains attributable.
- Extend artifact tests for batched installs and sequential fallback.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_bootstrap.py`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/artifacts.py cli/python/base_setup/engine.py cli/python/base_setup/tests/test_artifacts.py`
- `bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Fixes #336