### PR TITLE
Clarify repo init GitHub creation dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Updated the README status section to match the current `0.2.0` release.
 - Fixed `basectl repo init` to create new repositories under the configured
   workspace root instead of the caller's current directory.
+- Fixed `basectl repo init --dry-run` to explicitly report planned GitHub
+  repository creation or explain why GitHub creation is skipped.
 
 ## [0.2.0] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -312,10 +312,10 @@ contributing guide, MIT license, `.gitignore`, `base_manifest.yaml`, a
 By default, `repo init` creates the repository under `workspace.root` from
 `~/.base.d/config.yaml`; if that is not configured, it falls back to the parent
 directory of `BASE_HOME`. Use `--path <path>` for an explicit location.
-`repo init` also standardizes the GitHub repository when `--repo <owner/name>`
-is provided or when an existing `origin` remote can be inferred. Use
-`--no-configure` to skip the GitHub step, or rerun it later with
-`basectl repo configure`.
+`repo init` also creates the GitHub repository when needed and then
+standardizes its settings when `--repo <owner/name>` is provided or when an
+existing `origin` remote can be inferred. Use `--no-configure` to skip the
+GitHub step, or rerun it later with `basectl repo configure`.
 
 Check and repair the repo baseline with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -70,12 +70,12 @@ that delegate to `basectl`.
   doctor, profile, and project-discovery primitives. See
   `docs/basectl-onboard.md`.
 - `basectl repo init <name>` creates the standard local repository baseline and
-  configures the GitHub repository when `--repo <owner/name>` is provided or an
-  existing `origin` remote can be inferred. Without `--path`, it creates the
-  repository under `workspace.root` from `~/.base.d/config.yaml`, then falls
-  back to the parent directory of `BASE_HOME`. `basectl repo check [path]`
-  verifies the local baseline, and `basectl repo configure [path]` reapplies
-  the GitHub settings and labels.
+  creates and configures the GitHub repository when `--repo <owner/name>` is
+  provided or an existing `origin` remote can be inferred. Without `--path`, it
+  creates the repository under `workspace.root` from `~/.base.d/config.yaml`,
+  then falls back to the parent directory of `BASE_HOME`.
+  `basectl repo check [path]` verifies the local baseline, and
+  `basectl repo configure [path]` reapplies the GitHub settings and labels.
 - `basectl test [project]` runs the project's manifest `test.command` or
   `test.mise` from the project root with Base project environment variables
   exported. Use `basectl test <project> -- <args...>` to pass extra arguments

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -502,6 +502,26 @@ base_repo_configure_label() {
     gh label create "$label" --repo "$repo" --color "$color" --description "$description" --force
 }
 
