### PR TITLE
Add project activation startup hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ health:
     - DATABASE_URL
     - REDIS_URL
 
+activate:
+  source:
+    - .base/activate.sh
+
 test:
   command: pytest tests/
 
@@ -194,6 +198,12 @@ the project needs in the local shell. `basectl check <project>` and
 `basectl doctor <project>` report whether those variables are present and
 non-empty. Base only checks presence; it never reads, prints, or logs the
 variable values.
+
+The optional top-level `activate.source` list declares project-root-relative
+shell scripts to source when `basectl activate <project>` starts the runtime
+shell. Base sources those scripts after the Base runtime and project virtual
+environment are ready, rejects paths outside the project root, reports missing
+scripts clearly, and logs only the sourced script path.
 
 Future manifest fields should follow the same rule. A `mise` field causes Base
 to run `mise install` from the project root when a project chooses that
@@ -357,8 +367,9 @@ basectl activate example
 Activation spawns a project-specific subshell, changes to the project root, sets
 `BASE_PROJECT` and related project variables, adds project-owned commands from
 `$PROJECT_ROOT/bin` when that directory exists, and activates the project
-virtual environment at `~/.base.d/<project>/.venv`. Exit that shell to return to
-the original environment.
+virtual environment at `~/.base.d/<project>/.venv`. If the manifest declares
+`activate.source`, Base then sources each declared script in order. Exit that
+shell to return to the original environment.
 
 Use `basectl activate example --no-cd` to keep the caller's current directory
 while still loading the selected project's Base runtime environment.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ health:
     - DATABASE_URL
     - REDIS_URL
 
