### PR TITLE
Curate demo and product vision drafts into design docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,26 @@ similar constraints.
 
 ---
 
+## Product Direction
+
+Base's long-term product shape is a Mac-first control plane for multi-repo
+developer workspaces. It should make a folder of sibling repositories
+understandable, repeatable, diagnosable, and easy to onboard without becoming a
+replacement for Homebrew, `mise`, Docker, GitHub CLI, IDEs, or project-owned
+build systems.
+
+The coherent product loop is:
+
+```text
+discover -> setup -> activate -> run -> test -> doctor -> fix -> onboard
+```
+
+Major features should strengthen that loop at the project or workspace level.
+Unrelated commands belong outside the core product unless real use proves they
+need Base's orchestration model.
+
+---
+
 ## Core Principles
 
 - **Opinionated over flexible** — Base makes decisions for you. Fewer choices means
@@ -27,6 +47,11 @@ similar constraints.
   through real use.
 - **Idempotent by design** — running any setup command multiple times should produce
   the same result safely.
+- **Orchestrate, do not replace** — Base should discover, sequence, validate,
+  and explain mature tools rather than absorb their full configuration models.
+- **Observable and diagnosable** — Base commands should make local state and
+  failures understandable through clear output, stable finding IDs, JSON where
+  useful, and inspectable logs.
 
 ---
 
@@ -36,15 +61,15 @@ Base is a public GitHub repository. All projects managed by Base are also GitHub
 repositories, checked out as peers under a shared parent directory:
 
 ```
-~/projects/          ← shared parent directory
+~/work/              ← shared workspace root
   base/              ← the Base repository itself
-  myproject-a/       ← peer project with a base manifest
-  myproject-b/       ← peer project with a base manifest
-  banyanlabs/        ← peer project with a base manifest
+  myproject-a/       ← peer project with base_manifest.yaml
+  myproject-b/       ← peer project with base_manifest.yaml
+  banyanlabs/        ← peer project with base_manifest.yaml
 ```
 
-Base discovers peer repositories by scanning the parent directory for repos that contain
-a base manifest file.
+Base discovers peer repositories by scanning the workspace root for repositories
+that contain `base_manifest.yaml`.
 
 ---
 
@@ -76,8 +101,12 @@ layers. This keeps the product name and the control-plane action separate:
 - `basectl doctor`
 - `basectl update-profile`
 - `basectl projects list`
+- `basectl workspace status`
 - `basectl activate`
+- `basectl run`
 - `basectl test`
+- `basectl demo`
+- `basectl logs`
 
 Shebang-based Bash scripts can also use:
 
@@ -508,6 +537,58 @@ source of truth, and corrupt or unwritable cache files are ignored.
 
 ---
 
+## Workspace Operations
+
+Base's larger value is managing a full workspace, not just one repository. The
+workspace command surface should make local state visible before it mutates many
+projects.
+
+Current workspace-oriented commands include:
+
+```bash
+basectl projects list
+basectl workspace status
+```
+
+`basectl workspace status` is intentionally read-only. It reports project
+manifest state, virtual environment state, and Git state across discovered
+projects, including invalid manifests without stopping the whole scan. JSON
+output is part of the contract so automation and future CI smoke checks can use
+the same data.
+
+Future workspace commands should follow the same principles:
+
+- start with read-only status, check, and doctor behavior
+- require explicit flags before mutating many repositories
+- treat partial failure as normal in multi-repo workspaces
+- keep sibling repositories under a shared workspace root as the default
+  discovery model
+- report machine-readable summaries early
+
+---
+
+## Doctor And Observability
+
+`basectl doctor` is a core trust-building feature. It should explain what is
+wrong, why it matters, whether Base can fix it, and the safest next command.
+Doctor output must stay non-mutating unless a future explicit fix command is
+designed with dry-run behavior.
+
+Doctor findings use stable identifiers documented in
+[Doctor Finding IDs](doctor-findings.md). Automation and runbooks should match
+on those IDs instead of human-readable messages.
+
+Base should also remain locally observable. `basectl logs` exposes recent Base
+CLI runtime logs from the Base cache root without sending telemetry anywhere.
+Useful command metadata includes the command, target project or workspace,
+start and end time, exit code, manifest version where relevant, external tools
+invoked, and log file paths.
+
+The goal is explainability, not surveillance. Base should help users understand
+what happened on their own machine.
+
+---
+
 ## Mac Bootstrap Sequence
 
 When `basectl setup` runs on a fresh Mac:
@@ -547,6 +628,25 @@ through managed workstation provisioning before invoking `basectl setup`.
 
 ---
 
