### PR TITLE
Add basectl gh worktree pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Added `basectl repo init/check/configure` to create, validate, and configure
   a standard Base-managed repository baseline.
+- Added `basectl gh worktree prune` for dry-run-by-default cleanup of stale,
+  merged Git worktrees from PR trains.
 
 ### Fixed
 

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -17,6 +17,7 @@ Usage:
   basectl gh pr merge [gh options...]
   basectl gh branch stale [--days <days>]
   basectl gh branch prune [--dry-run] [--yes] [--remote]
+  basectl gh worktree prune [--dry-run] [--yes]
   basectl gh todo import [--dry-run] [--file <path>]
 
 Purpose:
@@ -30,7 +31,7 @@ Notes:
   - This command requires the GitHub CLI (`gh`) for GitHub operations.
   - Issues created through this command are assigned to codeforester.
   - Pull request implementation work should happen in a dedicated worktree.
-  - Branch pruning is dry-run by default and applies only when --yes is passed.
+  - Branch and worktree pruning are dry-run by default and apply only when --yes is passed.
   - TODO import is currently a dry-run planning command.
 EOF
 }
@@ -543,6 +544,143 @@ base_gh_branch_prune() {
     return "$status"
 }
 
+base_gh_resolve_physical_path() {
+    local path="$1"
+    (cd "$path" && pwd -P)
+}
+
+base_gh_list_worktree_branches() {
+    local line path="" branch=""
+
+    while IFS= read -r line; do
+        if [[ -z "$line" ]]; then
+            if [[ -n "$path" && -n "$branch" ]]; then
+                branch="${branch#refs/heads/}"
+                printf '%s\t%s\n' "$path" "$branch"
+            fi
+            path=""
+            branch=""
+            continue
+        fi
+        case "$line" in
+            "worktree "*)
+                path="${line#worktree }"
+                ;;
+            "branch "*)
+                branch="${line#branch }"
+                ;;
+        esac
+    done < <(git worktree list --porcelain; printf '\n')
+}
+
+base_gh_worktree_dirty() {
+    local path="$1"
+    [[ -n "$(git -C "$path" status --porcelain --ignore-submodules=none)" ]]
+}
+
+base_gh_worktree_prune_delete_branch() {
+    local branch="$1"
+    local upstream
+
+    upstream="$(base_gh_branch_upstream "$branch")"
+    if [[ -n "$upstream" ]] && ! base_gh_branch_merged_to_ref "$branch" "$upstream"; then
+        printf 'SKIP-BRANCH %s  not fully merged to upstream %s\n' "$branch" "$upstream"
+        return 0
+    fi
+
+    if git branch -d "$branch" >/dev/null 2>&1; then
+        printf 'DELETE %s\n' "$branch"
+    else
+        printf 'SKIP-BRANCH %s  git branch -d refused\n' "$branch"
+    fi
+}
+
+base_gh_worktree_prune() {
+    local dry_run=1 default_branch current_worktree
+    local path branch physical_path
+    local removed=0 skipped_current=0 skipped_dirty=0 skipped_unmerged=0 failed=0 candidates=0
+
+    while (($#)); do
+        case "$1" in
+            --dry-run)
+                dry_run=1
+                ;;
+            --yes)
+                dry_run=0
+                ;;
+            -h|--help)
+                base_gh_usage
+                return 0
+                ;;
+            *)
+                base_gh_error "Unknown option '$1'."
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    base_gh_require_git_repo || return 1
+    default_branch="$(base_gh_default_branch)"
+    current_worktree="$(base_gh_resolve_physical_path "$(git rev-parse --show-toplevel)")" || return 1
+
+    if ((dry_run)); then
+        printf '[DRY-RUN] Worktree prune preview for default branch %s.\n' "$default_branch"
+    fi
+    printf 'Worktrees\n'
+
+    while IFS=$'\t' read -r path branch; do
+        [[ -n "$path" && -n "$branch" ]] || continue
+        physical_path="$(base_gh_resolve_physical_path "$path")" || {
+            printf 'FAIL   %s (%s)  unable to inspect worktree path\n' "$path" "$branch"
+            failed=$((failed + 1))
+            continue
+        }
+        candidates=$((candidates + 1))
+
+        if [[ "$physical_path" == "$current_worktree" ]]; then
+            printf 'SKIP   %s (%s)  current worktree\n' "$path" "$branch"
+            skipped_current=$((skipped_current + 1))
+            continue
+        fi
+        if [[ "$branch" == "$default_branch" ]]; then
+            printf 'SKIP   %s (%s)  default branch worktree\n' "$path" "$branch"
+            skipped_current=$((skipped_current + 1))
+            continue
+        fi
+        if base_gh_worktree_dirty "$path"; then
+            printf 'SKIP   %s (%s)  dirty worktree\n' "$path" "$branch"
+            skipped_dirty=$((skipped_dirty + 1))
+            continue
+        fi
+        if ! base_gh_branch_merged_to_ref "$branch" "$default_branch"; then
+            printf 'SKIP   %s (%s)  branch is not merged into %s\n' "$path" "$branch" "$default_branch"
+            skipped_unmerged=$((skipped_unmerged + 1))
+            continue
+        fi
+
+        if ((dry_run)); then
+            printf '[DRY-RUN] REMOVE %s (%s) and delete local branch\n' "$path" "$branch"
+            removed=$((removed + 1))
+        elif git worktree remove "$path" >/dev/null 2>&1; then
+            printf 'REMOVE %s (%s)\n' "$path" "$branch"
+            removed=$((removed + 1))
+            base_gh_worktree_prune_delete_branch "$branch"
+        else
+            printf 'FAIL   %s (%s)  git worktree remove failed\n' "$path" "$branch"
+            failed=$((failed + 1))
+        fi
+    done < <(base_gh_list_worktree_branches)
+
+    if ((candidates == 0)); then
+        printf 'No Git worktrees found.\n'
+    fi
+    printf 'Summary: %s %s, %s skipped current/default, %s skipped dirty, %s skipped unmerged, %s failed.\n' \
+        "$removed" "$([[ "$dry_run" -eq 1 ]] && printf 'would remove' || printf 'removed')" \
+        "$skipped_current" "$skipped_dirty" "$skipped_unmerged" "$failed"
+    return "$failed"
+}
+
 base_gh_do_branch() {
     local command="${1:-}"
     shift || true
@@ -553,6 +691,21 @@ base_gh_do_branch() {
         -h|--help|help|"") base_gh_usage ;;
         *)
             base_gh_error "Unknown gh branch command '$command'."
