### PR TITLE
Add basectl run for project commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ basectl setup <project>
 basectl check <project>
 basectl doctor <project>
 basectl test <project>
+basectl run <project> <command>
 basectl activate <project>
 ```
 
@@ -76,7 +77,8 @@ basectl test base
 Success looks like a workspace where each participating project has a
 `base_manifest.yaml`, appears in `basectl projects list`, can be checked with
 `basectl check <project>`, and can run its declared test command through
-`basectl test <project>`.
+`basectl test <project>` or named project commands through
+`basectl run <project> <command>`.
 
 ## How Base Fits
 
@@ -116,6 +118,7 @@ Current implemented commands include:
 - `basectl projects list`
 - `basectl activate <project>`
 - `basectl test [project]`
+- `basectl run <project> <command>`
 - `basectl onboard`
 - `basectl version`
 
@@ -163,6 +166,10 @@ health:
 
 test:
   command: pytest tests/
+
+commands:
+  dev: uvicorn app:app --reload
+  lint: ruff check .
 ```
 
 `schema_version` is optional for existing manifests and defaults to `1`. It is
@@ -191,11 +198,18 @@ variable values.
 Future manifest fields should follow the same rule. A `mise` field causes Base
 to run `mise install` from the project root when a project chooses that
 substrate. A `test` field gives `basectl test` a single project-owned command
-to run. Projects that keep tasks in `mise` can declare `test.mise` instead:
+to run. A `commands` map gives `basectl run` named project commands that run
+from the project root with the same Base project environment contract as
+`basectl test`. Projects that keep tasks in `mise` can declare `test.mise`
+instead:
 
 ```yaml
 test:
   mise: test
+
+commands:
+  dev: mise run dev
+  lint: mise run lint
 ```
 
 For a polyglot project such as `banyanlabs`, keep Base at the workspace
