### PR TITLE
Pretty-print repo dry-run commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   workspace root instead of the caller's current directory.
 - Fixed `basectl repo init --dry-run` to explicitly report planned GitHub
   repository creation or explain why GitHub creation is skipped.
+- Fixed `basectl repo` dry-run output to print readable quoted GitHub command
+  arguments instead of backslash-escaped words.
 
 ## [0.2.0] - 2026-05-30
 

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -486,16 +486,29 @@ base_repo_require_gh() {
     }
 }
 
+base_repo_pretty_quote() {
+    local value="$1"
+
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\t'/\\t}"
+    printf '"%s"' "$value"
+}
+
 base_repo_configure_label() {
     local color="$3"
     local description="$4"
     local dry_run="$1"
     local label="$2"
     local repo="$5"
+    local quoted_description
 
     if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would run: gh label create %q --repo %q --color %q --description %q --force\n" \
-            "$label" "$repo" "$color" "$description"
+        quoted_description="$(base_repo_pretty_quote "$description")"
+        printf "[DRY-RUN] Would run: gh label create %s --repo %s --color %s --description %s --force\n" \
+            "$label" "$repo" "$color" "$quoted_description"
         return 0
     fi
 
@@ -528,7 +541,7 @@ base_repo_configure_github() {
     local status=0
 
     if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would run: gh repo edit %q --enable-issues --enable-projects --enable-squash-merge --enable-merge-commit=false --enable-rebase-merge=false --delete-branch-on-merge --squash-merge-commit-message pr-title-description\n" "$repo"
+        printf "[DRY-RUN] Would run: gh repo edit %s --enable-issues --enable-projects --enable-squash-merge --enable-merge-commit=false --enable-rebase-merge=false --delete-branch-on-merge --squash-merge-commit-message pr-title-description\n" "$repo"
     else
         base_repo_require_gh || return 1
         gh repo edit "$repo" \

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -24,6 +24,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"[DRY-RUN] Would create GitHub repository 'codeforester/base-demo' if it does not already exist."* ]]
     [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
     [[ "$output" == *"gh label create bug"* ]]
+    [[ "$output" == *'--description "Something is not working"'* ]]
+    [[ "$output" != *'Something\ is\ not\ working'* ]]
     [ ! -e "$repo_dir" ]
 }
 
@@ -133,6 +135,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--enable-squash-merge"* ]]
     [[ "$output" == *"--delete-branch-on-merge"* ]]
     [[ "$output" == *"gh label create needs-demo"* ]]
+    [[ "$output" == *'--description "Change should update a project demo"'* ]]
+    [[ "$output" != *'Change\ should\ update\ a\ project\ demo'* ]]
 }
 
 @test "basectl repo configure applies GitHub settings through gh" {


### PR DESCRIPTION
## Summary
- Replace `%q`-style dry-run rendering for repo GitHub commands with readable quoted arguments.
- Keep label descriptions unambiguous by wrapping them in normal double quotes.
- Add BATS assertions so dry-run output no longer includes backslash-escaped descriptions.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/repo.sh`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Closes #375