### PR TITLE
Add workspace check and doctor commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Added the workspace manifest design document to define the future team-shared
   repo-set contract and its relationship to discovered local projects.
+- Added `basectl workspace check` and `basectl workspace doctor` for read-only
+  project diagnostics across discovered workspace projects.
 - Expanded `STANDARDS.md` into a broader Base contributor standard covering
   architecture layering, Bash, Python CLIs, `base-wrapper`, manifests, testing,
   documentation, and GitHub workflow.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ basectl projects list
 basectl projects list --format json
 basectl workspace status
 basectl workspace status --format json
+basectl workspace check
+basectl workspace doctor
 ```
 
 By default this scans `workspace.root` from `~/.base.d/config.yaml` when that
@@ -325,9 +327,11 @@ value is configured. If it is not configured, Base falls back to the parent
 directory of `BASE_HOME`, which matches the source-checkout sibling-repo layout.
 Use `--workspace <path>` to inspect a different workspace root for one command.
 Project list output is tab-separated as `<project-name><TAB><path>`. Use
-`--format json` for machine-readable output. Workspace status is also read-only;
-it reports each discovered project's manifest validity and whether the
-Base-managed project virtual environment is present.
+`--format json` for machine-readable output. Workspace status, check, and
+doctor are read-only. Status reports each discovered project's manifest
+validity and whether the Base-managed project virtual environment is present.
+Check and doctor run project diagnostics across discovered projects and keep
+invalid project manifests visible as per-project findings.
 
 Start a new Base-managed repository with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -94,6 +94,8 @@ that delegate to `basectl`.
   project names and paths.
 - `basectl workspace status` reports a read-only workspace summary across
   discovered projects.
+- `basectl workspace check` and `basectl workspace doctor` run read-only
+  project checks and diagnostics across discovered projects.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -41,8 +41,8 @@ Commands:
     Update Base from Git and run setup.
   projects list [options]
     List Base-managed projects discovered in the workspace.
-  workspace status [options]
-    Show a read-only status summary for workspace projects.
+  workspace <status|check|doctor> [options]
+    Show read-only workspace project status, checks, or diagnostics.
   version
     Show the installed Base version.
   help

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -6,15 +6,15 @@ readonly _base_workspace_subcommand_sourced
 base_workspace_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl workspace status [options]
+  basectl workspace <status|check|doctor> [options]
 
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
-  --format <format>   Output format for status: text or json.
+  --format <format>   Output format for the workspace command: text or json.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
-Show a read-only status summary for Base-managed projects in the workspace.
+Show read-only status, check, or doctor output for Base-managed projects in the workspace.
 EOF
 }
 
@@ -28,7 +28,7 @@ base_workspace_subcommand_main() {
             base_workspace_subcommand_usage
             return 0
             ;;
-        status)
+        status|check|doctor)
             shift
             ;;
         *)
@@ -55,5 +55,5 @@ base_workspace_subcommand_main() {
     done
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    "$wrapper" --project base base_projects status "${args[@]}"
+    "$wrapper" --project base base_projects "$workspace_command" "${args[@]}"
 }

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -124,7 +124,7 @@ EOF
     [[ "$output" == *"test_options=--workspace --dry-run"* ]]
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
-    [[ "$output" == *"workspace_commands=status"* ]]
+    [[ "$output" == *"workspace_commands=status check doctor"* ]]
     [[ "$output" == *"workspace_options=--workspace --format"* ]]
     [[ "$output" == *"onboard_options=--dev --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -22,7 +22,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"onboard [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
-    [[ "$output" == *"workspace status [options]"* ]]
+    [[ "$output" == *"workspace <status|check|doctor> [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
@@ -51,7 +51,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  repo <init|check|configure> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
-    grep -Fqx '  workspace status [options]' <<<"$output"
+    grep -Fqx '  workspace <status|check|doctor> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -32,14 +32,76 @@ EOF
     [ "$(cat "$TEST_TMPDIR/workspace-status-state")" = "BASE_PROJECT=base" ]
 }
 
-@test "basectl workspace status prints help without requiring the Base Python venv" {
+@test "basectl workspace check delegates to the Python projects layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "check" ]]; then
+    printf 'ARGS=%s\n' "${*:4}"
+    exit 0
+fi
+printf 'unexpected workspace check python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace check --workspace "$workspace" --format json
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS=--workspace $workspace --format json" ]
+}
+
+@test "basectl workspace doctor delegates to the Python projects layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "doctor" ]]; then
+    printf 'ARGS=%s\n' "${*:4}"
+    exit 0
+fi
+printf 'unexpected workspace doctor python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace doctor --workspace "$workspace" --format json
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS=--workspace $workspace --format json" ]
+}
+
+@test "basectl workspace commands print help without requiring the Base Python venv" {
     run_basectl workspace status --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl workspace status [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--format <format>"* ]]
+
+    run_basectl workspace check --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
+
+    run_basectl workspace doctor --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
 }
 
 @test "basectl workspace rejects unknown subcommands" {

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -5,6 +5,7 @@ import json
 import os
 import shlex
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -13,7 +14,14 @@ import base_cli
 from base_cli.config import read_user_config
 from base_cli.paths import base_cache_root, base_state_root
 from base_cli.paths import discover_manifest
+from base_setup.checks import ArtifactCheck
+from base_setup.checks import check_to_doctor_json
+from base_setup.checks import check_to_json
+from base_setup.checks import doctor_status
+from base_setup.checks import print_doctor_finding
 from base_setup.demo import resolve_demo_script_path
+from base_setup.engine import manifest_checks
+from base_setup.engine import read_default_manifest
 from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest, ManifestError, TestConfig, read_manifest
 
@@ -46,6 +54,16 @@ class WorkspaceProjectStatus:
     issues: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class WorkspaceProjectCheckResult:
+    name: str
+    root: Path
+    manifest_path: Path
+    manifest: str
+    status: str
+    checks: tuple[ArtifactCheck, ...]
+
+
 def main(argv: list[str] | None = None) -> int:
     result = app.click_command.main(args=argv, standalone_mode=False)
     return int(result or 0)
@@ -57,7 +75,7 @@ def main(argv: list[str] | None = None) -> int:
     "--workspace",
     help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
 )
-@base_cli.option("--format", "output_format", default="text", help="Output format for list/status: text or json.")
+@base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
 def run(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
@@ -82,6 +100,12 @@ def dispatch_projects_command(
     handlers = {
         "list": lambda: list_projects_from_args(ctx, command_arguments, workspace, output_format),
         "status": lambda: workspace_status_from_args(ctx, command_arguments, workspace, output_format),
+        "check": lambda: require_no_args_and_run(
+            "check", command_arguments, lambda: workspace_check_command(ctx, workspace, output_format)
+        ),
+        "doctor": lambda: require_no_args_and_run(
+            "doctor", command_arguments, lambda: workspace_doctor_command(ctx, workspace, output_format)
+        ),
         "current": lambda: current_project_from_args(ctx, command_arguments),
         "manifest": lambda: manifest_project_from_args(ctx, command_arguments),
         "resolve": lambda: resolve_project_from_args(ctx, command_arguments, workspace),
@@ -97,7 +121,7 @@ def dispatch_projects_command(
 
     ctx.log.error(
         "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
-        "status, test-command, demo-script, activation-sources, run-command, run-commands.",
+        "status, check, doctor, test-command, demo-script, activation-sources, run-command, run-commands.",
         command,
     )
     return 2
@@ -112,6 +136,11 @@ def require_argument_count(command: str, arguments: tuple[str, ...], minimum: in
         raise ProjectUsageError(f"Project command '{command}' requires at least {minimum} argument(s).")
     if len(arguments) > maximum:
         raise ProjectUsageError(f"Project command '{command}' accepts at most {maximum} argument(s).")
+
+
+def require_no_args_and_run(command: str, arguments: tuple[str, ...], callback: Callable[[], int]) -> int:
+    require_argument_count(command, arguments, 0, 0)
+    return callback()
 
 
 def optional_project_argument(command: str, arguments: tuple[str, ...]) -> str | None:
@@ -227,6 +256,46 @@ def workspace_status_command(ctx: base_cli.Context, workspace: str | None, outpu
         print_workspace_status(workspace_root, statuses)
 
     return 1 if any(project.status == "error" for project in statuses) else 0
+
+
+def workspace_check_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
+    if output_format not in ("text", "json"):
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+        return 2
+
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        results = workspace_project_check_results(ctx, workspace_root)
+    except (ProjectDiscoveryError, ManifestError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    if output_format == "json":
+        print(json.dumps(workspace_check_to_json(workspace_root, results), separators=(",", ":")))
+    else:
+        print_workspace_check(workspace_root, results)
+
+    return 1 if any(result.status == "error" for result in results) else 0
+
+
+def workspace_doctor_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
+    if output_format not in ("text", "json"):
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+        return 2
+
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        results = workspace_project_check_results(ctx, workspace_root)
+    except (ProjectDiscoveryError, ManifestError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    if output_format == "json":
+        print(json.dumps(workspace_doctor_to_json(workspace_root, results), separators=(",", ":")))
+    else:
+        print_workspace_doctor(workspace_root, results)
+
+    return min(workspace_error_count(results), 125)
 
 
 def resolve_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
@@ -522,6 +591,95 @@ def project_venv_ready(venv_dir: Path) -> bool:
     return (venv_dir / "bin" / "python").is_file()
 
 
+def workspace_project_check_results(
+    ctx: base_cli.Context,
+    workspace_root: Path,
+) -> tuple[WorkspaceProjectCheckResult, ...]:
+    default_manifest = read_default_manifest(ctx)
+    return tuple(
+        workspace_project_check_result(entry, default_manifest)
+        for entry in workspace_manifest_entries(workspace_root)
+    )
+
+
+def workspace_project_check_result(
+    entry: ManifestEntry,
+    default_manifest: BaseManifest,
+) -> WorkspaceProjectCheckResult:
+    root = entry.path.parent.resolve()
+    manifest_path = entry.path.resolve()
+    try:
+        manifest = read_manifest(entry.path)
+    except ManifestError as exc:
+        checks = (invalid_manifest_check(str(exc)),)
+        return WorkspaceProjectCheckResult(
+            name=root.name,
+            root=root,
+            manifest_path=manifest_path,
+            manifest="invalid",
+            status="error",
+            checks=checks,
+        )
+
+    checks = (project_venv_check(manifest.project_name),)
+    if checks[0].ok:
+        checks += manifest_checks(default_manifest, manifest)
+
+    return WorkspaceProjectCheckResult(
+        name=manifest.project_name,
+        root=root,
+        manifest_path=manifest_path,
+        manifest="valid",
+        status=checks_status(checks),
+        checks=checks,
+    )
+
+
+def invalid_manifest_check(message: str) -> ArtifactCheck:
+    return ArtifactCheck(
+        name="project_manifest",
+        ok=False,
+        message=message,
+        fix="Fix base_manifest.yaml syntax and schema.",
+        status="error",
+        finding_id="BASE-P002",
+    )
+
+
+def project_venv_check(project_name: str) -> ArtifactCheck:
+    venv_dir = project_venv_dir(project_name)
+    if project_venv_ready(venv_dir):
+        return ArtifactCheck(
+            name="project_virtualenv",
+            ok=True,
+            message=f"Project virtual environment is ready at '{venv_dir}'.",
+            fix="",
+            finding_id="BASE-P050",
+        )
+
+    return ArtifactCheck(
+        name="project_virtualenv",
+        ok=False,
+        message=f"Project virtual environment is missing or incomplete at '{venv_dir}'.",
+        fix=f"Run 'basectl setup {project_name} --recreate-venv' to recreate the project virtual environment.",
+        status="error",
+        finding_id="BASE-P050",
+    )
+
+
+def checks_status(checks: tuple[ArtifactCheck, ...]) -> str:
+    statuses = tuple(doctor_status(check) for check in checks)
+    if "error" in statuses:
+        return "error"
+    if "warn" in statuses:
+        return "warn"
+    return "ok"
+
+
+def workspace_error_count(results: tuple[WorkspaceProjectCheckResult, ...]) -> int:
+    return sum(1 for result in results for check in result.checks if doctor_status(check) == "error")
+
+
 def workspace_status_to_json(workspace_root: Path, statuses: tuple[WorkspaceProjectStatus, ...]) -> dict[str, Any]:
     return {
         "workspace": str(workspace_root),
@@ -539,6 +697,46 @@ def workspace_status_to_json(workspace_root: Path, statuses: tuple[WorkspaceProj
             for status in statuses
         ],
     }
+
+
+def workspace_check_to_json(workspace_root: Path, results: tuple[WorkspaceProjectCheckResult, ...]) -> dict[str, Any]:
+    return workspace_checks_to_json(workspace_root, results, doctor=False)
+
+
+def workspace_doctor_to_json(workspace_root: Path, results: tuple[WorkspaceProjectCheckResult, ...]) -> dict[str, Any]:
+    return workspace_checks_to_json(workspace_root, results, doctor=True)
+
+
+def workspace_checks_to_json(
+    workspace_root: Path,
+    results: tuple[WorkspaceProjectCheckResult, ...],
+    doctor: bool,
+) -> dict[str, Any]:
+    return {
+        "workspace": str(workspace_root),
+        "status": checks_status(tuple(check for result in results for check in result.checks)),
+        "project_count": len(results),
+        "projects": [
+            {
+                "name": result.name,
+                "status": result.status,
+                "path": str(result.root),
+                "manifest_path": str(result.manifest_path),
+                "manifest": result.manifest,
+                "checks": [workspace_check_item_to_json(check, doctor) for check in result.checks],
+            }
+            for result in results
+        ],
+    }
+
+
+def workspace_check_item_to_json(check: ArtifactCheck, doctor: bool) -> dict[str, str | bool]:
+    if doctor:
+        return check_to_doctor_json(check)
+    payload = check_to_json(check)
+    payload["id"] = check.finding_id
+    payload["status"] = doctor_status(check)
+    return payload
 
 
 def print_workspace_status(workspace_root: Path, statuses: tuple[WorkspaceProjectStatus, ...]) -> None:
@@ -564,6 +762,39 @@ def print_workspace_status(workspace_root: Path, statuses: tuple[WorkspaceProjec
         print(f"\n{attention_count} project(s) need attention. Run 'basectl doctor <project>' for details.")
     else:
         print("\nAll discovered projects look ok.")
+
+
+def print_workspace_check(workspace_root: Path, results: tuple[WorkspaceProjectCheckResult, ...]) -> None:
+    print(f"Workspace check: {workspace_root} ({len(results)} projects)")
+    print_workspace_check_results(results)
+
+
+def print_workspace_doctor(workspace_root: Path, results: tuple[WorkspaceProjectCheckResult, ...]) -> None:
+    print(f"\nWorkspace doctor: {workspace_root} ({len(results)} projects)")
+    print_workspace_check_results(results)
+
+
+def print_workspace_check_results(results: tuple[WorkspaceProjectCheckResult, ...]) -> None:
+    if not results:
+        print("\nNo Base-managed projects discovered.")
+        return
+
+    for result in results:
+        print(f"\nProject: {result.name} [{result.status}]")
+        print(f"Path: {result.root}")
+        for check in result.checks:
+            print_doctor_finding(doctor_status(check), check.finding_id, check.name, check.message, check.fix)
+
+    error_count = workspace_error_count(results)
+    if error_count:
+        print(f"\nWorkspace has {error_count} error finding(s).")
+        return
+
+    warn_count = sum(1 for result in results for check in result.checks if doctor_status(check) == "warn")
+    if warn_count:
+        print(f"\nWorkspace has {warn_count} warning finding(s).")
+    else:
+        print("\nAll discovered projects passed.")
 
 
 def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: str | None) -> Project:

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_projects import engine
+
+
+def write_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
+def write_default_manifest(base_home: Path) -> None:
+    default_manifest = base_home / "lib" / "base" / "default_manifest.yaml"
+    default_manifest.parent.mkdir(parents=True)
+    default_manifest.write_text(
+        "project:\n  name: __base_defaults__\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
+def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    env = {
+        "HOME": str(home),
+        "BASE_HOME": str(base_home),
+        "BASE_PROJECT": "",
+        "BASE_PROJECT_MANIFEST": "",
+    }
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class WorkspaceCheckTests(unittest.TestCase):
+    def test_workspace_check_reports_project_findings_and_invalid_manifests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_manifest(workspace / "demo", "demo")
+            python_bin = home / ".base.d" / "demo" / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            broken_root = workspace / "broken"
+            broken_root.mkdir(parents=True)
+            (broken_root / "base_manifest.yaml").write_text("project: [", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace check: {workspace.resolve()} (2 projects)", stdout)
+        self.assertIn("Project: demo [ok]", stdout)
+        self.assertIn("BASE-P050", stdout)
+        self.assertIn("BASE-P001", stdout)
+        self.assertIn("Project: broken [error]", stdout)
+        self.assertIn("BASE-P002", stdout)
+        self.assertIn("Workspace has 1 error finding(s).", stdout)
+
+    def test_workspace_check_supports_json_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = invoke_engine(
+                ["check", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["workspace"], str(workspace.resolve()))
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["project_count"], 1)
+        self.assertEqual(payload["projects"][0]["name"], "demo")
+        self.assertEqual(payload["projects"][0]["status"], "error")
+        self.assertEqual(payload["projects"][0]["checks"][0]["id"], "BASE-P050")
+        self.assertEqual(payload["projects"][0]["checks"][0]["status"], "error")
+        self.assertEqual(payload["projects"][0]["checks"][0]["ok"], False)
+
+    def test_workspace_doctor_supports_json_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = invoke_engine(
+                ["doctor", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["workspace"], str(workspace.resolve()))
+        self.assertEqual(payload["projects"][0]["checks"][0]["id"], "BASE-P050")
+        self.assertEqual(payload["projects"][0]["checks"][0]["status"], "error")
+        self.assertNotIn("ok", payload["projects"][0]["checks"][0])
+
+    def test_workspace_doctor_text_reports_all_clear(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_manifest(workspace / "demo", "demo")
+            python_bin = home / ".base.d" / "demo" / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(["doctor", "--workspace", str(workspace)], base_home, home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace doctor: {workspace.resolve()} (1 projects)", stdout)
+        self.assertIn("Project: demo [ok]", stdout)
+        self.assertIn("All discovered projects passed.", stdout)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -560,13 +560,16 @@ Current workspace-oriented commands include:
 ```bash
 basectl projects list
 basectl workspace status