@@ -299,6 +313,40 @@ basectl test example -- -k focused_case
 ```
 
 For `test.mise`, Base passes those arguments after `mise run <task> --`.
+
+Run other manifest-declared project commands with:
+
+```bash
+basectl run example dev
+basectl run example lint
+```
+
+The `commands` map is intentionally small and declarative:
+
+```yaml
+commands:
+  dev: uvicorn app:app --reload
+  lint: ruff check .
+  format: ruff format .
+```
+
+`basectl run <project> <command>` runs the command from the project root,
+exports the same `BASE_PROJECT`, `BASE_PROJECT_ROOT`,
+`BASE_PROJECT_MANIFEST`, and `BASE_PROJECT_VENV_DIR` variables as
+`basectl test`, prepends the project virtual environment when it exists, and
+returns the command's exit status. Use `basectl run <project> --list` to see a
+project's runnable commands. When the current directory is inside a
+Base-managed project, `basectl run --list` lists that project.
+
+Pass additional arguments after `--`:
+
+```bash
+basectl run example lint -- --fix
+```
+
+The command name `test` is reserved for the top-level `test` contract, so
+`basectl run example test` delegates to the same command as
+`basectl test example`.
 
 Once a project is discoverable, activate it with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -72,6 +72,11 @@ that delegate to `basectl`.
   `test.mise` from the project root with Base project environment variables
   exported. Use `basectl test <project> -- <args...>` to pass extra arguments
   to the delegated test command.
+- `basectl run <project> <command>` runs a named command from the project's
+  manifest `commands` map with the same project root, environment variables,
+  virtual environment, dry-run, and extra-argument contract as `basectl test`.
+  `basectl run <project> test` delegates to the top-level manifest `test`
+  contract. Use `basectl run <project> --list` to inspect available commands.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -17,6 +17,8 @@ Commands:
     Verify the local Base CLI environment and optional project artifacts without making changes.
   test [project] [options]
     Run a project's declared test command.
+  run <project> <command> [options]
+    Run a project's declared command.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   config <path|show|doctor>
@@ -165,6 +167,11 @@ basectl_do_test() {
     base_test_subcommand_main "$@"
 }
 
+basectl_do_run() {
+    basectl_source_subcommand_module run || return 1
+    base_run_subcommand_main "$@"
+}
+
 basectl_do_clean() {
     basectl_source_subcommand_module clean || return 1
     base_clean_subcommand_main "$@"
@@ -304,6 +311,7 @@ basectl_main() {
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
         test)             basectl_do_test "$@" ;;
+        run)              basectl_do_run "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         config)           basectl_do_config "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/run.sh
+++ b/cli/bash/commands/basectl/subcommands/run.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_run_subcommand_sourced:-}" ]] && return
+_base_run_subcommand_sourced=1
+readonly _base_run_subcommand_sourced
+
+base_run_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl run <project> <command> [options] [-- extra args...]
+  basectl run [project] --list [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --dry-run           Print the resolved command without running it.
+  --list              List runnable commands for a project. Defaults to the nearest project.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Run a project's declared command from its project root.
+Use -- to pass additional arguments to the declared command.
+EOF
+}
+
+base_run_usage_error() {
+    base_run_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_run_project_venv_dir() {
+    local project="$1"
+
+    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+        printf '%s\n' "$BASE_PROJECT_VENV_DIR"
+        return 0
+    fi
+
+    printf '%s\n' "$HOME/.base.d/$project/.venv"
+}
+
+base_run_format_extra_args() {
+    local arg quoted output=""
+
+    for arg in "$@"; do
+        printf -v quoted '%q' "$arg"
+        output+=" $quoted"
+    done
+    printf '%s\n' "$output"
+}
+
+base_run_command_with_extra_args() {
+    local command="$1"
+    shift
+
+    if (($# == 0)); then
+        printf '%s\n' "$command"
+        return 0
+    fi
+
+    if [[ "$command" == mise\ run\ * ]]; then
+        printf '%s -- "$@"\n' "$command"
+    else
+        printf '%s "$@"\n' "$command"
+    fi
+}
+
+base_run_display_command() {
+    local command="$1"
+    shift
+
+    if (($# == 0)); then
+        printf '%s\n' "$command"
+        return 0
+    fi
+
+    if [[ "$command" == mise\ run\ * ]]; then
+        printf '%s --%s\n' "$command" "$(base_run_format_extra_args "$@")"
+    else
+        printf '%s%s\n' "$command" "$(base_run_format_extra_args "$@")"
+    fi
+}
+
+base_run_list_commands() {
+    local project="$1"
+    shift
+    local args=("$@")
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local command_args=(run-commands)
+    local list_output line resolved_name project_root manifest_path command_name command_text
+    local printed_header=0
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    [[ -z "$project" ]] || command_args+=("$project")
+
+    list_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}")" || return $?
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        IFS=$'\t' read -r resolved_name project_root manifest_path command_name command_text <<<"$line"
+        [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$command_name" ]] || {
+            fatal_error "Unable to parse runnable commands for project '$project'."
+        }
+        if ((printed_header == 0)); then
+            printf "Commands for project '%s'\n\n" "$resolved_name"
+            printed_header=1
+        fi
+        printf '%-20s %s\n' "$command_name" "$command_text"
+    done <<<"$list_output"
+}
+
+base_run_subcommand_main() {
+    local project="" command_name="" wrapper resolve_output resolved_name project_root manifest_path run_command venv_dir
+    local command_to_run display_command
+    local dry_run=0 list_commands=0 workspace_requested=0
+    local args=() extra_args=()
+
+    while (($#)); do
+        case "$1" in
+            --)
+                shift
+                extra_args=("$@")
+                break
+                ;;
+            -h|--help|help)
+                base_run_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --workspace)
+                [[ -n "${2:-}" ]] || {
+                    base_run_usage_error "Option '--workspace' requires an argument."
+                    return $?
+                }
+                workspace_requested=1
+                args+=(--workspace "$2")
+                shift 2
+                ;;
+            --workspace=*)
+                workspace_requested=1
+                args+=("$1")
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            --list)
+                list_commands=1
+                shift
+                ;;
+            -*)
+                base_run_usage_error "Unknown run option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -z "$project" ]]; then
+                    project="$1"
+                elif [[ -z "$command_name" ]]; then
+                    command_name="$1"
+                else
+                    base_run_usage_error "The 'run' command accepts one project name and one command name."
+                    return $?
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$project" || "$workspace_requested" != "1" ]] || {
+        base_run_usage_error "Option '--workspace' requires an explicit project name."
+        return $?
+    }
+    if [[ "$list_commands" == "1" ]]; then
+        [[ -z "$command_name" ]] || {
+            base_run_usage_error "Option '--list' cannot be combined with a command name."
+            return $?
+        }
+        [[ ${#extra_args[@]} -eq 0 ]] || {
+            base_run_usage_error "Option '--list' cannot be combined with extra command arguments."
+            return $?
+        }
+        base_run_list_commands "$project" "${args[@]}"
+        return $?
+    fi
+
+    [[ -n "$project" ]] || {
+        base_run_usage_error "Project name is required."
+        return $?
+    }
+    [[ -n "$command_name" ]] || {
+        base_run_usage_error "Command name is required."
+        return $?
+    }
+
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    resolve_output="$("$wrapper" --project base base_projects run-command "$project" "$command_name" "${args[@]}")" || return $?
+    IFS=$'\t' read -r resolved_name project_root manifest_path run_command <<<"$resolve_output"
+
+    [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$run_command" ]] || {
+        fatal_error "Unable to resolve command '$command_name' for project '$project'."
+    }
+
+    venv_dir="$(base_run_project_venv_dir "$resolved_name")"
+    export BASE_PROJECT="$resolved_name"
+    export BASE_PROJECT_ROOT="$project_root"
+    export BASE_PROJECT_MANIFEST="$manifest_path"
+    export BASE_PROJECT_VENV_DIR="$venv_dir"
+
+    if [[ -d "$venv_dir/bin" ]]; then
+        PATH="$venv_dir/bin:$PATH"
+        export PATH
+    elif [[ "$dry_run" != "1" ]]; then
+        log_warn "Project virtual environment was not found at '$venv_dir'. Run 'basectl setup $resolved_name' first."
+    fi
+
+    command_to_run="$(base_run_command_with_extra_args "$run_command" "${extra_args[@]}")"
+    display_command="$(base_run_display_command "$run_command" "${extra_args[@]}")"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf '[DRY-RUN] Would run command %q for project %q in %q: %s\n' \
+            "$command_name" "$resolved_name" "$project_root" "$display_command"
+        return 0
+    fi
+
+    log_info "Running command '$command_name' for project '$resolved_name': $display_command"
+    (cd "$project_root" && bash -c "$command_to_run" basectl-run "${extra_args[@]}")
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -47,6 +47,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "test_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl run ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "run_projects=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl check --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -55,6 +59,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "test_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl run demo --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "run_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl projects list --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -75,8 +83,10 @@ EOF
     [[ "$output" == *"check_projects=base demo"* ]]
     [[ "$output" == *"doctor_projects=base demo"* ]]
     [[ "$output" == *"test_projects=base demo"* ]]
+    [[ "$output" == *"run_projects=base demo"* ]]
     [[ "$output" == *"check_options=--dev --format"* ]]
     [[ "$output" == *"test_options=--workspace --dry-run"* ]]
+    [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -12,6 +12,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"test [project] [options]"* ]]
+    [[ "$output" == *"run <project> <command> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
@@ -44,6 +45,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  gh <area> <command> [options]' <<<"$output"
     grep -Fqx '  onboard [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
+    grep -Fqx '  run <project> <command> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -1,0 +1,264 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl run runs declared project command from project root" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/run-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "project=%s\nroot=%s\nmanifest=%s\nvenv=%s\npwd=%s\npath=%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" "$PATH" > "$BASE_TEST_RUN_STATE"; exit 7'
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    touch "$TEST_HOME/.base.d/demo/.venv/bin/uvicorn"
+    printf 'project:\n  name: demo\ncommands:\n  dev: uvicorn app:app --reload\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_RUN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo dev
+
+    [ "$status" -eq 7 ]
+    [[ "$(cat "$state_file")" == *"project=demo"* ]]
+    [[ "$(cat "$state_file")" == *"root=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"manifest=$workspace/demo/base_manifest.yaml"* ]]
+    [[ "$(cat "$state_file")" == *"venv=$TEST_HOME/.base.d/demo/.venv"* ]]
+    [[ "$(cat "$state_file")" == *"pwd=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"path=$TEST_HOME/.base.d/demo/.venv/bin:"* ]]
+}
+
+@test "basectl run dry-run prints resolved command without running it" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/run-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'touch "$BASE_TEST_RUN_STATE"; exit 7'
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ncommands:\n  dev: uvicorn app:app --reload\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_RUN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo dev --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run command dev for project demo"* ]]
+    [[ "$output" == *'touch "$BASE_TEST_RUN_STATE"; exit 7'* ]]
+    [ ! -e "$state_file" ]
+}
+
+@test "basectl run passes extra args after separator to command" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/run-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "lint" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'fake-lint src/'
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$TEST_HOME/.base.d/demo/.venv/bin/fake-lint" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${BASE_TEST_RUN_STATE:?}"
+EOF
+    chmod +x "$python_bin" "$TEST_HOME/.base.d/demo/.venv/bin/fake-lint"
+    printf 'project:\n  name: demo\ncommands:\n  lint: fake-lint src/\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_RUN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo lint -- --fix "name with spaces"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state_file")" = $'src/\n--fix\nname with spaces' ]
+}
+
+@test "basectl run passes extra args to mise task after separator" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/run-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'mise run dev'
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$TEST_HOME/.base.d/demo/.venv/bin/mise" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${BASE_TEST_RUN_STATE:?}"
+EOF
+    chmod +x "$python_bin" "$TEST_HOME/.base.d/demo/.venv/bin/mise"
+    printf 'project:\n  name: demo\ncommands:\n  dev: mise run dev\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_RUN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo dev -- --watch
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state_file")" = $'run\ndev\n--\n--watch' ]
+}
+
+@test "basectl run test delegates to the test contract" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "test" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "test-contract\n"'
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ntest:\n  command: pytest tests/\ncommands:\n  dev: uvicorn app:app\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo test
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"test-contract"* ]]
+}
+
+@test "basectl run --list prints runnable commands for explicit project" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-commands" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" test 'pytest tests/'
+    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" dev 'uvicorn app:app --reload'
+    exit 0
+fi
+printf 'unexpected run list python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ncommands:\n  dev: uvicorn app:app --reload\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Commands for project 'demo'"* ]]
+    [[ "$output" == *"test"*"pytest tests/"* ]]
+    [[ "$output" == *"dev"*"uvicorn app:app --reload"* ]]
+}
+
+@test "basectl run --list can resolve nearest project" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-commands" && -z "${4:-}" ]]; then
+    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" dev 'uvicorn app:app --reload'
+    exit 0
+fi
+printf 'unexpected run list python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ncommands:\n  dev: uvicorn app:app --reload\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        bash -c '
+            cd "$1"
+            shift
+            "$@"
+        ' bash "$workspace/demo" "$BASE_REPO_ROOT/bin/basectl" run --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Commands for project 'demo'"* ]]
+    [[ "$output" == *"dev"*"uvicorn app:app --reload"* ]]
+}
+
+@test "basectl run prints help without requiring the Base Python venv" {
+    run_basectl run --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl run <project> <command>"* ]]
+    [[ "$output" == *"--list"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "basectl run reports invalid arguments as usage errors" {
+    run_basectl run
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Project name is required."* ]]
+
+    run_basectl run demo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Command name is required."* ]]
+
+    run_basectl run --workspace "$TEST_TMPDIR" --list
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--workspace' requires an explicit project name."* ]]
+
+    run_basectl run demo dev --list
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--list' cannot be combined with a command name."* ]]
+
+    run_basectl run --unknown demo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unknown run option '--unknown'."* ]]
+}

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -132,7 +132,7 @@ EOF
 @test "basectl rejects removed legacy commands" {
     local legacy_command
 
-    for legacy_command in status run set-team set-shared-teams man embrace install shell; do
+    for legacy_command in status set-team set-shared-teams man embrace install shell; do
         run_basectl "$legacy_command"
         [ "$status" -eq 2 ]
         [[ "$output" == *"Unrecognized command: $legacy_command"* ]]

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -13,7 +13,7 @@ import base_cli
 from base_cli.config import read_user_config
 from base_cli.paths import base_cache_root
 from base_cli.paths import discover_manifest
-from base_setup.manifest import ManifestError, TestConfig, read_manifest
+from base_setup.manifest import BaseManifest, ManifestError, TestConfig, read_manifest
 
 
 app = base_cli.App(name="base_projects")
@@ -39,8 +39,7 @@ def main(argv: list[str] | None = None) -> int:
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
-@base_cli.argument("command", required=False)
-@base_cli.argument("project", required=False)
+@base_cli.argument("arguments", nargs=-1)
 @base_cli.option(
     "--workspace",
     help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
@@ -48,27 +47,100 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--format", "output_format", default="text", help="Output format for list: text or json.")
 def run(
     ctx: base_cli.Context,
-    command: str | None,
-    project: str | None,
+    arguments: tuple[str, ...],
     workspace: str | None,
     output_format: str,
 ) -> int:
-    if command in (None, "list"):
-        return list_projects_command(ctx, workspace, output_format)
-    if command == "current":
-        return current_project_command(ctx)
-    if command == "manifest":
-        return manifest_project_command(ctx, project)
-    if command == "resolve":
-        return resolve_project_command(ctx, project, workspace)
-    if command == "test-command":
-        return test_command_project_command(ctx, project, workspace)
+    try:
+        return dispatch_projects_command(ctx, arguments, workspace, output_format)
+    except ProjectUsageError as exc:
+        ctx.log.error(str(exc))
+        return 2
+
+
+def dispatch_projects_command(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    workspace: str | None,
+    output_format: str,
+) -> int:
+    command = arguments[0] if arguments else "list"
+    command_arguments = arguments[1:] if arguments else ()
+    handlers = {
+        "list": lambda: list_projects_from_args(ctx, command_arguments, workspace, output_format),
+        "current": lambda: current_project_from_args(ctx, command_arguments),
+        "manifest": lambda: manifest_project_from_args(ctx, command_arguments),
+        "resolve": lambda: resolve_project_from_args(ctx, command_arguments, workspace),
+        "test-command": lambda: test_command_project_from_args(ctx, command_arguments, workspace),
+        "run-command": lambda: run_command_project_from_args(ctx, command_arguments, workspace),
+        "run-commands": lambda: list_run_commands_from_args(ctx, command_arguments, workspace),
+    }
+    handler = handlers.get(command)
+    if handler is not None:
+        return handler()
 
     ctx.log.error(
-        "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, test-command.",
+        "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
+        "test-command, run-command, run-commands.",
         command,
     )
     return 2
+
+
+class ProjectUsageError(RuntimeError):
+    pass
+
+
+def require_argument_count(command: str, arguments: tuple[str, ...], minimum: int, maximum: int) -> None:
+    if len(arguments) < minimum:
+        raise ProjectUsageError(f"Project command '{command}' requires at least {minimum} argument(s).")
+    if len(arguments) > maximum:
+        raise ProjectUsageError(f"Project command '{command}' accepts at most {maximum} argument(s).")
+
+
+def optional_project_argument(command: str, arguments: tuple[str, ...]) -> str | None:
+    require_argument_count(command, arguments, 0, 1)
+    return arguments[0] if arguments else None
+
+
+def list_projects_from_args(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    workspace: str | None,
+    output_format: str,
+) -> int:
+    require_argument_count("list", arguments, 0, 0)
+    return list_projects_command(ctx, workspace, output_format)
+
+
+def current_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
+    require_argument_count("current", arguments, 0, 0)
+    return current_project_command(ctx)
+
+
+def manifest_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
+    require_argument_count("manifest", arguments, 0, 1)
+    return manifest_project_command(ctx, arguments[0] if arguments else None)
+
+
+def resolve_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
+    require_argument_count("resolve", arguments, 1, 1)
+    return resolve_project_command(ctx, arguments[0], workspace)
+
+
+def test_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
+    project = optional_project_argument("test-command", arguments)
+    return test_command_project_command(ctx, project, workspace)
+
+
+def run_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
+    require_argument_count("run-command", arguments, 2, 2)
+    return run_command_project_command(ctx, arguments[0], arguments[1], workspace)
+
+
+def list_run_commands_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
+    project = optional_project_argument("run-commands", arguments)
+    return list_run_commands_command(ctx, project, workspace)
 
 
 def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
@@ -135,6 +207,52 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
     return 0
 
 
+def run_command_project_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    command_name: str | None,
+    workspace: str | None,
+) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+    if not command_name:
+        ctx.log.error("Command name is required.")
+        return 2
+
+    try:
+        project = resolve_named_project(ctx, project_name, workspace)
+        manifest = read_manifest(project.manifest_path)
+        command_text = project_command(manifest, command_name)
+    except (ProjectDiscoveryError, ManifestError, ProjectCommandError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{command_text}")
+    return 0
+
+
+def list_run_commands_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+    try:
+        if project_name:
+            project = resolve_named_project(ctx, project_name, workspace)
+        else:
+            project = current_project()
+        manifest = read_manifest(project.manifest_path)
+    except (ProjectDiscoveryError, ManifestError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    commands = project_commands(manifest)
+    if not commands:
+        ctx.log.error("Project '%s' does not declare runnable commands in '%s'.", project.name, project.manifest_path)
+        return 1
+
+    for command_name, command_text in commands.items():
+        print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{command_name}\t{command_text}")
+    return 0
+
+
 def current_project_command(ctx: base_cli.Context) -> int:
     try:
         project = current_project()
@@ -160,6 +278,32 @@ def test_command(test_config: TestConfig) -> str:
     if test_config.mise is not None:
         return shlex.join(["mise", "run", test_config.mise])
     raise ValueError("TestConfig must have command or mise set.")
+
+
+class ProjectCommandError(RuntimeError):
+    pass
+
+
+def project_commands(manifest: BaseManifest) -> dict[str, str]:
+    commands: dict[str, str] = {}
+    if manifest.test is not None:
+        commands["test"] = test_command(manifest.test)
+    commands.update(manifest.commands)
+    return commands
+
+
+def project_command(manifest: BaseManifest, command_name: str) -> str:
+    commands = project_commands(manifest)
+    try:
+        return commands[command_name]
+    except KeyError as exc:
+        if command_name == "test":
+            raise ProjectCommandError(
+                f"Project '{manifest.project_name}' does not declare test.command or test.mise in '{manifest.path}'."
+            ) from exc
+        raise ProjectCommandError(
+            f"Project '{manifest.project_name}' does not declare command '{command_name}' in '{manifest.path}'."
+        ) from exc
 
 
 def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -38,6 +38,25 @@ def write_mise_test_manifest(project_root: Path, name: str, task: str) -> None:
     )
 
 
+def write_commands_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        "\n".join(
+            [
+                "project:",
+                f"  name: {name}",
+                "test:",
+                "  command: pytest tests/",
+                "commands:",
+                "  dev: uvicorn app:app --reload",
+                "  lint: ruff check .",
+                "artifacts: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def invoke_engine(
     args: list[str],
     base_home: Path,
@@ -468,6 +487,109 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 1)
         self.assertIn("does not declare test.command or test.mise", stderr)
+
+    def test_projects_run_command_prints_project_details_and_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_commands_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["run-command", "demo", "dev"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            "\tuvicorn app:app --reload\n",
+        )
+
+    def test_projects_run_command_test_delegates_to_test_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_commands_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["run-command", "demo", "test"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
+        )
+
+    def test_projects_run_command_reports_unknown_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_commands_manifest(project_root, "demo")
+
+            status, _stdout, stderr = run_engine(["run-command", "demo", "serve"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("does not declare command 'serve'", stderr)
+
+    def test_projects_run_commands_lists_test_and_manifest_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_commands_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["run-commands", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\ttest\tpytest tests/\n"
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            "\tdev\tuvicorn app:app --reload\n"
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            "\tlint\truff check .\n",
+        )
+
+    def test_projects_run_commands_defaults_to_current_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            nested = project_root / "docs"
+            write_commands_manifest(project_root, "demo")
+            nested.mkdir()
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(nested)
+                status, stdout, stderr = run_engine(["run-commands"], base_home)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("\ttest\tpytest tests/\n", stdout)
+        self.assertIn("\tdev\tuvicorn app:app --reload\n", stdout)
+
+    def test_projects_run_commands_requires_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, _stdout, stderr = run_engine(["run-commands", "demo"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("does not declare runnable commands", stderr)
 
     def test_projects_manifest_prints_project_details(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -271,4 +271,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         test=manifest.test,
         schema_version=manifest.schema_version,
         health=manifest.health,
+        commands=manifest.commands,
     )

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -22,6 +22,7 @@ else:
 
 CURRENT_MANIFEST_SCHEMA_VERSION = 1
 ENVIRONMENT_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
 
 
 class ManifestError(ValueError):
@@ -65,6 +66,7 @@ class BaseManifest:
     test: TestConfig | None = None
     schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
     health: HealthConfig = field(default_factory=HealthConfig)
+    commands: dict[str, str] = field(default_factory=dict)
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -84,7 +86,17 @@ def read_manifest(path: Path) -> BaseManifest:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
-    allowed_top_level = {"schema_version", "project", "brewfile", "mise", "ide", "artifacts", "test", "health"}
+    allowed_top_level = {
+        "schema_version",
+        "project",
+        "brewfile",
+        "mise",
+        "ide",
+        "artifacts",
+        "test",
+        "health",
+        "commands",
+    }
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
@@ -96,6 +108,7 @@ def read_manifest(path: Path) -> BaseManifest:
     ide = _read_ide(path, data.get("ide"))
     test = _read_test(path, data.get("test"))
     health = _read_health(path, data.get("health"))
+    commands = _read_commands(path, data.get("commands"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -108,6 +121,7 @@ def read_manifest(path: Path) -> BaseManifest:
         test=test,
         schema_version=schema_version,
         health=health,
+        commands=commands,
     )
 
 
@@ -213,6 +227,29 @@ def _read_health(path: Path, health_data: Any) -> HealthConfig:
         raise ManifestError(f"{path}: health has unsupported keys: {', '.join(unknown_keys)}.")
 
     return HealthConfig(required_env=_read_required_env(path, health_data.get("required_env", [])))
+
+
+def _read_commands(path: Path, commands_data: Any) -> dict[str, str]:
+    if commands_data is None:
+        return {}
+    if not isinstance(commands_data, dict):
+        raise ManifestError(f"{path}: commands must be a mapping when provided.")
+
+    commands: dict[str, str] = {}
+    for command_name_data, command_data in commands_data.items():
+        if not isinstance(command_name_data, str) or not command_name_data.strip():
+            raise ManifestError(f"{path}: commands keys must be non-empty strings.")
+        command_name = command_name_data.strip()
+        if not COMMAND_NAME_RE.fullmatch(command_name):
+            raise ManifestError(f"{path}: commands.{command_name} must be a valid command name.")
+        if command_name == "test":
+            raise ManifestError(f"{path}: commands.test is reserved; use top-level test.command or test.mise.")
+        if command_name in commands:
+            raise ManifestError(f"{path}: commands duplicates '{command_name}'.")
+        if not isinstance(command_data, str) or not command_data.strip():
+            raise ManifestError(f"{path}: commands.{command_name} must be a non-empty string.")
+        commands[command_name] = command_data.strip()
+    return commands
 
 
 def _read_required_env(path: Path, required_env_data: Any) -> tuple[str, ...]:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -184,6 +184,67 @@ class ManifestParsingTests(unittest.TestCase):
 
 
 
+    def test_reads_manifest_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "commands:",
+                        "  dev: uvicorn app:app --reload",
+                        "  lint: ruff check .",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(
+            manifest.commands,
+            {
+                "dev": "uvicorn app:app --reload",
+                "lint": "ruff check .",
+            },
+        )
+
+
+
+    def test_rejects_invalid_manifest_commands(self) -> None:
+        invalid_values = {
+            "scalar": "commands: pytest",
+            "empty_name": "commands:\n  '': pytest",
+            "invalid_name": "commands:\n  'bad command': pytest",
+            "reserved_test": "commands:\n  test: pytest",
+            "empty_command": "commands:\n  lint: ''",
+            "non_string_command": "commands:\n  lint: 7",
+        }
+        for name, commands_yaml in invalid_values.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                commands_yaml,
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(ManifestError):
+                        read_manifest(manifest_path)
+
+
+
     def test_reads_manifest_brewfile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -346,6 +346,10 @@ health:
 
 test:
   command: pytest tests/
+
+commands:
+  dev: uvicorn app:app --reload
+  lint: ruff check .
 ```
 
 `schema_version` is a manifest compatibility marker. Missing values are treated