+activate:
+  source:
+    - .base/activate.sh
+
 test:
   command: pytest tests/
 ```
@@ -187,6 +191,12 @@ the project needs in the local shell. `basectl check <project>` and
 `basectl doctor <project>` report whether those variables are present and
 non-empty. Base only checks presence; it never reads, prints, or logs the
 variable values.
+
+The optional top-level `activate.source` list declares project-root-relative
+shell scripts to source when `basectl activate <project>` starts the runtime
+shell. Base sources those scripts after the Base runtime and project virtual
+environment are ready, rejects paths outside the project root, reports missing
+scripts clearly, and logs only the sourced script path.
 
 Future manifest fields should follow the same rule. A `mise` field causes Base
 to run `mise install` from the project root when a project chooses that
@@ -309,8 +319,9 @@ basectl activate example
 Activation spawns a project-specific subshell, changes to the project root, sets
 `BASE_PROJECT` and related project variables, adds project-owned commands from
 `$PROJECT_ROOT/bin` when that directory exists, and activates the project
-virtual environment at `~/.base.d/<project>/.venv`. Exit that shell to return to
-the original environment.
+virtual environment at `~/.base.d/<project>/.venv`. If the manifest declares
+`activate.source`, Base then sources each declared script in order. Exit that
+shell to return to the original environment.
 
 Use `basectl activate example --no-cd` to keep the caller's current directory
 while still loading the selected project's Base runtime environment.

--- a/cli/bash/commands/basectl/tests/runtime-shell.bats
+++ b/cli/bash/commands/basectl/tests/runtime-shell.bats
@@ -74,6 +74,91 @@ EOF
     [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 
+@test "Base runtime shell sources manifest-declared project activation scripts" {
+    local project_root="$TEST_TMPDIR/demo"
+    local venv_dir="$TEST_TMPDIR/demo-venv"
+    local activation_script="$project_root/.base/activate.sh"
+
+    mkdir -p "$project_root/.base" "$venv_dir/bin"
+    cat > "$venv_dir/bin/activate" <<'EOF'
+VIRTUAL_ENV="$BASE_PROJECT_VENV_DIR"
+export VIRTUAL_ENV
+EOF
+    cat > "$venv_dir/bin/python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
+    printf '%s\n' "${BASE_TEST_ACTIVATION_SOURCE:?}"
+    exit 0
+fi
+printf 'unexpected base_projects args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$activation_script" <<'EOF'
+export PROJECT_ACTIVATION_PROJECT="$BASE_PROJECT"
+export PROJECT_ACTIVATION_VENV="$VIRTUAL_ENV"
+project_activation_function() {
+    printf '%s:%s\n' "$PROJECT_ACTIVATION_PROJECT" "$PROJECT_ACTIVATION_VENV"
+}
+EOF
+    chmod +x "$venv_dir/bin/python"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_PROJECT=demo \
+        BASE_PROJECT_ROOT="$project_root" \
+        BASE_PROJECT_MANIFEST="$project_root/base_manifest.yaml" \
+        BASE_PROJECT_VENV_DIR="$venv_dir" \
+        BASE_TEST_ACTIVATION_SOURCE="$activation_script" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            printf "PROJECT_ACTIVATION_PROJECT=%s\n" "${PROJECT_ACTIVATION_PROJECT:-}"; \
+            printf "PROJECT_ACTIVATION_VENV=%s\n" "${PROJECT_ACTIVATION_VENV:-}"; \
+            project_activation_function'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"INFO: Sourcing project activation script '$activation_script'."* ]]
+    [[ "$output" == *"PROJECT_ACTIVATION_PROJECT=demo"* ]]
+    [[ "$output" == *"PROJECT_ACTIVATION_VENV=$venv_dir"* ]]
+    [[ "$output" == *"demo:$venv_dir"* ]]
+}
+
+@test "Base runtime shell reports activation source resolution failures clearly" {
+    local project_root="$TEST_TMPDIR/demo"
+    local venv_dir="$TEST_TMPDIR/demo-venv"
+
+    mkdir -p "$project_root" "$venv_dir/bin"
+    cat > "$venv_dir/bin/activate" <<'EOF'
+VIRTUAL_ENV="$BASE_PROJECT_VENV_DIR"
+export VIRTUAL_ENV
+EOF
+    cat > "$venv_dir/bin/python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
+    printf 'ERROR: %s: activate.source[1] script %q does not exist.\n' "$BASE_PROJECT_MANIFEST" ".base/missing.sh" >&2
+    exit 1
+fi
+printf 'unexpected base_projects args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$venv_dir/bin/python"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_PROJECT=demo \
+        BASE_PROJECT_ROOT="$project_root" \
+        BASE_PROJECT_MANIFEST="$project_root/base_manifest.yaml" \
+        BASE_PROJECT_VENV_DIR="$venv_dir" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c 'printf "shell-continued\n"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"activate.source[1]"* ]]
+    [[ "$output" == *".base/missing.sh"* ]]
+    [[ "$output" == *"ERROR: Unable to resolve project activation scripts for 'demo'."* ]]
+}
+
 @test "Base runtime shell loads base_init before user bashrc and owns final prompt" {
     cat > "$TEST_HOME/.bashrc" <<'EOF'
 alias user_bashrc_alias='printf user-bashrc'

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -72,6 +72,7 @@ def dispatch_projects_command(
         "manifest": lambda: manifest_project_from_args(ctx, command_arguments),
         "resolve": lambda: resolve_project_from_args(ctx, command_arguments, workspace),
         "test-command": lambda: test_command_project_from_args(ctx, command_arguments, workspace),
+        "activation-sources": lambda: activation_sources_project_from_args(ctx, command_arguments, workspace),
         "run-command": lambda: run_command_project_from_args(ctx, command_arguments, workspace),
         "run-commands": lambda: list_run_commands_from_args(ctx, command_arguments, workspace),
     }
@@ -81,7 +82,7 @@ def dispatch_projects_command(
 
     ctx.log.error(
         "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
-        "test-command, run-command, run-commands.",
+        "test-command, activation-sources, run-command, run-commands.",
         command,
     )
     return 2
@@ -131,6 +132,15 @@ def resolve_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...],
 def test_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
     project = optional_project_argument("test-command", arguments)
     return test_command_project_command(ctx, project, workspace)
+
+
+def activation_sources_project_from_args(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    workspace: str | None,
+) -> int:
+    require_argument_count("activation-sources", arguments, 1, 1)
+    return activation_sources_project_command(ctx, arguments[0], workspace)
 
 
 def run_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
@@ -204,6 +214,24 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
         return 1
 
     print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{test_command(manifest.test)}")
+    return 0
+
+
+def activation_sources_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+
+    try:
+        project = resolve_named_project(ctx, project_name, workspace)
+        manifest = read_manifest(project.manifest_path)
+        sources = activation_source_paths(project, manifest.activate.source)
+    except (ProjectDiscoveryError, ManifestError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    for source in sources:
+        print(source)
     return 0
 
 
@@ -304,6 +332,37 @@ def project_command(manifest: BaseManifest, command_name: str) -> str:
         raise ProjectCommandError(
             f"Project '{manifest.project_name}' does not declare command '{command_name}' in '{manifest.path}'."
         ) from exc
+
+
+def activation_source_paths(project: Project, source_paths: tuple[str, ...]) -> tuple[Path, ...]:
+    return tuple(
+        resolve_activation_source_path(project, source_path, index)
+        for index, source_path in enumerate(source_paths, start=1)
+    )
+
+
+def resolve_activation_source_path(project: Project, source_path: str, index: int) -> Path:
+    field = f"activate.source[{index}]"
+    project_root = project.root.resolve()
+    declared_path = Path(source_path)
+    if declared_path.is_absolute():
+        raise ProjectDiscoveryError(
+            f"{project.manifest_path}: {field} must be a relative path inside the project root."
+        )
+
+    candidate = (project_root / declared_path).resolve()
+    try:
+        candidate.relative_to(project_root)
+    except ValueError as exc:
+        raise ProjectDiscoveryError(
+            f"{project.manifest_path}: {field} resolves outside the project root: {source_path}."
+        ) from exc
+
+    if not candidate.exists():
+        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' does not exist.")
+    if not candidate.is_file():
+        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' is not a file.")
+    return candidate
 
 
 def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -55,17 +55,21 @@ def run(
 ) -> int:
     if command in (None, "list"):
         return list_projects_command(ctx, workspace, output_format)
-    if command == "current":
-        return current_project_command(ctx)
-    if command == "manifest":
-        return manifest_project_command(ctx, project)
-    if command == "resolve":
-        return resolve_project_command(ctx, project, workspace)
-    if command == "test-command":
-        return test_command_project_command(ctx, project, workspace)
+
+    command_handlers = {
+        "current": lambda: current_project_command(ctx),
+        "manifest": lambda: manifest_project_command(ctx, project),
+        "resolve": lambda: resolve_project_command(ctx, project, workspace),
+        "activation-sources": lambda: activation_sources_project_command(ctx, project, workspace),
+        "test-command": lambda: test_command_project_command(ctx, project, workspace),
+    }
+    handler = command_handlers.get(command)
+    if handler is not None:
+        return handler()
 
     ctx.log.error(
-        "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, test-command.",
+        "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
+        "activation-sources, test-command.",
         command,
     )
     return 2
@@ -135,6 +139,24 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
     return 0
 
 
+def activation_sources_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+
+    try:
+        project = resolve_named_project(ctx, project_name, workspace)
+        manifest = read_manifest(project.manifest_path)
+        sources = activation_source_paths(project, manifest.activate.source)
+    except (ProjectDiscoveryError, ManifestError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    for source in sources:
+        print(source)
+    return 0
+
+
 def current_project_command(ctx: base_cli.Context) -> int:
     try:
         project = current_project()
@@ -160,6 +182,37 @@ def test_command(test_config: TestConfig) -> str:
     if test_config.mise is not None:
         return shlex.join(["mise", "run", test_config.mise])
     raise ValueError("TestConfig must have command or mise set.")
+
+
+def activation_source_paths(project: Project, source_paths: tuple[str, ...]) -> tuple[Path, ...]:
+    return tuple(
+        resolve_activation_source_path(project, source_path, index)
+        for index, source_path in enumerate(source_paths, start=1)
+    )
+
+
+def resolve_activation_source_path(project: Project, source_path: str, index: int) -> Path:
+    field = f"activate.source[{index}]"
+    project_root = project.root.resolve()
+    declared_path = Path(source_path)
+    if declared_path.is_absolute():
+        raise ProjectDiscoveryError(
+            f"{project.manifest_path}: {field} must be a relative path inside the project root."
+        )
+
+    candidate = (project_root / declared_path).resolve()
+    try:
+        candidate.relative_to(project_root)
+    except ValueError as exc:
+        raise ProjectDiscoveryError(
+            f"{project.manifest_path}: {field} resolves outside the project root: {source_path}."
+        ) from exc
+
+    if not candidate.exists():
+        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' does not exist.")
+    if not candidate.is_file():
+        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' is not a file.")
+    return candidate
 
 
 def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -38,6 +38,15 @@ def write_mise_test_manifest(project_root: Path, name: str, task: str) -> None:
     )
 
 
+def write_activation_manifest(project_root: Path, name: str, sources: list[str]) -> None:
+    project_root.mkdir(parents=True)
+    source_lines = "\n".join(f"    - {source}" for source in sources)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\nactivate:\n  source:\n{source_lines}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
 def invoke_engine(
     args: list[str],
     base_home: Path,
@@ -428,6 +437,100 @@ class ProjectDiscoveryTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tmise run unit\n",
         )
+
+    def test_projects_activation_sources_prints_validated_source_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            first_source = project_root / ".base" / "activate.sh"
+            second_source = project_root / "scripts" / "local-env.sh"
+            write_activation_manifest(project_root, "demo", [".base/activate.sh", "scripts/local-env.sh"])
+            first_source.parent.mkdir()
+            second_source.parent.mkdir()
+            first_source.write_text("export DEMO=1\n", encoding="utf-8")
+            second_source.write_text("export LOCAL_ENV=1\n", encoding="utf-8")
+
+            status, stdout, stderr = run_engine(["activation-sources", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"{first_source.resolve()}\n{second_source.resolve()}\n")
+
+    def test_projects_activation_sources_uses_active_project_manifest_without_workspace_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            base_home = root / "base"
+            base_home.mkdir()
+            project_root = root / "active" / "demo"
+            activation_script = project_root / ".base" / "activate.sh"
+            write_activation_manifest(project_root, "demo", [".base/activate.sh"])
+            activation_script.parent.mkdir()
+            activation_script.write_text("export DEMO=1\n", encoding="utf-8")
+
+            with mock.patch(
+                "base_projects.engine.discover_projects_cached",
+                side_effect=AssertionError("workspace scan should not run"),
+            ):
+                status, stdout, stderr = run_engine(
+                    ["activation-sources", "demo"],
+                    base_home,
+                    extra_env={
+                        "BASE_PROJECT": "demo",
+                        "BASE_PROJECT_MANIFEST": str(project_root / "base_manifest.yaml"),
+                    },
+                )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"{activation_script.resolve()}\n")
+
+    def test_projects_activation_sources_supports_empty_manifest_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(["activation-sources", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, "")
+
+    def test_projects_activation_sources_rejects_unsafe_paths(self) -> None:
+        cases = {
+            "absolute": ("/tmp/base-activate.sh", "must be a relative path"),
+            "outside": ("../outside.sh", "resolves outside the project root"),
+            "missing": ("missing.sh", "does not exist"),
+            "directory": ("scripts", "is not a file"),
+        }
+        for name, (source_path, expected_error) in cases.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    workspace = Path(tmpdir)
+                    base_home = workspace / "base"
+                    base_home.mkdir()
+                    project_root = workspace / "demo"
+                    write_activation_manifest(project_root, "demo", [source_path])
+                    if name == "directory":
+                        (project_root / "scripts").mkdir()
+
+                    status, _stdout, stderr = run_engine(["activation-sources", "demo"], base_home)
+
+                self.assertEqual(status, 1)
+                self.assertIn(expected_error, stderr)
+
+    def test_projects_activation_sources_requires_project_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_home = Path(tmpdir) / "base"
+            base_home.mkdir()
+
+            status, _stdout, stderr = run_engine(["activation-sources"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertIn("Project name is required", stderr)
 
     def test_test_command_rejects_invalid_config_without_assert(self) -> None:
         with self.assertRaisesRegex(ValueError, "TestConfig must have command or mise set"):

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -57,6 +57,15 @@ def write_commands_manifest(project_root: Path, name: str) -> None:
     )
 
 
+def write_activation_manifest(project_root: Path, name: str, sources: list[str]) -> None:
+    project_root.mkdir(parents=True)
+    source_lines = "\n".join(f"    - {source}" for source in sources)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\nactivate:\n  source:\n{source_lines}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
 def invoke_engine(
     args: list[str],
     base_home: Path,
@@ -447,6 +456,100 @@ class ProjectDiscoveryTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tmise run unit\n",
         )
+
+    def test_projects_activation_sources_prints_validated_source_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            first_source = project_root / ".base" / "activate.sh"
+            second_source = project_root / "scripts" / "local-env.sh"
+            write_activation_manifest(project_root, "demo", [".base/activate.sh", "scripts/local-env.sh"])
+            first_source.parent.mkdir()
+            second_source.parent.mkdir()
+            first_source.write_text("export DEMO=1\n", encoding="utf-8")
+            second_source.write_text("export LOCAL_ENV=1\n", encoding="utf-8")
+
+            status, stdout, stderr = run_engine(["activation-sources", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"{first_source.resolve()}\n{second_source.resolve()}\n")
+
+    def test_projects_activation_sources_uses_active_project_manifest_without_workspace_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            base_home = root / "base"
+            base_home.mkdir()
+            project_root = root / "active" / "demo"
+            activation_script = project_root / ".base" / "activate.sh"
+            write_activation_manifest(project_root, "demo", [".base/activate.sh"])
+            activation_script.parent.mkdir()
+            activation_script.write_text("export DEMO=1\n", encoding="utf-8")
+
+            with mock.patch(
+                "base_projects.engine.discover_projects_cached",
+                side_effect=AssertionError("workspace scan should not run"),
+            ):
+                status, stdout, stderr = run_engine(
+                    ["activation-sources", "demo"],
+                    base_home,
+                    extra_env={
+                        "BASE_PROJECT": "demo",
+                        "BASE_PROJECT_MANIFEST": str(project_root / "base_manifest.yaml"),
+                    },
+                )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"{activation_script.resolve()}\n")
+
+    def test_projects_activation_sources_supports_empty_manifest_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(["activation-sources", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, "")
+
+    def test_projects_activation_sources_rejects_unsafe_paths(self) -> None:
+        cases = {
+            "absolute": ("/tmp/base-activate.sh", "must be a relative path"),
+            "outside": ("../outside.sh", "resolves outside the project root"),
+            "missing": ("missing.sh", "does not exist"),
+            "directory": ("scripts", "is not a file"),
+        }
+        for name, (source_path, expected_error) in cases.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    workspace = Path(tmpdir)
+                    base_home = workspace / "base"
+                    base_home.mkdir()
+                    project_root = workspace / "demo"
+                    write_activation_manifest(project_root, "demo", [source_path])
+                    if name == "directory":
+                        (project_root / "scripts").mkdir()
+
+                    status, _stdout, stderr = run_engine(["activation-sources", "demo"], base_home)
+
+                self.assertEqual(status, 1)
+                self.assertIn(expected_error, stderr)
+
+    def test_projects_activation_sources_requires_project_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_home = Path(tmpdir) / "base"
+            base_home.mkdir()
+
+        status, _stdout, stderr = run_engine(["activation-sources"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertIn("Project command 'activation-sources' requires at least 1 argument", stderr)
 
     def test_test_command_rejects_invalid_config_without_assert(self) -> None:
         with self.assertRaisesRegex(ValueError, "TestConfig must have command or mise set"):

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -271,4 +271,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         test=manifest.test,
         schema_version=manifest.schema_version,
         health=manifest.health,
+        activate=manifest.activate,
     )

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -272,4 +272,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         schema_version=manifest.schema_version,
         health=manifest.health,
         commands=manifest.commands,
+        activate=manifest.activate,
     )

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -55,6 +55,11 @@ class HealthConfig:
 
 
 @dataclass(frozen=True)
+class ActivateConfig:
+    source: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class BaseManifest:
     path: Path
     project_name: str
@@ -65,6 +70,7 @@ class BaseManifest:
     test: TestConfig | None = None
     schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
     health: HealthConfig = field(default_factory=HealthConfig)
+    activate: ActivateConfig = field(default_factory=ActivateConfig)
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -84,7 +90,17 @@ def read_manifest(path: Path) -> BaseManifest:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
-    allowed_top_level = {"schema_version", "project", "brewfile", "mise", "ide", "artifacts", "test", "health"}
+    allowed_top_level = {
+        "schema_version",
+        "project",
+        "brewfile",
+        "mise",
+        "ide",
+        "artifacts",
+        "test",
+        "health",
+        "activate",
+    }
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
@@ -96,6 +112,7 @@ def read_manifest(path: Path) -> BaseManifest:
     ide = _read_ide(path, data.get("ide"))
     test = _read_test(path, data.get("test"))
     health = _read_health(path, data.get("health"))
+    activate = _read_activate(path, data.get("activate"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -108,6 +125,7 @@ def read_manifest(path: Path) -> BaseManifest:
         test=test,
         schema_version=schema_version,
         health=health,
+        activate=activate,
     )
 
 
@@ -213,6 +231,41 @@ def _read_health(path: Path, health_data: Any) -> HealthConfig:
         raise ManifestError(f"{path}: health has unsupported keys: {', '.join(unknown_keys)}.")
 
     return HealthConfig(required_env=_read_required_env(path, health_data.get("required_env", [])))
+
+
+def _read_activate(path: Path, activate_data: Any) -> ActivateConfig:
+    if activate_data is None:
+        return ActivateConfig()
+    if not isinstance(activate_data, dict):
+        raise ManifestError(f"{path}: activate must be a mapping when provided.")
+
+    allowed_keys = {"source"}
+    unknown_keys = sorted(set(activate_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: activate has unsupported keys: {', '.join(unknown_keys)}.")
+
+    return ActivateConfig(source=_read_activate_sources(path, activate_data.get("source", [])))
+
+
+def _read_activate_sources(path: Path, source_data: Any) -> tuple[str, ...]:
+    if source_data is None:
+        return ()
+    if not isinstance(source_data, list):
+        raise ManifestError(f"{path}: activate.source must be a list when provided.")
+
+    sources: list[str] = []
+    seen: set[str] = set()
+    for index, source_path_data in enumerate(source_data, start=1):
+        if not isinstance(source_path_data, str) or not source_path_data.strip():
+            raise ManifestError(f"{path}: activate.source[{index}] must be a non-empty string.")
+        source_path = source_path_data.strip()
+        if any(separator in source_path for separator in ("\0", "\n", "\r")):
+            raise ManifestError(f"{path}: activate.source[{index}] must not contain control line breaks.")
+        if source_path in seen:
+            raise ManifestError(f"{path}: activate.source[{index}] duplicates '{source_path}'.")
+        seen.add(source_path)
+        sources.append(source_path)
+    return tuple(sources)
 
 
 def _read_required_env(path: Path, required_env_data: Any) -> tuple[str, ...]:

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -56,6 +56,11 @@ class HealthConfig:
 
 
 @dataclass(frozen=True)
+class ActivateConfig:
+    source: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class BaseManifest:
     path: Path
     project_name: str
@@ -67,6 +72,7 @@ class BaseManifest:
     schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
     health: HealthConfig = field(default_factory=HealthConfig)
     commands: dict[str, str] = field(default_factory=dict)
+    activate: ActivateConfig = field(default_factory=ActivateConfig)
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -96,6 +102,7 @@ def read_manifest(path: Path) -> BaseManifest:
         "test",
         "health",
         "commands",
+        "activate",
     }
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
@@ -109,6 +116,7 @@ def read_manifest(path: Path) -> BaseManifest:
     test = _read_test(path, data.get("test"))
     health = _read_health(path, data.get("health"))
     commands = _read_commands(path, data.get("commands"))
+    activate = _read_activate(path, data.get("activate"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -122,6 +130,7 @@ def read_manifest(path: Path) -> BaseManifest:
         schema_version=schema_version,
         health=health,
         commands=commands,
+        activate=activate,
     )
 
 
@@ -250,6 +259,41 @@ def _read_commands(path: Path, commands_data: Any) -> dict[str, str]:
             raise ManifestError(f"{path}: commands.{command_name} must be a non-empty string.")
         commands[command_name] = command_data.strip()
     return commands
+
+
+def _read_activate(path: Path, activate_data: Any) -> ActivateConfig:
+    if activate_data is None:
+        return ActivateConfig()
+    if not isinstance(activate_data, dict):
+        raise ManifestError(f"{path}: activate must be a mapping when provided.")
+
+    allowed_keys = {"source"}
+    unknown_keys = sorted(set(activate_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: activate has unsupported keys: {', '.join(unknown_keys)}.")
+
+    return ActivateConfig(source=_read_activate_sources(path, activate_data.get("source", [])))
+
+
+def _read_activate_sources(path: Path, source_data: Any) -> tuple[str, ...]:
+    if source_data is None:
+        return ()
+    if not isinstance(source_data, list):
+        raise ManifestError(f"{path}: activate.source must be a list when provided.")
+
+    sources: list[str] = []
+    seen: set[str] = set()
+    for index, source_path_data in enumerate(source_data, start=1):
+        if not isinstance(source_path_data, str) or not source_path_data.strip():
+            raise ManifestError(f"{path}: activate.source[{index}] must be a non-empty string.")
+        source_path = source_path_data.strip()
+        if any(separator in source_path for separator in ("\0", "\n", "\r")):
+            raise ManifestError(f"{path}: activate.source[{index}] must not contain control line breaks.")
+        if source_path in seen:
+            raise ManifestError(f"{path}: activate.source[{index}] duplicates '{source_path}'.")
+        seen.add(source_path)
+        sources.append(source_path)
+    return tuple(sources)
 
 
 def _read_required_env(path: Path, required_env_data: Any) -> tuple[str, ...]:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -35,6 +35,7 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.artifacts[0].name, "terraform")
         self.assertEqual(manifest.artifacts[0].version, "1.8.5")
         self.assertFalse(manifest.artifacts[0].bootstrap)
+        self.assertEqual(manifest.activate.source, ())
 
 
 
@@ -152,6 +153,63 @@ class ManifestParsingTests(unittest.TestCase):
             manifest = read_manifest(manifest_path)
 
         self.assertEqual(manifest.health.required_env, ("DATABASE_URL", "REDIS_URL"))
+
+
+
+    def test_reads_manifest_activation_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "activate:",
+                        "  source:",
+                        "    - .base/activate.sh",
+                        "    - scripts/local-env.sh",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.activate.source, (".base/activate.sh", "scripts/local-env.sh"))
+
+
+
+    def test_rejects_invalid_manifest_activation_sources(self) -> None:
+        invalid_values = {
+            "scalar_activate": "activate: .base/activate.sh",
+            "unknown_key": "activate:\n  run:\n    - .base/activate.sh",
+            "scalar_source": "activate:\n  source: .base/activate.sh",
+            "empty": "activate:\n  source:\n    - ''",
+            "non_string": "activate:\n  source:\n    - 7",
+            "duplicate": "activate:\n  source:\n    - .base/activate.sh\n    - .base/activate.sh",
+            "newline": "activate:\n  source:\n    - \"scripts/env\\n.sh\"",
+        }
+        for name, activate_yaml in invalid_values.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                activate_yaml,
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(ManifestError):
+                        read_manifest(manifest_path)
 
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,11 +119,12 @@ basectl activate myproject
 2. Validate myproject exists and has a valid manifest
 3. Set BASE_PROJECT=myproject
 4. Spawn a new subshell
-5. In the subshell: source the project's shell environment script
+5. In the subshell: load the Base runtime and user Bash startup with guardrails
 6. In the subshell: activate the project's Python virtual environment
-7. Update the prompt to reflect the active project
-8. User works in subshell
-9. User exits → returns to base shell, prompt resets
+7. In the subshell: source manifest-declared activate.source scripts
+8. Update the prompt to reflect the active project
+9. User works in subshell
+10. User exits → returns to base shell, prompt resets
 ```
 
 ### `basectl activate` — Intelligence