+basectl workspace check
+basectl workspace doctor
 ```
 
-`basectl workspace status` is intentionally read-only. It reports project
-manifest state, virtual environment state, and Git state across discovered
-projects, including invalid manifests without stopping the whole scan. JSON
-output is part of the contract so automation and future CI smoke checks can use
-the same data.
+Workspace commands are intentionally read-only. `basectl workspace status`
+reports project manifest state, virtual environment state, and Git state across
+discovered projects, including invalid manifests without stopping the whole
+scan. `basectl workspace check` and `basectl workspace doctor` run project
+checks and diagnostics across discovered projects. JSON output is part of the
+contract so automation and future CI smoke checks can use the same data.
 
 Future workspace commands should follow the same principles:
 

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -47,6 +47,7 @@ part of the doctor workflow.
 | ID | Finding |
 | --- | --- |
 | `BASE-P001` | Empty project manifest artifact set |
+| `BASE-P002` | Project manifest validity |
 | `BASE-P010` | Brewfile path validity |
 | `BASE-P011` | Homebrew unavailable for Brewfile checks |
 | `BASE-P012` | Brewfile dependency status |

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -41,6 +41,8 @@ Current workspace commands operate on discovered local repositories only:
 ```bash
 basectl projects list
 basectl workspace status
+basectl workspace check
+basectl workspace doctor
 ```
 
 They do not read a workspace manifest and do not report missing expected
@@ -215,10 +217,8 @@ The workspace manifest should not:
 ## Implementation Sequence
 
 1. Keep current commands working against discovered local projects.
-2. Add `basectl workspace check` and `basectl workspace doctor` for discovered
-   projects only.
-3. Add parser and validation support for a local workspace manifest.
-4. Add `--manifest <path>` to read-only workspace commands.
-5. Report expected, missing, discovered, and extra repositories.
-6. Design explicit clone/onboard behavior only after read-only reporting proves
+2. Add parser and validation support for a local workspace manifest.
+3. Add `--manifest <path>` to read-only workspace commands.
+4. Report expected, missing, discovered, and extra repositories.
+5. Design explicit clone/onboard behavior only after read-only reporting proves
    useful.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -63,7 +63,7 @@ _base_basectl_completion() {
             ;;
         workspace)
             if ((COMP_CWORD == 2)); then
-                _base_basectl_completion_compgen "status" "$cur"
+                _base_basectl_completion_compgen "status check doctor" "$cur"
             else
                 _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
             fi

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -30,7 +30,7 @@ _base_basectl_completion() {
         'update-profile:Refresh Base-managed shell startup sections'
         'update:Update Base and rerun setup'
         'projects:List Base-managed projects'
-        'workspace:Show workspace-level project status'
+        'workspace:Show workspace-level project status, checks, and diagnostics'
         'version:Show the installed Base version'
         'help:Show help text'
     )
@@ -59,7 +59,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         workspace)
-            _arguments '1:workspace command:(status)' \
+            _arguments '1:workspace command:(status check doctor)' \
                 '--workspace[Workspace directory to scan]:path:_files' \
                 '--format[Output format]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'


### PR DESCRIPTION
## Summary
- Add read-only `basectl workspace check` and `basectl workspace doctor` commands.
- Aggregate project diagnostics across discovered workspace projects while keeping invalid manifests visible as per-project findings.
- Add text and JSON output, shell delegation, completions, docs, changelog, and tests.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_projects/tests -p 'test*.py'`\n- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests`\n- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')`\n- `bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/completions.bats cli/bash/commands/basectl/tests/help.bats`\n- `env -u BASE_HOME HOME=/private/tmp/base-workspace-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`\n- `git diff --check`\n\nCloses #393