### PR TITLE
Add repository baseline commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `basectl repo init/check/configure` to create, validate, and configure
+  a standard Base-managed repository baseline.
+
 ### Fixed
 
 - Updated the README status section to match the current `0.2.0` release.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Current implemented commands include:
 - `basectl update-profile`
 - `basectl update`
 - `basectl projects list`
+- `basectl repo init <name>`
+- `basectl repo check [path]`
+- `basectl repo configure [path]`
 - `basectl activate <project>`
 - `basectl test [project]`
 - `basectl run <project> <command>`
@@ -296,6 +299,32 @@ directory of `BASE_HOME`, which matches the source-checkout sibling-repo layout.
 Use `--workspace <path>` to inspect a different workspace root for one command.
 Output is tab-separated as `<project-name><TAB><path>`. Use `--format json` for
 machine-readable output.
+
+Start a new Base-managed repository with:
+
+```bash
+basectl repo init example --path ~/work/example --repo codeforester/example
+```
+
+This creates the local repository baseline: README, version, changelog,
+contributing guide, MIT license, `.gitignore`, `base_manifest.yaml`, a
+`tests/validate.sh` contract, and a GitHub Actions workflow that runs it.
+`repo init` also standardizes the GitHub repository when `--repo <owner/name>`
+is provided or when an existing `origin` remote can be inferred. Use
+`--no-configure` to skip the GitHub step, or rerun it later with
+`basectl repo configure`.
+
+Check and repair the repo baseline with:
+
+```bash
+basectl repo check ~/work/example
+basectl repo configure ~/work/example --repo codeforester/example
+```
+
+`repo configure` is intentionally idempotent. It enables Issues and Projects,
+standardizes merge settings, deletes branches after merge, and creates the
+standard GitHub labels documented in
+[Repository Baseline](docs/repo-baseline.md).
 
 Run a discovered project's declared test command with:
 
@@ -921,8 +950,8 @@ Base follows a few simple principles.
 
 Base `0.2.0` is the current release. The implemented command surface covers
 setup, checks, diagnostics, project discovery, project activation, project test
-execution, mise integration, cleanup, updates, onboarding, and GitHub workflow
-helpers.
+execution, mise integration, cleanup, updates, onboarding, repository baseline
+creation, and GitHub workflow helpers.
 
 For the documentation map and naming convention, see
 [docs/README.md](docs/README.md). For the architecture and product direction,

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -31,6 +31,7 @@ that delegate to `basectl`.
 - `doctor`
 - `gh`
 - `onboard`
+- `repo init/check/configure`
 - `test`
 - `update-profile`
 - `update`
@@ -68,6 +69,11 @@ that delegate to `basectl`.
 - `basectl onboard` guides first-run setup around existing setup, check,
   doctor, profile, and project-discovery primitives. See
   `docs/basectl-onboard.md`.
+- `basectl repo init <name>` creates the standard local repository baseline and
+  configures the GitHub repository when `--repo <owner/name>` is provided or an
+  existing `origin` remote can be inferred. `basectl repo check [path]`
+  verifies the local baseline, and `basectl repo configure [path]` reapplies the
+  GitHub settings and labels.
 - `basectl test [project]` runs the project's manifest `test.command` or
   `test.mise` from the project root with Base project environment variables
   exported. Use `basectl test <project> -- <args...>` to pass extra arguments

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -19,6 +19,8 @@ Commands:
     Run a project's declared test command.
   run <project> <command> [options]
     Run a project's declared command.
+  repo <init|check|configure> [options]
+    Create, check, and configure a standard Base-managed repository baseline.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   config <path|show|doctor>
@@ -172,6 +174,11 @@ basectl_do_run() {
     base_run_subcommand_main "$@"
 }
 
