### PR TITLE
Add basectl logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   a standard Base-managed repository baseline.
 - Added `basectl gh worktree prune` for dry-run-by-default cleanup of stale,
   merged Git worktrees from PR trains.
+- Added `basectl logs` to list, print, open, and tail recent Base CLI runtime
+  logs.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   merged Git worktrees from PR trains.
 - Added `basectl logs` to list, print, open, and tail recent Base CLI runtime
   logs.
+- Added `basectl workspace status` as the first read-only workspace-level
+  project health summary.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -293,14 +293,18 @@ You can inspect the projects Base can see with:
 ```bash
 basectl projects list
 basectl projects list --format json
+basectl workspace status
+basectl workspace status --format json
 ```
 
 By default this scans `workspace.root` from `~/.base.d/config.yaml` when that
 value is configured. If it is not configured, Base falls back to the parent
 directory of `BASE_HOME`, which matches the source-checkout sibling-repo layout.
 Use `--workspace <path>` to inspect a different workspace root for one command.
-Output is tab-separated as `<project-name><TAB><path>`. Use `--format json` for
-machine-readable output.
+Project list output is tab-separated as `<project-name><TAB><path>`. Use
+`--format json` for machine-readable output. Workspace status is also read-only;
+it reports each discovered project's manifest validity and whether the
+Base-managed project virtual environment is present.
 
 Start a new Base-managed repository with:
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,20 @@ to `~/Library/Caches/base` on macOS. Set `BASE_CACHE_DIR` to override it. Durabl
 state such as `~/.base.d/config.yaml` and project virtual environments under
 `~/.base.d/<project>/.venv` are outside this scope.
 
+Show recent Base CLI logs with:
+
+```bash
+basectl logs
+basectl logs --command check
+basectl logs --path
+basectl logs --open
+basectl logs --tail
+```
+
+`basectl logs` is read-only. It lists the newest runtime logs under the Base
+cache root so failed Python-layer runs can be inspected without rerunning with
+debug output enabled.
+
 Inspect machine-local Base config with:
 
 ```bash

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -58,6 +58,8 @@ that delegate to `basectl`.
   manage developer prerequisites through `lib/base/dev_manifest.yaml`.
 - `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
 - `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
+- `basectl logs` lists recent Base CLI runtime logs and can print, open, or tail
+  the newest matching log file.
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -92,6 +92,8 @@ that delegate to `basectl`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`
   when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
   project names and paths.
+- `basectl workspace status` reports a read-only workspace summary across
+  discovered projects.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -41,6 +41,8 @@ Commands:
     Update Base from Git and run setup.
   projects list [options]
     List Base-managed projects discovered in the workspace.
+  workspace status [options]
+    Show a read-only status summary for workspace projects.
   version
     Show the installed Base version.
   help
@@ -233,6 +235,11 @@ basectl_do_projects() {
     base_projects_subcommand_main "$@"
 }
 
+basectl_do_workspace() {
+    basectl_source_subcommand_module workspace || return 1
+    base_workspace_subcommand_main "$@"
+}
+
 basectl_source_version_library() {
     local version_lib="$BASE_HOME/lib/bash/version/lib_version.sh"
 
@@ -344,6 +351,7 @@ basectl_main() {
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;
+        workspace)        basectl_do_workspace "$@" ;;
         update)           basectl_do_update "$@" ;;
         update-profile)   basectl_do_update_profile "$@" ;;
         version)          basectl_do_version ;;

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -25,6 +25,8 @@ Commands:
     Create, check, and configure a standard Base-managed repository baseline.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
+  logs [options]
+    List and open recent Base CLI runtime logs.
   config <path|show|doctor>
     Inspect Base's machine-local user config.
   doctor [project] [options]
@@ -191,6 +193,11 @@ basectl_do_clean() {
     base_clean_subcommand_main "$@"
 }
 
