### PR TITLE
Default repo init to workspace root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 ### Fixed
 
 - Updated the README status section to match the current `0.2.0` release.
+- Fixed `basectl repo init` to create new repositories under the configured
+  workspace root instead of the caller's current directory.
 
 ## [0.2.0] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -303,12 +303,15 @@ machine-readable output.
 Start a new Base-managed repository with:
 
 ```bash
-basectl repo init example --path ~/work/example --repo codeforester/example
+basectl repo init example --repo codeforester/example
 ```
 
 This creates the local repository baseline: README, version, changelog,
 contributing guide, MIT license, `.gitignore`, `base_manifest.yaml`, a
 `tests/validate.sh` contract, and a GitHub Actions workflow that runs it.
+By default, `repo init` creates the repository under `workspace.root` from
+`~/.base.d/config.yaml`; if that is not configured, it falls back to the parent
+directory of `BASE_HOME`. Use `--path <path>` for an explicit location.
 `repo init` also standardizes the GitHub repository when `--repo <owner/name>`
 is provided or when an existing `origin` remote can be inferred. Use
 `--no-configure` to skip the GitHub step, or rerun it later with

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -71,9 +71,11 @@ that delegate to `basectl`.
   `docs/basectl-onboard.md`.
 - `basectl repo init <name>` creates the standard local repository baseline and
   configures the GitHub repository when `--repo <owner/name>` is provided or an
-  existing `origin` remote can be inferred. `basectl repo check [path]`
-  verifies the local baseline, and `basectl repo configure [path]` reapplies the
-  GitHub settings and labels.
+  existing `origin` remote can be inferred. Without `--path`, it creates the
+  repository under `workspace.root` from `~/.base.d/config.yaml`, then falls
+  back to the parent directory of `BASE_HOME`. `basectl repo check [path]`
+  verifies the local baseline, and `basectl repo configure [path]` reapplies
+  the GitHub settings and labels.
 - `basectl test [project]` runs the project's manifest `test.command` or
   `test.mise` from the project root with Base project environment variables
   exported. Use `basectl test <project> -- <args...>` to pass extra arguments

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -24,7 +24,7 @@ Usage:
   basectl repo configure [path] [options]
 
 Options:
-  --path <path>                 Target path for repo init. Defaults to ./<name>.
+  --path <path>                 Target path for repo init. Defaults to workspace root plus <name>.
   --repo <owner/name>           GitHub repository to configure.
   --description <text>          Repository description for generated README.
   --copyright-holder <name>     Copyright holder for generated LICENSE.
