### PR TITLE
Add demo manifest diagnostics

### DIFF
--- a/cli/python/base_setup/demo.py
+++ b/cli/python/base_setup/demo.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .checks import ArtifactCheck
+from .errors import ArtifactError
+from .manifest import BaseManifest
+
+
+def check_demo(manifest: BaseManifest) -> list[ArtifactCheck]:
+    if manifest.demo is None:
+        return []
+
+    return [
+        ArtifactCheck(
+            name="demo declaration",
+            ok=True,
+            message=f"Project '{manifest.project_name}' declares demo.script '{manifest.demo.script}'.",
+            fix="",
+            finding_id="BASE-P060",
+        ),
+        check_demo_script(manifest),
+    ]
+
+
+def check_demo_script(manifest: BaseManifest) -> ArtifactCheck:
+    try:
+        demo_script = resolve_demo_script_path(manifest)
+    except ArtifactError as exc:
+        return ArtifactCheck(
+            name="demo script",
+            ok=False,
+            message=str(exc),
+            fix=f"Update demo.script in '{manifest.path}'.",
+            finding_id="BASE-P061",
+        )
+
+    return ArtifactCheck(
+        name="demo script",
+        ok=True,
+        message=f"Demo script '{demo_script}' exists and is executable.",
+        fix="",
+        finding_id="BASE-P061",
+    )
+
+
+def resolve_demo_script_path(manifest: BaseManifest) -> Path:
+    if manifest.demo is None:
+        raise ArtifactError(f"{manifest.path}: demo is not configured.")
+
+    demo_script = Path(manifest.demo.script)
+    if demo_script.is_absolute():
+        raise ArtifactError(f"{manifest.path}: demo.script must be relative to the project root.")
+
+    project_root = manifest.path.parent.resolve()
+    demo_script_path = (project_root / demo_script).resolve()
+    if not demo_script_path.is_relative_to(project_root):
+        raise ArtifactError(f"{manifest.path}: demo.script must stay inside the project root.")
+    if not demo_script_path.exists():
+        raise ArtifactError(f"{manifest.path}: demo.script '{manifest.demo.script}' does not exist.")
+    if not demo_script_path.is_file():
+        raise ArtifactError(f"{manifest.path}: demo.script '{manifest.demo.script}' is not a file.")
+    if not os.access(demo_script_path, os.X_OK):
+        raise ArtifactError(f"{manifest.path}: demo.script '{manifest.demo.script}' is not executable.")
+    return demo_script_path

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -17,6 +17,7 @@ from .checks import check_to_doctor_json
 from .checks import check_to_json
 from .checks import doctor_status
 from .checks import print_doctor_finding
+from .demo import check_demo
 from .delegates import check_brewfile
 from .delegates import check_mise
 from .delegates import reconcile_brewfile
@@ -241,6 +242,7 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
         checks.append(check_mise(effective_manifest))
 
     checks.extend(check_required_env(effective_manifest))
+    checks.extend(check_demo(effective_manifest))
     checks.extend(check_ide_installs(effective_manifest))
     checks.extend(check_ide_extensions(effective_manifest))
     checks.extend(check_ide_settings(effective_manifest))
@@ -274,4 +276,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         health=manifest.health,
         commands=manifest.commands,
         activate=manifest.activate,
+        demo=manifest.demo,
     )

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -51,6 +51,12 @@ class TestConfig:
 
 
 @dataclass(frozen=True)
+class DemoConfig:
+    script: str
+    description: str | None = None
+
+
+@dataclass(frozen=True)
 class HealthConfig:
     required_env: tuple[str, ...] = ()
 
@@ -73,6 +79,7 @@ class BaseManifest:
     health: HealthConfig = field(default_factory=HealthConfig)
     commands: dict[str, str] = field(default_factory=dict)
     activate: ActivateConfig = field(default_factory=ActivateConfig)
+    demo: DemoConfig | None = None
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -103,6 +110,7 @@ def read_manifest(path: Path) -> BaseManifest:
         "health",
         "commands",
         "activate",
+        "demo",
     }
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
@@ -117,6 +125,7 @@ def read_manifest(path: Path) -> BaseManifest:
     health = _read_health(path, data.get("health"))
     commands = _read_commands(path, data.get("commands"))
     activate = _read_activate(path, data.get("activate"))
+    demo = _read_demo(path, data.get("demo"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -131,6 +140,7 @@ def read_manifest(path: Path) -> BaseManifest:
         health=health,
         commands=commands,
         activate=activate,
+        demo=demo,
     )
 
 
@@ -222,6 +232,33 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
         command=command.strip() if command is not None else None,
         mise=mise.strip() if mise is not None else None,
     )
