### PR TITLE
Simplify managed profile markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
   Homebrew, Git, Bash, and Base before handing off to `basectl`.
 - Added a top-level FAQ for common first-run and product questions.
 
+### Changed
+
+- Updated Base-managed shell profile sections to use shorter `>>> base: ...`
+  markers, clearer overwrite guidance, and quoted source paths.
+
 ### Fixed
 
 - Updated the README status section to match the current `0.2.0` release.

--- a/README.md
+++ b/README.md
@@ -805,9 +805,9 @@ variables if `~/.baserc` tries to change them.
 Base-managed sections use explicit markers such as:
 
 ```bash
-# --- BEGIN base bashrc MANAGED SECTION - DO NOT EDIT ---
+# >>> base: bashrc managed >>>
 # ... Base-managed content ...
-# --- END base bashrc MANAGED SECTION - DO NOT EDIT ---
+# <<< base: bashrc managed <<<
 ```
 
 ### Base Snippets

--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -37,16 +37,22 @@ base_update_profile_source_file_library() {
     import_base_lib file/lib_file.sh
 }
 
-base_update_profile_quote() {
+base_update_profile_shell_double_quote() {
     local value="$1"
-    printf '%q\n' "$value"
+    local escaped="$value"
+
+    escaped="${escaped//\\/\\\\}"
+    escaped="${escaped//\"/\\\"}"
+    escaped="${escaped//\$/\\$}"
+    escaped="${escaped//\`/\\\`}"
+    printf '"%s"\n' "$escaped"
 }
 
 base_update_profile_source_line() {
     local source_path="$1"
     local quoted_source_path
 
-    quoted_source_path="$(base_update_profile_quote "$source_path")" || return 1
+    quoted_source_path="$(base_update_profile_shell_double_quote "$source_path")" || return 1
     printf '%s\n' '# shellcheck source=/dev/null'
     printf 'source %s\n' "$quoted_source_path"
 }
@@ -55,7 +61,8 @@ base_update_profile_section_lines() {
     local snippet_name="$1"
     local snippet_path="$BASE_SHELL_DIR/$snippet_name"
 
-    printf '%s\n' "# Managed by Base. Run 'basectl update-profile' to refresh this section."
+    printf '%s\n' "# Managed by Base. Local edits inside this block may be overwritten."
+    printf '%s\n' "# Refresh with: basectl update-profile"
     base_update_profile_source_line "$snippet_path" || return 1
 }
 
@@ -82,8 +89,8 @@ base_update_profile_update_file() {
     local target_file="$1"
     local snippet_name="$2"
     local dry_run="$3"
-    local start_marker="# --- BEGIN base ${snippet_name} MANAGED SECTION - DO NOT EDIT ---"
-    local end_marker="# --- END base ${snippet_name} MANAGED SECTION - DO NOT EDIT ---"
+    local start_marker="# >>> base: ${snippet_name} managed >>>"
+    local end_marker="# <<< base: ${snippet_name} managed <<<"
     local lines=()
 
     mapfile -t lines < <(base_update_profile_section_lines "$snippet_name") || return 1

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -16,16 +16,18 @@ load ./setup_helpers.bash
         [[ "$(cat "$TEST_HOME/$dotfile")" != *"base_init.sh"* ]]
     done
 
-    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"# --- BEGIN base bash_profile MANAGED SECTION - DO NOT EDIT ---"* ]]
-    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"source $BASE_REPO_ROOT/lib/shell/bash_profile"* ]]
-    [[ "$(cat "$TEST_HOME/.bashrc")" == *"# --- BEGIN base bashrc MANAGED SECTION - DO NOT EDIT ---"* ]]
-    [[ "$(cat "$TEST_HOME/.bashrc")" == *"source $BASE_REPO_ROOT/lib/shell/bashrc"* ]]
+    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"# >>> base: bash_profile managed >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"source \"$BASE_REPO_ROOT/lib/shell/bash_profile\""* ]]
+    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"Local edits inside this block may be overwritten."* ]]
+    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"Refresh with: basectl update-profile"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"# >>> base: bashrc managed >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"source \"$BASE_REPO_ROOT/lib/shell/bashrc\""* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" != *"basectl_completion"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" != *"PATH="* ]]
-    [[ "$(cat "$TEST_HOME/.zprofile")" == *"# --- BEGIN base zprofile MANAGED SECTION - DO NOT EDIT ---"* ]]
-    [[ "$(cat "$TEST_HOME/.zprofile")" == *"source $BASE_REPO_ROOT/lib/shell/zprofile"* ]]
-    [[ "$(cat "$TEST_HOME/.zshrc")" == *"# --- BEGIN base zshrc MANAGED SECTION - DO NOT EDIT ---"* ]]
-    [[ "$(cat "$TEST_HOME/.zshrc")" == *"source $BASE_REPO_ROOT/lib/shell/zshrc"* ]]
+    [[ "$(cat "$TEST_HOME/.zprofile")" == *"# >>> base: zprofile managed >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.zprofile")" == *"source \"$BASE_REPO_ROOT/lib/shell/zprofile\""* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" == *"# >>> base: zshrc managed >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" == *"source \"$BASE_REPO_ROOT/lib/shell/zshrc\""* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" != *"basectl_completion"* ]]
     [[ "$(cat "$TEST_HOME/.zshrc")" != *"PATH="* ]]
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_PROFILE_VERSION=1"* ]]
@@ -47,12 +49,12 @@ load ./setup_helpers.bash
     [[ "$output" != *"Updating '$TEST_HOME/.bashrc'"* ]]
     [[ "$output" != *"Updating '$TEST_HOME/.zprofile'"* ]]
     [[ "$output" != *"Updating '$TEST_HOME/.zshrc'"* ]]
-    [ "$(grep -c '# --- BEGIN base bashrc MANAGED SECTION - DO NOT EDIT ---' "$TEST_HOME/.bashrc")" -eq 1 ]
-    [ "$(grep -c '# --- END base bashrc MANAGED SECTION - DO NOT EDIT ---' "$TEST_HOME/.bashrc")" -eq 1 ]
+    [ "$(grep -c '# >>> base: bashrc managed >>>' "$TEST_HOME/.bashrc")" -eq 1 ]
+    [ "$(grep -c '# <<< base: bashrc managed <<<' "$TEST_HOME/.bashrc")" -eq 1 ]
     [[ "$(cat "$TEST_HOME/.bashrc")" == *"user line before"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc")" == *$'user line before
 
-# --- BEGIN base bashrc MANAGED SECTION - DO NOT EDIT ---'* ]]
+# >>> base: bashrc managed >>>'* ]]
 }
 
 @test "basectl update-profile makes basectl available in interactive Bash without runtime bootstrap" {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,8 +239,8 @@ By default, Base updates all four files:
 Base does not symlink over the user's dotfiles and does not own content outside its clearly marked managed sections. The markers are intentionally explicit, for example:
 
 ```bash
-# --- BEGIN base bashrc MANAGED SECTION - DO NOT EDIT ---
-# --- END base bashrc MANAGED SECTION - DO NOT EDIT ---
+# >>> base: bashrc managed >>>
+# <<< base: bashrc managed <<<
 ```
 
 Optional Base shell defaults are enabled explicitly with `basectl update-profile --defaults`.


### PR DESCRIPTION
## Summary

- Replace Base's verbose `BEGIN/END ... MANAGED SECTION - DO NOT EDIT` dotfile markers with the shorter `>>> base: ... managed >>>` convention.
- Update generated managed-section guidance to explain that local edits inside the block may be overwritten.
- Generate double-quoted `source` paths and update README, architecture docs, changelog, and BATS expectations.

## Issue

Closes #416

## Validation

- bash -n cli/bash/commands/basectl/subcommands/update_profile.sh
- bats cli/bash/commands/basectl/tests/update-profile.bats
- bats cli/bash/commands/basectl/tests/update-profile.bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/check.bats
- bats lib/bash/file/tests/lib_file.bats
- git diff --check

## Demo Impact

None.

## Notes

`env BASE_CACHE_DIR=/private/tmp/base-test-cache bin/basectl test base` was also attempted. It failed in `test_unknown_python_package_artifact_dry_run_uses_pip` because the local Base project venv already had default bootstrap packages installed, so the dry-run output only included `rich`. That failure is local environment state and unrelated to this shell profile marker change.
