### PR TITLE
Fix basectl gh auth preflight

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -51,11 +51,23 @@ base_gh_require_command() {
 base_gh_require_auth() {
     base_gh_require_command gh || return 1
 
-    gh auth status >/dev/null 2>&1 || {
+    gh auth status -h github.com >/dev/null 2>&1 || {
         base_gh_error "GitHub CLI authentication is not ready."
         base_gh_error "Run 'gh auth login -h github.com' and retry."
         return 1
     }
+}
+
+base_gh_args_request_help() {
+    local arg
+
+    [[ "${1:-}" == "help" ]] && return 0
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) return 0 ;;
+        esac
+    done
+    return 1
 }
 
 base_gh_require_git_repo() {
@@ -141,6 +153,10 @@ base_gh_do_issue() {
 
     case "$command" in
         list)
+            if base_gh_args_request_help "$@"; then
+                base_gh_usage
+                return 0
+            fi
             base_gh_require_auth || return 1
             gh issue list "$@"
             ;;
@@ -263,6 +279,10 @@ base_gh_do_pr() {
 
     case "$command" in
         create)
+            if base_gh_args_request_help "$@"; then
+                base_gh_usage
+                return 0
+            fi
             base_gh_require_auth || return 1
             base_gh_require_git_repo || return 1
             issue="$(base_gh_current_issue_from_branch || true)"
@@ -277,18 +297,34 @@ base_gh_do_pr() {
             gh pr create --fill "$@"
             ;;
         status)
+            if base_gh_args_request_help "$@"; then
+                base_gh_usage
+                return 0
+            fi
             base_gh_require_auth || return 1
             gh pr status "$@"
             ;;
         checks)
+            if base_gh_args_request_help "$@"; then
+                base_gh_usage
+                return 0
+            fi
             base_gh_require_auth || return 1
             gh pr checks "$@"
             ;;
         ready)
+            if base_gh_args_request_help "$@"; then
+                base_gh_usage
+                return 0
+            fi
             base_gh_require_auth || return 1
             gh pr ready "$@"
             ;;
         merge)
+            if base_gh_args_request_help "$@"; then
+                base_gh_usage
+                return 0
+            fi
             base_gh_require_auth || return 1
             gh pr merge "$@"
             ;;

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -16,7 +16,7 @@ load ./basectl_helpers.bash
 @test "basectl gh issue create applies category label and assignee" {
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$*" == "auth status" ]]; then
+if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
@@ -38,10 +38,35 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Repair branch pruning --label bug --assignee codeforester" ]
 }
 
+@test "basectl gh issue create help does not require authentication" {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 99
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue create --help
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl gh issue create"* ]]
+    [[ "$output" != *"GitHub CLI authentication is not ready."* ]]
+    [[ "$output" != *"unexpected gh args"* ]]
+}
+
 @test "basectl gh issue list reports missing gh authentication clearly" {
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$*" == "auth status" ]]; then
+if [[ "$*" == "auth status -h github.com" ]]; then
     exit 1
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -75,7 +100,7 @@ EOF
 
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$*" == "auth status" ]]; then
+if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
 if [[ "$*" == "issue view 117 --json labels --jq .labels[].name | select(. == \"bug\" or . == \"enhancement\" or . == \"documentation\" or . == \"ci\" or . == \"security\")" ]]; then
@@ -189,7 +214,7 @@ EOF
 
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$*" == "auth status" ]]; then
+if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
@@ -220,6 +245,31 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$(cat "$TEST_STATE_DIR/gh-args")" == pr\ create\ --fill\ --body-file* ]]
     [ "$(cat "$TEST_STATE_DIR/body")" = "Fixes #117" ]
+}
+
+@test "basectl gh pr create help does not require authentication" {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 99
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main pr create --help
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl gh pr create"* ]]
+    [[ "$output" != *"GitHub CLI authentication is not ready."* ]]
+    [[ "$output" != *"unexpected gh args"* ]]
 }
 
 @test "basectl gh todo import dry-run classifies TODO items" {


### PR DESCRIPTION
## Summary
- Let `basectl gh` help paths return usage without running GitHub authentication preflight.
- Target the auth readiness check at `github.com` with `gh auth status -h github.com` for real GitHub operations.
- Add BATS coverage for help-only paths and authenticated/unauthenticated gh wrapper behavior.

## Validation
- `bats cli/bash/commands/basectl/tests/gh.bats`
- `bash -n cli/bash/commands/basectl/subcommands/gh.sh`
- `bin/basectl gh issue create --help`
- `bin/basectl gh pr create --help`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Fixes #351