+## Adoption Signals
+
+Base should measure product readiness through concrete local workflows:
+
+- one-command install works on a clean supported macOS machine
+- a public demo project can be cloned, set up, checked, tested, diagnosed, and
+  demonstrated by Base
+- a technically adjacent user can complete guided onboarding without reading
+  private internal notes
+- multiple project types are supported through adapters instead of
+  special-case code
+- `doctor` identifies and explains the most common local failure modes
+- JSON output is stable enough for automation and CI smoke checks
+
+These are not analytics goals. They are acceptance signals for whether Base is
+becoming useful beyond one personal machine.
+
+---
+
 ## Utility Scripts and Extras
 
 Base ships with a small collection of utility scripts useful for day-to-day Mac
@@ -577,11 +677,12 @@ These extras emerge organically from real needs — they are not designed upfron
 
 ## Open Questions (To Resolve Through Use)
 
-- Exact manifest file name (`base.yaml`, `.base.yaml`, `base_manifest.yaml`)
 - Version conflict resolution strategy across projects with different dependency versions
 - Docker/dev container integration path for banyanlabs
 - How Base handles projects that don't use Python at all
 - Fish shell support — revisit if real demand emerges
+- Workspace manifest location, trust model, and clone/update policy for team
+  onboarding
 
 ---
 

--- a/docs/base-managed-demo-project.md
+++ b/docs/base-managed-demo-project.md
@@ -1,15 +1,23 @@
-# Base-managed demo project
+# Base-managed Demo Project
 
 Base needs a real project that demonstrates the complete daily workflow without
 requiring a reader to infer how the pieces fit together. The demo should be a
 normal repository checked out next to Base, not synthetic fixtures inside the
 Base repo.
 
-## Candidate
+## Current Reference Project
 