+basectl_do_repo() {
+    basectl_source_subcommand_module repo || return 1
+    base_repo_subcommand_main "$@"
+}
+
 basectl_do_clean() {
     basectl_source_subcommand_module clean || return 1
     base_clean_subcommand_main "$@"
@@ -312,6 +319,7 @@ basectl_main() {
         check)            basectl_do_check "$@" ;;
         test)             basectl_do_test "$@" ;;
         run)              basectl_do_run "$@" ;;
+        repo)             basectl_do_repo "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         config)           basectl_do_config "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1,0 +1,680 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_repo_subcommand_sourced:-}" ]] && return
+_base_repo_subcommand_sourced=1
+readonly _base_repo_subcommand_sourced
+
+BASE_REPO_BASELINE_FILES=(
+    README.md
+    VERSION
+    CHANGELOG.md
+    CONTRIBUTING.md
+    LICENSE
+    .gitignore
+    base_manifest.yaml
+    tests/validate.sh
+    .github/workflows/tests.yml
+)
+
+base_repo_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl repo init <name> [options]
+  basectl repo check [path] [options]
+  basectl repo configure [path] [options]
+
+Options:
+  --path <path>                 Target path for repo init. Defaults to ./<name>.
+  --repo <owner/name>           GitHub repository to configure.
+  --description <text>          Repository description for generated README.
+  --copyright-holder <name>     Copyright holder for generated LICENSE.
+  --no-configure                Skip GitHub configuration during repo init.
+  --dry-run                     Print planned changes without applying them.
+  -v                            Enable DEBUG logging for this subcommand.
+  -h, --help                    Show this help text.
+
+Create, check, and configure a standard Base-managed repository baseline.
+EOF
+}
+
+base_repo_usage_error() {
+    base_repo_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_repo_default_description() {
+    local name="$1"
+
+    printf 'Base-managed project %s.\n' "$name"
+}
+
+base_repo_validate_name() {
+    local name="$1"
+
+    [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] || {
+        printf 'Repository name must start with a letter or digit and contain only letters, digits, dot, underscore, and dash.\n' >&2
+        return 1
+    }
+}
+
+base_repo_target_path() {
+    local path="$1"
+    local parent name
+
+    if [[ "$path" = /* ]]; then
+        printf '%s\n' "$path"
+        return 0
+    fi
+
+    parent="$(dirname -- "$path")"
+    name="$(basename -- "$path")"
+    if [[ -d "$parent" ]]; then
+        parent="$(cd -- "$parent" && pwd -P)"
+    else
+        parent="$(cd -- "$(pwd -P)" && pwd -P)/$parent"
+    fi
+    printf '%s/%s\n' "$parent" "$name"
+}
+
+base_repo_baseline_year() {
+    date +%Y
+}
+
+base_repo_write_stream() {
+    local dry_run="$1"
+    local target="$2"
+
+    if [[ -e "$target" ]]; then
+        log_info "Repository baseline file already exists at '$target'; leaving it unchanged."
+        return 0
+    fi
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would create '%s'.\n" "$target"
+        return 0
+    fi
+
+    mkdir -p "$(dirname -- "$target")"
+    cat > "$target"
+}
+
+base_repo_write_executable_stream() {
+    local dry_run="$1"
+    local target="$2"
+
+    if [[ -e "$target" ]]; then
+        log_info "Repository baseline file already exists at '$target'; leaving it unchanged."
+        return 0
+    fi
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would create executable '%s'.\n" "$target"
+        return 0
+    fi
+
+    mkdir -p "$(dirname -- "$target")"
+    cat > "$target"
+    chmod +x "$target"
+}
+
+base_repo_write_readme() {
+    local description="$3"
+    local dry_run="$1"
+    local name="$2"
+    local root="$4"
+
+    base_repo_write_stream "$dry_run" "$root/README.md" <<EOF
+# $name
+
+$description
+
+## Base
+
+This repository is managed by [Base](https://github.com/codeforester/base).
+
+Common commands:
+
+\`\`\`bash
+basectl setup $name
+basectl check $name
+basectl doctor $name
+basectl test $name
+\`\`\`
+EOF
+}
+
+base_repo_write_version() {
+    local dry_run="$1"
+    local root="$2"
+
+    base_repo_write_stream "$dry_run" "$root/VERSION" <<'EOF'
+0.1.0
+EOF
+}
+
+base_repo_write_changelog() {
+    local dry_run="$1"
+    local name="$2"
+    local root="$3"
+
+    base_repo_write_stream "$dry_run" "$root/CHANGELOG.md" <<EOF
+# Changelog
+
+All notable changes to $name will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and versions are tracked in the repo-root \`VERSION\` file.
+
+## [Unreleased]
+
+### Added
+
+- Initialized the repository with the Base-managed repo baseline.
+EOF
+}
+
+base_repo_write_contributing() {
+    local dry_run="$1"
+    local name="$2"
+    local root="$3"
+
+    base_repo_write_stream "$dry_run" "$root/CONTRIBUTING.md" <<EOF
+# Contributing to $name
+
+Thank you for improving this project.
+
+## Workflow
+
+1. Create or choose a GitHub issue before starting implementation work.
+2. Use one of the standard issue labels: \`bug\`, \`enhancement\`,
+   \`documentation\`, \`ci\`, or \`security\`.
+3. Use a focused branch and pull request for each issue.
+4. Run the project checks before opening or updating a pull request.
+
+Useful commands:
+
+\`\`\`bash
+basectl check $name
+basectl doctor $name
+basectl test $name
+\`\`\`
+EOF
+}
+
+base_repo_write_license() {
+    local copyright_holder="$2"
+    local dry_run="$1"
+    local root="$3"
+    local year
+
+    year="$(base_repo_baseline_year)"
+    base_repo_write_stream "$dry_run" "$root/LICENSE" <<EOF
+MIT License
+
+Copyright (c) $year $copyright_holder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+EOF
+}
+
+base_repo_write_gitignore() {
+    local dry_run="$1"
+    local root="$2"
+
+    base_repo_write_stream "$dry_run" "$root/.gitignore" <<'EOF'
+.DS_Store
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+dist/
+build/
+*.egg-info/
+EOF
+}
+
+base_repo_write_manifest() {
+    local dry_run="$1"
+    local name="$2"
+    local root="$3"
+
+    base_repo_write_stream "$dry_run" "$root/base_manifest.yaml" <<EOF
+schema_version: 1
+
+project:
+  name: $name
+
+test:
+  command: ./tests/validate.sh
+EOF
+}
+
+base_repo_write_validate_script() {
+    local dry_run="$1"
+    local root="$2"
+
+    base_repo_write_executable_stream "$dry_run" "$root/tests/validate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_files=(
+  README.md
+  VERSION
+  CHANGELOG.md
+  CONTRIBUTING.md
+  LICENSE
+  base_manifest.yaml
+)
+
+for file in "${required_files[@]}"; do
+  [[ -f "$file" ]] || {
+    printf 'Missing required file: %s\n' "$file" >&2
+    exit 1
+  }
+done
+
+printf 'Repository baseline is present.\n'
+EOF
+}
+
+base_repo_write_tests_workflow() {
+    local dry_run="$1"
+    local root="$2"
+
+    base_repo_write_stream "$dry_run" "$root/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate repository baseline
+        run: ./tests/validate.sh
+EOF
+}
+
+base_repo_write_baseline() {
+    local copyright_holder="$4"
+    local description="$3"
+    local dry_run="$1"
+    local name="$2"
+    local root="$5"
+    local status=0
+
+    if [[ "$dry_run" != "1" ]]; then
+        mkdir -p "$root" || return 1
+    fi
+
+    base_repo_write_readme "$dry_run" "$name" "$description" "$root" || status=1
+    base_repo_write_version "$dry_run" "$root" || status=1
+    base_repo_write_changelog "$dry_run" "$name" "$root" || status=1
+    base_repo_write_contributing "$dry_run" "$name" "$root" || status=1
+    base_repo_write_license "$dry_run" "$copyright_holder" "$root" || status=1
+    base_repo_write_gitignore "$dry_run" "$root" || status=1
+    base_repo_write_manifest "$dry_run" "$name" "$root" || status=1
+    base_repo_write_validate_script "$dry_run" "$root" || status=1
+    base_repo_write_tests_workflow "$dry_run" "$root" || status=1
+
+    return "$status"
+}
+
+base_repo_infer_github_repo() {
+    local path="$1"
+    local remote_url
+
+    remote_url="$(git -C "$path" remote get-url origin 2>/dev/null || true)"
+    [[ -n "$remote_url" ]] || return 1
+
+    case "$remote_url" in
+        git@github.com:*.git)
+            remote_url="${remote_url#git@github.com:}"
+            remote_url="${remote_url%.git}"
+            ;;
+        https://github.com/*.git)
+            remote_url="${remote_url#https://github.com/}"
+            remote_url="${remote_url%.git}"
+            ;;
+        https://github.com/*)
+            remote_url="${remote_url#https://github.com/}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    [[ "$remote_url" == */* ]] || return 1
+    printf '%s\n' "$remote_url"
+}
+
+base_repo_require_gh() {
+    command -v gh >/dev/null 2>&1 || {
+        log_error "GitHub CLI 'gh' is required for repository configuration."
+        return 1
+    }
+    gh auth status -h github.com >/dev/null 2>&1 || {
+        log_error "GitHub CLI authentication is not ready."
+        log_error "Run 'gh auth login -h github.com' and retry."
+        return 1
+    }
+}
+
+base_repo_configure_label() {
+    local color="$3"
+    local description="$4"
+    local dry_run="$1"
+    local label="$2"
+    local repo="$5"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would run: gh label create %q --repo %q --color %q --description %q --force\n" \
+            "$label" "$repo" "$color" "$description"
+        return 0
+    fi
+
+    gh label create "$label" --repo "$repo" --color "$color" --description "$description" --force
+}
+
+base_repo_configure_github() {
+    local dry_run="$1"
+    local repo="$2"
+    local status=0
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would run: gh repo edit %q --enable-issues --enable-projects --enable-squash-merge --enable-merge-commit=false --enable-rebase-merge=false --delete-branch-on-merge --squash-merge-commit-message pr-title-description\n" "$repo"
+    else
+        base_repo_require_gh || return 1
+        gh repo edit "$repo" \
+            --enable-issues \
+            --enable-projects \
+            --enable-squash-merge \
+            --enable-merge-commit=false \
+            --enable-rebase-merge=false \
+            --delete-branch-on-merge \
+            --squash-merge-commit-message pr-title-description || return 1
+    fi
+
+    base_repo_configure_label "$dry_run" bug "d73a4a" "Something is not working" "$repo" || status=1
+    base_repo_configure_label "$dry_run" enhancement "a2eeef" "New feature or product improvement" "$repo" || status=1
+    base_repo_configure_label "$dry_run" documentation "0075ca" "Documentation improvements" "$repo" || status=1
+    base_repo_configure_label "$dry_run" ci "0e8a16" "Continuous integration, tests, automation, or release workflows" "$repo" || status=1
+    base_repo_configure_label "$dry_run" security "ee0701" "Security hardening or vulnerability work" "$repo" || status=1
+    base_repo_configure_label "$dry_run" needs-demo "fbca04" "Change should update a project demo" "$repo" || status=1
+
+    return "$status"
+}
+
+base_repo_check_baseline() {
+    local missing=0
+    local path="$1"
+    local rel
+
+    for rel in "${BASE_REPO_BASELINE_FILES[@]}"; do
+        if [[ ! -f "$path/$rel" ]]; then
+            log_warn "Missing repository baseline file '$rel'."
+            missing=1
+        else
+            log_info "Repository baseline file '$rel' exists."
+        fi
+    done
+
+    if [[ -f "$path/tests/validate.sh" && ! -x "$path/tests/validate.sh" ]]; then
+        log_warn "Repository baseline file 'tests/validate.sh' is not executable."
+        missing=1
+    fi
+
+    if ((missing)); then
+        log_warn "Repository baseline check found missing requirements."
+        return 1
+    fi
+
+    log_info "Repository baseline check passed."
+    return 0
+}
+
+base_repo_init() {
+    local configure=1
+    local copyright_holder="Ramesh Padmanabhaiah"
+    local description=""
+    local dry_run=0
+    local github_repo=""
+    local name=""
+    local path=""
+    local root
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_repo_subcommand_usage
+                return 0
+                ;;
+            --path)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--path' requires an argument."
+                    return $?
+                }
+                path="$2"
+                shift 2
+                ;;
+            --path=*)
+                path="${1#--path=}"
+                shift
+                ;;
+            --repo)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--repo' requires an argument."
+                    return $?
+                }
+                github_repo="$2"
+                shift 2
+                ;;
+            --repo=*)
+                github_repo="${1#--repo=}"
+                shift
+                ;;
+            --description)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--description' requires an argument."
+                    return $?
+                }
+                description="$2"
+                shift 2
+                ;;
+            --copyright-holder)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--copyright-holder' requires an argument."
+                    return $?
+                }
+                copyright_holder="$2"
+                shift 2
+                ;;
+            --no-configure)
+                configure=0
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            -v)
+                set_log_level DEBUG
+                export LOG_DEBUG=1
+                shift
+                ;;
+            -*)
+                base_repo_usage_error "Unknown repo init option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$name" ]]; then
+                    base_repo_usage_error "The 'repo init' command accepts exactly one repository name."
+                    return $?
+                fi
+                name="$1"
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$name" ]] || {
+        base_repo_usage_error "Repository name is required."
+        return $?
+    }
+    base_repo_validate_name "$name" || return 2
+    [[ -n "$path" ]] || path="./$name"
+    [[ -n "$description" ]] || description="$(base_repo_default_description "$name")"
+    root="$(base_repo_target_path "$path")"
+
+    base_repo_write_baseline "$dry_run" "$name" "$description" "$copyright_holder" "$root" || return 1
+
+    if ((configure)); then
+        if [[ -z "$github_repo" ]]; then
+            github_repo="$(base_repo_infer_github_repo "$root" || true)"
+        fi
+        if [[ -n "$github_repo" ]]; then
+            base_repo_configure_github "$dry_run" "$github_repo" || return 1
+        else
+            log_info "Skipping GitHub repository configuration because no GitHub repo was provided or inferred."
+        fi
+    fi
+}
+
+base_repo_check() {
+    local path="."
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_repo_subcommand_usage
+                return 0
+                ;;
+            -v)
+                set_log_level DEBUG
+                export LOG_DEBUG=1
+                shift
+                ;;
+            -*)
+                base_repo_usage_error "Unknown repo check option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ "$path" != "." ]]; then
+                    base_repo_usage_error "The 'repo check' command accepts at most one path."
+                    return $?
+                fi
+                path="$1"
+                shift
+                ;;
+        esac
+    done
+
+    path="$(base_repo_target_path "$path")"
+    base_repo_check_baseline "$path"
+}
+
+base_repo_configure() {
+    local dry_run=0
+    local github_repo=""
+    local path="."
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_repo_subcommand_usage
+                return 0
+                ;;
+            --repo)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--repo' requires an argument."
+                    return $?
+                }
+                github_repo="$2"
+                shift 2
+                ;;
+            --repo=*)
+                github_repo="${1#--repo=}"
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            -v)
+                set_log_level DEBUG
+                export LOG_DEBUG=1
+                shift
+                ;;
+            -*)
+                base_repo_usage_error "Unknown repo configure option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ "$path" != "." ]]; then
+                    base_repo_usage_error "The 'repo configure' command accepts at most one path."
+                    return $?
+                fi
+                path="$1"
+                shift
+                ;;
+        esac
+    done
+
+    path="$(base_repo_target_path "$path")"
+    if [[ -z "$github_repo" ]]; then
+        github_repo="$(base_repo_infer_github_repo "$path" || true)"
+    fi
+    [[ -n "$github_repo" ]] || {
+        log_error "Unable to infer GitHub repository from '$path'."
+        log_error "Pass --repo <owner/name> to configure a GitHub repository explicitly."
+        return 1
+    }
+
+    base_repo_configure_github "$dry_run" "$github_repo"
+}
+
+base_repo_subcommand_main() {
+    local command="${1:-}"
+
+    case "$command" in
+        -h|--help|help|"")
+            base_repo_subcommand_usage
+            return 0
+            ;;
+        init)
+            shift
+            base_repo_init "$@"
+            ;;
+        check)
+            shift
+            base_repo_check "$@"
+            ;;
+        configure)
+            shift
+            base_repo_configure "$@"
+            ;;
+        *)
+            base_repo_usage_error "Unknown repo command '$command'."
+            ;;
+    esac
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -74,7 +74,19 @@ EOF
             COMP_WORDS=(basectl clean --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
-            printf "clean_options=%s\n" "${COMPREPLY[*]}"'
+            printf "clean_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl repo ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "repo_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl repo init --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "repo_init_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl repo configure --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "repo_configure_options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
@@ -90,6 +102,9 @@ EOF
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
+    [[ "$output" == *"repo_commands=init check configure"* ]]
+    [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --no-configure --dry-run"* ]]
+    [[ "$output" == *"repo_configure_options=--repo --dry-run"* ]]
 }
 
 @test "Bash completion includes setup notification options" {

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -13,6 +13,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
+    [[ "$output" == *"repo <init|check|configure> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
@@ -46,6 +47,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  onboard [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
+    grep -Fqx '  repo <init|check|configure> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl repo prints help" {
+    run_basectl repo --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl repo init <name>"* ]]
+    [[ "$output" == *"basectl repo check [path]"* ]]
+    [[ "$output" == *"basectl repo configure [path]"* ]]
+}
+
+@test "basectl repo init dry-run prints baseline and configuration plan" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir" --repo codeforester/base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create executable '$repo_dir/tests/validate.sh'."* ]]
+    [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
+    [[ "$output" == *"gh label create bug"* ]]
+    [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo init creates the standard repository baseline" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir" --no-configure
+
+    [ "$status" -eq 0 ]
+    [ -f "$repo_dir/README.md" ]
+    [ -f "$repo_dir/VERSION" ]
+    [ -f "$repo_dir/CHANGELOG.md" ]
+    [ -f "$repo_dir/CONTRIBUTING.md" ]
+    [ -f "$repo_dir/LICENSE" ]
+    [ -f "$repo_dir/.gitignore" ]
+    [ -f "$repo_dir/base_manifest.yaml" ]
+    [ -x "$repo_dir/tests/validate.sh" ]
+    [ -f "$repo_dir/.github/workflows/tests.yml" ]
+    grep -Fqx "0.1.0" "$repo_dir/VERSION"
+    grep -Fq "name: base-demo" "$repo_dir/base_manifest.yaml"
+    grep -Fq "command: ./tests/validate.sh" "$repo_dir/base_manifest.yaml"
+}
+
+@test "basectl repo init leaves existing files unchanged" {
+    local repo_dir="$TEST_TMPDIR/custom"
+
+    mkdir -p "$repo_dir"
+    printf 'custom readme\n' > "$repo_dir/README.md"
+
+    run_basectl repo init custom --path "$repo_dir" --no-configure
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$repo_dir/README.md")" = "custom readme" ]
+    [ -f "$repo_dir/base_manifest.yaml" ]
+}
+
+@test "basectl repo check passes for a generated baseline" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir" --no-configure
+    [ "$status" -eq 0 ]
+
+    run_basectl repo check "$repo_dir"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository baseline check passed."* ]]
+}
+
+@test "basectl repo check reports missing baseline files" {
+    local repo_dir="$TEST_TMPDIR/incomplete"
+
+    mkdir -p "$repo_dir"
+    printf '# Incomplete\n' > "$repo_dir/README.md"
+
+    run_basectl repo check "$repo_dir"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Missing repository baseline file 'VERSION'."* ]]
+    [[ "$output" == *"Repository baseline check found missing requirements."* ]]
+}
+
+@test "basectl repo configure dry-run prints GitHub settings and labels" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+
+    run_basectl repo configure "$repo_dir" --repo codeforester/base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
+    [[ "$output" == *"--enable-squash-merge"* ]]
+    [[ "$output" == *"--delete-branch-on-merge"* ]]
+    [[ "$output" == *"gh label create needs-demo"* ]]
+}
+
+@test "basectl repo configure applies GitHub settings through gh" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 0 ]
+    grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+    grep -Fq "label create bug --repo codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+    grep -Fq "label create needs-demo --repo codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+}
+
+@test "basectl repo init configures GitHub when repo is provided" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo init base-demo --path "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 0 ]
+    [ -f "$repo_dir/base_manifest.yaml" ]
+    grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+}
+
+@test "basectl repo configure can infer GitHub repo from origin remote" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    init_git_repo "$repo_dir"
+    git -C "$repo_dir" remote add origin git@github.com:codeforester/base-demo.git
+
+    run_basectl repo configure "$repo_dir" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,9 @@ reference. The filename should answer "what is this about?"
 - [Python Manifest Section](python-manifest.md) records the future structured
   Python manifest shape and its relationship to current `python-package`
   artifacts.
