### PR TITLE
Default repo creation to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Changed `basectl repo init --repo` to create private GitHub repositories by
+  default, with explicit `--public` and `--private` visibility flags.
 - Updated Base-managed shell profile sections to use shorter `>>> base: ...`
   markers, clearer overwrite guidance, and quoted source paths.
 

--- a/README.md
+++ b/README.md
@@ -347,8 +347,10 @@ By default, `repo init` creates the repository under `workspace.root` from
 directory of `BASE_HOME`. Use `--path <path>` for an explicit location.
 `repo init` also creates the GitHub repository when needed and then
 standardizes its settings when `--repo <owner/name>` is provided or when an
-existing `origin` remote can be inferred. Use `--no-configure` to skip the
-GitHub step, or rerun it later with `basectl repo configure`.
+existing `origin` remote can be inferred. Newly created GitHub repositories are
+private by default; pass `--public` when a public repository is intentional. Use
+`--no-configure` to skip the GitHub step, or rerun it later with
+`basectl repo configure`.
 
 Check and repair the repo baseline with:
 

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -28,6 +28,8 @@ Options:
   --repo <owner/name>           GitHub repository to configure.
   --description <text>          Repository description for generated README.
   --copyright-holder <name>     Copyright holder for generated LICENSE. Defaults to git config user.name.
+  --private                     Create a private GitHub repository when needed. This is the default.
+  --public                      Create a public GitHub repository when needed.
   --no-configure                Skip GitHub configuration during repo init.
   --dry-run                     Print planned changes without applying them.
   -v                            Enable DEBUG logging for this subcommand.