+            base_gh_usage >&2
+            return 1
+            ;;
+    esac
+}
+
+base_gh_do_worktree() {
+    local command="${1:-}"
+    shift || true
+
+    case "$command" in
+        prune) base_gh_worktree_prune "$@" ;;
+        -h|--help|help|"") base_gh_usage ;;
+        *)
+            base_gh_error "Unknown gh worktree command '$command'."
             base_gh_usage >&2
             return 1
             ;;
@@ -651,6 +804,7 @@ base_gh_subcommand_main() {
         issue) base_gh_do_issue "$@" ;;
         pr) base_gh_do_pr "$@" ;;
         branch) base_gh_do_branch "$@" ;;
+        worktree) base_gh_do_worktree "$@" ;;
         todo) base_gh_do_todo "$@" ;;
         -h|--help|help|"") base_gh_usage ;;
         *)

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -86,7 +86,19 @@ EOF
             COMP_WORDS=(basectl repo configure --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
-            printf "repo_configure_options=%s\n" "${COMPREPLY[*]}"'
+            printf "repo_configure_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl gh ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "gh_areas=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl gh worktree ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "gh_worktree_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl gh worktree prune --); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "gh_worktree_prune_options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"complete -F _base_basectl_completion basectl"* ]]
@@ -105,6 +117,9 @@ EOF
     [[ "$output" == *"repo_commands=init check configure"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --no-configure --dry-run"* ]]
     [[ "$output" == *"repo_configure_options=--repo --dry-run"* ]]
+    [[ "$output" == *"gh_areas=issue pr branch worktree todo"* ]]
+    [[ "$output" == *"gh_worktree_commands=prune"* ]]
+    [[ "$output" == *"gh_worktree_prune_options=--dry-run --yes"* ]]
 }
 
 @test "Bash completion includes setup notification options" {

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -9,6 +9,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl gh issue start <number>"* ]]
+    [[ "$output" == *"basectl gh worktree prune"* ]]
     [[ "$output" == *"<category>/<issue>-<YYYYMMDD>-<slug>"* ]]
     [[ "$output" == *"assigned to codeforester"* ]]
 }
@@ -289,6 +290,125 @@ EOF
     [[ "$output" != *"Pruning origin"* ]]
     [[ "$output" != *"URL:"* ]]
     ! git -C "$repo" show-ref --verify --quiet refs/remotes/origin/stale-branch
+}
+
+@test "basectl gh worktree prune defaults to dry-run" {
+    local repo worktree
+
+    repo="$TEST_TMPDIR/repo"
+    worktree="$TEST_TMPDIR/merged-worktree"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" branch merged-work
+    git -C "$repo" worktree add "$worktree" merged-work >/dev/null 2>&1
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main worktree prune
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Worktree prune preview for default branch master."* ]]
+    [[ "$output" == *"[DRY-RUN] REMOVE "*"/merged-worktree (merged-work) and delete local branch"* ]]
+    [[ "$output" == *"SKIP   "*"/repo (master)  current worktree"* ]]
+    [[ "$output" == *"Summary: 1 would remove, 1 skipped current/default, 0 skipped dirty, 0 skipped unmerged, 0 failed."* ]]
+    [ -d "$worktree" ]
+    git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
+}
+
+@test "basectl gh worktree prune removes safe merged worktrees and branch" {
+    local repo worktree
+
+    repo="$TEST_TMPDIR/repo"
+    worktree="$TEST_TMPDIR/merged-worktree"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" branch merged-work
+    git -C "$repo" worktree add "$worktree" merged-work >/dev/null 2>&1
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main worktree prune --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOVE "*"/merged-worktree (merged-work)"* ]]
+    [[ "$output" == *"DELETE merged-work"* ]]
+    [[ "$output" == *"Summary: 1 removed, 1 skipped current/default, 0 skipped dirty, 0 skipped unmerged, 0 failed."* ]]
+    [ ! -e "$worktree" ]
+    ! git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
+}
+
+@test "basectl gh worktree prune skips dirty worktrees" {
+    local repo worktree
+
+    repo="$TEST_TMPDIR/repo"
+    worktree="$TEST_TMPDIR/dirty-worktree"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" branch dirty-work
+    git -C "$repo" worktree add "$worktree" dirty-work >/dev/null 2>&1
+    printf 'notes\n' > "$worktree/local-notes.md"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main worktree prune --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP   "*"/dirty-worktree (dirty-work)  dirty worktree"* ]]
+    [[ "$output" == *"Summary: 0 removed, 1 skipped current/default, 1 skipped dirty, 0 skipped unmerged, 0 failed."* ]]
+    [ -d "$worktree" ]
+    git -C "$repo" show-ref --verify --quiet refs/heads/dirty-work
+}
+
+@test "basectl gh worktree prune skips unmerged branches" {
+    local repo worktree
+
+    repo="$TEST_TMPDIR/repo"
+    worktree="$TEST_TMPDIR/unmerged-worktree"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c unmerged-work >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Topic commit"
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" worktree add "$worktree" unmerged-work >/dev/null 2>&1
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main worktree prune --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP   "*"/unmerged-worktree (unmerged-work)  branch is not merged into master"* ]]
+    [[ "$output" == *"Summary: 0 removed, 1 skipped current/default, 0 skipped dirty, 1 skipped unmerged, 0 failed."* ]]
+    [ -d "$worktree" ]
+    git -C "$repo" show-ref --verify --quiet refs/heads/unmerged-work
 }
 
 @test "basectl gh pr create links current branch issue" {

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -115,13 +115,16 @@ Base can also help with branch cleanup:
 basectl gh branch prune
 basectl gh branch prune --yes
 basectl gh branch prune --remote --yes
+basectl gh worktree prune
+basectl gh worktree prune --yes
 ```
 
 The command is dry-run by default. It reports merged local branches as delete
 candidates, reports branches attached to worktrees as skipped, and keeps remote
-cleanup scoped to stale `origin/*` tracking refs. Removing stale worktree
-directories is intentionally a separate workflow because it deletes files on
-disk.
+cleanup scoped to stale `origin/*` tracking refs. Worktree pruning is also
+dry-run by default; it removes only clean, non-current worktrees whose branches
+are merged into the default branch, then deletes the now-free local branch when
+safe.
 
 ## Pull Requests
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -103,7 +103,7 @@ _base_basectl_completion() {
         gh)
             case "${COMP_WORDS[2]:-}" in
                 "")
-                    _base_basectl_completion_compgen "issue pr branch todo" "$cur"
+                    _base_basectl_completion_compgen "issue pr branch worktree todo" "$cur"
                     ;;
                 issue)
                     if ((COMP_CWORD == 3)); then
@@ -122,6 +122,13 @@ _base_basectl_completion() {
                         _base_basectl_completion_compgen "stale prune" "$cur"
                     else
                         _base_basectl_completion_compgen "--days --dry-run --yes --remote -h --help" "$cur"
+                    fi
+                    ;;
+                worktree)
+                    if ((COMP_CWORD == 3)); then
+                        _base_basectl_completion_compgen "prune" "$cur"
+                    else
+                        _base_basectl_completion_compgen "--dry-run --yes -h --help" "$cur"
                     fi
                     ;;
                 todo)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -147,7 +147,7 @@ _base_basectl_completion() {
         gh)
             case "${words[3]:-}" in
                 issue)
-                    _arguments '1:gh area:(issue pr branch todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo)' \
                         '2:issue command:(list create start)' \
                         '--category[Issue category]:category:(bug enhancement documentation ci security)' \
                         '--title[Issue title]:title:' \
@@ -155,11 +155,11 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 pr)
-                    _arguments '1:gh area:(issue pr branch todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo)' \
                         '2:pr command:(create status checks ready merge)'
                     ;;
                 branch)
-                    _arguments '1:gh area:(issue pr branch todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo)' \
                         '2:branch command:(stale prune)' \
                         '--days[Stale threshold in days]:days:' \
                         '--dry-run[Show planned deletions]' \
@@ -167,15 +167,22 @@ _base_basectl_completion() {
                         '--remote[Prune stale remote tracking refs]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
+                worktree)
+                    _arguments '1:gh area:(issue pr branch worktree todo)' \
+                        '2:worktree command:(prune)' \
+                        '--dry-run[Show planned removals]' \
+                        '--yes[Apply worktree pruning]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
                 todo)
-                    _arguments '1:gh area:(issue pr branch todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo)' \
                         '2:todo command:(import)' \
                         '--dry-run[Show planned issues]' \
                         '--file[TODO file]:path:_files' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)
-                    _arguments '1:gh area:(issue pr branch todo)'
+                    _arguments '1:gh area:(issue pr branch worktree todo)'
                     ;;
             esac
             ;;


### PR DESCRIPTION
## Summary
- Add `basectl gh worktree prune` as a dry-run-by-default cleanup command for stale PR-train worktrees.
- Remove only clean, non-current worktrees whose branches are merged into the default branch, then delete the now-free local branch when safe.
- Add Bash and Zsh completions plus workflow docs for the worktree cleanup path.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/gh.sh`
- `bats cli/bash/commands/basectl/tests/gh.bats`
- `bats cli/bash/commands/basectl/tests/completions.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`
- `git diff --check`

Closes #383