@@ -182,6 +183,7 @@ Contains:
 - Project-specific environment variables
 - Project-specific aliases and functions
 - Project-specific Python virtual environment activation
+- Manifest-declared `activate.source` scripts
 - `BASE_PROJECT` updated to the project name
 
 Project-specific settings layer on top of the Base runtime environment. Settings
@@ -344,6 +346,10 @@ health:
     - DATABASE_URL
     - REDIS_URL
 
+activate:
+  source:
+    - .base/activate.sh
+
 test:
   command: pytest tests/
 
@@ -381,11 +387,15 @@ orchestration actions. The design rule is delegation-first:
   top-level `test` contract.
 - Use `health.required_env` for local environment contracts that `basectl check`
   and `basectl doctor` should validate without exposing secret values.
+- Use `activate.source` for explicit project activation scripts that need to
+  affect the interactive runtime shell, such as local environment loading,
+  aliases, or functions. Source paths must be relative to the project root and
+  must resolve inside that root.
 - Let Base own the project virtual environment and Base-aware package
   reconciliation.
 - Do not run arbitrary project setup hooks until Base has a clear safety
-  contract for execution timing, dry-run behavior, interactivity, and
-  diagnostics. See [setup-hooks.md](setup-hooks.md) for the current no-hooks
+  contract for dry-run behavior, interactivity, setup diagnostics, and broader
+  side effects. See [setup-hooks.md](setup-hooks.md) for the setup no-hooks
   decision and future reconsideration criteria.
 
 Base owns the curated tool artifact registry only for things it must manage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,11 +119,12 @@ basectl activate myproject
 2. Validate myproject exists and has a valid manifest
 3. Set BASE_PROJECT=myproject
 4. Spawn a new subshell
