### PR TITLE
Expand virtualenv integrity diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ Use `basectl doctor` when you want a human-oriented diagnosis with suggested
 fixes. Each finding includes a stable identifier that automation can use
 instead of matching on human-readable messages; see
 [docs/doctor-findings.md](docs/doctor-findings.md).
+`basectl check` and `basectl doctor` validate virtual environment integrity,
+not just path existence, and recommend `--recreate-venv` when a Base-managed
+venv is broken.
 
 ```bash
 basectl doctor

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -26,7 +26,7 @@ Check does:
   1. Verify Homebrew is installed.
   2. Verify Xcode Command Line Tools are installed.
   3. Verify Python 3.13 is installed via Homebrew.
-  4. Verify ~/.base.d/base/.venv exists.
+  4. Verify ~/.base.d/base/.venv is healthy.
   5. Verify developer prerequisites from lib/base/dev_manifest.yaml when --dev is passed.
   6. Verify project manifest artifacts when a project name is passed.
 EOF

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -175,18 +175,15 @@ base_doctor_check_python() {
 }
 
 base_doctor_check_virtualenv() {
-    local venv_dir
-
     setup_ensure_cached_paths
-    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
-    if setup_virtualenv_exists; then
-        base_doctor_print_finding "ok" "BASE-D004" "Base virtualenv" "Virtual environment exists at '$venv_dir'."
+    if setup_virtualenv_healthy; then
+        base_doctor_print_finding "ok" "BASE-D004" "Base virtualenv" "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
         return 0
     fi
 
     base_doctor_print_finding "error" "BASE-D004" "Base virtualenv" \
-        "Virtual environment is missing at '$venv_dir'." \
-        "basectl setup"
+        "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
+        "basectl setup --recreate-venv"
     return 1
 }
 

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -24,6 +24,7 @@ _BASE_SETUP_CHECK_OK=()
 _BASE_SETUP_CHECK_MESSAGES=()
 _BASE_SETUP_CHECK_RECOVERIES=()
 _BASE_SETUP_CHECK_DEBUG_MESSAGES=()
+_BASE_SETUP_VENV_HEALTH_MESSAGE=""
 
 setup_refresh_cached_paths() {
     local base_pythonpath old_pythonpath
@@ -107,6 +108,77 @@ setup_virtualenv_exists() {
     setup_ensure_cached_paths
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     [[ -f "$venv_dir/bin/activate" || -f "$venv_dir/pyvenv.cfg" ]]
+}
+
+setup_pyvenv_cfg_value() {
+    local key="$1"
+    local pyvenv_cfg="$2"
+    local line value
+
+    [[ -f "$pyvenv_cfg" ]] || return 1
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        case "$line" in
+            "$key = "*)
+                value="${line#"$key = "}"
+                printf '%s\n' "$value"
+                return 0
+                ;;
+        esac
+    done <"$pyvenv_cfg"
+    return 1
+}
+
+setup_virtualenv_home_has_python() {
+    local candidate home_path="$1"
+
+    [[ -d "$home_path" ]] || return 1
+    for candidate in "$home_path"/python*; do
+        [[ -x "$candidate" && ! -d "$candidate" ]] && return 0
+    done
+    return 1
+}
+
+setup_virtualenv_healthy_path() {
+    local executable_path home_path pyvenv_cfg python_bin venv_dir="$1"
+
+    pyvenv_cfg="$venv_dir/pyvenv.cfg"
+    python_bin="$venv_dir/bin/python"
+    if [[ ! -d "$venv_dir" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is missing at '$venv_dir'."
+        return 1
+    fi
+    if [[ ! -f "$pyvenv_cfg" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is missing pyvenv.cfg at '$pyvenv_cfg'."
+        return 1
+    fi
+    if [[ ! -x "$python_bin" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is missing or not executable at '$python_bin'."
+        return 1
+    fi
+    if ! "$python_bin" --version >/dev/null 2>&1; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python failed to run at '$python_bin'."
+        return 1
+    fi
+
+    executable_path="$(setup_pyvenv_cfg_value executable "$pyvenv_cfg" || true)"
+    if [[ -n "$executable_path" && ! -x "$executable_path" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is broken because '$executable_path' no longer exists."
+        return 1
+    fi
+
+    home_path="$(setup_pyvenv_cfg_value home "$pyvenv_cfg" || true)"
+    if [[ -n "$home_path" ]] && ! setup_virtualenv_home_has_python "$home_path"; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is broken because home path '$home_path' no longer provides Python."
+        return 1
+    fi
+
+    _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is healthy at '$venv_dir'."
+    return 0
+}
+
+setup_virtualenv_healthy() {
+    setup_ensure_cached_paths
+    setup_virtualenv_healthy_path "$_BASE_SETUP_VENV_DIR_CACHE"
 }
 
 setup_venv_dir() {
@@ -595,6 +667,34 @@ setup_project_venv_python_bin() {
     printf '%s\n' "$venv_dir/bin/python"
 }
 
+setup_recovery_project_venv() {
+    local project="$1"
+
+    printf "Run 'basectl setup %s --recreate-venv' to back up and recreate the project virtual environment.\n" "$project"
+}
+
+setup_print_project_venv_check_json() {
+    local ok="$1"
+    local message="$2"
+    local fix="$3"
+
+    printf '[{"name":"project_virtualenv","ok":%s,"message":"%s","fix":"%s"}]\n' \
+        "$ok" \
+        "$(setup_json_escape "$message")" \
+        "$(setup_json_escape "$fix")"
+}
+
+setup_print_project_venv_doctor_json() {
+    local status="$1"
+    local message="$2"
+    local fix="$3"
+
+    printf '[{"id":"BASE-P050","status":"%s","name":"project_virtualenv","message":"%s","fix":"%s"}]\n' \
+        "$(setup_json_escape "$status")" \
+        "$(setup_json_escape "$message")" \
+        "$(setup_json_escape "$fix")"
+}
+
 setup_run_project_artifact_setup() {
     setup_run_project_artifact_layer setup text
 }
@@ -631,7 +731,7 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path project python_bin resolved_name resolved_root resolve_output venv_dir
+    local exit_code manifest_path project project_venv_dir python_bin resolved_name resolved_root resolve_output venv_dir
     local args=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
@@ -693,14 +793,30 @@ setup_run_project_artifact_layer() {
         fi
     fi
 
-    if ! setup_project_venv_python_bin "$project" >/dev/null 2>&1; then
+    project_venv_dir="$(setup_project_venv_dir "$project")"
+    if ! setup_virtualenv_healthy_path "$project_venv_dir"; then
         if setup_is_dry_run && [[ "$action" == setup ]]; then
             log_info "[DRY-RUN] Would run Python project setup layer through base-wrapper for project '$project'."
             return 0
         fi
-        if [[ "$output_format" != json ]]; then
-            log_warn "Project virtual environment Python was not found at '$(setup_project_venv_dir "$project")/bin/python'."
-            log_warn "Run 'basectl setup $project' to bootstrap the project virtual environment."
+        if [[ "$output_format" == json ]]; then
+            if [[ "$action" == doctor ]]; then
+                setup_print_project_venv_doctor_json \
+                    "error" \
+                    "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
+                    "$(setup_recovery_project_venv "$project")"
+            else
+                setup_print_project_venv_check_json \
+                    false \
+                    "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
+                    "$(setup_recovery_project_venv "$project")"
+            fi
+        elif [[ "$action" == doctor ]]; then
+            printf 'error  %-9s  %-26s  %s\n' "BASE-P050" "Project virtualenv" "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+            printf '       Fix: %s\n' "$(setup_recovery_project_venv "$project")"
+        else
+            log_warn "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+            log_warn "$(setup_recovery_project_venv "$project")"
         fi
         return 1
     fi
@@ -787,14 +903,12 @@ setup_collect_base_check_results() {
     local missing=0
     local pyyaml_ok=false pyyaml_package
     local refresh_brew_failure_mode="${1:-warn}"
-    local venv_dir
 
     setup_clear_check_results
     setup_require_macos
     click_package="$(setup_click_package)"
     pyyaml_package="$(setup_pyyaml_package)"
     setup_ensure_cached_paths
-    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
 
     if brew_bin="$(setup_find_brew_bin)"; then
         if setup_refresh_brew_path; then
@@ -840,13 +954,13 @@ setup_collect_base_check_results() {
         missing=1
     fi
 
-    if setup_virtualenv_exists; then
-        setup_add_check_result "base_virtualenv" true "Virtual environment exists at '$venv_dir'."
+    if setup_virtualenv_healthy; then
+        setup_add_check_result "base_virtualenv" true "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
     else
         setup_add_check_result \
             "base_virtualenv" \
             false \
-            "Virtual environment is missing at '$venv_dir'." \
+            "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
             "$(setup_recovery_venv)"
         missing=1
     fi

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -33,7 +33,7 @@ load ./setup_helpers.bash
     [[ "$output" == *"Xcode Command Line Tools are installed."* ]]
     [[ "$output" == *"Python formula 'python@3.13' is installed via Homebrew."* ]]
     [[ "$output" != *"BATS formula 'bats-core'"* ]]
-    [[ "$output" == *"Virtual environment exists at '$venv_dir'."* ]]
+    [[ "$output" == *"Virtual environment is healthy at '$venv_dir'."* ]]
     [[ "$output" == *"Python package 'PyYAML' is installed in the Base virtual environment."* ]]
     [[ "$output" == *"Python package 'click' is installed in the Base virtual environment."* ]]
     [[ "$output" == *"Base CLI environment check passed."* ]]
@@ -81,7 +81,7 @@ load ./setup_helpers.bash
     run_base_command check
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Virtual environment exists at '$venv_dir'."* ]]
+    [[ "$output" == *"Virtual environment is healthy at '$venv_dir'."* ]]
     [[ "$output" == *"Python package 'PyYAML' is not installed in the Base virtual environment."* ]]
     [[ "$output" == *"Run 'basectl setup' to install Base Python bootstrap packages."* ]]
     [[ "$output" == *"Python package 'click' is installed in the Base virtual environment."* ]]
@@ -178,6 +178,39 @@ load ./setup_helpers.bash
     [ "${stderr:-}" = "" ]
 }
 
+@test "basectl check --format json reports broken Base virtualenv integrity" {
+    local missing_home="$TEST_TMPDIR/missing-python-home"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/bats-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+    printf 'home = %s\n' "$missing_home" > "$venv_dir/pyvenv.cfg"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        OSTYPE="darwin24" \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
+        "$BASE_REPO_ROOT/bin/basectl" check --format json
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"name":"base_virtualenv","ok":false'* ]]
+    [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
+    [ "${stderr:-}" = "" ]
+}
+
 @test "basectl check --format json escapes C0 control characters and DEL in strings" {
     local control_package
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
@@ -243,6 +276,46 @@ load ./setup_helpers.bash
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
     [[ "$output" == *'"name":"demo-artifact","ok":true'* || "$output" == *'"name": "demo-artifact"'* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl check project --format json reports broken project virtualenv integrity" {
+    local missing_home="$TEST_TMPDIR/missing-project-python-home"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/bats-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$TEST_HOME/.base.d/demo/.venv"
+    printf 'home = %s\n' "$missing_home" > "$TEST_HOME/.base.d/demo/.venv/pyvenv.cfg"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        OSTYPE="darwin24" \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
+        BASE_SETUP_TEST_WORKSPACE="$workspace" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
+        "$BASE_REPO_ROOT/bin/basectl" check demo --format json
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"project_checks":'* ]]
+    [[ "$output" == *'"name":"project_virtualenv","ok":false'* ]]
+    [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
+    [[ "$output" == *"Run 'basectl setup demo --recreate-venv' to back up and recreate the project virtual environment."* ]]
     [ "${stderr:-}" = "" ]
 }
 

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -52,6 +52,10 @@ printf 'gh version test\n'
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     case "${4:-}" in
         PyYAML|click) exit 0 ;;
@@ -82,7 +86,7 @@ EOF
     [[ "$output" == *"ok"*"Homebrew"*"Homebrew is installed."* ]]
     [[ "$output" == *"ok"*"bats-core"*"Artifact 'bats-core' is installed via Homebrew package 'bats-core'."* ]]
     [[ "$output" == *"ok"*"gh"*"Artifact 'gh' is installed via Homebrew package 'gh'."* ]]
-    [[ "$output" == *"ok"*"Base virtualenv"*"Virtual environment exists at"* ]]
+    [[ "$output" == *"ok"*"Base virtualenv"*"Virtual environment is healthy at"* ]]
     [[ "$output" == *"Base doctor found no blocking issues."* ]]
 }
 
@@ -122,6 +126,10 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     case "${4:-}" in
         PyYAML|click) exit 0 ;;
@@ -167,6 +175,64 @@ EOF
     [[ "$output" == *"error"*"Homebrew"*"Homebrew is not installed."* ]]
     [[ "$output" == *"Fix: basectl setup"* ]]
     [[ "$output" == *"Base doctor found"*"blocking issue(s)."* ]]
+}
+
+@test "basectl doctor reports broken Base virtualenv integrity" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local missing_home="$TEST_TMPDIR/missing-python-home"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+exit 1
+EOF
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$venv_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
+    printf 'home = %s\n' "$missing_home" > "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"error"*"BASE-D004"*"Base virtualenv"*"home path '$missing_home'"* ]]
+    [[ "$output" == *"Fix: basectl setup --recreate-venv"* ]]
 }
 
 @test "basectl doctor --format json reports structured findings" {
@@ -230,6 +296,10 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     case "${4:-}" in
         PyYAML|click) exit 0 ;;
@@ -251,6 +321,7 @@ EOF
     mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
     touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+    touch "$TEST_HOME/.base.d/demo/.venv/pyvenv.cfg"
 
     run env \
         HOME="$TEST_HOME" \
@@ -308,6 +379,10 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     case "${4:-}" in
         PyYAML|click) exit 0 ;;
@@ -329,6 +404,7 @@ EOF
     mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
     touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+    touch "$TEST_HOME/.base.d/demo/.venv/pyvenv.cfg"
 
     run --separate-stderr env \
         HOME="$TEST_HOME" \
@@ -345,5 +421,79 @@ EOF
     [[ "$output" == *'"project_findings":'* ]]
     [[ "$output" == *'"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"'* ]]
     [[ "$output" != *"Running Python project doctor layer."* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl doctor project --format json reports broken project virtualenv integrity" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local missing_home="$TEST_TMPDIR/missing-project-python-home"
+    local project_python="$TEST_HOME/.base.d/demo/.venv/bin/python"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$(dirname "$project_python")" "$workspace/demo"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected doctor project broken venv python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cp "$venv_python" "$project_python"
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$venv_python" "$project_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+    printf 'home = %s\n' "$missing_home" > "$TEST_HOME/.base.d/demo/.venv/pyvenv.cfg"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor demo --format json
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"project_findings":'* ]]
+    [[ "$output" == *'"id":"BASE-P050","status":"error","name":"project_virtualenv"'* ]]
+    [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
+    [[ "$output" == *"Run 'basectl setup demo --recreate-venv' to back up and recreate the project virtual environment."* ]]
     [ "${stderr:-}" = "" ]
 }

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -37,11 +37,16 @@ load ./setup_helpers.bash
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
     mkdir -p "$venv_dir/bin"
+    : > "$venv_dir/pyvenv.cfg"
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -80,6 +80,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
@@ -153,6 +157,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
@@ -297,6 +305,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
@@ -417,11 +429,16 @@ create_base_venv_stub() {
     local venv_dir="${1:-$TEST_HOME/.base.d/base/.venv}"
 
     mkdir -p "$venv_dir/bin"
+    : > "$venv_dir/pyvenv.cfg"
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
     printf '%s\n' "$4" >> "${BASE_SETUP_TEST_STATE_DIR:?}/pip-show.log"
     [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
@@ -458,11 +475,16 @@ create_project_setup_venv_stub() {
     local venv_dir="${1:-$TEST_HOME/.base.d/base/.venv}"
 
     mkdir -p "$venv_dir/bin"
+    : > "$venv_dir/pyvenv.cfg"
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     shift 2
     printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-args"

--- a/docs/check-parallelism.md
+++ b/docs/check-parallelism.md
@@ -15,7 +15,7 @@ Good candidates:
 - Homebrew presence and path discovery
 - Xcode Command Line Tools presence
 - Homebrew Python formula presence
-- Base virtual environment presence
+- Base virtual environment integrity
 - Base bootstrap Python package checks
 
 Do not parallelize steps that mutate process state or depend on an earlier
@@ -51,7 +51,7 @@ order:
 1. Homebrew
 2. Xcode Command Line Tools
 3. Python formula
-4. Base virtual environment
+4. Base virtual environment integrity
 5. PyYAML
 6. click
 7. developer prerequisite checks, when `--dev` is set

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -22,7 +22,7 @@ fix text, or severity over time, but its ID keeps the same meaning.
 | `BASE-D001` | Homebrew availability and PATH refresh |
 | `BASE-D002` | Xcode Command Line Tools availability |
 | `BASE-D003` | Homebrew Python formula availability |
-| `BASE-D004` | Base virtual environment availability |
+| `BASE-D004` | Base virtual environment integrity |
 | `BASE-D005` | Base `PyYAML` package availability |
 | `BASE-D006` | Base `click` package availability |
 | `BASE-D101` | Unsupported developer prerequisite manager |
@@ -48,6 +48,7 @@ fix text, or severity over time, but its ID keeps the same meaning.
 | `BASE-P032` | Homebrew unavailable for artifact checks |
 | `BASE-P033` | Homebrew artifact package status |
 | `BASE-P040` | Python package artifact status in the project virtual environment |
+| `BASE-P050` | Project virtual environment integrity |
 | `BASE-P100` | User config disables all IDE setup and checks |
 | `BASE-P101` | User config disables setup and checks for one IDE |
 | `BASE-P102` | User IDE setting conflicts with a project manifest setting |


### PR DESCRIPTION
## Summary
- Validate Base and project virtualenvs beyond path existence: pyvenv.cfg, executable Python, python --version, and pyvenv.cfg home/executable references.
- Surface broken project virtualenvs through check/doctor text and JSON with the new BASE-P050 finding.
- Update docs and tests for the stronger virtualenv diagnostics.

## Validation
- bats cli/bash/commands/basectl/tests/check.bats
- bats cli/bash/commands/basectl/tests/doctor.bats
- bats cli/bash/commands/basectl/tests/setup.bats
- env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test
- git diff --check

Closes #323