### PR TITLE
Add stable doctor finding IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,9 @@ while pruning older logs. This retention mode applies only to `*.log` files;
 temp and cache artifacts continue to use `--older-than`.
 
 Use `basectl doctor` when you want a human-oriented diagnosis with suggested
-fixes:
+fixes. Each finding includes a stable identifier that automation can use
+instead of matching on human-readable messages; see
+[docs/doctor-findings.md](docs/doctor-findings.md).
 
 ```bash
 basectl doctor

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -26,11 +26,12 @@ EOF
 
 base_doctor_print_finding() {
     local status="$1"
-    local name="$2"
-    local message="$3"
-    local fix="${4:-}"
+    local finding_id="$2"
+    local name="$3"
+    local message="$4"
+    local fix="${5:-}"
 
-    printf '%-5s  %-26s  %s\n' "$status" "$name" "$message"
+    printf '%-5s  %-9s  %-26s  %s\n' "$status" "$finding_id" "$name" "$message"
     if [[ -n "$fix" ]]; then
         printf '       Fix: %s\n' "$fix"
     fi
@@ -39,16 +40,44 @@ base_doctor_print_finding() {
 base_doctor_print_json_finding() {
     local trailing_comma="$1"
     local status="$2"
-    local name="$3"
-    local message="$4"
-    local fix="${5:-}"
+    local finding_id="$3"
+    local name="$4"
+    local message="$5"
+    local fix="${6:-}"
 
-    printf '    {"status":"%s","name":"%s","message":"%s","fix":"%s"}%s\n' \
+    printf '    {"id":"%s","status":"%s","name":"%s","message":"%s","fix":"%s"}%s\n' \
+        "$(setup_json_escape "$finding_id")" \
         "$(setup_json_escape "$status")" \
         "$(setup_json_escape "$name")" \
         "$(setup_json_escape "$message")" \
         "$(setup_json_escape "$fix")" \
         "$trailing_comma"
+}
+
+base_doctor_base_finding_id() {
+    case "$1" in
+        homebrew)
+            printf '%s\n' "BASE-D001"
+            ;;
+        xcode_command_line_tools)
+            printf '%s\n' "BASE-D002"
+            ;;
+        python)
+            printf '%s\n' "BASE-D003"
+            ;;
+        base_virtualenv)
+            printf '%s\n' "BASE-D004"
+            ;;
+        pyyaml)
+            printf '%s\n' "BASE-D005"
+            ;;
+        click)
+            printf '%s\n' "BASE-D006"
+            ;;
+        *)
+            printf '%s\n' "BASE-D000"
+            ;;
+    esac
 }
 
 base_doctor_print_check_json_results() {
@@ -75,6 +104,7 @@ base_doctor_print_check_json_results() {
         base_doctor_print_json_finding \
             "$trailing_comma" \
             "$status" \
+            "$(base_doctor_base_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
             "${_BASE_SETUP_CHECK_NAMES[$i]}" \
             "${_BASE_SETUP_CHECK_MESSAGES[$i]}" \
             "$fix"
@@ -99,27 +129,31 @@ base_doctor_check_homebrew() {
 
     if brew_bin="$(setup_find_brew_bin)"; then
         if setup_refresh_brew_path; then
-            base_doctor_print_finding "ok" "Homebrew" "Homebrew is installed."
+            base_doctor_print_finding "ok" "BASE-D001" "Homebrew" "Homebrew is installed."
             log_debug "Resolved Homebrew binary: $brew_bin"
             return 0
         fi
-        base_doctor_print_finding "error" "Homebrew" \
+        base_doctor_print_finding "error" "BASE-D001" "Homebrew" \
             "Homebrew is installed, but its bin directory could not be added to PATH." \
             "Check Homebrew installation and PATH."
         return 1
     fi
 
-    base_doctor_print_finding "error" "Homebrew" "Homebrew is not installed." "basectl setup"
+    base_doctor_print_finding "error" "BASE-D001" "Homebrew" "Homebrew is not installed." "basectl setup"
     return 1
 }
 
 base_doctor_check_xcode() {
     if setup_xcode_tools_installed; then
-        base_doctor_print_finding "ok" "Xcode Command Line Tools" "Xcode Command Line Tools are installed."
+        base_doctor_print_finding \
+            "ok" \
+            "BASE-D002" \
+            "Xcode Command Line Tools" \
+            "Xcode Command Line Tools are installed."
         return 0
     fi
 
-    base_doctor_print_finding "error" "Xcode Command Line Tools" \
+    base_doctor_print_finding "error" "BASE-D002" "Xcode Command Line Tools" \
         "Xcode Command Line Tools are not installed." \
         "basectl setup"
     return 1
@@ -130,11 +164,11 @@ base_doctor_check_python() {
 
     formula="$(setup_python_formula)"
     if setup_python_installed; then
-        base_doctor_print_finding "ok" "Python" "Python formula '$formula' is installed via Homebrew."
+        base_doctor_print_finding "ok" "BASE-D003" "Python" "Python formula '$formula' is installed via Homebrew."
         return 0
     fi
 
-    base_doctor_print_finding "error" "Python" \
+    base_doctor_print_finding "error" "BASE-D003" "Python" \
         "Python formula '$formula' is not installed via Homebrew." \
         "basectl setup"
     return 1
@@ -146,11 +180,11 @@ base_doctor_check_virtualenv() {
     setup_ensure_cached_paths
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     if setup_virtualenv_exists; then
-        base_doctor_print_finding "ok" "Base virtualenv" "Virtual environment exists at '$venv_dir'."
+        base_doctor_print_finding "ok" "BASE-D004" "Base virtualenv" "Virtual environment exists at '$venv_dir'."
         return 0
     fi
 
-    base_doctor_print_finding "error" "Base virtualenv" \
+    base_doctor_print_finding "error" "BASE-D004" "Base virtualenv" \
         "Virtual environment is missing at '$venv_dir'." \
         "basectl setup"
     return 1
@@ -158,13 +192,22 @@ base_doctor_check_virtualenv() {
 
 base_doctor_check_python_package() {
     local package="$1"
+    local finding_id="BASE-D005"
+
+    if [[ "$package" == "$(setup_click_package)" ]]; then
+        finding_id="BASE-D006"
+    fi
 
     if setup_base_python_package_installed "$package"; then
-        base_doctor_print_finding "ok" "$package" "$(setup_base_python_package_check_message "$package" true)"
+        base_doctor_print_finding \
+            "ok" \
+            "$finding_id" \
+            "$package" \
+            "$(setup_base_python_package_check_message "$package" true)"
         return 0
     fi
 
-    base_doctor_print_finding "error" "$package" \
+    base_doctor_print_finding "error" "$finding_id" "$package" \
         "$(setup_base_python_package_check_message "$package" false)" \
         "basectl setup"
     return 1

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -181,12 +181,12 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *'"ok": false'* ]]
     [[ "$output" == *'"findings":'* ]]
-    [[ "$output" == *'"status":"error","name":"homebrew","message":"Homebrew is not installed.","fix":"Run '\''basectl setup'\'' to install Homebrew, or install it manually from https://brew.sh/."'* ]]
-    [[ "$output" == *'"status":"error","name":"xcode_command_line_tools"'* ]]
-    [[ "$output" == *'"status":"error","name":"python"'* ]]
-    [[ "$output" == *'"status":"error","name":"base_virtualenv"'* ]]
-    [[ "$output" == *'"status":"error","name":"pyyaml"'* ]]
-    [[ "$output" == *'"status":"error","name":"click"'* ]]
+    [[ "$output" == *'"id":"BASE-D001","status":"error","name":"homebrew","message":"Homebrew is not installed.","fix":"Run '\''basectl setup'\'' to install Homebrew, or install it manually from https://brew.sh/."'* ]]
+    [[ "$output" == *'"id":"BASE-D002","status":"error","name":"xcode_command_line_tools"'* ]]
+    [[ "$output" == *'"id":"BASE-D003","status":"error","name":"python"'* ]]
+    [[ "$output" == *'"id":"BASE-D004","status":"error","name":"base_virtualenv"'* ]]
+    [[ "$output" == *'"id":"BASE-D005","status":"error","name":"pyyaml"'* ]]
+    [[ "$output" == *'"id":"BASE-D006","status":"error","name":"click"'* ]]
     [[ "$output" != *"Base doctor"* ]]
     [ "${stderr:-}" = "" ]
 }
@@ -318,7 +318,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
-    printf '[{"status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"}]\n'
+    printf '[{"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"}]\n'
     exit 0
 fi
 printf 'unexpected doctor project json python args: %s\n' "$*" >&2
@@ -343,7 +343,7 @@ EOF
     [[ "$output" == *'"ok": true'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_findings":'* ]]
-    [[ "$output" == *'"status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"'* ]]
+    [[ "$output" == *'"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"'* ]]
     [[ "$output" != *"Running Python project doctor layer."* ]]
     [ "${stderr:-}" = "" ]
 }

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -22,6 +22,7 @@ class DevCheck:
     message: str
     fix: str
     status: str = ""
+    finding_id: str = "BASE-D100"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -121,10 +122,10 @@ def doctor_dev_artifacts(
     for check in checks:
         status = doctor_status(check)
         if status == "error":
-            print_doctor_finding("error", check.name, check.message, check.fix)
+            print_doctor_finding("error", check.finding_id, check.name, check.message, check.fix)
             error_count += 1
         else:
-            print_doctor_finding(status, check.name, check.message, check.fix)
+            print_doctor_finding(status, check.finding_id, check.name, check.message, check.fix)
     return min(error_count, 125)
 
 
@@ -150,6 +151,7 @@ def check_homebrew_artifact(artifact: ArtifactRequest, definition: ArtifactDefin
                 f"Artifact '{artifact.name}' uses unsupported developer prerequisite manager '{definition.manager}'."
             ),
             fix="Update lib/base/dev_manifest.yaml to use a Homebrew-managed tool.",
+            finding_id="BASE-D101",
         )
     if artifact.version != "latest":
         return DevCheck(
@@ -157,6 +159,7 @@ def check_homebrew_artifact(artifact: ArtifactRequest, definition: ArtifactDefin
             ok=False,
             message=f"Artifact '{artifact.name}' uses unsupported developer prerequisite version '{artifact.version}'.",
             fix="Use version 'latest' for Homebrew-managed developer prerequisites.",
+            finding_id="BASE-D102",
         )
 
     if not command_exists("brew"):
@@ -165,6 +168,7 @@ def check_homebrew_artifact(artifact: ArtifactRequest, definition: ArtifactDefin
             ok=False,
             message=f"Homebrew is required to check developer prerequisite '{artifact.name}'.",
             fix="basectl setup",
+            finding_id="BASE-D103",
         )
 
     ok = run_check(["brew", "list", definition.package])
@@ -174,12 +178,14 @@ def check_homebrew_artifact(artifact: ArtifactRequest, definition: ArtifactDefin
             ok=True,
             message=f"Artifact '{artifact.name}' is installed via Homebrew package '{definition.package}'.",
             fix="",
+            finding_id="BASE-D104",
         )
     return DevCheck(
         name=artifact.name,
         ok=False,
         message=f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'.",
         fix="basectl setup --dev",
+        finding_id="BASE-D104",
     )
 
 
@@ -190,6 +196,7 @@ def check_github_cli_auth() -> DevCheck:
             ok=False,
             message="GitHub CLI 'gh' was not found.",
             fix="basectl setup --dev",
+            finding_id="BASE-D105",
         )
 
     ok = run_check(["gh", "auth", "status"])
@@ -199,12 +206,14 @@ def check_github_cli_auth() -> DevCheck:
             ok=True,
             message="GitHub CLI authentication is ready.",
             fix="",
+            finding_id="BASE-D106",
         )
     return DevCheck(
         name="gh-auth",
         ok=False,
         message="GitHub CLI authentication is not ready.",
         fix="gh auth login -h github.com",
+        finding_id="BASE-D106",
     )
 
 
@@ -219,6 +228,7 @@ def check_to_json(check: DevCheck) -> dict[str, str | bool]:
 
 def check_to_doctor_json(check: DevCheck) -> dict[str, str]:
     return {
+        "id": check.finding_id,
         "status": doctor_status(check),
         "name": check.name,
         "message": check.message,
@@ -230,7 +240,7 @@ def doctor_status(check: DevCheck) -> str:
     return check.status or ("ok" if check.ok else "error")
 
 
-def print_doctor_finding(status: str, name: str, message: str, fix: str = "") -> None:
-    print(f"{status:<5}  {name:<26}  {message}")
+def print_doctor_finding(status: str, finding_id: str, name: str, message: str, fix: str = "") -> None:
+    print(f"{status:<5}  {finding_id:<9}  {name:<26}  {message}")
     if fix:
         print(f"       Fix: {fix}")

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -308,6 +308,7 @@ class DevManifestTests(unittest.TestCase):
 
         findings = json.loads(stdout.getvalue())
         self.assertEqual(status, 3)
+        self.assertEqual(findings[0]["id"], "BASE-D104")
         self.assertEqual(findings[0]["status"], "error")
         self.assertEqual(findings[0]["fix"], "basectl setup --dev")
 
@@ -321,6 +322,7 @@ class DevManifestTests(unittest.TestCase):
         )
 
         self.assertEqual(engine.doctor_status(check), "warn")
+        self.assertEqual(engine.check_to_doctor_json(check)["id"], "BASE-D100")
         self.assertEqual(engine.check_to_doctor_json(check)["status"], "warn")
 
         manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")

--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -72,6 +72,7 @@ def check_artifact(
         ok=False,
         message=f"Artifact manager '{definition.manager}' is not implemented.",
         fix=f"basectl setup {project}",
+        finding_id="BASE-P030",
     )
 
 
@@ -89,6 +90,7 @@ def check_homebrew_artifact(
                 "but Base only supports Homebrew artifact version 'latest' right now."
             ),
             fix=f"Update '{artifact.name}' in the project manifest to use version 'latest'.",
+            finding_id="BASE-P031",
         )
     if not process.command_exists("brew"):
         return ArtifactCheck(
@@ -96,6 +98,7 @@ def check_homebrew_artifact(
             ok=False,
             message=f"Homebrew is required to check artifact '{artifact.name}'.",
             fix="basectl setup",
+            finding_id="BASE-P032",
         )
     ok = process.run_check(["brew", "list", definition.package])
     if ok:
@@ -104,12 +107,14 @@ def check_homebrew_artifact(
             ok=True,
             message=f"Artifact '{artifact.name}' is installed via Homebrew package '{definition.package}'.",
             fix="",
+            finding_id="BASE-P033",
         )
     return ArtifactCheck(
         name=artifact.name,
         ok=False,
         message=f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'.",
         fix=f"basectl setup {project}",
+        finding_id="BASE-P033",
     )
 
 
@@ -126,12 +131,14 @@ def check_python_artifact(
             ok=True,
             message=f"Python artifact '{artifact.name}' is installed in the project virtual environment.",
             fix="",
+            finding_id="BASE-P040",
         )
     return ArtifactCheck(
         name=artifact.name,
         ok=False,
         message=f"Python artifact '{artifact.name}' is not installed in the project virtual environment.",
         fix=f"basectl setup {project}",
+        finding_id="BASE-P040",
     )
 
 

--- a/cli/python/base_setup/checks.py
+++ b/cli/python/base_setup/checks.py
@@ -10,6 +10,7 @@ class ArtifactCheck:
     message: str
     fix: str
     status: str = ""
+    finding_id: str = "BASE-P000"
 
 
 def check_to_json(check: ArtifactCheck) -> dict[str, str | bool]:
@@ -23,6 +24,7 @@ def check_to_json(check: ArtifactCheck) -> dict[str, str | bool]:
 
 def check_to_doctor_json(check: ArtifactCheck) -> dict[str, str]:
     return {
+        "id": check.finding_id,
         "status": doctor_status(check),
         "name": check.name,
         "message": check.message,
@@ -34,7 +36,7 @@ def doctor_status(check: ArtifactCheck) -> str:
     return check.status or ("ok" if check.ok else "error")
 
 
-def print_doctor_finding(status: str, name: str, message: str, fix: str = "") -> None:
-    print(f"{status:<5}  {name:<26}  {message}")
+def print_doctor_finding(status: str, finding_id: str, name: str, message: str, fix: str = "") -> None:
+    print(f"{status:<5}  {finding_id:<9}  {name:<26}  {message}")
     if fix:
         print(f"       Fix: {fix}")

--- a/cli/python/base_setup/delegates.py
+++ b/cli/python/base_setup/delegates.py
@@ -19,6 +19,7 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             ok=False,
             message=str(exc),
             fix=f"Update '{manifest.path}' or run 'basectl setup {manifest.project_name}'.",
+            finding_id="BASE-P010",
         )
 
     if not process.command_exists("brew"):
@@ -27,6 +28,7 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             ok=False,
             message=f"Homebrew is required to check Brewfile dependencies from '{brewfile_path}'.",
             fix="basectl setup",
+            finding_id="BASE-P011",
         )
 
     ok = process.run_check(["brew", "bundle", "check", f"--file={brewfile_path}"])
@@ -36,12 +38,14 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             ok=True,
             message=f"Brewfile dependencies are satisfied for '{brewfile_path}'.",
             fix="",
+            finding_id="BASE-P012",
         )
     return ArtifactCheck(
         name="brewfile",
         ok=False,
         message=f"Brewfile dependencies are not satisfied for '{brewfile_path}'.",
         fix=f"basectl setup {manifest.project_name}",
+        finding_id="BASE-P012",
     )
 
 
@@ -54,6 +58,7 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
             ok=False,
             message=str(exc),
             fix=f"Update '{manifest.path}' or run 'basectl setup {manifest.project_name}'.",
+            finding_id="BASE-P020",
         )
 
     if not process.command_exists("mise"):
@@ -62,6 +67,7 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
             ok=False,
             message=f"mise is required for project config '{mise_path}'.",
             fix="Install mise, then run 'basectl setup'.",
+            finding_id="BASE-P021",
         )
 
     return ArtifactCheck(
@@ -73,6 +79,7 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
         ),
         fix=f"Run 'basectl setup {manifest.project_name}' to install declared mise tools.",
         status="warn",
+        finding_id="BASE-P022",
     )
 
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -219,10 +219,10 @@ def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest, outp
     for check in checks:
         status = doctor_status(check)
         if status == "error":
-            print_doctor_finding("error", check.name, check.message, check.fix)
+            print_doctor_finding("error", check.finding_id, check.name, check.message, check.fix)
             error_count += 1
         else:
-            print_doctor_finding(status, check.name, check.message, check.fix)
+            print_doctor_finding(status, check.finding_id, check.name, check.message, check.fix)
     return min(error_count, 125)
 
 
@@ -255,6 +255,7 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
                 ok=True,
                 message=f"Project '{effective_manifest.project_name}' declares no artifacts.",
                 fix="",
+                finding_id="BASE-P001",
             )
         )
     return tuple(checks)

--- a/cli/python/base_setup/health.py
+++ b/cli/python/base_setup/health.py
@@ -17,10 +17,12 @@ def check_required_env_var(env_name: str) -> ArtifactCheck:
             ok=True,
             message=f"Environment variable '{env_name}' is set.",
             fix="",
+            finding_id="BASE-H001",
         )
     return ArtifactCheck(
         name=env_name,
         ok=False,
         message=f"Environment variable '{env_name}' is not set.",
         fix=f"Set {env_name} in your shell, .env, or secrets manager.",
+        finding_id="BASE-H001",
     )

--- a/cli/python/base_setup/ide.py
+++ b/cli/python/base_setup/ide.py
@@ -65,6 +65,7 @@ def ide_preference_warning_checks(manifest: BaseManifest, user_config: UserConfi
                 message="User config disables all IDE setup and checks for this machine.",
                 fix="Remove or change 'ide.enabled: false' in ~/.base.d/config.yaml to re-enable IDE work.",
                 status="warn",
+                finding_id="BASE-P100",
             )
         )
 
@@ -80,6 +81,7 @@ def ide_preference_warning_checks(manifest: BaseManifest, user_config: UserConfi
                     message=f"User config disables {ide_name} IDE setup and checks for this machine.",
                     fix=f"Remove or change 'ide.{ide_name}.enabled: false' in ~/.base.d/config.yaml to re-enable it.",
                     status="warn",
+                    finding_id="BASE-P101",
                 )
             )
             continue
@@ -100,6 +102,7 @@ def ide_preference_warning_checks(manifest: BaseManifest, user_config: UserConfi
                         "or update the project manifest."
                     ),
                     status="warn",
+                    finding_id="BASE-P102",
                 )
             )
     return checks
@@ -227,6 +230,7 @@ def check_ide_extension(project: str, definition: IdeDefinition, extension: str)
                 f"Enable the '{definition.cli}' shell command from {definition.label}, "
                 f"then run 'basectl setup {project}'."
             ),
+            finding_id="BASE-P110",
         )
 
     try:
@@ -237,6 +241,7 @@ def check_ide_extension(project: str, definition: IdeDefinition, extension: str)
             ok=False,
             message=str(exc),
             fix=f"basectl setup {project}",
+            finding_id="BASE-P111",
         )
 
     if extension in installed_extensions:
@@ -245,12 +250,14 @@ def check_ide_extension(project: str, definition: IdeDefinition, extension: str)
             ok=True,
             message=f"{definition.label} extension '{extension}' is installed.",
             fix="",
+            finding_id="BASE-P112",
         )
     return ArtifactCheck(
         name=extension,
         ok=False,
         message=f"{definition.label} extension '{extension}' is not installed.",
         fix=f"basectl setup {project}",
+        finding_id="BASE-P112",
     )
 
 
@@ -372,6 +379,7 @@ def check_ide_setting(
             ok=False,
             message=str(exc),
             fix=f"Repair '{settings_file}' and run 'basectl setup {project}'.",
+            finding_id="BASE-P120",
         )
 
     if key not in current_settings:
@@ -380,6 +388,7 @@ def check_ide_setting(
             ok=False,
             message=f"{definition.label} setting '{key}' is absent from '{settings_file}'.",
             fix=f"basectl setup {project}",
+            finding_id="BASE-P121",
         )
     if current_settings[key] == expected_value:
         return ArtifactCheck(
@@ -387,6 +396,7 @@ def check_ide_setting(
             ok=True,
             message=f"{definition.label} setting '{key}' matches the Base manifest.",
             fix="",
+            finding_id="BASE-P122",
         )
     return ArtifactCheck(
         name=f"{definition.label} setting: {key}",
@@ -396,6 +406,7 @@ def check_ide_setting(
             f"expected {json.dumps(expected_value, sort_keys=True)}. Base will not overwrite user settings."
         ),
         fix=f"Update '{settings_file}' manually or remove the key and run 'basectl setup {project}'.",
+        finding_id="BASE-P123",
     )
 
 
@@ -406,6 +417,7 @@ def check_ide_install(project: str, definition: IdeDefinition) -> ArtifactCheck:
             ok=False,
             message=f"Homebrew is required to check {definition.label} installation.",
             fix="basectl setup",
+            finding_id="BASE-P130",
         )
 
     cask_installed = process.run_check(["brew", "list", "--cask", definition.cask])
@@ -417,6 +429,7 @@ def check_ide_install(project: str, definition: IdeDefinition) -> ArtifactCheck:
             ok=True,
             message=f"{definition.label} is installed and CLI '{definition.cli}' is on PATH.",
             fix="",
+            finding_id="BASE-P131",
         )
     if not cask_installed:
         return ArtifactCheck(
@@ -424,10 +437,12 @@ def check_ide_install(project: str, definition: IdeDefinition) -> ArtifactCheck:
             ok=False,
             message=f"{definition.label} is not installed via Homebrew cask '{definition.cask}'.",
             fix=f"basectl setup {project}",
+            finding_id="BASE-P131",
         )
     return ArtifactCheck(
         name=f"{definition.label} CLI",
         ok=False,
         message=f"{definition.label} is installed, but CLI '{definition.cli}' is not on PATH.",
         fix=f"Enable the '{definition.cli}' shell command from {definition.label}.",
+        finding_id="BASE-P132",
     )

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -106,6 +106,7 @@ class ProjectCheckTests(unittest.TestCase):
 
         findings = json.loads(stdout.getvalue())
         self.assertEqual(status, 1)
+        self.assertEqual(findings[0]["id"], "BASE-P040")
         self.assertEqual(findings[0]["status"], "error")
         self.assertEqual(findings[0]["fix"], "basectl setup demo")
 
@@ -121,6 +122,7 @@ class ProjectCheckTests(unittest.TestCase):
         )
 
         self.assertEqual(engine.doctor_status(check), "warn")
+        self.assertEqual(setup_checks.check_to_doctor_json(check)["id"], "BASE-P000")
         self.assertEqual(setup_checks.check_to_doctor_json(check)["status"], "warn")
 
         default_manifest = BaseManifest(

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -1,0 +1,69 @@
+# Doctor Finding IDs
+
+`basectl doctor` emits stable finding identifiers in both text and JSON output.
+Automation, runbooks, and suppression policies should match on `id` instead of
+human-readable names or messages.
+
+Finding IDs are never reused after they ship. A finding may change its message,
+fix text, or severity over time, but its ID keeps the same meaning.
+
+## Namespaces
+
+| Prefix | Scope |
+| --- | --- |
+| `BASE-D` | Base runtime and developer-prerequisite findings |
+| `BASE-P` | Project manifest, artifact, IDE, and command-delegation findings |
+| `BASE-H` | Project health declaration findings |
+
+## Base Runtime Findings
+
+| ID | Finding |
+| --- | --- |
+| `BASE-D001` | Homebrew availability and PATH refresh |
+| `BASE-D002` | Xcode Command Line Tools availability |
+| `BASE-D003` | Homebrew Python formula availability |
+| `BASE-D004` | Base virtual environment availability |
+| `BASE-D005` | Base `PyYAML` package availability |
+| `BASE-D006` | Base `click` package availability |
+| `BASE-D101` | Unsupported developer prerequisite manager |
+| `BASE-D102` | Unsupported developer prerequisite version |
+| `BASE-D103` | Homebrew unavailable for developer prerequisite checks |
+| `BASE-D104` | Developer prerequisite Homebrew package status |
+| `BASE-D105` | GitHub CLI availability |
+| `BASE-D106` | GitHub CLI authentication status |
+
+## Project Findings
+
+| ID | Finding |
+| --- | --- |
+| `BASE-P001` | Empty project manifest artifact set |
+| `BASE-P010` | Brewfile path validity |
+| `BASE-P011` | Homebrew unavailable for Brewfile checks |
+| `BASE-P012` | Brewfile dependency status |
+| `BASE-P020` | mise config path validity |
+| `BASE-P021` | mise CLI availability |
+| `BASE-P022` | mise tool verification status |
+| `BASE-P030` | Unsupported artifact manager |
+| `BASE-P031` | Unsupported Homebrew artifact version |
+| `BASE-P032` | Homebrew unavailable for artifact checks |
+| `BASE-P033` | Homebrew artifact package status |
+| `BASE-P040` | Python package artifact status in the project virtual environment |
+| `BASE-P100` | User config disables all IDE setup and checks |
+| `BASE-P101` | User config disables setup and checks for one IDE |
+| `BASE-P102` | User IDE setting conflicts with a project manifest setting |
+| `BASE-P110` | IDE CLI unavailable for extension checks |
+| `BASE-P111` | IDE extension listing failure |
+| `BASE-P112` | IDE extension install status |
+| `BASE-P120` | IDE settings file validity |
+| `BASE-P121` | IDE setting presence |
+| `BASE-P122` | IDE setting expected-value match |
+| `BASE-P123` | IDE setting value differs from the Base manifest |
+| `BASE-P130` | Homebrew unavailable for IDE app checks |
+| `BASE-P131` | IDE app install status |
+| `BASE-P132` | IDE CLI PATH status |
+
+## Health Findings
+
+| ID | Finding |
+| --- | --- |
+| `BASE-H001` | Required environment variable presence |


### PR DESCRIPTION
## Summary
- Add stable `id` values to `basectl doctor` text and JSON findings across Base runtime, developer prerequisites, project artifacts, IDE checks, and health checks.
- Document the finding ID namespaces and assigned IDs in `docs/doctor-findings.md`.
- Keep `basectl check` output unchanged while making doctor output automation-friendly.

## Validation
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_diagnostics.py cli/python/base_dev/tests/test_engine.py
- bats cli/bash/commands/basectl/tests/doctor.bats
- bash -n cli/bash/commands/basectl/subcommands/doctor.sh
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup cli/python/base_dev
- git diff --check
- BASE_CACHE_DIR=/private/tmp/base-review-cache bin/basectl doctor --format json | /Users/rameshhp/.base.d/base/.venv/bin/python -m json.tool >/private/tmp/base-doctor-json.out
- env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test

Closes #321