### PR TITLE
Add required environment health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ artifacts:
     name: requests
     version: latest
 
+health:
+  required_env:
+    - DATABASE_URL
+    - REDIS_URL
+
 test:
   command: pytest tests/
 ```
@@ -176,6 +181,12 @@ to the project root. When present, `basectl setup` runs
 `brew bundle --file=<project-root>/<brewfile>` before reconciling artifacts. Use
 this for ordinary Homebrew formulae and casks instead of adding every Homebrew
 package to Base's hand-curated artifact registry.
+
+The optional top-level `health.required_env` list declares environment variables
+the project needs in the local shell. `basectl check <project>` and
+`basectl doctor <project>` report whether those variables are present and
+non-empty. Base only checks presence; it never reads, prints, or logs the
+variable values.
 
 Future manifest fields should follow the same rule. A `mise` field causes Base
 to run `mise install` from the project root when a project chooses that

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -22,6 +22,7 @@ from .delegates import check_mise
 from .delegates import reconcile_brewfile
 from .delegates import reconcile_mise
 from .errors import ArtifactError
+from .health import check_required_env
 from .ide import check_ide_extensions
 from .ide import check_ide_installs
 from .ide import check_ide_settings
@@ -239,6 +240,7 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
     if effective_manifest.mise is not None:
         checks.append(check_mise(effective_manifest))
 
+    checks.extend(check_required_env(effective_manifest))
     checks.extend(check_ide_installs(effective_manifest))
     checks.extend(check_ide_extensions(effective_manifest))
     checks.extend(check_ide_settings(effective_manifest))
@@ -268,4 +270,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         mise=manifest.mise,
         test=manifest.test,
         schema_version=manifest.schema_version,
+        health=manifest.health,
     )

--- a/cli/python/base_setup/health.py
+++ b/cli/python/base_setup/health.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+
+from .checks import ArtifactCheck
+from .manifest import BaseManifest
+
+
+def check_required_env(manifest: BaseManifest) -> list[ArtifactCheck]:
+    return [check_required_env_var(env_name) for env_name in manifest.health.required_env]
+
+
+def check_required_env_var(env_name: str) -> ArtifactCheck:
+    if os.environ.get(env_name, ""):
+        return ArtifactCheck(
+            name=env_name,
+            ok=True,
+            message=f"Environment variable '{env_name}' is set.",
+            fix="",
+        )
+    return ArtifactCheck(
+        name=env_name,
+        ok=False,
+        message=f"Environment variable '{env_name}' is not set.",
+        fix=f"Set {env_name} in your shell, .env, or secrets manager.",
+    )

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
@@ -20,6 +21,7 @@ else:
 
 
 CURRENT_MANIFEST_SCHEMA_VERSION = 1
+ENVIRONMENT_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class ManifestError(ValueError):
@@ -48,6 +50,11 @@ class TestConfig:
 
 
 @dataclass(frozen=True)
+class HealthConfig:
+    required_env: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class BaseManifest:
     path: Path
     project_name: str
@@ -57,6 +64,7 @@ class BaseManifest:
     mise: str | None = None
     test: TestConfig | None = None
     schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
+    health: HealthConfig = field(default_factory=HealthConfig)
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -76,7 +84,7 @@ def read_manifest(path: Path) -> BaseManifest:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
-    allowed_top_level = {"schema_version", "project", "brewfile", "mise", "ide", "artifacts", "test"}
+    allowed_top_level = {"schema_version", "project", "brewfile", "mise", "ide", "artifacts", "test", "health"}
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
@@ -87,6 +95,7 @@ def read_manifest(path: Path) -> BaseManifest:
     mise = _read_mise(path, data.get("mise"))
     ide = _read_ide(path, data.get("ide"))
     test = _read_test(path, data.get("test"))
+    health = _read_health(path, data.get("health"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -98,6 +107,7 @@ def read_manifest(path: Path) -> BaseManifest:
         mise=mise,
         test=test,
         schema_version=schema_version,
+        health=health,
     )
 
 
@@ -189,6 +199,43 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
         command=command.strip() if command is not None else None,
         mise=mise.strip() if mise is not None else None,
     )
+
+
+def _read_health(path: Path, health_data: Any) -> HealthConfig:
+    if health_data is None:
+        return HealthConfig()
+    if not isinstance(health_data, dict):
+        raise ManifestError(f"{path}: health must be a mapping when provided.")
+
+    allowed_keys = {"required_env"}
+    unknown_keys = sorted(set(health_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: health has unsupported keys: {', '.join(unknown_keys)}.")
+
+    return HealthConfig(required_env=_read_required_env(path, health_data.get("required_env", [])))
+
+
+def _read_required_env(path: Path, required_env_data: Any) -> tuple[str, ...]:
+    if required_env_data is None:
+        return ()
+    if not isinstance(required_env_data, list):
+        raise ManifestError(f"{path}: health.required_env must be a list when provided.")
+
+    required_env: list[str] = []
+    seen: set[str] = set()
+    for index, env_name_data in enumerate(required_env_data, start=1):
+        if not isinstance(env_name_data, str) or not env_name_data.strip():
+            raise ManifestError(f"{path}: health.required_env[{index}] must be a non-empty string.")
+        env_name = env_name_data.strip()
+        if not ENVIRONMENT_VARIABLE_NAME_RE.fullmatch(env_name):
+            raise ManifestError(
+                f"{path}: health.required_env[{index}] must be a valid environment variable name."
+            )
+        if env_name in seen:
+            raise ManifestError(f"{path}: health.required_env[{index}] duplicates '{env_name}'.")
+        seen.add(env_name)
+        required_env.append(env_name)
+    return tuple(required_env)
 
 
 def _read_ide_config(path: Path, ide_name: str, config_data: Any) -> IdeConfig:

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from unittest import mock
 
 from base_setup import artifacts, checks as setup_checks, engine, ide
-from base_setup.manifest import ArtifactRequest, BaseManifest, IdeConfig, read_manifest
+from base_setup.manifest import ArtifactRequest, BaseManifest, HealthConfig, IdeConfig, read_manifest
 from base_setup.registry import get_artifact_definition
 from base_setup.tests.helpers import fake_context, run_engine
 
@@ -142,6 +142,86 @@ class ProjectCheckTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("warn", stdout.getvalue())
+
+
+
+    def test_check_manifest_reports_required_environment_variables(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            health=HealthConfig(
+                required_env=(
+                    "BASE_TEST_REQUIRED_PRESENT",
+                    "BASE_TEST_REQUIRED_MISSING",
+                )
+            ),
+        )
+
+        with mock.patch.dict(os.environ, {"BASE_TEST_REQUIRED_PRESENT": "super-secret-value"}, clear=False):
+            os.environ.pop("BASE_TEST_REQUIRED_MISSING", None)
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+
+        output = stdout.getvalue()
+        parsed_checks = json.loads(output)
+        self.assertEqual(status, 1)
+        self.assertEqual(
+            [check["name"] for check in parsed_checks],
+            ["BASE_TEST_REQUIRED_PRESENT", "BASE_TEST_REQUIRED_MISSING"],
+        )
+        self.assertTrue(parsed_checks[0]["ok"])
+        self.assertFalse(parsed_checks[1]["ok"])
+        self.assertEqual(
+            parsed_checks[1]["fix"],
+            "Set BASE_TEST_REQUIRED_MISSING in your shell, .env, or secrets manager.",
+        )
+        self.assertNotIn("super-secret-value", output)
+
+
+
+    def test_doctor_manifest_reports_required_environment_variables_without_values(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            health=HealthConfig(
+                required_env=(
+                    "BASE_TEST_DOCTOR_PRESENT",
+                    "BASE_TEST_DOCTOR_MISSING",
+                )
+            ),
+        )
+
+        with mock.patch.dict(os.environ, {"BASE_TEST_DOCTOR_PRESENT": "another-secret-value"}, clear=False):
+            os.environ.pop("BASE_TEST_DOCTOR_MISSING", None)
+            with redirect_stdout(io.StringIO()) as stdout:
+                status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
+
+        output = stdout.getvalue()
+        self.assertEqual(status, 1)
+        self.assertIn("ok", output)
+        self.assertIn("BASE_TEST_DOCTOR_PRESENT", output)
+        self.assertIn("Environment variable 'BASE_TEST_DOCTOR_PRESENT' is set.", output)
+        self.assertIn("error", output)
+        self.assertIn("BASE_TEST_DOCTOR_MISSING", output)
+        self.assertIn("Fix: Set BASE_TEST_DOCTOR_MISSING in your shell, .env, or secrets manager.", output)
+        self.assertNotIn("another-secret-value", output)
 
 
 

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -129,6 +129,61 @@ class ManifestParsingTests(unittest.TestCase):
 
 
 
+    def test_reads_manifest_required_environment_variables(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "health:",
+                        "  required_env:",
+                        "    - DATABASE_URL",
+                        "    - REDIS_URL",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.health.required_env, ("DATABASE_URL", "REDIS_URL"))
+
+
+
+    def test_rejects_invalid_manifest_required_environment_variables(self) -> None:
+        invalid_values = {
+            "scalar": "health:\n  required_env: DATABASE_URL",
+            "empty": "health:\n  required_env:\n    - ''",
+            "non_string": "health:\n  required_env:\n    - 7",
+            "invalid_name": "health:\n  required_env:\n    - DATABASE-URL",
+            "duplicate": "health:\n  required_env:\n    - DATABASE_URL\n    - DATABASE_URL",
+        }
+        for name, health_yaml in invalid_values.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                health_yaml,
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(ManifestError):
+                        read_manifest(manifest_path)
+
+
+
     def test_reads_manifest_brewfile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -339,6 +339,11 @@ artifacts:
     name: requests
     version: latest
 
+health:
+  required_env:
+    - DATABASE_URL
+    - REDIS_URL
+
 test:
   command: pytest tests/
 ```
@@ -365,6 +370,8 @@ orchestration actions. The design rule is delegation-first:
   Projects can declare either `test.command` for a shell command or `test.mise`
   for a `mise run <task>` delegation. Extra arguments after `basectl test
   <project> --` are passed through to the delegated command.
+- Use `health.required_env` for local environment contracts that `basectl check`
+  and `basectl doctor` should validate without exposing secret values.
 - Let Base own the project virtual environment and Base-aware package
   reconciliation.
 - Do not run arbitrary project setup hooks until Base has a clear safety


### PR DESCRIPTION
## Summary
- Add `health.required_env` parsing to Base manifests, including validation for shell-style environment variable names and duplicates.
- Report required environment variables through project `check` and `doctor` findings without reading or logging secret values.
- Document the manifest health contract in the README and architecture guide.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_bootstrap.py`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/manifest.py cli/python/base_setup/health.py cli/python/base_setup/engine.py cli/python/base_setup/tests/test_manifest.py cli/python/base_setup/tests/test_diagnostics.py`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Closes #320