@@ -75,6 +75,112 @@ base_repo_target_path() {
         parent="$(cd -- "$(pwd -P)" && pwd -P)/$parent"
     fi
     printf '%s/%s\n' "$parent" "$name"
+}
+
+base_repo_strip_config_value() {
+    local value="$1"
+
+    value="${value%%#*}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+
+    case "$value" in
+        \"*\")
+            value="${value#\"}"
+            value="${value%\"}"
+            ;;
+        \'*\')
+            value="${value#\'}"
+            value="${value%\'}"
+            ;;
+    esac
+
+    printf '%s\n' "$value"
+}
+
+base_repo_expand_path() {
+    local path="$1"
+
+    case "$path" in
+        "~")
+            printf '%s\n' "$HOME"
+            ;;
+        "~/"*)
+            printf '%s/%s\n' "$HOME" "${path#~/}"
+            ;;
+        *)
+            printf '%s\n' "$path"
+            ;;
+    esac
+}
+
+base_repo_configured_workspace_root() {
+    local config_path="$HOME/.base.d/config.yaml"
+    local in_workspace=0 line value
+
+    [[ -f "$config_path" ]] || return 1
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ "$line" =~ ^[[:space:]]*(#.*)?$ ]] && continue
+
+        if [[ "$line" =~ ^workspace:[[:space:]]*(#.*)?$ ]]; then
+            in_workspace=1
+            continue
+        fi
+
+        if ((in_workspace)) && [[ ! "$line" =~ ^[[:space:]] ]]; then
+            return 1
+        fi
+
+        if ((in_workspace)) && [[ "$line" =~ ^[[:space:]]+root:[[:space:]]*(.*)$ ]]; then
+            value="$(base_repo_strip_config_value "${BASH_REMATCH[1]}")"
+            [[ -n "$value" ]] || {
+                log_error "$config_path: workspace.root must be a non-empty path."
+                return 2
+            }
+            value="$(base_repo_expand_path "$value")"
+            [[ "$value" = /* ]] || {
+                log_error "$config_path: workspace.root must be an absolute path or start with '~'."
+                return 2
+            }
+            printf '%s\n' "$value"
+            return 0
+        fi
+    done < "$config_path"
+
+    return 1
+}
+
+base_repo_default_workspace_root() {
+    local configured_root status
+
+    configured_root="$(base_repo_configured_workspace_root)"
+    status=$?
+    case "$status" in
+        0)
+            printf '%s\n' "$configured_root"
+            return 0
+            ;;
+        1)
+            ;;
+        *)
+            return "$status"
+            ;;
+    esac
+
+    [[ -n "${BASE_HOME:-}" ]] || {
+        log_error "BASE_HOME is required to resolve the default repository path."
+        return 1
+    }
+    cd -- "$BASE_HOME/.." && pwd -P
+}
+
+base_repo_default_target_path() {
+    local name="$1"
+    local workspace_root
+
+    workspace_root="$(base_repo_default_workspace_root)" || return $?
+    printf '%s/%s\n' "$workspace_root" "$name"
 }
 
 base_repo_baseline_year() {
@@ -542,7 +648,7 @@ base_repo_init() {
         return $?
     }
     base_repo_validate_name "$name" || return 2
-    [[ -n "$path" ]] || path="./$name"
+    [[ -n "$path" ]] || path="$(base_repo_default_target_path "$name")"
     [[ -n "$description" ]] || description="$(base_repo_default_description "$name")"
     root="$(base_repo_target_path "$path")"
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -26,6 +26,40 @@ load ./basectl_helpers.bash
     [ ! -e "$repo_dir" ]
 }
 
+@test "basectl repo init defaults to configured workspace root" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+    local workspace_root="$TEST_TMPDIR/workspace-root"
+    local repo_dir="$workspace_root/base-demo"
+
+    mkdir -p "$TEST_HOME/.base.d" "$nested_dir" "$workspace_root"
+    printf 'workspace:\n  root: %s\n' "$workspace_root" > "$TEST_HOME/.base.d/config.yaml"
+
+    cd "$nested_dir"
+    run_basectl repo init base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
+    [[ "$output" != *"$nested_dir/base-demo"* ]]
+    [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo init falls back to BASE_HOME parent when workspace root is not configured" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+    local workspace_root
+    local repo_dir
+
+    workspace_root="$(cd "$BASE_REPO_ROOT/.." && pwd -P)"
+    repo_dir="$workspace_root/base-demo"
+    mkdir -p "$nested_dir"
+
+    cd "$nested_dir"
+    run_basectl repo init base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
+    [[ "$output" != *"$nested_dir/base-demo"* ]]
+}
+
 @test "basectl repo init creates the standard repository baseline" {
     local repo_dir="$TEST_TMPDIR/base-demo"
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -11,7 +11,7 @@ product-specific setup.
 Create a new repo baseline:
 
 ```bash
-basectl repo init base-demo --path ~/work/base-demo --repo codeforester/base-demo
+basectl repo init base-demo --repo codeforester/base-demo
 ```
 
 `repo init` creates the local files and then configures the GitHub repository
@@ -19,6 +19,16 @@ when `--repo <owner/name>` is provided or an existing `origin` remote can be
 inferred. That keeps the common new-repo path to one command. Use
 `--no-configure` when the GitHub repo does not exist yet or when local-only
 initialization is desired.
+
+Without `--path`, `repo init` creates the repository under the configured
+workspace root:
+
+1. `workspace.root` from `~/.base.d/config.yaml` when configured.
+2. The parent directory of `BASE_HOME` when no workspace root is configured.
+
+That keeps `repo init base-demo` stable even when it is run from inside another
+repository or from a nested directory such as `~/work/base/docs`. Use
+`--path <path>` when the new repository should live somewhere else.
 
 Check the local baseline:
 


### PR DESCRIPTION
## Summary
- Change `basectl repo init <name>` to default new repositories under `workspace.root`, then the parent of `BASE_HOME`, instead of the caller current directory.
- Keep explicit `--path` behavior unchanged.
- Make `repo init` create the GitHub repository when `--repo <owner/name>` or an inferred remote identifies one, then apply standard repo settings and labels.
- Make `repo init --dry-run` explicitly report planned GitHub repository creation, or explain why GitHub creation is skipped.
- Document the default path and GitHub creation behavior, with BATS coverage for configured workspace roots, fallback behavior, and GitHub dry-run output.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/repo.sh`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Closes #371