### PR TITLE
Handle repo baseline write failures

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -201,9 +201,23 @@ base_repo_baseline_year() {
     date +%Y
 }
 
+base_repo_create_directory() {
+    local target_dir="$1"
+
+    [[ -d "$target_dir" ]] && return 0
+
+    if mkdir -p "$target_dir" 2>/dev/null; then
+        return 0
+    fi
+
+    log_error "Failed to create parent directory '$target_dir'."
+    return 1
+}
+
 base_repo_write_stream() {
     local dry_run="$1"
     local target="$2"
+    local target_dir
 
     if [[ -e "$target" ]]; then
         log_info "Repository baseline file already exists at '$target'; leaving it unchanged."
@@ -215,13 +229,18 @@ base_repo_write_stream() {
         return 0
     fi
 
-    mkdir -p "$(dirname -- "$target")"
-    cat > "$target"
+    target_dir="$(dirname -- "$target")"
+    base_repo_create_directory "$target_dir" || return 1
+    if ! cat 2>/dev/null > "$target"; then
+        log_error "Failed to write '$target'."
+        return 1
+    fi
 }
 
 base_repo_write_executable_stream() {
     local dry_run="$1"
     local target="$2"
+    local target_dir
 
     if [[ -e "$target" ]]; then
         log_info "Repository baseline file already exists at '$target'; leaving it unchanged."
@@ -233,9 +252,16 @@ base_repo_write_executable_stream() {
         return 0
     fi
 
-    mkdir -p "$(dirname -- "$target")"
-    cat > "$target"
-    chmod +x "$target"
+    target_dir="$(dirname -- "$target")"
+    base_repo_create_directory "$target_dir" || return 1
+    if ! cat 2>/dev/null > "$target"; then
+        log_error "Failed to write '$target'."
+        return 1
+    fi
+    if ! chmod +x "$target" 2>/dev/null; then
+        log_error "Failed to make '$target' executable."
+        return 1
+    fi
 }
 
 base_repo_write_readme() {
@@ -443,7 +469,7 @@ base_repo_write_baseline() {
     local status=0
 
     if [[ "$dry_run" != "1" ]]; then
-        mkdir -p "$root" || return 1
+        base_repo_create_directory "$root" || return 1
     fi
 
     base_repo_write_readme "$dry_run" "$name" "$description" "$root" || status=1

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -141,6 +141,22 @@ EOF
     [ -f "$repo_dir/base_manifest.yaml" ]
 }
 
+@test "basectl repo init reports baseline parent directory creation failures" {
+    local blocked_parent="$TEST_TMPDIR/blocked"
+    local repo_dir="$blocked_parent/base-demo"
+
+    printf 'not a directory\n' > "$blocked_parent"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo init base-demo --path "$repo_dir" --no-configure
+
+    [ "$status" -eq 1 ]
+    [[ "${output:-}${stderr:-}" == *"Failed to create parent directory '$repo_dir'."* ]]
+    [ ! -e "$repo_dir/README.md" ]
+}
+
 @test "basectl repo check passes for a generated baseline" {
     local repo_dir="$TEST_TMPDIR/base-demo"
 


### PR DESCRIPTION
## Summary
- Add explicit repository baseline directory creation handling before writing generated files.
- Report structured errors for directory, file-write, and chmod failures instead of relying on raw shell failures.
- Add BATS coverage for a blocked repo init target path.

## Issue Validity
Issue #427 is valid: `basectl repo init` used unguarded filesystem writes, so setup failures could surface as raw command errors without a clear Base-level diagnostic.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/repo.sh`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Closes #427