### PR TITLE
Add Base self-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ basectl setup <project>
 basectl check <project>
 basectl doctor <project>
 basectl test <project>
+basectl demo <project>
 basectl run <project> <command>
 basectl activate <project>
 ```
 
-For Base itself, run the dogfood test contract:
+For Base itself, run the self-demo or the dogfood test contract:
 
 ```bash
+basectl demo base -- --non-interactive
 basectl test base
 ```
 

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -8,6 +8,10 @@ project:
 test:
   command: ./bin/base-test
 
+demo:
+  script: ./demo/demo.sh
+  description: Self-contained walkthrough of Base's core project workflow
+
 # Optional relative path to a Homebrew Brewfile for ordinary macOS tools.
 # Base runs `brew bundle --file=<path>` during setup when this is set.
 # Keep Base-specific managed dependencies in `artifacts`; use Brewfile for

--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -152,3 +152,82 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"demo.script './demo.sh' does not exist"* ]]
 }
+
+@test "Base manifest declares the self-demo script" {
+    run grep -F "script: ./demo/demo.sh" "$BASE_REPO_ROOT/base_manifest.yaml"
+
+    [ "$status" -eq 0 ]
+    [ -x "$BASE_REPO_ROOT/demo/demo.sh" ]
+}
+
+@test "basectl demo base runs the self-demo in non-interactive mode" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local fake_bin="$TEST_TMPDIR/fake-bin"
+    local state_file="$TEST_TMPDIR/self-demo-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$TEST_HOME/.base.d/base/.venv/bin" "$fake_bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "base" ]]; then
+    printf 'base\t%s\t%s\t%s\n' "${BASE_REPO_ROOT:?}" "${BASE_REPO_ROOT:?}/base_manifest.yaml" "${BASE_REPO_ROOT:?}/demo/demo.sh"
+    exit 0
+fi
+printf 'unexpected self-demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bin/basectl" <<'EOF'
+#!/usr/bin/env bash
+printf 'basectl %s\n' "$*" >> "${BASE_TEST_SELF_DEMO_STATE:?}"
+case "$*" in
+    projects\ list\ --workspace\ *)
+        printf 'base\t%s\n' "${BASE_REPO_ROOT:?}"
+        ;;
+    check\ base)
+        printf 'Base CLI environment and project base check passed.\n'
+        ;;
+    doctor\ base)
+        printf 'Base doctor found no blocking issues for project base.\n'
+        ;;
+    run\ base\ test\ --dry-run)
+        printf '[DRY-RUN] Would run command test for project base.\n'
+        ;;
+    test\ base\ --dry-run)
+        printf '[DRY-RUN] Would run tests for project base.\n'
+        ;;
+    *)
+        printf 'unexpected fake basectl args: %s\n' "$*" >&2
+        exit 1
+        ;;
+esac
+EOF
+    cat > "$fake_bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'base-wrapper %s\n' "$*" >> "${BASE_TEST_SELF_DEMO_STATE:?}"
+if [[ "$*" == "--project base base_projects resolve base" ]]; then
+    printf 'base\t%s\t%s\n' "${BASE_REPO_ROOT:?}" "${BASE_REPO_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected fake base-wrapper args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin" "$fake_bin/basectl" "$fake_bin/base-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        BASE_TEST_SELF_DEMO_STATE="$state_file" \
+        BASE_DEMO_BASECTL="$fake_bin/basectl" \
+        BASE_DEMO_BASE_WRAPPER="$fake_bin/base-wrapper" \
+        "$BASE_REPO_ROOT/bin/basectl" demo base -- --non-interactive
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base Self-Demo"* ]]
+    [[ "$output" == *"Base self-demo complete."* ]]
+    grep -Fqx "basectl projects list --workspace $(dirname "$BASE_REPO_ROOT")" "$state_file"
+    grep -Fqx "basectl check base" "$state_file"
+    grep -Fqx "basectl doctor base" "$state_file"
+    grep -Fqx "basectl run base test --dry-run" "$state_file"
+    grep -Fqx "basectl test base --dry-run" "$state_file"
+    grep -Fqx "base-wrapper --project base base_projects resolve base" "$state_file"
+}

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env basectl
+
+set -euo pipefail
+
+base_demo_script_dir() {
+    cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
+}
+
+base_demo_home() {
+    if [[ -n "${BASE_HOME:-}" ]]; then
+        cd -- "$BASE_HOME" && pwd -P
+        return
+    fi
+
+    cd -- "$(base_demo_script_dir)/.." && pwd -P
+}
+
+BASE_HOME="$(base_demo_home)"
+export BASE_HOME
+
+# shellcheck source=/dev/null
+source "$BASE_HOME/base_init.sh"
+
+BASE_DEMO_BASECTL="${BASE_DEMO_BASECTL:-basectl}"
+BASE_DEMO_BASE_WRAPPER="${BASE_DEMO_BASE_WRAPPER:-base-wrapper}"
+BASE_DEMO_NON_INTERACTIVE=0
+
+base_demo_usage() {
+    cat <<'EOF'
+Usage:
+  demo/demo.sh [--non-interactive] [-h|--help]
+
+Run Base's self-contained project workflow demo.
+EOF
+}
+
+base_demo_parse_args() {
+    while (($#)); do
+        case "$1" in
+            --non-interactive)
+                BASE_DEMO_NON_INTERACTIVE=1
+                ;;
+            -h|--help|help)
+                base_demo_usage
+                return 2
+                ;;
+            *)
+                printf 'ERROR: Unknown demo option %q\n' "$1" >&2
+                base_demo_usage >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+}
+
+base_demo_pause() {
+    if [[ "$BASE_DEMO_NON_INTERACTIVE" == "1" || ! -t 0 ]]; then
+        return 0
+    fi
+
+    printf '\nPress Enter to continue...'
+    read -r _
+    printf '\n'
+}
+
+base_demo_step() {
+    local number="$1"
+    local title="$2"
+
+    printf '\n== Step %s: %s ==\n\n' "$number" "$title"
+}
+
+base_demo_run() {
+    printf '  $'
+    printf ' %q' "$@"
+    printf '\n'
+
+    if ! "$@"; then
+        printf '\nDemo step failed while running the command above.\n' >&2
+        printf 'Run it manually with -v for more detail, then retry the demo.\n' >&2
+        return 1
+    fi
+}
+
+base_demo_capture() {
+    local output
+
+    printf '  $'
+    printf ' %q' "$@"
+    printf '\n'
+
+    if ! output="$("$@" 2>&1)"; then
+        printf '%s\n' "$output" >&2
+        printf '\nDemo step failed while running the command above.\n' >&2
+        printf 'Run it manually with -v for more detail, then retry the demo.\n' >&2
+        return 1
+    fi
+
+    printf '%s\n' "$output"
+}
+
+base_demo_require_output() {
+    local label="$1"
+    local output="$2"
+    local expected="$3"
+
+    if [[ "$output" != *"$expected"* ]]; then
+        printf 'ERROR: Expected %s output to contain %q.\n' "$label" "$expected" >&2
+        return 1
+    fi
+}
+
+base_demo_intro() {
+    printf '\nBase Self-Demo\n\n'
+    printf 'This walkthrough exercises the current Base project workflow using the Base repo itself.\n'
+    printf 'It is intentionally local, inspectable, and safe to run repeatedly.\n'
+    base_demo_pause
+}
+
+base_demo_runtime_step() {
+    base_demo_step 1 "Runtime Contract"
+    printf 'BASE_HOME=%s\n' "$BASE_HOME"
+    printf 'BASE_PROJECT=%s\n' "${BASE_PROJECT:-base}"
+    printf 'BASE_PROJECT_ROOT=%s\n' "${BASE_PROJECT_ROOT:-$BASE_HOME}"
+    printf 'BASE_BASH_LIB_DIR=%s\n' "$BASE_BASH_LIB_DIR"
+    base_demo_pause
+}
+
+base_demo_manifest_step() {
+    base_demo_step 2 "Manifest Contract"
+    printf 'Base declares its test and demo contracts in base_manifest.yaml.\n\n'
+    base_demo_run grep -n "^demo:" "$BASE_HOME/base_manifest.yaml"
+    base_demo_run grep -n "script: ./demo/demo.sh" "$BASE_HOME/base_manifest.yaml"
+    base_demo_pause
+}
+
+base_demo_discovery_step() {
+    local workspace_root
+    local output
+
+    base_demo_step 3 "Project Discovery"
+    workspace_root="$(cd -- "$BASE_HOME/.." && pwd -P)"
+    output="$(base_demo_capture "$BASE_DEMO_BASECTL" projects list --workspace "$workspace_root")"
+    printf '%s\n' "$output"
+    base_demo_require_output "project discovery" "$output" "base"
+    base_demo_pause
+}
+
+base_demo_health_step() {
+    base_demo_step 4 "Check And Doctor"
+    base_demo_run "$BASE_DEMO_BASECTL" check base
+    base_demo_run "$BASE_DEMO_BASECTL" doctor base
+    base_demo_pause
+}
+
+base_demo_wrapper_step() {
+    base_demo_step 5 "Base Wrapper"
+    base_demo_run "$BASE_DEMO_BASE_WRAPPER" --project base base_projects resolve base
+    base_demo_pause
+}
+
+base_demo_delegation_step() {
+    base_demo_step 6 "Run And Test Delegation"
+    base_demo_run "$BASE_DEMO_BASECTL" run base test --dry-run
+    base_demo_run "$BASE_DEMO_BASECTL" test base --dry-run
+    base_demo_pause
+}
+
+main() {
+    base_demo_parse_args "$@" || {
+        local status=$?
+        [[ "$status" -eq 2 ]] && return 0
+        return "$status"
+    }
+
+    base_demo_intro
+    base_demo_runtime_step
+    base_demo_manifest_step
+    base_demo_discovery_step
+    base_demo_health_step
+    base_demo_wrapper_step
+    base_demo_delegation_step
+
+    printf '\nBase self-demo complete.\n'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env basectl
+# shellcheck shell=bash
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Add `demo/demo.sh`, a self-contained Base workflow demo that runs through the Base script runtime.
- Declare the self-demo in Base's own `base_manifest.yaml` with `demo.script`.
- Add non-interactive BATS coverage for `basectl demo base -- --non-interactive` with deterministic command stubs.
- Mention the Base self-demo in the README quick development loop.

## Validation

- `bats cli/bash/commands/basectl/tests/demo.bats`
- `./bin/base-test`
- `git diff --cached --check`

Note: a direct sandboxed run with the real local environment reached `basectl check base` and stopped because this host does not currently report Homebrew `python@3.13` as installed. The non-interactive command path itself is covered in BATS with check/doctor stubs.

Depends on #381.
Next train car: `needs-demo` maintenance process for #367.

Closes #363
