### PR TITLE
Add manifest schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ root. It declares the project name and the project contracts Base should
 orchestrate:
 
 ```yaml
+schema_version: 1
+
 project:
   name: example
 
@@ -157,6 +159,11 @@ artifacts:
 test:
   command: pytest tests/
 ```
+
+`schema_version` is optional for existing manifests and defaults to `1`. It is
+an integer compatibility marker for the manifest contract, not a Base release
+number. Base rejects manifests with a newer schema version than it understands
+and asks the user to upgrade Base.
 
 The manifest intentionally describes what the project needs, not arbitrary
 commands to execute. Base's direction is delegation-first: use mature tools for
@@ -185,6 +192,8 @@ orchestration layer and let the language-native tools own their usual files.
 Base should see a small manifest contract:
 
 ```yaml
+schema_version: 1
+
 project:
   name: banyanlabs
 

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 project:
   # Project name used by Base for setup logs and the project virtual
   # environment at ~/.base.d/<project>/.venv.

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -267,4 +267,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         ide=effective_ide_config(manifest.ide, user_config),
         mise=manifest.mise,
         test=manifest.test,
+        schema_version=manifest.schema_version,
     )

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -19,6 +19,9 @@ else:
     _yaml_import_error = None
 
 
+CURRENT_MANIFEST_SCHEMA_VERSION = 1
+
+
 class ManifestError(ValueError):
     pass
 
@@ -53,6 +56,7 @@ class BaseManifest:
     ide: dict[str, IdeConfig] = field(default_factory=dict)
     mise: str | None = None
     test: TestConfig | None = None
+    schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -72,11 +76,12 @@ def read_manifest(path: Path) -> BaseManifest:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
-    allowed_top_level = {"project", "brewfile", "mise", "ide", "artifacts", "test"}
+    allowed_top_level = {"schema_version", "project", "brewfile", "mise", "ide", "artifacts", "test"}
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
 
+    schema_version = _read_schema_version(path, data.get("schema_version"))
     project_name = _read_project_name(path, data.get("project"))
     brewfile = _read_brewfile(path, data.get("brewfile"))
     mise = _read_mise(path, data.get("mise"))
@@ -92,7 +97,23 @@ def read_manifest(path: Path) -> BaseManifest:
         ide=ide,
         mise=mise,
         test=test,
+        schema_version=schema_version,
     )
+
+
+def _read_schema_version(path: Path, schema_version_data: Any) -> int:
+    if schema_version_data is None:
+        return CURRENT_MANIFEST_SCHEMA_VERSION
+    if isinstance(schema_version_data, bool) or not isinstance(schema_version_data, int):
+        raise ManifestError(f"{path}: schema_version must be an integer when provided.")
+    if schema_version_data < 1:
+        raise ManifestError(f"{path}: schema_version must be greater than or equal to 1.")
+    if schema_version_data > CURRENT_MANIFEST_SCHEMA_VERSION:
+        raise ManifestError(
+            f"{path}: schema_version {schema_version_data} is newer than supported schema version "
+            f"{CURRENT_MANIFEST_SCHEMA_VERSION}. Upgrade Base to read this manifest."
+        )
+    return schema_version_data
 
 
 def _read_project_name(path: Path, project_data: Any) -> str:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -28,12 +28,104 @@ class ManifestParsingTests(unittest.TestCase):
 
             manifest = read_manifest(manifest_path)
 
+        self.assertEqual(manifest.schema_version, 1)
         self.assertEqual(manifest.project_name, "demo")
         self.assertIsNone(manifest.brewfile)
         self.assertEqual(manifest.artifacts[0].artifact_type, "tool")
         self.assertEqual(manifest.artifacts[0].name, "terraform")
         self.assertEqual(manifest.artifacts[0].version, "1.8.5")
         self.assertFalse(manifest.artifacts[0].bootstrap)
+
+
+
+    def test_reads_manifest_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "schema_version: 1",
+                        "",
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.schema_version, 1)
+
+
+
+    def test_rejects_non_integer_manifest_schema_version(self) -> None:
+        for schema_version in ("true", "1.5", "v1"):
+            with self.subTest(schema_version=schema_version):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                f"schema_version: {schema_version}",
+                                "",
+                                "project:",
+                                "  name: demo",
+                                "",
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaisesRegex(ManifestError, "schema_version must be an integer"):
+                        read_manifest(manifest_path)
+
+
+
+    def test_rejects_manifest_schema_version_below_one(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "schema_version: 0",
+                        "",
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "schema_version must be greater than or equal to 1"):
+                read_manifest(manifest_path)
+
+
+
+    def test_rejects_newer_manifest_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "schema_version: 2",
+                        "",
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "Upgrade Base to read this manifest"):
+                read_manifest(manifest_path)
 
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -325,6 +325,8 @@ File: `base_manifest.yaml`
 Current and planned structure:
 
 ```yaml
+schema_version: 1
+
 project:
   name: myproject
 
@@ -340,6 +342,12 @@ artifacts:
 test:
   command: pytest tests/
 ```
+
+`schema_version` is a manifest compatibility marker. Missing values are treated
+as schema version `1`, which keeps existing project manifests valid. Base rejects
+manifests with a schema version newer than the installed Base understands so
+future team-facing manifest expansion can fail with a clear upgrade message
+instead of ambiguous parser behavior.
 
 The Python layer interprets this declarative manifest and translates it into
 orchestration actions. The design rule is delegation-first:

--- a/docs/base-managed-demo-project.md
+++ b/docs/base-managed-demo-project.md
@@ -30,7 +30,7 @@ manifest `test.command`.
 
 The demo project should include:
 
-- `base_manifest.yaml` with the real project name.
+- `base_manifest.yaml` with `schema_version: 1` and the real project name.
 - a `Brewfile` if it needs Homebrew tools.
 - Python artifacts only when the project actually needs a Base-managed venv.
 - IDE settings or extensions only when they demonstrate a concrete workflow.

--- a/lib/base/default_manifest.yaml
+++ b/lib/base/default_manifest.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 project:
   name: __base_defaults__
 

--- a/lib/base/dev_manifest.yaml
+++ b/lib/base/dev_manifest.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 project:
   name: __base_dev__
 


### PR DESCRIPTION
## Summary
- Add root-level `schema_version` parsing for Base manifests, defaulting absent values to schema version 1.
- Reject invalid schema values and manifests newer than the installed Base supports with clear upgrade guidance.
- Stamp Base-owned manifests with `schema_version: 1` and document the compatibility contract.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_dev/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/manifest.py cli/python/base_setup/engine.py cli/python/base_setup/tests/test_manifest.py`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Fixes #319