+basectl_do_logs() {
+    basectl_source_subcommand_module logs || return 1
+    base_logs_subcommand_main "$@"
+}
+
 basectl_do_config() {
     basectl_source_subcommand_module config || return 1
     base_config_subcommand_main "$@"
@@ -329,6 +336,7 @@ basectl_main() {
         run)              basectl_do_run "$@" ;;
         repo)             basectl_do_repo "$@" ;;
         clean)            basectl_do_clean "$@" ;;
+        logs)             basectl_do_logs "$@" ;;
         config)           basectl_do_config "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;
         gh)               basectl_do_gh "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -1,0 +1,60 @@
+# shellcheck shell=bash
+[[ -n "${_base_logs_subcommand_sourced:-}" ]] && return
+_base_logs_subcommand_sourced=1
+readonly _base_logs_subcommand_sourced
+
+base_logs_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl logs [options]
+
+Options:
+  --command <name>  Filter by basectl command or Python CLI name.
+  --limit <count>   Number of recent log entries to list. Defaults to 10.
+  --path            Print the most recent matching log path only.
+  --tail            Tail and follow the most recent matching log.
+  --open            Open the most recent matching log in PAGER or EDITOR.
+  --lines <count>   Line count to show before following with --tail. Defaults to 40.
+  -v                Enable DEBUG logging for this subcommand.
+  -h, --help        Show this help text.
+
+Surface recent Base CLI runtime logs from the Base cache root.
+EOF
+}
+
+base_logs_subcommand_main() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    while (($# > 0)); do
+        case "$1" in
+            -h|--help)
+                base_logs_subcommand_usage
+                return 0
+                ;;
+            -v)
+                shift
+                ;;
+            --command|--limit|--lines)
+                [[ -n "${2:-}" ]] || {
+                    base_logs_subcommand_usage >&2
+                    printf 'ERROR: Option '\''%s'\'' requires an argument.\n' "$1" >&2
+                    return 2
+                }
+                args+=("$1" "$2")
+                shift 2
+                ;;
+            --command=*|--limit=*|--lines=*|--path|--tail|--open)
+                args+=("$1")
+                shift
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_logs "${args[@]}"
+}

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+[[ -n "${_base_workspace_subcommand_sourced:-}" ]] && return
+_base_workspace_subcommand_sourced=1
+readonly _base_workspace_subcommand_sourced
+
+base_workspace_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl workspace status [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --format <format>   Output format for status: text or json.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Show a read-only status summary for Base-managed projects in the workspace.
+EOF
+}
+
+base_workspace_subcommand_main() {
+    local workspace_command="${1:-}"
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    case "$workspace_command" in
+        ""|-h|--help)
+            base_workspace_subcommand_usage
+            return 0
+            ;;
+        status)
+            shift
+            ;;
+        *)
+            base_workspace_subcommand_usage >&2
+            fatal_error "Unknown workspace command '$workspace_command'."
+            ;;
+    esac
+
+    while (($# > 0)); do
+        case "$1" in
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            -h|--help)
+                base_workspace_subcommand_usage
+                return 0
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_projects status "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -67,6 +67,14 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "projects_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "workspace_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace status --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "workspace_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl onboard --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -116,6 +124,8 @@ EOF
     [[ "$output" == *"test_options=--workspace --dry-run"* ]]
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
+    [[ "$output" == *"workspace_commands=status"* ]]
+    [[ "$output" == *"workspace_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -75,6 +75,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "clean_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl logs --); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "logs_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl repo ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -114,6 +118,7 @@ EOF
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
+    [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"repo_commands=init check configure"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --no-configure --dry-run"* ]]
     [[ "$output" == *"repo_configure_options=--repo --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -22,6 +22,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"onboard [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
+    [[ "$output" == *"workspace status [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
@@ -50,6 +51,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  repo <init|check|configure> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
+    grep -Fqx '  workspace status [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -15,6 +15,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"run <project> <command> [options]"* ]]
     [[ "$output" == *"repo <init|check|configure> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
+    [[ "$output" == *"logs [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"gh <area> <command> [options]"* ]]
@@ -48,6 +49,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  repo <init|check|configure> [options]' <<<"$output"
+    grep -Fqx '  logs [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]

--- a/cli/bash/commands/basectl/tests/logs.bats
+++ b/cli/bash/commands/basectl/tests/logs.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl logs delegates to the Python logs layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
+    printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected logs python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl logs --command check --limit 3 --path
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=base"* ]]
+    [[ "$output" == *"ARGS=--command check --limit 3 --path"* ]]
+}
+
+@test "basectl logs prints help without requiring the Base Python venv" {
+    run_basectl logs --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl logs [options]"* ]]
+    [[ "$output" == *"--command <name>"* ]]
+    [[ "$output" == *"--path"* ]]
+}
+
+@test "basectl logs reports missing option arguments as usage errors" {
+    run_basectl logs --command
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--command' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl logs --limit
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--limit' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+}

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl workspace status delegates to the Python projects layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "status" ]]; then
+    printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT" > "${BASE_TEST_WORKSPACE_STATUS_STATE:?}"
+    printf 'ARGS=%s\n' "${*:4}"
+    exit 0
+fi
+printf 'unexpected workspace status python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_WORKSPACE_STATUS_STATE="$TEST_TMPDIR/workspace-status-state" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace status --workspace "$workspace" --format json
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS=--workspace $workspace --format json" ]
+    [ "$(cat "$TEST_TMPDIR/workspace-status-state")" = "BASE_PROJECT=base" ]
+}
+
+@test "basectl workspace status prints help without requiring the Base Python venv" {
+    run_basectl workspace status --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl workspace status [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--format <format>"* ]]
+}
+
+@test "basectl workspace rejects unknown subcommands" {
+    run_basectl workspace repair
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown workspace command 'repair'"* ]]
+    [[ "$output" != *"Traceback"* ]]
+}

--- a/cli/python/base_logs/__init__.py
+++ b/cli/python/base_logs/__init__.py
@@ -1,0 +1,2 @@
+"""Surface Base CLI runtime log files."""
+

--- a/cli/python/base_logs/__main__.py
+++ b/cli/python/base_logs/__main__.py
@@ -1,0 +1,6 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from base_cli.paths import base_cache_root
+
+
+RUN_ID_RE = re.compile(r"^(?P<stamp>\d{8}T\d{6})_[A-Za-z0-9]+$")
+
+
+@dataclass(frozen=True)
+class LogEntry:
+    command: str
+    raw_command: str
+    run_id: str
+    path: Path
+    timestamp: datetime
+    status: str
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return run(args)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="base_logs", description="List recent Base CLI runtime logs.")
+    parser.add_argument("--command", help="Filter by basectl command or Python CLI name.")
+    parser.add_argument("--limit", type=parse_positive_int, default=10, help="Maximum log entries to list.")
+    parser.add_argument("--path", action="store_true", help="Print the most recent matching log path only.")
+    parser.add_argument("--tail", action="store_true", help="Tail and follow the most recent matching log.")
+    parser.add_argument("--open", action="store_true", help="Open the most recent matching log in PAGER or EDITOR.")
+    parser.add_argument("--lines", type=parse_positive_int, default=40, help="Line count to show before following.")
+    return parser
+
+
+def parse_positive_int(value: str) -> int:
+    if not value.isdigit():
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    amount = int(value)
+    if amount <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return amount
+
+
+def run(args: argparse.Namespace) -> int:
+    selected_actions = sum(1 for name in ("path", "tail", "open") if getattr(args, name))
+    if selected_actions > 1:
+        print("ERROR: Choose only one of --path, --tail, or --open.", file=sys.stderr)
+        return 2
+
+    entries = recent_logs(base_cache_root(), command_filter=args.command)
+    if not entries:
+        return report_no_logs(args)
+    return run_with_entries(args, entries)
+
+
+def report_no_logs(args: argparse.Namespace) -> int:
+    if args.path or args.tail or args.open:
+        print("ERROR: No Base CLI logs found.", file=sys.stderr)
+        return 1
+    print(f"No Base CLI logs found under {base_cache_root() / 'cli'}.")
+    return 0
+
+
+def run_with_entries(args: argparse.Namespace, entries: list[LogEntry]) -> int:
+    newest = entries[0]
+    if args.path:
+        print(newest.path)
+        return 0
+    if args.tail:
+        return tail_log(newest.path, args.lines)
+    if args.open:
+        return open_log(newest.path)
+
+    print_log_table(entries[: args.limit])
+    return 0
+
+
+def recent_logs(cache_root: Path, command_filter: str | None = None) -> list[LogEntry]:
+    entries = list(discover_log_entries(cache_root))
+    if command_filter:
+        normalized = normalize_command_filter(command_filter)
+        entries = [
+            entry
+            for entry in entries
+            if normalize_command_filter(entry.command) == normalized
+            or normalize_command_filter(entry.raw_command) == normalized
+        ]
+    return sorted(entries, key=lambda entry: (entry.timestamp, entry.path.name), reverse=True)
+
+
+def discover_log_entries(cache_root: Path) -> list[LogEntry]:
+    cli_root = cache_root / "cli"
+    if not cli_root.is_dir():
+        return []
+
+    entries: list[LogEntry] = []
+    for logs_dir in sorted(cli_root.glob("*/logs"), key=str):
+        if not logs_dir.is_dir():
+            continue
+        raw_command = logs_dir.parent.name
+        for path in sorted(logs_dir.glob("*.log"), key=lambda item: item.name):
+            if not path.is_file():
+                continue
+            entries.append(
+                LogEntry(
+                    command=infer_display_command(raw_command, path),
+                    raw_command=raw_command,
+                    run_id=path.stem,
+                    path=path,
+                    timestamp=entry_timestamp(path),
+                    status=infer_status(path),
+                )
+            )
+    return entries
+
+
+def infer_display_command(raw_command: str, path: Path) -> str:
+    if raw_command == "base_setup":
+        action = infer_base_setup_action(path)
+        return action or "setup"
+    if raw_command.startswith("base_"):
+        return raw_command.removeprefix("base_").replace("_", "-")
+    return raw_command.replace("_", "-")
+
+
+def infer_base_setup_action(path: Path) -> str | None:
+    try:
+        for line in first_lines(path, limit=20):
+            for action in ("setup", "bootstrap", "check", "doctor"):
+                if f"'--action', '{action}'" in line or f'"--action", "{action}"' in line:
+                    return action
+                if f"--action {action}" in line:
+                    return action
+    except OSError:
+        return None
+    return None
+
+
+def first_lines(path: Path, limit: int) -> list[str]:
+    lines: list[str] = []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for _index, line in zip(range(limit), handle):
+            lines.append(line.rstrip("\n"))
+    return lines
+
+
+def entry_timestamp(path: Path) -> datetime:
+    match = RUN_ID_RE.match(path.stem)
+    if match is not None:
+        try:
+            return datetime.strptime(match.group("stamp"), "%Y%m%dT%H%M%S")
+        except ValueError:
+            pass
+    return datetime.fromtimestamp(path.stat().st_mtime)
+
+
+def infer_status(path: Path) -> str:
+    try:
+        line = last_nonempty_line(path)
+    except OSError:
+        return "?"
+    if line is None:
+        return "?"
+    if " FATAL " in line or " ERROR " in line:
+        return "error"
+    if " WARN " in line:
+        return "warn"
+    return "ok"
+
+
+def last_nonempty_line(path: Path) -> str | None:
+    last_line = None
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            stripped = line.rstrip("\n")
+            if stripped:
+                last_line = stripped
+    return last_line
+
+
+def normalize_command_filter(value: str) -> str:
+    normalized = value.removeprefix("base_")
+    return normalized.replace("_", "-")
+
+
+def print_log_table(entries: list[LogEntry]) -> None:
+    print(f"{'TIME':<19}  {'COMMAND':<12}  {'RUN ID':<24}  {'STATUS':<6}  PATH")
+    for entry in entries:
+        print(
+            f"{entry.timestamp:%Y-%m-%d %H:%M:%S}  "
+            f"{entry.command:<12}  "
+            f"{entry.run_id:<24}  "
+            f"{entry.status:<6}  "
+            f"{compact_path(entry.path)}"
+        )
+
+
+def compact_path(path: Path) -> str:
+    try:
+        return f"~/{path.expanduser().resolve().relative_to(Path.home().resolve())}"
+    except ValueError:
+        return str(path)
+
+
+def tail_log(path: Path, lines: int) -> int:
+    tail = shutil.which("tail")
+    if tail is None:
+        print(f"ERROR: tail was not found on PATH. Log path: {path}", file=sys.stderr)
+        return 1
+    os.execv(tail, [tail, "-n", str(lines), "-f", str(path)])
+    return 1
+
+
+def open_log(path: Path) -> int:
+    command = os.environ.get("PAGER") or os.environ.get("EDITOR")
+    if not command:
+        print(path)
+        return 0
+
+    args = shlex.split(command)
+    if not args:
+        print(path)
+        return 0
+    if shutil.which(args[0]) is None:
+        print(f"ERROR: {args[0]} was not found on PATH. Log path: {path}", file=sys.stderr)
+        return 1
+    return subprocess.call([*args, str(path)])

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_logs import engine
+
+
+def write_log(cache_root: Path, cli_name: str, run_id: str, text: str) -> Path:
+    path = cache_root / "cli" / cli_name / "logs" / f"{run_id}.log"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class BaseLogsTests(unittest.TestCase):
+    def test_recent_logs_sorts_by_run_id_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            old_path = write_log(cache_root, "base_projects", "20260601T010000_aaaaaaaa", "INFO old\n")
+            new_path = write_log(cache_root, "base_clean", "20260601T010100_bbbbbbbb", "INFO new\n")
+
+            entries = engine.recent_logs(cache_root)
+
+        self.assertEqual([entry.path for entry in entries], [new_path, old_path])
+        self.assertEqual([entry.command for entry in entries], ["clean", "projects"])
+
+    def test_base_setup_command_is_inferred_from_action(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            check_path = write_log(
+                cache_root,
+                "base_setup",
+                "20260601T010000_aaaaaaaa",
+                "2026-06-01 01:00:00 DEBUG argv=['base_setup', '--action', 'check']\n",
+            )
+            setup_path = write_log(
+                cache_root,
+                "base_setup",
+                "20260601T010100_bbbbbbbb",
+                "2026-06-01 01:01:00 DEBUG argv=['base_setup']\n",
+            )
+
+            entries = engine.recent_logs(cache_root)
+            check_entries = engine.recent_logs(cache_root, command_filter="check")
+
+        self.assertEqual({entry.path: entry.command for entry in entries}, {check_path: "check", setup_path: "setup"})
+        self.assertEqual([entry.path for entry in check_entries], [check_path])
+
+    def test_status_comes_from_last_log_line(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_log(
+                cache_root,
+                "base_setup",
+                "20260601T010000_aaaaaaaa",
+                "\n".join(
+                    [
+                        "2026-06-01 01:00:00 INFO start",
+                        "2026-06-01 01:00:01 ERROR failed",
+                    ]
+                ),
+            )
+
+            entries = engine.recent_logs(cache_root)
+
+        self.assertEqual(entries[0].status, "error")
+
+    def test_default_output_lists_recent_logs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
+
+            status, stdout, stderr = invoke([], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("TIME", stdout)
+        self.assertIn("COMMAND", stdout)
+        self.assertIn("clean", stdout)
+        self.assertIn("20260601T010000_aaaaaaaa", stdout)
+
+    def test_path_prints_most_recent_matching_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            older = write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
+            newer = write_log(cache_root, "base_projects", "20260601T010100_bbbbbbbb", "INFO projects\n")
+
+            status, stdout, stderr = invoke(["--path"], cache_root)
+            filter_status, filter_stdout, filter_stderr = invoke(["--command", "clean", "--path"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout.strip(), str(newer))
+        self.assertEqual(filter_status, 0)
+        self.assertEqual(filter_stderr, "")
+        self.assertEqual(filter_stdout.strip(), str(older))
+
+    def test_empty_log_set_is_not_an_error_for_table_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = invoke([], Path(tmpdir))
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("No Base CLI logs found", stdout)
+
+    def test_path_errors_when_no_log_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = invoke(["--path"], Path(tmpdir))
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("No Base CLI logs found", stderr)
+
+    def test_action_options_are_mutually_exclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
+
+            status, stdout, stderr = invoke(["--path", "--open"], cache_root)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("Choose only one", stderr)
+

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import base_cli
 from base_cli.config import read_user_config
-from base_cli.paths import base_cache_root
+from base_cli.paths import base_cache_root, base_state_root
 from base_cli.paths import discover_manifest
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
@@ -35,6 +35,17 @@ class ManifestEntry:
     size: int
 
 
+@dataclass(frozen=True)
+class WorkspaceProjectStatus:
+    name: str
+    root: Path
+    manifest_path: Path
+    status: str
+    venv: str
+    manifest: str
+    issues: tuple[str, ...]
+
+
 def main(argv: list[str] | None = None) -> int:
     result = app.click_command.main(args=argv, standalone_mode=False)
     return int(result or 0)
@@ -46,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
     "--workspace",
     help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
 )
-@base_cli.option("--format", "output_format", default="text", help="Output format for list: text or json.")
+@base_cli.option("--format", "output_format", default="text", help="Output format for list/status: text or json.")
 def run(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
@@ -70,6 +81,7 @@ def dispatch_projects_command(
     command_arguments = arguments[1:] if arguments else ()
     handlers = {
         "list": lambda: list_projects_from_args(ctx, command_arguments, workspace, output_format),
+        "status": lambda: workspace_status_from_args(ctx, command_arguments, workspace, output_format),
         "current": lambda: current_project_from_args(ctx, command_arguments),
         "manifest": lambda: manifest_project_from_args(ctx, command_arguments),
         "resolve": lambda: resolve_project_from_args(ctx, command_arguments, workspace),
@@ -85,7 +97,7 @@ def dispatch_projects_command(
 
     ctx.log.error(
         "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
-        "test-command, demo-script, activation-sources, run-command, run-commands.",
+        "status, test-command, demo-script, activation-sources, run-command, run-commands.",
         command,
     )
     return 2
@@ -115,6 +127,16 @@ def list_projects_from_args(
 ) -> int:
     require_argument_count("list", arguments, 0, 0)
     return list_projects_command(ctx, workspace, output_format)
+
+
+def workspace_status_from_args(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    workspace: str | None,
+    output_format: str,
+) -> int:
+    require_argument_count("status", arguments, 0, 0)
+    return workspace_status_command(ctx, workspace, output_format)
 
 
 def current_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
@@ -185,6 +207,26 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_f
     for project in projects:
         print(f"{project.name}\t{project.root}")
     return 0
+
+
+def workspace_status_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
+    if output_format not in ("text", "json"):
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+        return 2
+
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        statuses = workspace_project_statuses(workspace_root)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    if output_format == "json":
+        print(json.dumps(workspace_status_to_json(workspace_root, statuses), separators=(",", ":")))
+    else:
+        print_workspace_status(workspace_root, statuses)
+
+    return 1 if any(project.status == "error" for project in statuses) else 0
 
 
 def resolve_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
@@ -428,6 +470,100 @@ def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path
     if ctx.base_home is None:
         raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
     return ctx.base_home.parent.resolve()
+
+
+def workspace_project_statuses(workspace_root: Path) -> tuple[WorkspaceProjectStatus, ...]:
+    return tuple(workspace_project_status(entry) for entry in workspace_manifest_entries(workspace_root))
+
+
+def workspace_project_status(entry: ManifestEntry) -> WorkspaceProjectStatus:
+    root = entry.path.parent.resolve()
+    try:
+        manifest = read_manifest(entry.path)
+    except ManifestError as exc:
+        return WorkspaceProjectStatus(
+            name=root.name,
+            root=root,
+            manifest_path=entry.path.resolve(),
+            status="error",
+            venv="unknown",
+            manifest="invalid",
+            issues=(str(exc),),
+        )
+
+    venv_dir = project_venv_dir(manifest.project_name)
+    if project_venv_ready(venv_dir):
+        return WorkspaceProjectStatus(
+            name=manifest.project_name,
+            root=root,
+            manifest_path=entry.path.resolve(),
+            status="ok",
+            venv="ready",
+            manifest="valid",
+            issues=(),
+        )
+
+    return WorkspaceProjectStatus(
+        name=manifest.project_name,
+        root=root,
+        manifest_path=entry.path.resolve(),
+        status="warn",
+        venv="missing",
+        manifest="valid",
+        issues=(f"project virtual environment missing at {venv_dir}",),
+    )
+
+
+def project_venv_dir(project_name: str) -> Path:
+    return base_state_root() / project_name / ".venv"
+
+
+def project_venv_ready(venv_dir: Path) -> bool:
+    return (venv_dir / "bin" / "python").is_file()
+
+
+def workspace_status_to_json(workspace_root: Path, statuses: tuple[WorkspaceProjectStatus, ...]) -> dict[str, Any]:
+    return {
+        "workspace": str(workspace_root),
+        "project_count": len(statuses),
+        "projects": [
+            {
+                "name": status.name,
+                "status": status.status,
+                "path": str(status.root),
+                "manifest_path": str(status.manifest_path),
+                "venv": status.venv,
+                "manifest": status.manifest,
+                "issues": list(status.issues),
+            }
+            for status in statuses
+        ],
+    }
+
+
+def print_workspace_status(workspace_root: Path, statuses: tuple[WorkspaceProjectStatus, ...]) -> None:
+    print(f"Workspace: {workspace_root} ({len(statuses)} projects)")
+    print()
+    if not statuses:
+        print("No Base-managed projects discovered.")
+        return
+
+    print(f"{'PROJECT':<20} {'STATUS':<6} {'VENV':<8} {'MANIFEST':<8} {'LAST CHECK':<10} PATH")
+    for status in statuses:
+        print(
+            f"{status.name:<20} "
+            f"{status.status:<6} "
+            f"{status.venv:<8} "
+            f"{status.manifest:<8} "
+            f"{'-':<10} "
+            f"{status.root}"
+        )
+
+    attention_count = sum(1 for status in statuses if status.status != "ok")
+    if attention_count:
+        print(f"\n{attention_count} project(s) need attention. Run 'basectl doctor <project>' for details.")
+    else:
+        print("\nAll discovered projects look ok.")
 
 
 def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: str | None) -> Project:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -213,6 +213,77 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(json.loads(stdout), [{"name": "demo", "path": str((workspace / "demo").resolve())}])
 
+    def test_workspace_status_reports_manifest_and_venv_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_manifest(workspace / "base", "base")
+            write_manifest(workspace / "demo", "demo")
+            python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace: {workspace.resolve()} (2 projects)", stdout)
+        self.assertIn("base                 ok     ready    valid", stdout)
+        self.assertIn("demo                 warn   missing  valid", stdout)
+        self.assertIn("1 project(s) need attention", stdout)
+
+    def test_workspace_status_supports_json_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = invoke_engine(
+                ["status", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["workspace"], str(workspace.resolve()))
+        self.assertEqual(payload["project_count"], 1)
+        self.assertEqual(payload["projects"][0]["name"], "demo")
+        self.assertEqual(payload["projects"][0]["status"], "warn")
+        self.assertEqual(payload["projects"][0]["venv"], "missing")
+        self.assertEqual(payload["projects"][0]["manifest"], "valid")
+        self.assertIn("project virtual environment missing", payload["projects"][0]["issues"][0])
+
+    def test_workspace_status_reports_invalid_manifest_without_stopping_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+            broken_root = workspace / "broken"
+            broken_root.mkdir(parents=True)
+            (broken_root / "base_manifest.yaml").write_text("project: [", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("broken               error  unknown  invalid", stdout)
+        self.assertIn("demo                 warn   missing  valid", stdout)
+        self.assertIn("2 project(s) need attention", stdout)
+
     def test_projects_list_reuses_project_cache_when_manifests_are_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test demo run repo clean config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup check test demo run repo clean logs config doctor gh onboard update-profile update projects version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -94,6 +94,9 @@ _base_basectl_completion() {
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"
+            ;;
+        logs)
+            _base_basectl_completion_compgen "--command --limit --path --tail --open --lines -v -h --help" "$cur"
             ;;
         config)
             if ((COMP_CWORD == 2)); then

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test demo run repo clean logs config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup check test demo run repo clean logs config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -57,6 +57,13 @@ _base_basectl_completion() {
         projects)
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "list" "$cur"
+            else
+                _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
+            fi
+            ;;
+        workspace)
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "status" "$cur"
             else
                 _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
             fi

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -30,6 +30,7 @@ _base_basectl_completion() {
         'update-profile:Refresh Base-managed shell startup sections'
         'update:Update Base and rerun setup'
         'projects:List Base-managed projects'
+        'workspace:Show workspace-level project status'
         'version:Show the installed Base version'
         'help:Show help text'
     )
@@ -53,6 +54,12 @@ _base_basectl_completion() {
             ;;
         projects)
             _arguments '1:projects command:(list)' \
+                '--workspace[Workspace directory to scan]:path:_files' \
+                '--format[Output format]:format:(text json)' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        workspace)
+            _arguments '1:workspace command:(status)' \
                 '--workspace[Workspace directory to scan]:path:_files' \
                 '--format[Output format]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -22,6 +22,7 @@ _base_basectl_completion() {
         'run:Run a project command'
         'repo:Create, check, and configure repository baseline'
         'clean:Remove old Base CLI runtime artifacts'
+        'logs:List and open recent Base CLI runtime logs'
         'config:Inspect Base machine-local user config'
         'doctor:Diagnose the local Base environment'
         'gh:Manage GitHub issues, pull requests, branches, and hygiene'
@@ -141,6 +142,15 @@ _base_basectl_completion() {
             _arguments '--older-than[Artifact age]:age:' \
                 '--keep-last[Keep newest log files per CLI log directory]:count:' \
                 '--dry-run[Log without removing files]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        logs)
+            _arguments '--command[Filter by command]:command:' \
+                '--limit[Number of entries]:count:' \
+                '--path[Print most recent log path]' \
+                '--tail[Tail and follow most recent log]' \
+                '--open[Open most recent log]' \
+                '--lines[Lines to show before following]:count:' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         config)


### PR DESCRIPTION
## Summary

- Add `basectl logs` for listing recent Base CLI runtime logs.
- Support filtering by command, printing the newest log path, opening a log, and tailing the newest matching log.
- Add Bash/Zsh completions, README coverage, changelog entry, and focused Python/BATS tests.

## Validation

- `PYTHONPATH=lib/python:cli/python python3 -m unittest cli.python.base_logs.tests.test_engine`
- `bats cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_logs`
- `git diff --check`
- `./bin/basectl logs --limit 3`

Depends on #389.

Closes #325