+- [Repository Baseline](repo-baseline.md) documents `basectl repo init`,
+  `basectl repo check`, and `basectl repo configure` for standardizing new
+  Base-managed repositories.
 - [Setup Hooks Boundary](setup-hooks.md) records why Base does not support
   arbitrary manifest setup hooks yet.
 - [`basectl onboard`](basectl-onboard.md) captures the guided setup experience

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -1,0 +1,111 @@
+# Repository Baseline
+
+`basectl repo` standardizes the first useful layer of a Base-managed
+repository. It is intentionally smaller than project scaffolding: Base creates
+common repo hygiene files, a minimal manifest, and a validation command, while
+the project still owns its source tree, language framework, packaging, and
+product-specific setup.
+
+## Commands
+
+Create a new repo baseline:
+
+```bash
+basectl repo init base-demo --path ~/work/base-demo --repo codeforester/base-demo
+```
+
+`repo init` creates the local files and then configures the GitHub repository
+when `--repo <owner/name>` is provided or an existing `origin` remote can be
+inferred. That keeps the common new-repo path to one command. Use
+`--no-configure` when the GitHub repo does not exist yet or when local-only
+initialization is desired.
+
+Check the local baseline:
+
+```bash
+basectl repo check ~/work/base-demo
+```
+
+Reapply GitHub-side repository settings and labels:
+
+```bash
+basectl repo configure ~/work/base-demo --repo codeforester/base-demo
+```
+
+`repo configure` is idempotent and safe to rerun when repository settings drift.
+Use `--dry-run` on `repo init` or `repo configure` to print the planned file and
+GitHub changes without applying them.
+
+## Local Baseline
+
+`repo init` creates these files when they do not already exist:
+
+- `README.md`
+- `VERSION`
+- `CHANGELOG.md`
+- `CONTRIBUTING.md`
+- `LICENSE`
+- `.gitignore`
+- `base_manifest.yaml`
+- `tests/validate.sh`
+- `.github/workflows/tests.yml`
+
+Existing files are left unchanged. This makes `repo init` useful both for a
+fresh directory and for bringing a small existing repository up to Base's
+minimum expectations.
+
+The generated `base_manifest.yaml` declares the project name and a test command:
+
+```yaml
+schema_version: 1
+
+project:
+  name: base-demo
+
+test:
+  command: ./tests/validate.sh
+```
+
+The generated validation script checks for the required baseline files. It is
+not a replacement for project tests; it is the seed contract that lets
+`basectl test <project>` work immediately.
+
+## GitHub Configuration
+
+`repo init` and `repo configure` standardize the current GitHub repository
+policy:
+
+- Issues enabled
+- Projects enabled
+- squash merge enabled
+- merge commits disabled
+- rebase merge disabled
+- delete branch on merge enabled
+- squash commit message set to PR title and description
+
+They also create or update these labels:
+
+- `bug`
+- `enhancement`
+- `documentation`
+- `ci`
+- `security`
+- `needs-demo`
+
+In apply mode, GitHub configuration requires the GitHub CLI and an authenticated
+session:
+
+```bash
+gh auth login -h github.com
+```
+
+Dry-run mode does not require authentication because it only prints the planned
+`gh` commands.
+
+## Boundaries
+
+The MVP does not create the remote GitHub repository, configure branch
+protection, manage repository secrets, create teams, or add CODEOWNERS. Those
+are separate workflow and policy decisions. Base can grow those capabilities
+once the baseline command has proven useful for real repos such as the Base demo
+project.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test run clean config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup check test run repo clean config doctor gh onboard update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -72,6 +72,22 @@ _base_basectl_completion() {
             ;;
         run)
             _base_basectl_completion_project_or_options "--workspace --dry-run --list -v -h --help" "$cur"
