### PR TITLE
Link base-demo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ basectl demo base -- --non-interactive
 basectl test base
 ```
 
+To inspect a small, real Base-managed project, clone
+[`codeforester/base-demo`](https://github.com/codeforester/base-demo) next to
+Base and run its walkthrough:
+
+```bash
+git clone https://github.com/codeforester/base-demo.git
+basectl setup base-demo
+basectl demo base-demo
+```
+
 Success looks like a workspace where each participating project has a
 `base_manifest.yaml`, appears in `basectl projects list`, can be checked with
 `basectl check <project>`, and can run its declared test command through


### PR DESCRIPTION
## Summary

- Link the public `codeforester/base-demo` reference project from the README.
- Add the short clone/setup/demo flow near the existing self-demo instructions.

## Issue

Closes #408

## Validation

- git diff --check

## Demo Impact

None.

## Notes

Docs-only change.