+base_repo_ensure_github_repo() {
+    local description="$3"
+    local dry_run="$1"
+    local repo="$2"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would create GitHub repository '%s' if it does not already exist.\n" "$repo"
+        return 0
+    fi
+
+    base_repo_require_gh || return 1
+    if gh repo view "$repo" >/dev/null 2>&1; then
+        log_info "GitHub repository '$repo' already exists."
+        return 0
+    fi
+
+    log_info "Creating GitHub repository '$repo'."
+    gh repo create "$repo" --public --description "$description"
+}
+
 base_repo_configure_github() {
     local dry_run="$1"
     local repo="$2"
@@ -659,9 +679,14 @@ base_repo_init() {
             github_repo="$(base_repo_infer_github_repo "$root" || true)"
         fi
         if [[ -n "$github_repo" ]]; then
+            base_repo_ensure_github_repo "$dry_run" "$github_repo" "$description" || return 1
             base_repo_configure_github "$dry_run" "$github_repo" || return 1
         else
-            log_info "Skipping GitHub repository configuration because no GitHub repo was provided or inferred."
+            if [[ "$dry_run" == "1" ]]; then
+                printf "[DRY-RUN] Would not create or configure a GitHub repository because no GitHub repo was provided or inferred. Pass --repo <owner/name> to include GitHub repository creation and configuration.\n"
+            else
+                log_info "Skipping GitHub repository creation and configuration because no GitHub repo was provided or inferred."
+            fi
         fi
     fi
 }

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -21,6 +21,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
     [[ "$output" == *"[DRY-RUN] Would create executable '$repo_dir/tests/validate.sh'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create GitHub repository 'codeforester/base-demo' if it does not already exist."* ]]
     [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
     [[ "$output" == *"gh label create bug"* ]]
     [ ! -e "$repo_dir" ]
@@ -40,6 +41,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
     [[ "$output" != *"$nested_dir/base-demo"* ]]
+    [[ "$output" == *"[DRY-RUN] Would not create or configure a GitHub repository because no GitHub repo was provided or inferred."* ]]
     [ ! -e "$repo_dir" ]
 }
 
@@ -58,6 +60,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
     [[ "$output" != *"$nested_dir/base-demo"* ]]
+    [[ "$output" == *"[DRY-RUN] Would not create or configure a GitHub repository because no GitHub repo was provided or inferred."* ]]
 }
 
 @test "basectl repo init creates the standard repository baseline" {
@@ -141,6 +144,9 @@ load ./basectl_helpers.bash
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
+if [[ "$*" == "repo view codeforester/base-demo" ]]; then
+    exit 1
+fi
 printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
 EOF
     chmod +x "$TEST_MOCKBIN/gh"
@@ -165,6 +171,9 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
+if [[ "$*" == "repo view codeforester/base-demo" ]]; then
+    exit 1
+fi
 printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
 EOF
     chmod +x "$TEST_MOCKBIN/gh"
@@ -177,6 +186,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [ -f "$repo_dir/base_manifest.yaml" ]
+    grep -Fq "repo create codeforester/base-demo --public --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
 }
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -14,10 +14,11 @@ Create a new repo baseline:
 basectl repo init base-demo --repo codeforester/base-demo
 ```
 
-`repo init` creates the local files and then configures the GitHub repository
-when `--repo <owner/name>` is provided or an existing `origin` remote can be
+`repo init` creates the local files, creates the GitHub repository if it does
+not already exist, and then configures that GitHub repository when
+`--repo <owner/name>` is provided or an existing `origin` remote can be
 inferred. That keeps the common new-repo path to one command. Use
-`--no-configure` when the GitHub repo does not exist yet or when local-only
+`--no-configure` when GitHub setup should be skipped or when local-only
 initialization is desired.
 
 Without `--path`, `repo init` creates the repository under the configured
@@ -44,7 +45,9 @@ basectl repo configure ~/work/base-demo --repo codeforester/base-demo
 
 `repo configure` is idempotent and safe to rerun when repository settings drift.
 Use `--dry-run` on `repo init` or `repo configure` to print the planned file and
-GitHub changes without applying them.
+GitHub changes without applying them. In dry-run mode, `repo init` explicitly
+reports whether it would create a GitHub repository or why GitHub creation is
+being skipped.
 
 ## Local Baseline
 
@@ -82,8 +85,8 @@ not a replacement for project tests; it is the seed contract that lets
 
 ## GitHub Configuration
 
-`repo init` and `repo configure` standardize the current GitHub repository
-policy:
+`repo init` creates the GitHub repository when needed, then `repo init` and
+`repo configure` standardize the current GitHub repository policy:
 
 - Issues enabled
 - Projects enabled
@@ -114,8 +117,7 @@ Dry-run mode does not require authentication because it only prints the planned
 
 ## Boundaries
 
-The MVP does not create the remote GitHub repository, configure branch
-protection, manage repository secrets, create teams, or add CODEOWNERS. Those
-are separate workflow and policy decisions. Base can grow those capabilities
-once the baseline command has proven useful for real repos such as the Base demo
-project.
+The MVP does not configure branch protection, manage repository secrets, create
+teams, or add CODEOWNERS. Those are separate workflow and policy decisions.
+Base can grow those capabilities once the baseline command has proven useful
+for real repos such as the Base demo project.


### PR DESCRIPTION
## Summary
- Make `basectl repo init --dry-run --repo <owner/name>` explicitly report that Base would create the GitHub repository if it does not already exist.
- Make apply mode create the GitHub repository when needed before applying standard settings and labels.
- Explain in dry-run output when GitHub creation/configuration is skipped because no repo was provided or inferred.
- Update docs and tests for the GitHub creation path.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/repo.sh`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Closes #373