### PR TITLE
Document project demo workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ Key starting points:
 - [Tool Boundaries](docs/tool-boundaries.md)
 - [IDE Bootstrapping](docs/ide-bootstrapping.md)
 - [Local Config](docs/local-config.md)
+- [Project Demo Workflow](docs/project-demo-workflow.md)
 
 ## Compatibility
 

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env basectl
+# shellcheck shell=bash
 
 set -euo pipefail
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,8 @@ reference. The filename should answer "what is this about?"
   implementation constraints for parallel check probes.
 - [Base-managed demo project](base-managed-demo-project.md) defines the proof
   project criteria for showing Base's complete workspace workflow.
+- [Project Demo Workflow](project-demo-workflow.md) documents `demo.script`,
+  `basectl demo`, Base's self-demo, and the `base-demo` reference repository.
 - [Demo Maintenance](demo-maintenance.md) defines the `needs-demo` label and PR
   convention for keeping executable demos aligned with product changes.
 - [base_cli Runtime Package](base-cli.md) describes the Python CLI foundation

--- a/docs/project-demo-workflow.md
+++ b/docs/project-demo-workflow.md
@@ -1,0 +1,149 @@
+# Project Demo Workflow
+
+Base demos are project-owned walkthrough scripts that Base can discover,
+validate, and run through a common command:
+
+```bash
+basectl demo <project>
+```
+
+The demo feature is intentionally small. Base does not define a demo language,
+dependency model, shell selector, or hidden setup hook. A project declares one
+script, keeps that script in its repository, and tests a non-interactive path
+for CI.
+
+## Manifest Contract
+
+Projects opt in through `base_manifest.yaml`:
+
+```yaml
+demo:
+  script: ./demo/demo.sh
+  description: Interactive walkthrough of this project
+```
+
+`demo.script` is required when `demo` is present. It must be a non-empty string,
+relative to the project root, stay inside the project, point to a file, and be
+executable.
+
+`demo.description` is optional. It is human-facing metadata for documentation
+and future listing surfaces; Base does not currently display it in command
+output.
+
+Unsupported `demo` keys fail manifest parsing. Keep project-specific setup,
+dependency installation, and product logic inside existing Base contracts such
+as `brewfile`, `artifacts`, `activate.source`, `commands`, and `test`.
+
+## Command Behavior
+
+`basectl demo <project>`:
+
+1. Resolves the project through the same workspace discovery path as
+   `basectl test` and `basectl run`.
+2. Reads `demo.script` from the project manifest.
+3. Validates that the script exists, is a file, is executable, and stays inside
+   the project root.
+4. Exports `BASE_PROJECT`, `BASE_PROJECT_ROOT`, `BASE_PROJECT_MANIFEST`, and
+   `BASE_PROJECT_VENV_DIR`.
+5. Prepends the project virtualenv `bin` directory to `PATH` when it exists.
+6. Runs the script from the project root and returns the script exit status.
+
+Useful forms:
+
+```bash
+basectl demo base-demo
+basectl demo base-demo --dry-run
+basectl demo base-demo -- --non-interactive
+basectl demo base-demo --workspace ~/work -- --non-interactive
+```
+
+Arguments after `--` are passed to the demo script unchanged.
+
+When no demo is declared, Base exits with a clear message telling the project to
+add `demo.script` to its manifest.
+
+## Writing Demo Scripts
+
+A good project demo should:
+
+- explain one workflow at a time
+- run real project commands rather than only printing instructions
+- stop on errors with a useful recovery hint
+- avoid heavyweight installs, external accounts, and long-running services
+- support `--non-interactive` so CI can run it without prompts
+- reuse current Base contracts instead of inventing private setup hooks
+
+For shell demos, the common shape is:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+non_interactive=0
+
+while (($#)); do
+  case "$1" in
+    --non-interactive) non_interactive=1 ;;
+    -h|--help) echo "Usage: demo/demo.sh [--non-interactive]"; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+pause() {
+  ((non_interactive)) && return 0
+  read -r -p "Press Enter to continue..." _
+}
+```
+
+Tests should cover at least:
+
+- the demo script exists and is executable
+- `base_manifest.yaml` declares the same script path
+- `demo/demo.sh --non-interactive` runs without blocking
+- meaningful demo steps call the expected project commands
+
+## Base Self-Demo
+
+Base has its own self-demo:
+
+```bash
+basectl demo base -- --non-interactive
+```
+
+That script lives in the Base repository at `demo/demo.sh`. It demonstrates the
+Base control-plane workflow using Base itself and does not depend on the
+external reference repository.
+
+## Reference Project
+
+The public reference repository is
+[`codeforester/base-demo`](https://github.com/codeforester/base-demo).
+
+Clone it next to Base:
+
+```bash
+git clone https://github.com/codeforester/base.git
+git clone https://github.com/codeforester/base-demo.git
+```
+
+Then run:
+
+```bash
+basectl projects list
+basectl setup base-demo
+basectl check base-demo
+basectl doctor base-demo
+basectl test base-demo
+basectl demo base-demo -- --non-interactive
+```
+
+`base-demo` is the reference implementation for a normal Base-managed project.
+Base's self-demo is for the Base repository itself; `base-demo` is the separate
+peer project that shows how another repository should participate.
+
+## Maintenance
+
+When a Base change affects the demos, label the issue or PR with `needs-demo`
+and include a `Demo Impact` section in the PR body. See
+[Demo Maintenance](demo-maintenance.md).


### PR DESCRIPTION
## Summary

- Add `docs/project-demo-workflow.md` covering `demo.script`, `basectl demo`, script expectations, non-interactive testing, Base's self-demo, and `codeforester/base-demo`.
- Link the new workflow doc from the README and docs index.
- Tie demo updates back to the `needs-demo` maintenance process.

## Validation

- `rg -n "Project Demo Workflow|basectl demo|demo.script|base-demo|needs-demo" README.md docs/project-demo-workflow.md docs/README.md`
- `git diff --check`

Depends on #385.

Closes #366