+            ;;
+        repo)
+            case "${COMP_WORDS[2]:-}" in
+                "")
+                    _base_basectl_completion_compgen "init check configure" "$cur"
+                    ;;
+                init)
+                    _base_basectl_completion_compgen "--path --repo --description --copyright-holder --no-configure --dry-run -v -h --help" "$cur"
+                    ;;
+                check)
+                    _base_basectl_completion_compgen "-v -h --help" "$cur"
+                    ;;
+                configure)
+                    _base_basectl_completion_compgen "--repo --dry-run -v -h --help" "$cur"
+                    ;;
+            esac
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -19,6 +19,7 @@ _base_basectl_completion() {
         'check:Verify the local Base CLI environment'
         'test:Run a project test command'
         'run:Run a project command'
+        'repo:Create, check, and configure repository baseline'
         'clean:Remove old Base CLI runtime artifacts'
         'config:Inspect Base machine-local user config'
         'doctor:Diagnose the local Base environment'
@@ -91,6 +92,39 @@ _base_basectl_completion() {
                 project_names=("${(@f)$(_base_basectl_completion_project_names)}")
                 _describe -t projects 'Base project' project_names
             fi
+            ;;
+        repo)
+            case "${words[3]:-}" in
+                init)
+                    _arguments '1:repo command:(init check configure)' \
+                        '2:repository name:' \
+                        '--path[Target path]:path:_files' \
+                        '--repo[GitHub repository]:repo:' \
+                        '--description[Repository description]:description:' \
+                        '--copyright-holder[Copyright holder]:name:' \
+                        '--no-configure[Skip GitHub configuration]' \
+                        '--dry-run[Print planned changes]' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                check)
+                    _arguments '1:repo command:(init check configure)' \
+                        '2:path:_files' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                configure)
+                    _arguments '1:repo command:(init check configure)' \
+                        '2:path:_files' \
+                        '--repo[GitHub repository]:repo:' \
+                        '--dry-run[Print planned changes]' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                *)
+                    _arguments '1:repo command:(init check configure)'
+                    ;;
+            esac
             ;;
         clean)
             _arguments '--older-than[Artifact age]:age:' \


### PR DESCRIPTION
## Summary
- Add `basectl repo init` for creating a standard Base-managed repository baseline.
- Add `basectl repo check` for local baseline validation and `basectl repo configure` for idempotent GitHub settings/labels.
- Wire help, Bash/Zsh completions, BATS coverage, README docs, and the repo-baseline feature doc.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/basectl.sh lib/shell/completions/basectl_completion.sh`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `bats lib/shell/completions/tests/completions.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Closes #368