### PR TITLE
Add workspace status command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   merged Git worktrees from PR trains.
 - Added `basectl logs` to list, print, open, and tail recent Base CLI runtime
   logs.
+- Added `basectl workspace status` as the first read-only workspace-level
+  project health summary.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -293,14 +293,18 @@ You can inspect the projects Base can see with:
 ```bash
 basectl projects list
 basectl projects list --format json
+basectl workspace status
+basectl workspace status --format json
 ```
 
 By default this scans `workspace.root` from `~/.base.d/config.yaml` when that
 value is configured. If it is not configured, Base falls back to the parent
 directory of `BASE_HOME`, which matches the source-checkout sibling-repo layout.
 Use `--workspace <path>` to inspect a different workspace root for one command.
-Output is tab-separated as `<project-name><TAB><path>`. Use `--format json` for
-machine-readable output.
+Project list output is tab-separated as `<project-name><TAB><path>`. Use
+`--format json` for machine-readable output. Workspace status is also read-only;
+it reports each discovered project's manifest validity and whether the
+Base-managed project virtual environment is present.
 
 Start a new Base-managed repository with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -92,6 +92,8 @@ that delegate to `basectl`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`
   when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
   project names and paths.
+- `basectl workspace status` reports a read-only workspace summary across
+  discovered projects.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -41,6 +41,8 @@ Commands:
     Update Base from Git and run setup.
   projects list [options]
     List Base-managed projects discovered in the workspace.
+  workspace status [options]
+    Show a read-only status summary for workspace projects.
   version
     Show the installed Base version.
   help
@@ -233,6 +235,11 @@ basectl_do_projects() {
     base_projects_subcommand_main "$@"
 }
 
+basectl_do_workspace() {
+    basectl_source_subcommand_module workspace || return 1
+    base_workspace_subcommand_main "$@"
+}
+
 basectl_source_version_library() {
     local version_lib="$BASE_HOME/lib/bash/version/lib_version.sh"
 
@@ -344,6 +351,7 @@ basectl_main() {
         setup)            basectl_do_setup "$@" ;;
         help)             basectl_show_help ;;
         projects)         basectl_do_projects "$@" ;;
+        workspace)        basectl_do_workspace "$@" ;;
         update)           basectl_do_update "$@" ;;
         update-profile)   basectl_do_update_profile "$@" ;;
         version)          basectl_do_version ;;

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+[[ -n "${_base_workspace_subcommand_sourced:-}" ]] && return
+_base_workspace_subcommand_sourced=1
+readonly _base_workspace_subcommand_sourced
+
+base_workspace_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl workspace status [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --format <format>   Output format for status: text or json.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Show a read-only status summary for Base-managed projects in the workspace.
+EOF
+}
+
+base_workspace_subcommand_main() {
+    local workspace_command="${1:-}"
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    case "$workspace_command" in
+        ""|-h|--help)
+            base_workspace_subcommand_usage
+            return 0
+            ;;
+        status)
+            shift
+            ;;
+        *)
+            base_workspace_subcommand_usage >&2
+            fatal_error "Unknown workspace command '$workspace_command'."
+            ;;
+    esac
+
+    while (($# > 0)); do
+        case "$1" in
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            -h|--help)
+                base_workspace_subcommand_usage
+                return 0
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_projects status "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -67,6 +67,14 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "projects_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "workspace_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace status --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "workspace_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl onboard --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -116,6 +124,8 @@ EOF
     [[ "$output" == *"test_options=--workspace --dry-run"* ]]
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
+    [[ "$output" == *"workspace_commands=status"* ]]
+    [[ "$output" == *"workspace_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -22,6 +22,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"onboard [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
+    [[ "$output" == *"workspace status [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
@@ -50,6 +51,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  repo <init|check|configure> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
+    grep -Fqx '  workspace status [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl workspace status delegates to the Python projects layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "status" ]]; then
+    printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT" > "${BASE_TEST_WORKSPACE_STATUS_STATE:?}"
+    printf 'ARGS=%s\n' "${*:4}"
+    exit 0
+fi
+printf 'unexpected workspace status python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_WORKSPACE_STATUS_STATE="$TEST_TMPDIR/workspace-status-state" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace status --workspace "$workspace" --format json
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS=--workspace $workspace --format json" ]
+    [ "$(cat "$TEST_TMPDIR/workspace-status-state")" = "BASE_PROJECT=base" ]
+}
+
+@test "basectl workspace status prints help without requiring the Base Python venv" {
+    run_basectl workspace status --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl workspace status [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--format <format>"* ]]
+}
+
+@test "basectl workspace rejects unknown subcommands" {
+    run_basectl workspace repair
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown workspace command 'repair'"* ]]
+    [[ "$output" != *"Traceback"* ]]
+}

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import base_cli
 from base_cli.config import read_user_config
-from base_cli.paths import base_cache_root
+from base_cli.paths import base_cache_root, base_state_root
 from base_cli.paths import discover_manifest
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
@@ -35,6 +35,17 @@ class ManifestEntry:
     size: int
 
 
+@dataclass(frozen=True)
+class WorkspaceProjectStatus:
+    name: str
+    root: Path
+    manifest_path: Path
+    status: str
+    venv: str
+    manifest: str
+    issues: tuple[str, ...]
+
+
 def main(argv: list[str] | None = None) -> int:
     result = app.click_command.main(args=argv, standalone_mode=False)
     return int(result or 0)
@@ -46,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
     "--workspace",
     help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
 )
-@base_cli.option("--format", "output_format", default="text", help="Output format for list: text or json.")
+@base_cli.option("--format", "output_format", default="text", help="Output format for list/status: text or json.")
 def run(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
@@ -70,6 +81,7 @@ def dispatch_projects_command(
     command_arguments = arguments[1:] if arguments else ()
     handlers = {
         "list": lambda: list_projects_from_args(ctx, command_arguments, workspace, output_format),
+        "status": lambda: workspace_status_from_args(ctx, command_arguments, workspace, output_format),
         "current": lambda: current_project_from_args(ctx, command_arguments),
         "manifest": lambda: manifest_project_from_args(ctx, command_arguments),
         "resolve": lambda: resolve_project_from_args(ctx, command_arguments, workspace),
@@ -85,7 +97,7 @@ def dispatch_projects_command(
 
     ctx.log.error(
         "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
-        "test-command, demo-script, activation-sources, run-command, run-commands.",
+        "status, test-command, demo-script, activation-sources, run-command, run-commands.",
         command,
     )
     return 2
@@ -115,6 +127,16 @@ def list_projects_from_args(
 ) -> int:
     require_argument_count("list", arguments, 0, 0)
     return list_projects_command(ctx, workspace, output_format)
+
+
+def workspace_status_from_args(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    workspace: str | None,
+    output_format: str,
+) -> int:
+    require_argument_count("status", arguments, 0, 0)
+    return workspace_status_command(ctx, workspace, output_format)
 
 
 def current_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
@@ -185,6 +207,26 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_f
     for project in projects:
         print(f"{project.name}\t{project.root}")
     return 0
+
+
+def workspace_status_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
+    if output_format not in ("text", "json"):
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+        return 2
+
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        statuses = workspace_project_statuses(workspace_root)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    if output_format == "json":
+        print(json.dumps(workspace_status_to_json(workspace_root, statuses), separators=(",", ":")))
+    else:
+        print_workspace_status(workspace_root, statuses)
+
+    return 1 if any(project.status == "error" for project in statuses) else 0
 
 
 def resolve_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
@@ -428,6 +470,100 @@ def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path
     if ctx.base_home is None:
         raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
     return ctx.base_home.parent.resolve()
+
+
+def workspace_project_statuses(workspace_root: Path) -> tuple[WorkspaceProjectStatus, ...]:
+    return tuple(workspace_project_status(entry) for entry in workspace_manifest_entries(workspace_root))
+
+
+def workspace_project_status(entry: ManifestEntry) -> WorkspaceProjectStatus:
+    root = entry.path.parent.resolve()
+    try:
+        manifest = read_manifest(entry.path)
+    except ManifestError as exc:
+        return WorkspaceProjectStatus(
+            name=root.name,
+            root=root,
+            manifest_path=entry.path.resolve(),
+            status="error",
+            venv="unknown",
+            manifest="invalid",
+            issues=(str(exc),),
+        )
+
+    venv_dir = project_venv_dir(manifest.project_name)
+    if project_venv_ready(venv_dir):
+        return WorkspaceProjectStatus(
+            name=manifest.project_name,
+            root=root,
+            manifest_path=entry.path.resolve(),
+            status="ok",
+            venv="ready",
+            manifest="valid",
+            issues=(),
+        )
+
+    return WorkspaceProjectStatus(
+        name=manifest.project_name,
+        root=root,
+        manifest_path=entry.path.resolve(),
+        status="warn",
+        venv="missing",
+        manifest="valid",
+        issues=(f"project virtual environment missing at {venv_dir}",),
+    )
+
+
+def project_venv_dir(project_name: str) -> Path:
+    return base_state_root() / project_name / ".venv"
+
+
+def project_venv_ready(venv_dir: Path) -> bool:
+    return (venv_dir / "bin" / "python").is_file()
+
+
+def workspace_status_to_json(workspace_root: Path, statuses: tuple[WorkspaceProjectStatus, ...]) -> dict[str, Any]:
+    return {
+        "workspace": str(workspace_root),
+        "project_count": len(statuses),
+        "projects": [
+            {
+                "name": status.name,
+                "status": status.status,
+                "path": str(status.root),
+                "manifest_path": str(status.manifest_path),
+                "venv": status.venv,
+                "manifest": status.manifest,
+                "issues": list(status.issues),
+            }
+            for status in statuses
+        ],
+    }
+
+
+def print_workspace_status(workspace_root: Path, statuses: tuple[WorkspaceProjectStatus, ...]) -> None:
+    print(f"Workspace: {workspace_root} ({len(statuses)} projects)")
+    print()
+    if not statuses:
+        print("No Base-managed projects discovered.")
+        return
+
+    print(f"{'PROJECT':<20} {'STATUS':<6} {'VENV':<8} {'MANIFEST':<8} {'LAST CHECK':<10} PATH")
+    for status in statuses:
+        print(
+            f"{status.name:<20} "
+            f"{status.status:<6} "
+            f"{status.venv:<8} "
+            f"{status.manifest:<8} "
+            f"{'-':<10} "
+            f"{status.root}"
+        )
+
+    attention_count = sum(1 for status in statuses if status.status != "ok")
+    if attention_count:
+        print(f"\n{attention_count} project(s) need attention. Run 'basectl doctor <project>' for details.")
+    else:
+        print("\nAll discovered projects look ok.")
 
 
 def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: str | None) -> Project:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -213,6 +213,77 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(json.loads(stdout), [{"name": "demo", "path": str((workspace / "demo").resolve())}])
 
+    def test_workspace_status_reports_manifest_and_venv_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_manifest(workspace / "base", "base")
+            write_manifest(workspace / "demo", "demo")
+            python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace: {workspace.resolve()} (2 projects)", stdout)
+        self.assertIn("base                 ok     ready    valid", stdout)
+        self.assertIn("demo                 warn   missing  valid", stdout)
+        self.assertIn("1 project(s) need attention", stdout)
+
+    def test_workspace_status_supports_json_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = invoke_engine(
+                ["status", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["workspace"], str(workspace.resolve()))
+        self.assertEqual(payload["project_count"], 1)
+        self.assertEqual(payload["projects"][0]["name"], "demo")
+        self.assertEqual(payload["projects"][0]["status"], "warn")
+        self.assertEqual(payload["projects"][0]["venv"], "missing")
+        self.assertEqual(payload["projects"][0]["manifest"], "valid")
+        self.assertIn("project virtual environment missing", payload["projects"][0]["issues"][0])
+
+    def test_workspace_status_reports_invalid_manifest_without_stopping_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+            broken_root = workspace / "broken"
+            broken_root.mkdir(parents=True)
+            (broken_root / "base_manifest.yaml").write_text("project: [", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("broken               error  unknown  invalid", stdout)
+        self.assertIn("demo                 warn   missing  valid", stdout)
+        self.assertIn("2 project(s) need attention", stdout)
+
     def test_projects_list_reuses_project_cache_when_manifests_are_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -35,7 +35,7 @@ _base_basectl_completion_project_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test demo run repo clean logs config doctor gh onboard update-profile update projects version help"
+    local commands="activate setup check test demo run repo clean logs config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -57,6 +57,13 @@ _base_basectl_completion() {
         projects)
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "list" "$cur"
+            else
+                _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
+            fi
+            ;;
+        workspace)
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "status" "$cur"
             else
                 _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
             fi

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -30,6 +30,7 @@ _base_basectl_completion() {
         'update-profile:Refresh Base-managed shell startup sections'
         'update:Update Base and rerun setup'
         'projects:List Base-managed projects'
+        'workspace:Show workspace-level project status'
         'version:Show the installed Base version'
         'help:Show help text'
     )
@@ -53,6 +54,12 @@ _base_basectl_completion() {
             ;;
         projects)
             _arguments '1:projects command:(list)' \
+                '--workspace[Workspace directory to scan]:path:_files' \
+                '--format[Output format]:format:(text json)' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        workspace)
+            _arguments '1:workspace command:(status)' \
                 '--workspace[Workspace directory to scan]:path:_files' \
                 '--format[Output format]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'


### PR DESCRIPTION
## Summary

- Add `basectl workspace status` as a read-only workspace-level project summary.
- Report each discovered project's status, virtual environment state, manifest state, and path.
- Add JSON output, Bash/Zsh completions, docs, changelog entry, and focused tests.

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_engine`
- `bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_projects`
- `git diff --check`
- `BASE_CACHE_DIR=/private/tmp/base-workspace-status-cache ./bin/basectl workspace status --workspace /Users/rameshhp/work`
- `BASE_CACHE_DIR=/private/tmp/base-workspace-status-cache ./bin/basectl workspace status --workspace /Users/rameshhp/work --format json`

Depends on #390.

Closes #322
