### PR TITLE
Allow basectl update with untracked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   repository creation or explain why GitHub creation is skipped.
 - Fixed `basectl repo` dry-run output to print readable quoted GitHub command
   arguments instead of backslash-escaped words.
+- Fixed `basectl update` to allow harmless untracked files while still blocking
+  tracked local changes.
 
 ## [0.2.0] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -719,8 +719,11 @@ Update Base itself from the checked-out repository with:
 basectl update
 ```
 
-This command is intentionally conservative: it only runs from a clean `master`
-worktree, pulls the latest changes through Git, and then runs `basectl setup`.
+This command is intentionally conservative: it only runs from the Base
+repository's default branch, requires tracked Base files to be clean, pulls the
+latest changes through Git, and then runs `basectl setup`. Untracked files do
+not block the update; Git still stops the pull if an incoming tracked file would
+overwrite them.
 
 Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
 is user-managed and may be hand-edited. It is intended for simple,

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -23,7 +23,8 @@ Purpose:
 
 Notes:
   - The repository must be on its default branch.
-  - The worktree must be clean, including untracked files.
+  - Tracked Base files must be clean; untracked files are left to Git's normal
+    pull-time overwrite protection.
 EOF
 }
 
@@ -63,7 +64,12 @@ base_update_default_branch() {
 
 base_update_worktree_clean() {
     local repo="$1"
-    [[ -z "$(git -C "$repo" status --porcelain --untracked-files=normal --ignore-submodules=none)" ]]
+    [[ -z "$(git -C "$repo" status --porcelain --untracked-files=no --ignore-submodules=none)" ]]
+}
+
+base_update_has_untracked_files() {
+    local repo="$1"
+    [[ -n "$(git -C "$repo" ls-files --others --exclude-standard --directory --no-empty-directory)" ]]
 }
 
 base_update_run_setup() {
@@ -119,8 +125,11 @@ base_update_subcommand_main() {
     fi
 
     if ! base_update_worktree_clean "$BASE_HOME"; then
-        log_error "Base repository has local changes. Commit, stash, or remove them before running basectl update."
+        log_error "Base repository has tracked local changes. Commit, stash, or remove them before running basectl update."
         return 1
+    fi
+    if base_update_has_untracked_files "$BASE_HOME"; then
+        log_warn "Base repository has untracked files. Continuing because tracked files are clean."
     fi
 
     if ((dry_run)); then

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -10,6 +10,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl update [options]"* ]]
     [[ "$output" == *"Update the Base repository from Git"* ]]
+    [[ "$output" == *"Tracked Base files must be clean"* ]]
 }
 
 @test "basectl update dry-run reports planned update and setup" {
@@ -22,6 +23,7 @@ load ./basectl_helpers.bash
             base_update_current_branch() { printf "%s\n" master; }
             base_update_default_branch() { printf "%s\n" master; }
             base_update_worktree_clean() { return 0; }
+            base_update_has_untracked_files() { return 1; }
             base_update_subcommand_main --dry-run
         '
 
@@ -47,10 +49,40 @@ load ./basectl_helpers.bash
         '
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Base repository has local changes."* ]]
+    [[ "$output" == *"Base repository has tracked local changes."* ]]
     [[ "$output" != *"git library should not load"* ]]
     [[ "$output" != *"git update should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
+}
+
+@test "basectl update allows untracked files before pulling" {
+    local repo="$TEST_TMPDIR/repo"
+
+    init_git_repo "$repo"
+    printf 'base\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    printf 'notes\n' > "$repo/local-notes.md"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_REPO="$repo" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            BASE_HOME="$BASE_TEST_REPO"
+            base_update_source_git_library() { :; }
+            git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
+            base_update_head_revision() { printf "%s\n" abc1234; }
+            base_update_run_setup() { printf "setup ran\n"; }
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base repository has untracked files. Continuing because tracked files are clean."* ]]
+    [[ "$output" == *"git update repo=$repo branch=master"* ]]
+    [[ "$output" == *"setup ran"* ]]
+    [[ "$output" == *"Base update is complete."* ]]
 }
 
 @test "basectl update refuses non-default branches" {
@@ -83,6 +115,7 @@ load ./basectl_helpers.bash
             base_update_current_branch() { printf "%s\n" master; }
             base_update_default_branch() { printf "%s\n" master; }
             base_update_worktree_clean() { return 0; }
+            base_update_has_untracked_files() { return 1; }
             base_update_source_git_library() { :; }
             git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
             base_update_head_revision() { printf "%s\n" abc1234; }
@@ -109,6 +142,7 @@ load ./basectl_helpers.bash
             base_update_current_branch() { printf "%s\n" main; }
             base_update_default_branch() { printf "%s\n" main; }
             base_update_worktree_clean() { return 0; }
+            base_update_has_untracked_files() { return 1; }
             base_update_source_git_library() { :; }
             git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
             base_update_head_revision() {

--- a/lib/bash/git/tests/lib_git.bats
+++ b/lib/bash/git/tests/lib_git.bats
@@ -109,6 +109,32 @@ setup() {
     [ -z "$(git -C "$repo" status --porcelain)" ]
 }
 
+@test "git_update_repo lets git protect untracked files from incoming tracked paths" {
+    local before_head
+    local other="$TEST_TMPDIR/other"
+    local remote="$TEST_TMPDIR/remote.git"
+    local repo="$TEST_TMPDIR/repo"
+
+    create_tracked_repo_with_upstream "$repo" "$remote" "data.txt" "base"
+    before_head="$(git -C "$repo" rev-parse HEAD)"
+    git clone "$remote" "$other" >/dev/null 2>&1
+    git -C "$other" config user.name "Bats Test"
+    git -C "$other" config user.email "bats@example.com"
+    printf 'incoming tracked\n' > "$other/local-notes.md"
+    git -C "$other" add local-notes.md
+    git -C "$other" commit -m "Add tracked notes" >/dev/null 2>&1
+    git -C "$other" push origin master >/dev/null 2>&1
+    printf 'local untracked\n' > "$repo/local-notes.md"
+
+    bats_run git_update_repo "$repo" "" master
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"git pull failed on repo '$repo'"* ]]
+    [ "$(git -C "$repo" rev-parse HEAD)" = "$before_head" ]
+    [ "$(cat "$repo/local-notes.md")" = "local untracked" ]
+    ! git -C "$repo" ls-files --error-unmatch local-notes.md >/dev/null 2>&1
+}
+
 @test "git_update_repo accepts main as the detected update branch" {
     local repo="$TEST_TMPDIR/repo"
 


### PR DESCRIPTION
## Summary
- Change `basectl update` to block only tracked local Base changes before pulling.
- Warn when untracked files are present, then let Git perform normal pull-time overwrite protection.
- Update README/help text and add BATS coverage for harmless untracked files plus the conflicting untracked-file safety case.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/update.sh`
- `bats cli/bash/commands/basectl/tests/update.bats`
- `bats lib/bash/git/tests/lib_git.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Closes #377