@@ -558,9 +560,10 @@ base_repo_ensure_github_repo() {
     local description="$3"
     local dry_run="$1"
     local repo="$2"
+    local visibility="$4"
 
     if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would create GitHub repository '%s' if it does not already exist.\n" "$repo"
+        printf "[DRY-RUN] Would create %s GitHub repository '%s' if it does not already exist.\n" "$visibility" "$repo"
         return 0
     fi
 
@@ -570,8 +573,8 @@ base_repo_ensure_github_repo() {
         return 0
     fi
 
-    log_info "Creating GitHub repository '$repo'."
-    gh repo create "$repo" --public --description "$description"
+    log_info "Creating $visibility GitHub repository '$repo'."
+    gh repo create "$repo" "--$visibility" --description "$description"
 }
 
 base_repo_configure_github() {
@@ -637,8 +640,11 @@ base_repo_init() {
     local description=""
     local dry_run=0
     local github_repo=""
+    local github_visibility="private"
+    local github_visibility_explicit=0
     local name=""
     local path=""
+    local requested_visibility=""
     local root
 
     while (($#)); do
@@ -687,6 +693,16 @@ base_repo_init() {
                 copyright_holder="$2"
                 shift 2
                 ;;
+            --private|--public)
+                requested_visibility="${1#--}"
+                if ((github_visibility_explicit)) && [[ "$github_visibility" != "$requested_visibility" ]]; then
+                    base_repo_usage_error "Options '--private' and '--public' cannot be used together."
+                    return $?
+                fi
+                github_visibility="$requested_visibility"
+                github_visibility_explicit=1
+                shift
+                ;;
             --no-configure)
                 configure=0
                 shift
@@ -732,7 +748,7 @@ base_repo_init() {
             github_repo="$(base_repo_infer_github_repo "$root" || true)"
         fi
         if [[ -n "$github_repo" ]]; then
-            base_repo_ensure_github_repo "$dry_run" "$github_repo" "$description" || return 1
+            base_repo_ensure_github_repo "$dry_run" "$github_repo" "$description" "$github_visibility" || return 1
             base_repo_configure_github "$dry_run" "$github_repo" || return 1
         else
             if [[ "$dry_run" == "1" ]]; then

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -130,7 +130,7 @@ EOF
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"repo_commands=init check configure"* ]]
-    [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --no-configure --dry-run"* ]]
+    [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --dry-run"* ]]
     [[ "$output" == *"repo_configure_options=--repo --dry-run"* ]]
     [[ "$output" == *"gh_areas=issue pr branch worktree todo"* ]]
     [[ "$output" == *"gh_worktree_commands=prune"* ]]

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -21,7 +21,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
     [[ "$output" == *"[DRY-RUN] Would create executable '$repo_dir/tests/validate.sh'."* ]]
-    [[ "$output" == *"[DRY-RUN] Would create GitHub repository 'codeforester/base-demo' if it does not already exist."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create private GitHub repository 'codeforester/base-demo' if it does not already exist."* ]]
     [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
     [[ "$output" == *"gh label create bug"* ]]
     [[ "$output" == *'--description "Something is not working"'* ]]
@@ -249,8 +249,43 @@ EOF
 
     [ "$status" -eq 0 ]
     [ -f "$repo_dir/base_manifest.yaml" ]
-    grep -Fq "repo create codeforester/base-demo --public --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
+    grep -Fq "repo create codeforester/base-demo --private --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+}
+
+@test "basectl repo init can create a public GitHub repo when requested" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$*" == "repo view codeforester/base-demo" ]]; then
+    exit 1
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo init base-demo --path "$repo_dir" --repo codeforester/base-demo --public
+
+    [ "$status" -eq 0 ]
+    grep -Fq "repo create codeforester/base-demo --public --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
+}
+
+@test "basectl repo init rejects conflicting GitHub repo visibility flags" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir" --repo codeforester/base-demo --private --public
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Options '--private' and '--public' cannot be used together."* ]]
+    [ ! -e "$repo_dir" ]
 }
 
 @test "basectl repo configure can infer GitHub repo from origin remote" {

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -17,9 +17,10 @@ basectl repo init base-demo --repo codeforester/base-demo
 `repo init` creates the local files, creates the GitHub repository if it does
 not already exist, and then configures that GitHub repository when
 `--repo <owner/name>` is provided or an existing `origin` remote can be
-inferred. That keeps the common new-repo path to one command. Use
-`--no-configure` when GitHub setup should be skipped or when local-only
-initialization is desired.
+inferred. New GitHub repositories are private by default; pass `--public` only
+when public visibility is intentional. That keeps the common new-repo path to
+one command. Use `--no-configure` when GitHub setup should be skipped or when
+local-only initialization is desired.
 
 Without `--path`, `repo init` creates the repository under the configured
 workspace root:
@@ -85,8 +86,9 @@ not a replacement for project tests; it is the seed contract that lets
 
 ## GitHub Configuration
 
-`repo init` creates the GitHub repository when needed, then `repo init` and
-`repo configure` standardize the current GitHub repository policy:
+`repo init` creates the GitHub repository when needed, using private visibility
+unless `--public` is passed. Then `repo init` and `repo configure` standardize
+the current GitHub repository policy:
 
 - Issues enabled
 - Projects enabled

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -89,7 +89,7 @@ _base_basectl_completion() {
                     _base_basectl_completion_compgen "init check configure" "$cur"
                     ;;
                 init)
-                    _base_basectl_completion_compgen "--path --repo --description --copyright-holder --no-configure --dry-run -v -h --help" "$cur"
+                    _base_basectl_completion_compgen "--path --repo --description --copyright-holder --private --public --no-configure --dry-run -v -h --help" "$cur"
                     ;;
                 check)
                     _base_basectl_completion_compgen "-v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -121,6 +121,8 @@ _base_basectl_completion() {
                         '--repo[GitHub repository]:repo:' \
                         '--description[Repository description]:description:' \
                         '--copyright-holder[Copyright holder]:name:' \
+                        '--private[Create a private GitHub repository when needed]' \
+                        '--public[Create a public GitHub repository when needed]' \
                         '--no-configure[Skip GitHub configuration]' \
                         '--dry-run[Print planned changes]' \
                         '-v[Enable DEBUG logging]' \


### PR DESCRIPTION
## Summary
- Default `basectl repo init --repo` GitHub repository creation to private visibility.
- Add explicit `--private` and `--public` flags, with conflict validation.
- Update dry-run output, completions, tests, README, repository baseline docs, and changelog.

## Issue Validity
Issue #426 is valid: `basectl repo init --repo ...` previously invoked `gh repo create ... --public`, which could publish a repository unexpectedly. The safe default is private, with public visibility requiring an explicit flag.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/repo.sh lib/shell/completions/basectl_completion.sh`
- `bats cli/bash/commands/basectl/tests/repo.bats cli/bash/commands/basectl/tests/completions.bats`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Closes #426