+
+
+def _read_demo(path: Path, demo_data: Any) -> DemoConfig | None:
+    if demo_data is None:
+        return None
+    if not isinstance(demo_data, dict):
+        raise ManifestError(f"{path}: demo must be a mapping when provided.")
+
+    allowed_keys = {"script", "description"}
+    unknown_keys = sorted(set(demo_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: demo has unsupported keys: {', '.join(unknown_keys)}.")
+
+    script = demo_data.get("script")
+    if not isinstance(script, str) or not script.strip():
+        raise ManifestError(f"{path}: demo.script must be a non-empty string when demo is provided.")
+    script = script.strip()
+    if any(separator in script for separator in ("\0", "\n", "\r")):
+        raise ManifestError(f"{path}: demo.script must not contain control line breaks.")
+
+    description = demo_data.get("description")
+    if description is not None:
+        if not isinstance(description, str) or not description.strip():
+            raise ManifestError(f"{path}: demo.description must be a non-empty string when provided.")
+        description = description.strip()
+
+    return DemoConfig(script=script, description=description)
 
 
 def _read_health(path: Path, health_data: Any) -> HealthConfig:

--- a/cli/python/base_setup/tests/test_demo.py
+++ b/cli/python/base_setup/tests/test_demo.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from base_setup import demo, engine
+from base_setup.manifest import BaseManifest, DemoConfig
+from base_setup.tests.helpers import fake_context
+
+
+def demo_manifest(manifest_path: Path, script: str) -> BaseManifest:
+    return BaseManifest(
+        path=manifest_path,
+        project_name="demo",
+        brewfile=None,
+        artifacts=(),
+        demo=DemoConfig(script=script, description="Interactive demo"),
+    )
+
+
+class DemoDiagnosticsTests(unittest.TestCase):
+    def test_resolve_demo_script_path_returns_executable_project_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo" / "demo.sh"
+            script.parent.mkdir()
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo/demo.sh")
+
+            resolved = demo.resolve_demo_script_path(manifest)
+
+        self.assertEqual(resolved, script.resolve())
+
+    def test_check_demo_script_rejects_missing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo/demo.sh")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P061")
+        self.assertIn("does not exist", check.message)
+
+    def test_check_demo_script_rejects_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "demo").mkdir()
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("is not a file", check.message)
+
+    def test_check_demo_script_rejects_non_executable_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo.sh"
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o644)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo.sh")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("is not executable", check.message)
+
+    def test_check_demo_script_rejects_absolute_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", str(project_root / "demo.sh"))
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("must be relative to the project root", check.message)
+
+    def test_check_demo_script_rejects_paths_that_escape_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "../demo.sh")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("must stay inside the project root", check.message)
+
+    def test_check_manifest_reports_demo_declaration_and_script(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo.sh"
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo.sh")
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+
+        checks = json.loads(stdout.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual([check["name"] for check in checks], ["demo declaration", "demo script"])
+        self.assertTrue(all(check["ok"] for check in checks))
+
+    def test_doctor_manifest_reports_demo_finding_ids(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo.sh"
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o644)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo.sh")
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                status = engine.doctor_manifest(default_manifest, manifest, output_format="json")
+
+        findings = json.loads(stdout.getvalue())
+        self.assertEqual(status, 1)
+        self.assertEqual([finding["id"] for finding in findings], ["BASE-P060", "BASE-P061"])
+        self.assertEqual([finding["status"] for finding in findings], ["ok", "error"])

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -181,6 +181,33 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.activate.source, (".base/activate.sh", "scripts/local-env.sh"))
 
 
+    def test_reads_manifest_demo_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "demo:",
+                        "  script: ./demo/demo.sh",
+                        "  description: Interactive project walkthrough",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.demo)
+        assert manifest.demo is not None
+        self.assertEqual(manifest.demo.script, "./demo/demo.sh")
+        self.assertEqual(manifest.demo.description, "Interactive project walkthrough")
+
+
 
     def test_rejects_invalid_manifest_activation_sources(self) -> None:
         invalid_values = {
@@ -202,6 +229,37 @@ class ManifestParsingTests(unittest.TestCase):
                                 "project:",
                                 "  name: demo",
                                 activate_yaml,
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(ManifestError):
+                        read_manifest(manifest_path)
+
+
+    def test_rejects_invalid_manifest_demo_config(self) -> None:
+        invalid_values = {
+            "scalar": "demo: ./demo/demo.sh",
+            "unknown_key": "demo:\n  script: ./demo/demo.sh\n  shell: bash",
+            "missing_script": "demo:\n  description: Interactive project walkthrough",
+            "empty_script": "demo:\n  script: ''",
+            "non_string_script": "demo:\n  script: 7",
+            "newline_script": "demo:\n  script: \"demo\\n/demo.sh\"",
+            "empty_description": "demo:\n  script: ./demo/demo.sh\n  description: ''",
+            "non_string_description": "demo:\n  script: ./demo/demo.sh\n  description: 7",
+        }
+        for name, demo_yaml in invalid_values.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                demo_yaml,
                                 "artifacts: []",
                             ]
                         ),

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -49,6 +49,8 @@ fix text, or severity over time, but its ID keeps the same meaning.
 | `BASE-P033` | Homebrew artifact package status |
 | `BASE-P040` | Python package artifact status in the project virtual environment |
 | `BASE-P050` | Project virtual environment integrity |
+| `BASE-P060` | Project demo declaration |
+| `BASE-P061` | Project demo script path and executable status |
 | `BASE-P100` | User config disables all IDE setup and checks |
 | `BASE-P101` | User config disables setup and checks for one IDE |
 | `BASE-P102` | User IDE setting conflicts with a project manifest setting |


### PR DESCRIPTION
## Summary

- Add `demo.script` and optional `demo.description` to the Base manifest parser.
- Add project check/doctor diagnostics for declared demo scripts, including missing, non-file, non-executable, absolute, and escaping paths.
- Document the new stable doctor finding IDs for demo declaration and demo script validity.

## Validation

- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests/test_manifest.py cli/python/base_setup/tests/test_demo.py cli/python/base_setup/tests/test_diagnostics.py`
- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint cli/python/base_setup lib/python/base_cli`
- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest`
- `git diff --cached --check`

Train base for #362.

Closes #361