### PR TITLE
Add basectl demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ basectl setup <project>
 basectl check <project>
 basectl doctor <project>
 basectl test <project>
+basectl demo <project>
 basectl run <project> <command>
 basectl activate <project>
 ```
 
-For Base itself, run the dogfood test contract:
+For Base itself, run the self-demo or the dogfood test contract:
 
 ```bash
+basectl demo base -- --non-interactive
 basectl test base
 ```
 

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -8,6 +8,10 @@ project:
 test:
   command: ./bin/base-test
 
+demo:
+  script: ./demo/demo.sh
+  description: Self-contained walkthrough of Base's core project workflow
+
 # Optional relative path to a Homebrew Brewfile for ordinary macOS tools.
 # Base runs `brew bundle --file=<path>` during setup when this is set.
 # Keep Base-specific managed dependencies in `artifacts`; use Brewfile for

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -17,6 +17,8 @@ Commands:
     Verify the local Base CLI environment and optional project artifacts without making changes.
   test [project] [options]
     Run a project's declared test command.
+  demo <project> [options]
+    Run a project's declared interactive demo.
   run <project> <command> [options]
     Run a project's declared command.
   repo <init|check|configure> [options]
@@ -169,6 +171,11 @@ basectl_do_test() {
     base_test_subcommand_main "$@"
 }
 
+basectl_do_demo() {
+    basectl_source_subcommand_module demo || return 1
+    base_demo_subcommand_main "$@"
+}
+
 basectl_do_run() {
     basectl_source_subcommand_module run || return 1
     base_run_subcommand_main "$@"
@@ -318,6 +325,7 @@ basectl_main() {
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
         test)             basectl_do_test "$@" ;;
+        demo)             basectl_do_demo "$@" ;;
         run)              basectl_do_run "$@" ;;
         repo)             basectl_do_repo "$@" ;;
         clean)            basectl_do_clean "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/demo.sh
+++ b/cli/bash/commands/basectl/subcommands/demo.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_demo_subcommand_sourced:-}" ]] && return
+_base_demo_subcommand_sourced=1
+readonly _base_demo_subcommand_sourced
+
+base_demo_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl demo <project> [options] [-- extra args...]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --dry-run           Print the resolved demo script without running it.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Run a project's declared interactive demo from its project root.
+Use -- to pass additional arguments to the demo script.
+EOF
+}
+
+base_demo_usage_error() {
+    base_demo_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_demo_project_venv_dir() {
+    local project="$1"
+
+    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+        printf '%s\n' "$BASE_PROJECT_VENV_DIR"
+        return 0
+    fi
+
+    printf '%s\n' "$HOME/.base.d/$project/.venv"
+}
+
+base_demo_format_extra_args() {
+    local arg quoted output=""
+
+    for arg in "$@"; do
+        printf -v quoted '%q' "$arg"
+        output+=" $quoted"
+    done
+    printf '%s\n' "$output"
+}
+
+base_demo_subcommand_main() {
+    local project="" wrapper resolve_output resolved_name project_root manifest_path demo_script venv_dir
+    local dry_run=0 workspace_requested=0
+    local args=() extra_args=()
+
+    while (($#)); do
+        case "$1" in
+            --)
+                shift
+                extra_args=("$@")
+                break
+                ;;
+            -h|--help|help)
+                base_demo_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --workspace)
+                [[ -n "${2:-}" ]] || {
+                    base_demo_usage_error "Option '--workspace' requires an argument."
+                    return $?
+                }
+                workspace_requested=1
+                args+=(--workspace "$2")
+                shift 2
+                ;;
+            --workspace=*)
+                workspace_requested=1
+                args+=("$1")
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            -*)
+                base_demo_usage_error "Unknown demo option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -z "$project" ]]; then
+                    project="$1"
+                else
+                    base_demo_usage_error "The 'demo' command accepts one project name."
+                    return $?
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$project" ]] || {
+        base_demo_usage_error "Project name is required."
+        return $?
+    }
+    [[ "$workspace_requested" != "1" || -n "$project" ]] || {
+        base_demo_usage_error "Option '--workspace' requires an explicit project name."
+        return $?
+    }
+
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    resolve_output="$("$wrapper" --project base base_projects demo-script "$project" "${args[@]}")" || return $?
+    IFS=$'\t' read -r resolved_name project_root manifest_path demo_script <<<"$resolve_output"
+
+    [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$demo_script" ]] || {
+        fatal_error "Unable to resolve demo script for project '$project'."
+    }
+
+    venv_dir="$(base_demo_project_venv_dir "$resolved_name")"
+    export BASE_PROJECT="$resolved_name"
+    export BASE_PROJECT_ROOT="$project_root"
+    export BASE_PROJECT_MANIFEST="$manifest_path"
+    export BASE_PROJECT_VENV_DIR="$venv_dir"
+
+    if [[ -d "$venv_dir/bin" ]]; then
+        PATH="$venv_dir/bin:$PATH"
+        export PATH
+    elif [[ "$dry_run" != "1" ]]; then
+        log_warn "Project virtual environment was not found at '$venv_dir'. Run 'basectl setup $resolved_name' first."
+    fi
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf '[DRY-RUN] Would run demo for project %q in %q: %q%s\n' \
+            "$resolved_name" "$project_root" "$demo_script" "$(base_demo_format_extra_args "${extra_args[@]}")"
+        return 0
+    fi
+
+    log_info "Running demo for project '$resolved_name': $demo_script$(base_demo_format_extra_args "${extra_args[@]}")"
+    (cd "$project_root" && "$demo_script" "${extra_args[@]}")
+}

--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl demo prints help" {
+    run_basectl demo --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl demo <project> [options]"* ]]
+}
+
+@test "basectl demo runs declared project demo from project root" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/demo-state"
+    local script_path="$workspace/demo/demo/demo.sh"
+
+    mkdir -p "$(dirname "$python_bin")" "$(dirname "$script_path")" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo/demo.sh"
+    exit 0
+fi
+printf 'unexpected demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$script_path" <<'EOF'
+#!/usr/bin/env bash
+{
+    printf 'project=%s\n' "$BASE_PROJECT"
+    printf 'root=%s\n' "$BASE_PROJECT_ROOT"
+    printf 'manifest=%s\n' "$BASE_PROJECT_MANIFEST"
+    printf 'venv=%s\n' "$BASE_PROJECT_VENV_DIR"
+    printf 'pwd=%s\n' "$PWD"
+    printf 'path=%s\n' "$PATH"
+    printf 'args='
+    printf '<%s>' "$@"
+    printf '\n'
+} > "$BASE_TEST_DEMO_STATE"
+exit 7
+EOF
+    chmod +x "$python_bin" "$script_path"
+    touch "$TEST_HOME/.base.d/demo/.venv/bin/demo-tool"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_DEMO_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" demo demo -- --non-interactive "name with spaces"
+
+    [ "$status" -eq 7 ]
+    [[ "$(cat "$state_file")" == *"project=demo"* ]]
+    [[ "$(cat "$state_file")" == *"root=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"manifest=$workspace/demo/base_manifest.yaml"* ]]
+    [[ "$(cat "$state_file")" == *"venv=$TEST_HOME/.base.d/demo/.venv"* ]]
+    [[ "$(cat "$state_file")" == *"pwd=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"path=$TEST_HOME/.base.d/demo/.venv/bin:"* ]]
+    [[ "$(cat "$state_file")" == *"args=<--non-interactive><name with spaces>"* ]]
+}
+
+@test "basectl demo dry-run prints resolved script without running it" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/demo-state"
+    local script_path="$workspace/demo/demo.sh"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" && "${5:-}" == "--workspace" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo.sh"
+    exit 0
+fi
+printf 'unexpected demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$script_path" <<'EOF'
+#!/usr/bin/env bash
+touch "$BASE_TEST_DEMO_STATE"
+EOF
+    chmod +x "$python_bin" "$script_path"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_DEMO_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" demo demo --workspace "$workspace" --dry-run -- --non-interactive
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run demo for project demo"* ]]
+    [[ "$output" == *"$workspace/demo/demo.sh"* ]]
+    [[ "$output" == *"--non-interactive"* ]]
+    [ ! -e "$state_file" ]
+}
+
+@test "basectl demo reports missing demo declaration" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
+    printf "ERROR: No demo declared for project 'demo'. Add demo.script to '%s/base_manifest.yaml'.\n" "${BASE_TEST_PROJECT_ROOT:?}" >&2
+    exit 1
+fi
+printf 'unexpected demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" demo demo
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"No demo declared for project 'demo'"* ]]
+}
+
+@test "basectl demo reports invalid demo script from resolver" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
+    printf "ERROR: %s/base_manifest.yaml: demo.script './demo.sh' does not exist.\n" "${BASE_TEST_PROJECT_ROOT:?}" >&2
+    exit 1
+fi
+printf 'unexpected demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" demo demo
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"demo.script './demo.sh' does not exist"* ]]
+}

--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -152,3 +152,82 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"demo.script './demo.sh' does not exist"* ]]
 }
+
+@test "Base manifest declares the self-demo script" {
+    run grep -F "script: ./demo/demo.sh" "$BASE_REPO_ROOT/base_manifest.yaml"
+
+    [ "$status" -eq 0 ]
+    [ -x "$BASE_REPO_ROOT/demo/demo.sh" ]
+}
+
+@test "basectl demo base runs the self-demo in non-interactive mode" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local fake_bin="$TEST_TMPDIR/fake-bin"
+    local state_file="$TEST_TMPDIR/self-demo-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$TEST_HOME/.base.d/base/.venv/bin" "$fake_bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "base" ]]; then
+    printf 'base\t%s\t%s\t%s\n' "${BASE_REPO_ROOT:?}" "${BASE_REPO_ROOT:?}/base_manifest.yaml" "${BASE_REPO_ROOT:?}/demo/demo.sh"
+    exit 0
+fi
+printf 'unexpected self-demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bin/basectl" <<'EOF'
+#!/usr/bin/env bash
+printf 'basectl %s\n' "$*" >> "${BASE_TEST_SELF_DEMO_STATE:?}"
+case "$*" in
+    projects\ list\ --workspace\ *)
+        printf 'base\t%s\n' "${BASE_REPO_ROOT:?}"
+        ;;
+    check\ base)
+        printf 'Base CLI environment and project base check passed.\n'
+        ;;
+    doctor\ base)
+        printf 'Base doctor found no blocking issues for project base.\n'
+        ;;
+    run\ base\ test\ --dry-run)
+        printf '[DRY-RUN] Would run command test for project base.\n'
+        ;;
+    test\ base\ --dry-run)
+        printf '[DRY-RUN] Would run tests for project base.\n'
+        ;;
+    *)
+        printf 'unexpected fake basectl args: %s\n' "$*" >&2
+        exit 1
+        ;;
+esac
+EOF
+    cat > "$fake_bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'base-wrapper %s\n' "$*" >> "${BASE_TEST_SELF_DEMO_STATE:?}"
+if [[ "$*" == "--project base base_projects resolve base" ]]; then
+    printf 'base\t%s\t%s\n' "${BASE_REPO_ROOT:?}" "${BASE_REPO_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected fake base-wrapper args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin" "$fake_bin/basectl" "$fake_bin/base-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        BASE_TEST_SELF_DEMO_STATE="$state_file" \
+        BASE_DEMO_BASECTL="$fake_bin/basectl" \
+        BASE_DEMO_BASE_WRAPPER="$fake_bin/base-wrapper" \
+        "$BASE_REPO_ROOT/bin/basectl" demo base -- --non-interactive
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base Self-Demo"* ]]
+    [[ "$output" == *"Base self-demo complete."* ]]
+    grep -Fqx "basectl projects list --workspace $(dirname "$BASE_REPO_ROOT")" "$state_file"
+    grep -Fqx "basectl check base" "$state_file"
+    grep -Fqx "basectl doctor base" "$state_file"
+    grep -Fqx "basectl run base test --dry-run" "$state_file"
+    grep -Fqx "basectl test base --dry-run" "$state_file"
+    grep -Fqx "base-wrapper --project base base_projects resolve base" "$state_file"
+}

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -13,6 +13,8 @@ import base_cli
 from base_cli.config import read_user_config
 from base_cli.paths import base_cache_root
 from base_cli.paths import discover_manifest
+from base_setup.demo import resolve_demo_script_path
+from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest, ManifestError, TestConfig, read_manifest
 
 
@@ -72,6 +74,7 @@ def dispatch_projects_command(
         "manifest": lambda: manifest_project_from_args(ctx, command_arguments),
         "resolve": lambda: resolve_project_from_args(ctx, command_arguments, workspace),
         "test-command": lambda: test_command_project_from_args(ctx, command_arguments, workspace),
+        "demo-script": lambda: demo_script_project_from_args(ctx, command_arguments, workspace),
         "activation-sources": lambda: activation_sources_project_from_args(ctx, command_arguments, workspace),
         "run-command": lambda: run_command_project_from_args(ctx, command_arguments, workspace),
         "run-commands": lambda: list_run_commands_from_args(ctx, command_arguments, workspace),
@@ -82,7 +85,7 @@ def dispatch_projects_command(
 
     ctx.log.error(
         "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
-        "test-command, activation-sources, run-command, run-commands.",
+        "test-command, demo-script, activation-sources, run-command, run-commands.",
         command,
     )
     return 2
@@ -132,6 +135,11 @@ def resolve_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...],
 def test_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
     project = optional_project_argument("test-command", arguments)
     return test_command_project_command(ctx, project, workspace)
+
+
+def demo_script_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
+    require_argument_count("demo-script", arguments, 1, 1)
+    return demo_script_project_command(ctx, arguments[0], workspace)
 
 
 def activation_sources_project_from_args(
@@ -214,6 +222,30 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
         return 1
 
     print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{test_command(manifest.test)}")
+    return 0
+
+
+def demo_script_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+
+    try:
+        project = resolve_named_project(ctx, project_name, workspace)
+        manifest = read_manifest(project.manifest_path)
+        if manifest.demo is None:
+            ctx.log.error(
+                "No demo declared for project '%s'. Add demo.script to '%s'.",
+                project.name,
+                project.manifest_path,
+            )
+            return 1
+        demo_script = resolve_demo_script_path(manifest)
+    except (ProjectDiscoveryError, ManifestError, ArtifactError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{demo_script}")
     return 0
 
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -57,6 +57,14 @@ def write_commands_manifest(project_root: Path, name: str) -> None:
     )
 
 
+def write_demo_manifest(project_root: Path, name: str, script: str) -> None:
+    project_root.mkdir(parents=True, exist_ok=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\ndemo:\n  script: {script}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
 def write_activation_manifest(project_root: Path, name: str, sources: list[str]) -> None:
     project_root.mkdir(parents=True)
     source_lines = "\n".join(f"    - {source}" for source in sources)
@@ -638,6 +646,53 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 1)
         self.assertIn("does not declare command 'serve'", stderr)
+
+    def test_projects_demo_script_prints_project_details_and_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            script = project_root / "demo" / "demo.sh"
+            script.parent.mkdir(parents=True)
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            write_demo_manifest(project_root, "demo", "./demo/demo.sh")
+
+            status, stdout, stderr = run_engine(["demo-script", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\t{script.resolve()}\n",
+        )
+
+    def test_projects_demo_script_requires_demo_declaration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, _stdout, stderr = run_engine(["demo-script", "demo"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("No demo declared for project 'demo'", stderr)
+
+    def test_projects_demo_script_rejects_missing_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_demo_manifest(project_root, "demo", "./demo/demo.sh")
+
+            status, _stdout, stderr = run_engine(["demo-script", "demo"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("does not exist", stderr)
 
     def test_projects_run_commands_lists_test_and_manifest_commands(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/demo.py
+++ b/cli/python/base_setup/demo.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .checks import ArtifactCheck
+from .errors import ArtifactError
+from .manifest import BaseManifest
+
+
+def check_demo(manifest: BaseManifest) -> list[ArtifactCheck]:
+    if manifest.demo is None:
+        return []
+
+    return [
+        ArtifactCheck(
+            name="demo declaration",
+            ok=True,
+            message=f"Project '{manifest.project_name}' declares demo.script '{manifest.demo.script}'.",
+            fix="",
+            finding_id="BASE-P060",
+        ),
+        check_demo_script(manifest),
+    ]
+
+
+def check_demo_script(manifest: BaseManifest) -> ArtifactCheck:
+    try:
+        demo_script = resolve_demo_script_path(manifest)
+    except ArtifactError as exc:
+        return ArtifactCheck(
+            name="demo script",
+            ok=False,
+            message=str(exc),
+            fix=f"Update demo.script in '{manifest.path}'.",
+            finding_id="BASE-P061",
+        )
+
+    return ArtifactCheck(
+        name="demo script",
+        ok=True,
+        message=f"Demo script '{demo_script}' exists and is executable.",
+        fix="",
+        finding_id="BASE-P061",
+    )
+
+
+def resolve_demo_script_path(manifest: BaseManifest) -> Path:
+    if manifest.demo is None:
+        raise ArtifactError(f"{manifest.path}: demo is not configured.")
+
+    demo_script = Path(manifest.demo.script)
+    if demo_script.is_absolute():
+        raise ArtifactError(f"{manifest.path}: demo.script must be relative to the project root.")
+
+    project_root = manifest.path.parent.resolve()
+    demo_script_path = (project_root / demo_script).resolve()
+    if not demo_script_path.is_relative_to(project_root):
+        raise ArtifactError(f"{manifest.path}: demo.script must stay inside the project root.")
+    if not demo_script_path.exists():
+        raise ArtifactError(f"{manifest.path}: demo.script '{manifest.demo.script}' does not exist.")
+    if not demo_script_path.is_file():
+        raise ArtifactError(f"{manifest.path}: demo.script '{manifest.demo.script}' is not a file.")
+    if not os.access(demo_script_path, os.X_OK):
+        raise ArtifactError(f"{manifest.path}: demo.script '{manifest.demo.script}' is not executable.")
+    return demo_script_path

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -17,6 +17,7 @@ from .checks import check_to_doctor_json
 from .checks import check_to_json
 from .checks import doctor_status
 from .checks import print_doctor_finding
+from .demo import check_demo
 from .delegates import check_brewfile
 from .delegates import check_mise
 from .delegates import reconcile_brewfile
@@ -241,6 +242,7 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
         checks.append(check_mise(effective_manifest))
 
     checks.extend(check_required_env(effective_manifest))
+    checks.extend(check_demo(effective_manifest))
     checks.extend(check_ide_installs(effective_manifest))
     checks.extend(check_ide_extensions(effective_manifest))
     checks.extend(check_ide_settings(effective_manifest))
@@ -274,4 +276,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         health=manifest.health,
         commands=manifest.commands,
         activate=manifest.activate,
+        demo=manifest.demo,
     )

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -51,6 +51,12 @@ class TestConfig:
 
 
 @dataclass(frozen=True)
+class DemoConfig:
+    script: str
+    description: str | None = None
+
+
+@dataclass(frozen=True)
 class HealthConfig:
     required_env: tuple[str, ...] = ()
 
@@ -73,6 +79,7 @@ class BaseManifest:
     health: HealthConfig = field(default_factory=HealthConfig)
     commands: dict[str, str] = field(default_factory=dict)
     activate: ActivateConfig = field(default_factory=ActivateConfig)
+    demo: DemoConfig | None = None
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -103,6 +110,7 @@ def read_manifest(path: Path) -> BaseManifest:
         "health",
         "commands",
         "activate",
+        "demo",
     }
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
@@ -117,6 +125,7 @@ def read_manifest(path: Path) -> BaseManifest:
     health = _read_health(path, data.get("health"))
     commands = _read_commands(path, data.get("commands"))
     activate = _read_activate(path, data.get("activate"))
+    demo = _read_demo(path, data.get("demo"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -131,6 +140,7 @@ def read_manifest(path: Path) -> BaseManifest:
         health=health,
         commands=commands,
         activate=activate,
+        demo=demo,
     )
 
 
@@ -222,6 +232,33 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
         command=command.strip() if command is not None else None,
         mise=mise.strip() if mise is not None else None,
     )
+
+
+def _read_demo(path: Path, demo_data: Any) -> DemoConfig | None:
+    if demo_data is None:
+        return None
+    if not isinstance(demo_data, dict):
+        raise ManifestError(f"{path}: demo must be a mapping when provided.")
+
+    allowed_keys = {"script", "description"}
+    unknown_keys = sorted(set(demo_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: demo has unsupported keys: {', '.join(unknown_keys)}.")
+
+    script = demo_data.get("script")
+    if not isinstance(script, str) or not script.strip():
+        raise ManifestError(f"{path}: demo.script must be a non-empty string when demo is provided.")
+    script = script.strip()
+    if any(separator in script for separator in ("\0", "\n", "\r")):
+        raise ManifestError(f"{path}: demo.script must not contain control line breaks.")
+
+    description = demo_data.get("description")
+    if description is not None:
+        if not isinstance(description, str) or not description.strip():
+            raise ManifestError(f"{path}: demo.description must be a non-empty string when provided.")
+        description = description.strip()
+
+    return DemoConfig(script=script, description=description)
 
 
 def _read_health(path: Path, health_data: Any) -> HealthConfig:

--- a/cli/python/base_setup/tests/test_demo.py
+++ b/cli/python/base_setup/tests/test_demo.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from base_setup import demo, engine
+from base_setup.manifest import BaseManifest, DemoConfig
+from base_setup.tests.helpers import fake_context
+
+
+def demo_manifest(manifest_path: Path, script: str) -> BaseManifest:
+    return BaseManifest(
+        path=manifest_path,
+        project_name="demo",
+        brewfile=None,
+        artifacts=(),
+        demo=DemoConfig(script=script, description="Interactive demo"),
+    )
+
+
+class DemoDiagnosticsTests(unittest.TestCase):
+    def test_resolve_demo_script_path_returns_executable_project_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo" / "demo.sh"
+            script.parent.mkdir()
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo/demo.sh")
+
+            resolved = demo.resolve_demo_script_path(manifest)
+
+        self.assertEqual(resolved, script.resolve())
+
+    def test_check_demo_script_rejects_missing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo/demo.sh")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P061")
+        self.assertIn("does not exist", check.message)
+
+    def test_check_demo_script_rejects_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "demo").mkdir()
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("is not a file", check.message)
+
+    def test_check_demo_script_rejects_non_executable_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo.sh"
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o644)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo.sh")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("is not executable", check.message)
+
+    def test_check_demo_script_rejects_absolute_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", str(project_root / "demo.sh"))
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("must be relative to the project root", check.message)
+
+    def test_check_demo_script_rejects_paths_that_escape_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "../demo.sh")
+
+            check = demo.check_demo_script(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertIn("must stay inside the project root", check.message)
+
+    def test_check_manifest_reports_demo_declaration_and_script(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo.sh"
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo.sh")
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+
+        checks = json.loads(stdout.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual([check["name"] for check in checks], ["demo declaration", "demo script"])
+        self.assertTrue(all(check["ok"] for check in checks))
+
+    def test_doctor_manifest_reports_demo_finding_ids(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            script = project_root / "demo.sh"
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o644)
+            manifest = demo_manifest(project_root / "base_manifest.yaml", "./demo.sh")
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                status = engine.doctor_manifest(default_manifest, manifest, output_format="json")
+
+        findings = json.loads(stdout.getvalue())
+        self.assertEqual(status, 1)
+        self.assertEqual([finding["id"] for finding in findings], ["BASE-P060", "BASE-P061"])
+        self.assertEqual([finding["status"] for finding in findings], ["ok", "error"])

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -181,6 +181,33 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.activate.source, (".base/activate.sh", "scripts/local-env.sh"))
 
 
+    def test_reads_manifest_demo_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "demo:",
+                        "  script: ./demo/demo.sh",
+                        "  description: Interactive project walkthrough",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.demo)
+        assert manifest.demo is not None
+        self.assertEqual(manifest.demo.script, "./demo/demo.sh")
+        self.assertEqual(manifest.demo.description, "Interactive project walkthrough")
+
+
 
     def test_rejects_invalid_manifest_activation_sources(self) -> None:
         invalid_values = {
@@ -202,6 +229,37 @@ class ManifestParsingTests(unittest.TestCase):
                                 "project:",
                                 "  name: demo",
                                 activate_yaml,
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(ManifestError):
+                        read_manifest(manifest_path)
+
+
+    def test_rejects_invalid_manifest_demo_config(self) -> None:
+        invalid_values = {
+            "scalar": "demo: ./demo/demo.sh",
+            "unknown_key": "demo:\n  script: ./demo/demo.sh\n  shell: bash",
+            "missing_script": "demo:\n  description: Interactive project walkthrough",
+            "empty_script": "demo:\n  script: ''",
+            "non_string_script": "demo:\n  script: 7",
+            "newline_script": "demo:\n  script: \"demo\\n/demo.sh\"",
+            "empty_description": "demo:\n  script: ./demo/demo.sh\n  description: ''",
+            "non_string_description": "demo:\n  script: ./demo/demo.sh\n  description: 7",
+        }
+        for name, demo_yaml in invalid_values.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                demo_yaml,
                                 "artifacts: []",
                             ]
                         ),

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env basectl
+# shellcheck shell=bash
+
+set -euo pipefail
+
+base_demo_script_dir() {
+    cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
+}
+
+base_demo_home() {
+    if [[ -n "${BASE_HOME:-}" ]]; then
+        cd -- "$BASE_HOME" && pwd -P
+        return
+    fi
+
+    cd -- "$(base_demo_script_dir)/.." && pwd -P
+}
+
+BASE_HOME="$(base_demo_home)"
+export BASE_HOME
+
+# shellcheck source=/dev/null
+source "$BASE_HOME/base_init.sh"
+
+BASE_DEMO_BASECTL="${BASE_DEMO_BASECTL:-basectl}"
+BASE_DEMO_BASE_WRAPPER="${BASE_DEMO_BASE_WRAPPER:-base-wrapper}"
+BASE_DEMO_NON_INTERACTIVE=0
+
+base_demo_usage() {
+    cat <<'EOF'
+Usage:
+  demo/demo.sh [--non-interactive] [-h|--help]
+
+Run Base's self-contained project workflow demo.
+EOF
+}
+
+base_demo_parse_args() {
+    while (($#)); do
+        case "$1" in
+            --non-interactive)
+                BASE_DEMO_NON_INTERACTIVE=1
+                ;;
+            -h|--help|help)
+                base_demo_usage
+                return 2
+                ;;
+            *)
+                printf 'ERROR: Unknown demo option %q\n' "$1" >&2
+                base_demo_usage >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+}
+
+base_demo_pause() {
+    if [[ "$BASE_DEMO_NON_INTERACTIVE" == "1" || ! -t 0 ]]; then
+        return 0
+    fi
+
+    printf '\nPress Enter to continue...'
+    read -r _
+    printf '\n'
+}
+
+base_demo_step() {
+    local number="$1"
+    local title="$2"
+
+    printf '\n== Step %s: %s ==\n\n' "$number" "$title"
+}
+
+base_demo_run() {
+    printf '  $'
+    printf ' %q' "$@"
+    printf '\n'
+
+    if ! "$@"; then
+        printf '\nDemo step failed while running the command above.\n' >&2
+        printf 'Run it manually with -v for more detail, then retry the demo.\n' >&2
+        return 1
+    fi
+}
+
+base_demo_capture() {
+    local output
+
+    printf '  $'
+    printf ' %q' "$@"
+    printf '\n'
+
+    if ! output="$("$@" 2>&1)"; then
+        printf '%s\n' "$output" >&2
+        printf '\nDemo step failed while running the command above.\n' >&2
+        printf 'Run it manually with -v for more detail, then retry the demo.\n' >&2
+        return 1
+    fi
+
+    printf '%s\n' "$output"
+}
+
+base_demo_require_output() {
+    local label="$1"
+    local output="$2"
+    local expected="$3"
+
+    if [[ "$output" != *"$expected"* ]]; then
+        printf 'ERROR: Expected %s output to contain %q.\n' "$label" "$expected" >&2
+        return 1
+    fi
+}
+
+base_demo_intro() {
+    printf '\nBase Self-Demo\n\n'
+    printf 'This walkthrough exercises the current Base project workflow using the Base repo itself.\n'
+    printf 'It is intentionally local, inspectable, and safe to run repeatedly.\n'
+    base_demo_pause
+}
+
+base_demo_runtime_step() {
+    base_demo_step 1 "Runtime Contract"
+    printf 'BASE_HOME=%s\n' "$BASE_HOME"
+    printf 'BASE_PROJECT=%s\n' "${BASE_PROJECT:-base}"
+    printf 'BASE_PROJECT_ROOT=%s\n' "${BASE_PROJECT_ROOT:-$BASE_HOME}"
+    printf 'BASE_BASH_LIB_DIR=%s\n' "$BASE_BASH_LIB_DIR"
+    base_demo_pause
+}
+
+base_demo_manifest_step() {
+    base_demo_step 2 "Manifest Contract"
+    printf 'Base declares its test and demo contracts in base_manifest.yaml.\n\n'
+    base_demo_run grep -n "^demo:" "$BASE_HOME/base_manifest.yaml"
+    base_demo_run grep -n "script: ./demo/demo.sh" "$BASE_HOME/base_manifest.yaml"
+    base_demo_pause
+}
+
+base_demo_discovery_step() {
+    local workspace_root
+    local output
+
+    base_demo_step 3 "Project Discovery"
+    workspace_root="$(cd -- "$BASE_HOME/.." && pwd -P)"
+    output="$(base_demo_capture "$BASE_DEMO_BASECTL" projects list --workspace "$workspace_root")"
+    printf '%s\n' "$output"
+    base_demo_require_output "project discovery" "$output" "base"
+    base_demo_pause
+}
+
+base_demo_health_step() {
+    base_demo_step 4 "Check And Doctor"
+    base_demo_run "$BASE_DEMO_BASECTL" check base
+    base_demo_run "$BASE_DEMO_BASECTL" doctor base
+    base_demo_pause
+}
+
+base_demo_wrapper_step() {
+    base_demo_step 5 "Base Wrapper"
+    base_demo_run "$BASE_DEMO_BASE_WRAPPER" --project base base_projects resolve base
+    base_demo_pause
+}
+
+base_demo_delegation_step() {
+    base_demo_step 6 "Run And Test Delegation"
+    base_demo_run "$BASE_DEMO_BASECTL" run base test --dry-run
+    base_demo_run "$BASE_DEMO_BASECTL" test base --dry-run
+    base_demo_pause
+}
+
+main() {
+    base_demo_parse_args "$@" || {
+        local status=$?
+        [[ "$status" -eq 2 ]] && return 0
+        return "$status"
+    }
+
+    base_demo_intro
+    base_demo_runtime_step
+    base_demo_manifest_step
+    base_demo_discovery_step
+    base_demo_health_step
+    base_demo_wrapper_step
+    base_demo_delegation_step
+
+    printf '\nBase self-demo complete.\n'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -49,6 +49,8 @@ fix text, or severity over time, but its ID keeps the same meaning.
 | `BASE-P033` | Homebrew artifact package status |
 | `BASE-P040` | Python package artifact status in the project virtual environment |
 | `BASE-P050` | Project virtual environment integrity |
+| `BASE-P060` | Project demo declaration |
+| `BASE-P061` | Project demo script path and executable status |
 | `BASE-P100` | User config disables all IDE setup and checks |
 | `BASE-P101` | User config disables setup and checks for one IDE |
 | `BASE-P102` | User IDE setting conflicts with a project manifest setting |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test run repo clean config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup check test demo run repo clean config doctor gh onboard update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -68,6 +68,9 @@ _base_basectl_completion() {
             _base_basectl_completion_project_or_options "--dev --format -v -h --help" "$cur"
             ;;
         test)
+            _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
+            ;;
+        demo)
             _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
             ;;
         run)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -18,6 +18,7 @@ _base_basectl_completion() {
         'setup:Install and bootstrap the local Base CLI environment'
         'check:Verify the local Base CLI environment'
         'test:Run a project test command'
+        'demo:Run a project interactive demo'
         'run:Run a project command'
         'repo:Create, check, and configure repository baseline'
         'clean:Remove old Base CLI runtime artifacts'
@@ -75,6 +76,16 @@ _base_basectl_completion() {
         test)
             _arguments '--workspace[Workspace directory to scan]:path:_files' \
                 '--dry-run[Print the resolved test command without running it]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
+            ;;
+        demo)
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--dry-run[Print the resolved demo script without running it]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then


### PR DESCRIPTION
## Summary

- Add `base_projects demo-script` to resolve project demo scripts through the manifest contract from PR #378.
- Add `basectl demo <project>` with `--workspace`, `--dry-run`, `-v`, and `--` pass-through support.
- Export the project runtime environment, prepend the project venv bin directory when present, and return the demo script exit status.
- Add Bash/Zsh completion entries and command-focused BATS/Python coverage.

## Validation

- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_projects/tests/test_engine.py cli/python/base_setup/tests/test_demo.py`
- `bats cli/bash/commands/basectl/tests/demo.bats lib/shell/completions/tests/completions.bats`
- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint cli/python/base_projects cli/python/base_setup lib/python/base_cli`
- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest`
- `./bin/base-test`
- `git diff --cached --check`

Depends on #378.
Next train car: Base self-demo for #363.

Closes #362