-Use Banyanlabs when it is ready to be public enough for documentation. Until
-then, keep the demo plan project-neutral and avoid hard-coding private
-repository assumptions into Base.
+Use [`codeforester/base-demo`](https://github.com/codeforester/base-demo) as
+the public reference project.
+
+`base-demo` should be small, inspectable, and safe to run on a fresh supported
+Mac. Its purpose is to show Base's project contract in a real repository, not
+to become a broad sample app or a private-project stand-in.
+
+Future domain-specific demos should be separate repositories when they need a
+different setup story. For example, a Kubernetes walkthrough belongs in a
+future `base-demo-kubernetes` repository rather than as a long-lived branch of
+`base-demo`.
 
 ## Demo Goals
 
@@ -21,10 +29,13 @@ basectl setup <project>
 basectl check <project>
 basectl doctor <project>
 basectl activate <project>
+basectl test <project>
+basectl demo <project>
 ```
 
-The same demo should include `basectl test <project>` once it declares a
-manifest `test.command`.
+It should also be useful as an interactive walkthrough. A new user should be
+able to run the demo, inspect the repository, and understand the minimum shape
+of a Base-managed project.
 
 ## Project Requirements
 
@@ -32,6 +43,8 @@ The demo project should include:
 
 - `base_manifest.yaml` with `schema_version: 1` and the real project name.
 - a `Brewfile` if it needs Homebrew tools.
+- a `demo.script` declaration that points at an executable project-owned demo.
+- a non-interactive demo path that can run in CI.
 - Python artifacts only when the project actually needs a Base-managed venv.
 - IDE settings or extensions only when they demonstrate a concrete workflow.
 - a README section titled "Base setup" with the exact commands above.
@@ -54,12 +67,14 @@ A new developer should be able to:
 5. Run `basectl setup <project>`.
 6. Run `basectl check <project>` and get a clean result.
 7. Run `basectl doctor <project>` and get no error findings.
-8. Run `basectl activate <project>` and land in a project shell with the
+8. Run `basectl test <project>` successfully.
+9. Run `basectl demo <project> -- --non-interactive` successfully.
+10. Run `basectl activate <project>` and land in a project shell with the
    expected prompt and environment.
 
 ## Documentation Placement
 
-Once the real project is selected, link it from:
+Link the reference project from:
 
 - Base's top-level README
 - the demo project's README

--- a/docs/basectl-onboard.md
+++ b/docs/basectl-onboard.md
@@ -22,6 +22,12 @@ The stable split is:
 - `<project>/install.sh` or a packaged project installer guides product-specific
   onboarding and calls Base internally.
 
+Future workspace or team onboarding should start from a workspace manifest
+design, not from project-specific product logic inside Base. A command such as
+`basectl onboard <workspace>` would need an explicit manifest location, clone
+policy, trust model, partial-failure model, and dry-run story before it becomes
+part of the product surface.
+
 ## Audience
 
 `basectl onboard` is for someone who can use a terminal but does not yet know

--- a/docs/demo-maintenance.md
+++ b/docs/demo-maintenance.md
@@ -40,8 +40,8 @@ edits.
 
 ## `base-demo` Repository
 
-Once `codeforester/base-demo` exists, it should use the same `needs-demo` label
-with the same color and description as this repository:
+`codeforester/base-demo` should use the same `needs-demo` label with the same
+color and description as this repository:
 
 - color: `fbca04`
 - description: `Change should update a project demo`

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -7,6 +7,16 @@ human-readable names or messages.
 Finding IDs are never reused after they ship. A finding may change its message,
 fix text, or severity over time, but its ID keeps the same meaning.
 
+## Principles
+
+Doctor findings should be specific, actionable, and non-alarming. Text output
+is for humans who need a safe next step; JSON output is for automation that
+needs stable IDs, statuses, names, messages, and fix guidance.
+
+`basectl doctor` should not mutate local state. A future fix path must be
+explicit, reviewable, and paired with dry-run behavior before Base offers it as
+part of the doctor workflow.
+
 ## Namespaces
 
 | Prefix | Scope |

--- a/docs/project-demo-workflow.md
+++ b/docs/project-demo-workflow.md
@@ -12,6 +12,16 @@ dependency model, shell selector, or hidden setup hook. A project declares one
 script, keeps that script in its repository, and tests a non-interactive path
 for CI.
 
+There are two demo layers:
+
+- Base's self-demo lives in this repository and demonstrates Base itself.
+- `codeforester/base-demo` is a separate peer repository that demonstrates how a
+  normal Base-managed project participates in the workflow.
+
+Those layers should stay separate. `basectl demo base` must not depend on the
+external `base-demo` repository, and `base-demo` should remain a normal project
+rather than a hidden Base test fixture.
+
 ## Manifest Contract
 
 Projects opt in through `base_manifest.yaml`:
@@ -120,6 +130,16 @@ external reference repository.
 The public reference repository is
 [`codeforester/base-demo`](https://github.com/codeforester/base-demo).
 
+`base-demo` serves two roles:
+
+- a reference implementation for the files and conventions a small
+  Base-managed repository should carry
+- an interactive walkthrough that a new user can run to see the workflow in
+  action
+
+It is not primarily a test harness. Its tests prove that the walkthrough stays
+executable, but its product role is onboarding and inspection.
+
 Clone it next to Base:
 
 ```bash
@@ -141,6 +161,11 @@ basectl demo base-demo -- --non-interactive
 `base-demo` is the reference implementation for a normal Base-managed project.
 Base's self-demo is for the Base repository itself; `base-demo` is the separate
 peer project that shows how another repository should participate.
+
+Future specialized demos should use separate repositories, such as
+`base-demo-kubernetes` or `base-demo-services`, when they need different
+dependencies or storylines. Avoid using long-lived demo branches for distinct
+demo products.
 
 ## Maintenance
 

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -37,6 +37,21 @@ Base gets weaker when it drifts into becoming any of these:
 - a generic task runner
 - a full reproducible package manager or environment solver
 
+## Adapter Quality Bar
+
+Base should grow through adapters before it grows through replacements. For any
+external tool integration, the adapter should answer:
+
+- How does Base detect whether this tool is relevant to a project?
+- How does Base check whether the tool is installed and healthy?
+- How does Base invoke the tool without hiding the underlying command?
+- How does Base report failures in Base-native check, doctor, and JSON output?
+- How does Base avoid owning the tool's full configuration model?
+- How does Base behave when the tool is absent?
+
+The result should feel like one workspace story while leaving mature tools in
+charge of their own domains.
+
 ## Quick Decision Matrix
 
 | Tool | What it primarily owns | Build directly into Base? | Coexist with Base? | How much to care |


### PR DESCRIPTION
## Summary

- Fold durable `base-demo` draft guidance into the canonical demo docs without promoting stale script names or manifest schema.
- Add product-direction, workspace, doctor, observability, adoption-signal, and adapter-quality guidance to existing design docs.
- Clarify future workspace onboarding boundaries and doctor finding principles.
- Leave the untracked draft files untouched for manual removal.

## Follow-up Issues Created

- #393 Add read-only workspace check and doctor commands
- #394 Add project port health declarations
- #395 Add project Git remote health diagnostics
- #396 Design local command history and explanation surfaces
- #397 Add clean macOS install validation checklist

## Validation

- `git diff --check`
- searched tracked docs for stale exact draft terms: `manifest.yaml`, `base-demo.sh`, `Claude API`, `LinkedIn`

Closes #392