-5. In the subshell: source the project's shell environment script
+5. In the subshell: load the Base runtime and user Bash startup with guardrails
 6. In the subshell: activate the project's Python virtual environment
-7. Update the prompt to reflect the active project
-8. User works in subshell
-9. User exits → returns to base shell, prompt resets
+7. In the subshell: source manifest-declared activate.source scripts
+8. Update the prompt to reflect the active project
+9. User works in subshell
+10. User exits → returns to base shell, prompt resets
 ```
 
 ### `basectl activate` — Intelligence
@@ -182,6 +183,7 @@ Contains:
 - Project-specific environment variables
 - Project-specific aliases and functions
 - Project-specific Python virtual environment activation
+- Manifest-declared `activate.source` scripts
 - `BASE_PROJECT` updated to the project name
 
 Project-specific settings layer on top of the Base runtime environment. Settings
@@ -344,6 +346,10 @@ health:
     - DATABASE_URL
     - REDIS_URL
 
+activate:
+  source:
+    - .base/activate.sh
+
 test:
   command: pytest tests/
 ```
@@ -372,11 +378,15 @@ orchestration actions. The design rule is delegation-first:
   <project> --` are passed through to the delegated command.
 - Use `health.required_env` for local environment contracts that `basectl check`
   and `basectl doctor` should validate without exposing secret values.
+- Use `activate.source` for explicit project activation scripts that need to
+  affect the interactive runtime shell, such as local environment loading,
+  aliases, or functions. Source paths must be relative to the project root and
+  must resolve inside that root.
 - Let Base own the project virtual environment and Base-aware package
   reconciliation.
 - Do not run arbitrary project setup hooks until Base has a clear safety
-  contract for execution timing, dry-run behavior, interactivity, and
-  diagnostics. See [setup-hooks.md](setup-hooks.md) for the current no-hooks
+  contract for dry-run behavior, interactivity, setup diagnostics, and broader
+  side effects. See [setup-hooks.md](setup-hooks.md) for the setup no-hooks
   decision and future reconsideration criteria.
 
 Base owns the curated tool artifact registry only for things it must manage

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -196,10 +196,11 @@ $BASE_HOME/lib/bash/runtime/bashrc
 ```
 
 The runtime rcfile sources `base_init.sh`, sources the user's `~/.bashrc` once
