### PR TITLE
Default repo license holder from user

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -27,7 +27,7 @@ Options:
   --path <path>                 Target path for repo init. Defaults to workspace root plus <name>.
   --repo <owner/name>           GitHub repository to configure.
   --description <text>          Repository description for generated README.
-  --copyright-holder <name>     Copyright holder for generated LICENSE.
+  --copyright-holder <name>     Copyright holder for generated LICENSE. Defaults to git config user.name.
   --no-configure                Skip GitHub configuration during repo init.
   --dry-run                     Print planned changes without applying them.
   -v                            Enable DEBUG logging for this subcommand.
@@ -47,6 +47,20 @@ base_repo_default_description() {
     local name="$1"
 
     printf 'Base-managed project %s.\n' "$name"
+}
+
+base_repo_default_copyright_holder() {
+    local holder=""
+
+    holder="$(git config --global user.name 2>/dev/null || true)"
+    if [[ -z "$holder" ]]; then
+        holder="$(id -un 2>/dev/null || true)"
+    fi
+    if [[ -z "$holder" ]]; then
+        holder="Unknown"
+    fi
+
+    printf '%s\n' "$holder"
 }
 
 base_repo_validate_name() {
@@ -593,7 +607,7 @@ base_repo_check_baseline() {
 
 base_repo_init() {
     local configure=1
-    local copyright_holder="Ramesh Padmanabhaiah"
+    local copyright_holder=""
     local description=""
     local dry_run=0
     local github_repo=""
@@ -682,6 +696,7 @@ base_repo_init() {
     base_repo_validate_name "$name" || return 2
     [[ -n "$path" ]] || path="$(base_repo_default_target_path "$name")"
     [[ -n "$description" ]] || description="$(base_repo_default_description "$name")"
+    [[ -n "$copyright_holder" ]] || copyright_holder="$(base_repo_default_copyright_holder)"
     root="$(base_repo_target_path "$path")"
 
     base_repo_write_baseline "$dry_run" "$name" "$description" "$copyright_holder" "$root" || return 1

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -86,6 +86,48 @@ load ./basectl_helpers.bash
     grep -Fq "command: ./tests/validate.sh" "$repo_dir/base_manifest.yaml"
 }
 
+@test "basectl repo init defaults copyright holder to git user name" {
+    local repo_dir="$TEST_TMPDIR/git-owner"
+
+    cat > "$TEST_MOCKBIN/git" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "config" && "${2:-}" == "--global" && "${3:-}" == "user.name" ]]; then
+    printf 'Ada Lovelace\n'
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/git"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo init git-owner --path "$repo_dir" --no-configure
+
+    [ "$status" -eq 0 ]
+    grep -Fq "Copyright (c) $(date +%Y) Ada Lovelace" "$repo_dir/LICENSE"
+}
+
+@test "basectl repo init falls back to system username for copyright holder" {
+    local repo_dir="$TEST_TMPDIR/system-owner"
+    local username
+
+    cat > "$TEST_MOCKBIN/git" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/git"
+    username="$(id -un)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo init system-owner --path "$repo_dir" --no-configure
+
+    [ "$status" -eq 0 ]
+    grep -Fq "Copyright (c) $(date +%Y) $username" "$repo_dir/LICENSE"
+}
+
 @test "basectl repo init leaves existing files unchanged" {
     local repo_dir="$TEST_TMPDIR/custom"
 


### PR DESCRIPTION
## Summary

- Replace the hardcoded `repo init` copyright holder with a derived user default.
- Prefer `git config --global user.name`, then fall back to the system username, then `Unknown`.
- Update help text and add deterministic BATS coverage for git-config and username fallback behavior.

## Issue

Closes #422

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/repo.sh`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`

## Demo Impact

None.

## Notes

The issue is valid: generated repositories should not inherit a personal copyright holder from Base itself.