@@ -370,6 +374,11 @@ orchestration actions. The design rule is delegation-first:
   Projects can declare either `test.command` for a shell command or `test.mise`
   for a `mise run <task>` delegation. Extra arguments after `basectl test
   <project> --` are passed through to the delegated command.
+- Use a project-owned `commands` map for additional named commands that
+  `basectl run <project> <command>` can execute from the project root. These
+  commands use the same Base project environment and virtual environment
+  contract as `basectl test`; the command name `test` is reserved for the
+  top-level `test` contract.
 - Use `health.required_env` for local environment contracts that `basectl check`
   and `basectl doctor` should validate without exposing secret values.
 - Let Base own the project virtual environment and Base-aware package

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -126,6 +126,7 @@ It owns the current Base subcommands:
 - `doctor`
 - `activate`
 - `test`
+- `run`
 - `projects list`
 - `update-profile`
 - `version`

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test clean config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup check test run clean config doctor gh onboard update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -69,6 +69,9 @@ _base_basectl_completion() {
             ;;
         test)
             _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
+            ;;
+        run)
+            _base_basectl_completion_project_or_options "--workspace --dry-run --list -v -h --help" "$cur"
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -18,6 +18,7 @@ _base_basectl_completion() {
         'setup:Install and bootstrap the local Base CLI environment'
         'check:Verify the local Base CLI environment'
         'test:Run a project test command'
+        'run:Run a project command'
         'clean:Remove old Base CLI runtime artifacts'
         'config:Inspect Base machine-local user config'
         'doctor:Diagnose the local Base environment'
@@ -75,6 +76,17 @@ _base_basectl_completion() {
                 '--dry-run[Print the resolved test command without running it]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
+            ;;
+        run)
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--dry-run[Print the resolved command without running it]' \
+                '--list[List runnable project commands]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects' '2:Project command:'
             if [[ "$state" == projects ]]; then
                 project_names=("${(@f)$(_base_basectl_completion_project_names)}")
                 _describe -t projects 'Base project' project_names


### PR DESCRIPTION
## Summary
- Add a manifest `commands` map for declarative project commands, reserving `test` for the top-level test contract.
- Add `basectl run <project> <command>` and `basectl run [project] --list` with project-root execution, project environment exports, project venv PATH handling, dry-run support, and extra argument forwarding.
- Extend project command resolution, shell completions, tests, and docs for the new command.

## Validation
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py cli/python/base_projects/tests/test_engine.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/manifest.py cli/python/base_setup/engine.py cli/python/base_setup/tests/test_manifest.py cli/python/base_projects/engine.py cli/python/base_projects/tests/test_engine.py
- bats cli/bash/commands/basectl/tests/run.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats
- bash -n cli/bash/commands/basectl/subcommands/run.sh cli/bash/commands/basectl/basectl.sh
- git diff --check
- BASE_CACHE_DIR=/private/tmp/base-review-cache bin/basectl run base --list
- env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test

Closes #324