### PR TITLE
Infer current project for demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Changed `basectl demo` to infer the current project from the nearest
+  `base_manifest.yaml` when the project argument is omitted.
 - Changed `basectl repo init --repo` to create private GitHub repositories by
   default, with explicit `--public` and `--private` visibility flags.
 - Updated Base-managed shell profile sections to use shorter `>>> base: ...`

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ basectl setup <project>
 basectl check <project>
 basectl doctor <project>
 basectl test <project>
-basectl demo <project>
+basectl demo [project]
 basectl run <project> <command>
 basectl activate <project>
 ```

--- a/cli/bash/commands/basectl/subcommands/demo.sh
+++ b/cli/bash/commands/basectl/subcommands/demo.sh
@@ -7,7 +7,7 @@ readonly _base_demo_subcommand_sourced
 base_demo_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl demo <project> [options] [-- extra args...]
+  basectl demo [project] [options] [-- extra args...]
 
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
@@ -50,7 +50,7 @@ base_demo_format_extra_args() {
 base_demo_subcommand_main() {
     local project="" wrapper resolve_output resolved_name project_root manifest_path demo_script venv_dir
     local dry_run=0 workspace_requested=0
-    local args=() extra_args=()
+    local args=() extra_args=() project_args=()
 
     while (($#)); do
         case "$1" in
@@ -101,10 +101,6 @@ base_demo_subcommand_main() {
         esac
     done
 
-    [[ -n "$project" ]] || {
-        base_demo_usage_error "Project name is required."
-        return $?
-    }
     [[ "$workspace_requested" != "1" || -n "$project" ]] || {
         base_demo_usage_error "Option '--workspace' requires an explicit project name."
         return $?
@@ -113,11 +109,12 @@ base_demo_subcommand_main() {
     wrapper="$BASE_HOME/bin/base-wrapper"
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
-    resolve_output="$("$wrapper" --project base base_projects demo-script "$project" "${args[@]}")" || return $?
+    [[ -n "$project" ]] && project_args+=("$project")
+    resolve_output="$("$wrapper" --project base base_projects demo-script "${project_args[@]}" "${args[@]}")" || return $?
     IFS=$'\t' read -r resolved_name project_root manifest_path demo_script <<<"$resolve_output"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$demo_script" ]] || {
-        fatal_error "Unable to resolve demo script for project '$project'."
+        fatal_error "Unable to resolve demo script for project '${project:-current project}'."
     }
 
     venv_dir="$(base_demo_project_venv_dir "$resolved_name")"

--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -7,7 +7,7 @@ load ./basectl_helpers.bash
     run_basectl demo --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl demo <project> [options]"* ]]
+    [[ "$output" == *"basectl demo [project] [options]"* ]]
 }
 
 @test "basectl demo runs declared project demo from project root" {
@@ -60,6 +60,45 @@ EOF
     [[ "$(cat "$state_file")" == *"pwd=$workspace/demo"* ]]
     [[ "$(cat "$state_file")" == *"path=$TEST_HOME/.base.d/demo/.venv/bin:"* ]]
     [[ "$(cat "$state_file")" == *"args=<--non-interactive><name with spaces>"* ]]
+}
+
+@test "basectl demo can resolve the current project when omitted" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/demo-state"
+    local script_path="$workspace/demo/demo.sh"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && -z "${4:-}" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo.sh"
+    exit 0
+fi
+printf 'unexpected demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$script_path" <<'EOF'
+#!/usr/bin/env bash
+printf 'current-project-demo\n' > "$BASE_TEST_DEMO_STATE"
+EOF
+    chmod +x "$python_bin" "$script_path"
+    printf 'project:\n  name: demo\ndemo:\n  script: ./demo.sh\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_DEMO_STATE="$state_file" \
+        bash -c '
+            cd "$1"
+            shift
+            "$@"
+        ' bash "$workspace/demo" "$BASE_REPO_ROOT/bin/basectl" demo
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state_file")" = "current-project-demo" ]
 }
 
 @test "basectl demo dry-run prints resolved script without running it" {

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -189,8 +189,8 @@ def test_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, 
 
 
 def demo_script_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
-    require_argument_count("demo-script", arguments, 1, 1)
-    return demo_script_project_command(ctx, arguments[0], workspace)
+    project = optional_project_argument("demo-script", arguments)
+    return demo_script_project_command(ctx, project, workspace)
 
 
 def activation_sources_project_from_args(
@@ -337,12 +337,11 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
 
 
 def demo_script_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
-    if not project_name:
-        ctx.log.error("Project name is required.")
-        return 2
-
     try:
-        project = resolve_named_project(ctx, project_name, workspace)
+        if project_name:
+            project = resolve_named_project(ctx, project_name, workspace)
+        else:
+            project = current_project()
         manifest = read_manifest(project.manifest_path)
         if manifest.demo is None:
             ctx.log.error(

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -740,6 +740,35 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"\t{script.resolve()}\n",
         )
 
+    def test_projects_demo_script_defaults_to_current_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            nested = project_root / "docs"
+            script = project_root / "demo" / "demo.sh"
+            script.parent.mkdir(parents=True)
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            write_demo_manifest(project_root, "demo", "./demo/demo.sh")
+            nested.mkdir()
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(nested)
+                status, stdout, stderr = run_engine(["demo-script"], base_home)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\t{script.resolve()}\n",
+        )
+
     def test_projects_demo_script_requires_demo_declaration(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)

--- a/docs/project-demo-workflow.md
+++ b/docs/project-demo-workflow.md
@@ -46,10 +46,11 @@ as `brewfile`, `artifacts`, `activate.source`, `commands`, and `test`.
 
 ## Command Behavior
 
-`basectl demo <project>`:
+`basectl demo [project]`:
 
 1. Resolves the project through the same workspace discovery path as
-   `basectl test` and `basectl run`.
+   `basectl test` and `basectl run`. When the project is omitted, Base resolves
+   the nearest `base_manifest.yaml` from the current directory.
 2. Reads `demo.script` from the project manifest.
 3. Validates that the script exists, is a file, is executable, and stays inside
    the project root.
@@ -62,6 +63,7 @@ Useful forms:
 
 ```bash
 basectl demo base-demo
+basectl demo
 basectl demo base-demo --dry-run
 basectl demo base-demo -- --non-interactive
 basectl demo base-demo --workspace ~/work -- --non-interactive


### PR DESCRIPTION
## Summary
- Allow `basectl demo` to omit the project argument and resolve the nearest current project.
- Update the Python `base_projects demo-script` resolver to mirror `test-command` optional project behavior.
- Add Bash and Python tests plus README/demo workflow documentation updates.

## Issue Validity
Issue #430 is valid: `basectl test` already infers the current project from the nearest `base_manifest.yaml`, but `basectl demo` rejected omitted projects even though it follows the same project-declared command pattern.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/demo.sh`
- `bats cli/bash/commands/basectl/tests/demo.bats`
- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Closes #430