-with guardrails, and then sets the Base runtime prompt. This gives the user their
-normal interactive Bash behavior while also making Base stdlib functions such as
-`import_base_lib` available during user Bash startup. Base still owns the final
-runtime prompt.
+with guardrails, activates the project virtual environment, sources any
+manifest-declared `activate.source` scripts, and then sets the Base runtime
+prompt. This gives the user their normal interactive Bash behavior while also
+making Base stdlib functions such as `import_base_lib` available during user
+Bash startup. Base still owns the final runtime prompt.
 
 Bash startup paths share `lib/shell/baserc_guard.sh` for safe `~/.baserc`
 loading and Base-owned variable protection.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -195,10 +195,11 @@ $BASE_HOME/lib/bash/runtime/bashrc
 ```
 
 The runtime rcfile sources `base_init.sh`, sources the user's `~/.bashrc` once
-with guardrails, and then sets the Base runtime prompt. This gives the user their
-normal interactive Bash behavior while also making Base stdlib functions such as
-`import_base_lib` available during user Bash startup. Base still owns the final
-runtime prompt.
+with guardrails, activates the project virtual environment, sources any
+manifest-declared `activate.source` scripts, and then sets the Base runtime
+prompt. This gives the user their normal interactive Bash behavior while also
+making Base stdlib functions such as `import_base_lib` available during user
+Bash startup. Base still owns the final runtime prompt.
 
 Bash startup paths share `lib/shell/baserc_guard.sh` for safe `~/.baserc`
 loading and Base-owned variable protection.

--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -24,7 +24,13 @@ Instead, use the typed contracts Base already understands:
 - `mise` for language runtimes, tool versions, environment variables, and tasks
 - `ide` for supported IDE app, extension, and settings bootstrap
 - `artifacts` for Base-managed artifacts
+- `activate.source` for explicit activation-time shell scripts that run inside
+  the interactive project runtime shell
 - `test.command` or `test.mise` for project-owned test execution
+
+`activate.source` is intentionally not a setup hook: it does not run during
+`basectl setup`, `basectl check`, or `basectl doctor`, and it exists only for
+shell state that must affect the activated interactive subshell.
 
 When a project needs a product-specific guided installer or imperative
 bootstrap, that logic should live in the project repository, for example:

--- a/lib/bash/runtime/README.md
+++ b/lib/bash/runtime/README.md
@@ -14,6 +14,8 @@ project manifest is found.
 - sources `base_init.sh`
 - adds `$BASE_PROJECT_ROOT/bin` to `PATH` when it exists, keeping `$BASE_HOME/bin` first
 - sources the user's `~/.bashrc` with guardrails
+- activates the project virtual environment
+- sources manifest-declared `activate.source` scripts
 - owns the final runtime prompt
 
 ## Behavior Notes

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -28,6 +28,10 @@ _base_runtime_debug() {
     esac
 }
 
+_base_runtime_info() {
+    printf 'INFO: %s\n' "$*" >&2
+}
+
 _base_runtime_source_baserc_guard() {
     local guard_path="$BASE_HOME/lib/shell/baserc_guard.sh"
 
@@ -73,6 +77,36 @@ _base_runtime_activate_project_venv() {
     export VIRTUAL_ENV_DISABLE_PROMPT=1
     # shellcheck source=/dev/null
     source "$activate_script"
+}
+
+_base_runtime_source_project_activation_scripts() {
+    local script
+    local scripts_output
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+
+    [[ -n "${BASE_PROJECT:-}" ]] || return 0
+    [[ -n "${BASE_PROJECT_ROOT:-}" ]] || return 0
+    [[ -n "${BASE_PROJECT_MANIFEST:-}" ]] || return 0
+
+    [[ -x "$wrapper" ]] || {
+        _base_runtime_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+
+    scripts_output="$("$wrapper" base_projects activation-sources "$BASE_PROJECT")" || {
+        _base_runtime_error "Unable to resolve project activation scripts for '$BASE_PROJECT'."
+        return 1
+    }
+
+    while IFS= read -r script; do
+        [[ -n "$script" ]] || continue
+        _base_runtime_info "Sourcing project activation script '$script'."
+        # shellcheck source=/dev/null
+        source "$script" || {
+            _base_runtime_error "Project activation script '$script' failed."
+            return 1
+        }
+    done <<< "$scripts_output"
 }
 
 _base_runtime_add_project_bin_to_path() {
@@ -185,6 +219,7 @@ _base_runtime_main() {
     _base_runtime_add_project_bin_to_path || return $?
     _base_runtime_source_user_bashrc || return $?
     _base_runtime_activate_project_venv || return $?
+    _base_runtime_source_project_activation_scripts || return $?
     _base_runtime_set_prompt
     __base_runtime_bashrc_loaded__=1
     _base_runtime_debug "complete"


### PR DESCRIPTION
## Summary
- Add `activate.source` manifest parsing for explicit project activation scripts.
- Add `base_projects activation-sources` to resolve declared scripts safely under the project root.
- Source validated activation scripts from the runtime shell after Base/user startup and project venv activation, with docs and tests.

## Validation
- env PYTHONPATH=/Users/rameshhp/work/base-worktrees/enhancement-350-project-activation-hooks/lib/python:/Users/rameshhp/work/base-worktrees/enhancement-350-project-activation-hooks/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py cli/python/base_projects/tests/test_engine.py
- bats cli/bash/commands/basectl/tests/runtime-shell.bats lib/bash/runtime/tests/runtime_bashrc.bats cli/bash/commands/basectl/tests/activate.bats
- env PYTHONPATH=/Users/rameshhp/work/base-worktrees/enhancement-350-project-activation-hooks/lib/python:/Users/rameshhp/work/base-worktrees/enhancement-350-project-activation-hooks/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest
- env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test
- git diff --check HEAD~1

Closes #350