### PR TITLE
Enable debug logging for logs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Changed `base_logs` to use `base_cli.App` without default persistent log
+  creation, so `basectl logs -v` enables debug diagnostics without adding a
+  self-log entry.
 - Changed `basectl demo` to infer the current project from the nearest
   `base_manifest.yaml` when the project argument is omitted.
 - Changed `basectl repo init --repo` to create private GitHub repositories by

--- a/README.md
+++ b/README.md
@@ -468,11 +468,13 @@ basectl logs --command check
 basectl logs --path
 basectl logs --open
 basectl logs --tail
+basectl logs -v
 ```
 
 `basectl logs` is read-only. It lists the newest runtime logs under the Base
 cache root so failed Python-layer runs can be inspected without rerunning with
-debug output enabled.
+debug output enabled. It supports `-v`/`--debug` for its own diagnostics without
+creating a new default log entry for the inspection run.
 
 Inspect machine-local Base config with:
 

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -33,6 +33,7 @@ base_logs_subcommand_main() {
                 return 0
                 ;;
             -v)
+                args+=(--debug)
                 shift
                 ;;
             --command|--limit|--lines)

--- a/cli/bash/commands/basectl/tests/logs.bats
+++ b/cli/bash/commands/basectl/tests/logs.bats
@@ -26,6 +26,27 @@ EOF
     [[ "$output" == *"ARGS=--command check --limit 3 --path"* ]]
 }
 
+@test "basectl logs forwards verbose flag to the Python logs layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected logs python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl logs -v --path
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ARGS=--debug --path"* ]]
+}
+
 @test "basectl logs prints help without requiring the Base Python venv" {
     run_basectl logs --help
 

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import os
 import re
 import shlex
@@ -11,10 +10,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+import base_cli
+import click
 from base_cli.paths import base_cache_root
 
 
 RUN_ID_RE = re.compile(r"^(?P<stamp>\d{8}T\d{6})_[A-Za-z0-9]+$")
+
+app = base_cli.App(name="base_logs", log_to_file=False)
 
 
 @dataclass(frozen=True)
@@ -27,63 +30,98 @@ class LogEntry:
     status: str
 
 
+@dataclass(frozen=True)
+class LogCommandOptions:
+    command_filter: str | None
+    limit: int
+    path_only: bool
+    tail: bool
+    open_file: bool
+    lines: int
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-    return run(args)
+    try:
+        result = app.click_command.main(args=argv, standalone_mode=False)
+    except click.ClickException as exc:
+        exc.show()
+        return int(exc.exit_code)
+    return int(result or 0)
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="base_logs", description="List recent Base CLI runtime logs.")
-    parser.add_argument("--command", help="Filter by basectl command or Python CLI name.")
-    parser.add_argument("--limit", type=parse_positive_int, default=10, help="Maximum log entries to list.")
-    parser.add_argument("--path", action="store_true", help="Print the most recent matching log path only.")
-    parser.add_argument("--tail", action="store_true", help="Tail and follow the most recent matching log.")
-    parser.add_argument("--open", action="store_true", help="Open the most recent matching log in PAGER or EDITOR.")
-    parser.add_argument("--lines", type=parse_positive_int, default=40, help="Line count to show before following.")
-    return parser
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.option("--command", "command_filter", help="Filter by basectl command or Python CLI name.")
+@base_cli.option("--limit", default="10", help="Maximum log entries to list.")
+@base_cli.option("--path", "path_only", is_flag=True, help="Print the most recent matching log path only.")
+@base_cli.option("--tail", is_flag=True, help="Tail and follow the most recent matching log.")
+@base_cli.option("--open", "open_file", is_flag=True, help="Open the most recent matching log in PAGER or EDITOR.")
+@base_cli.option("--lines", default="40", help="Line count to show before following.")
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def run(
+    ctx: base_cli.Context,
+    command_filter: str | None,
+    limit: str,
+    path_only: bool,
+    tail: bool,
+    open_file: bool,
+    lines: str,
+) -> int:
+    try:
+        limit_value = parse_positive_int("--limit", limit)
+        line_count = parse_positive_int("--lines", lines)
+    except ValueError as exc:
+        ctx.log.error(str(exc))
+        return 2
+
+    options = LogCommandOptions(
+        command_filter=command_filter,
+        limit=limit_value,
+        path_only=path_only,
+        tail=tail,
+        open_file=open_file,
+        lines=line_count,
+    )
+    selected_actions = sum(1 for selected in (path_only, tail, open_file) if selected)
+    if selected_actions > 1:
+        ctx.log.error("Choose only one of --path, --tail, or --open.")
+        return 2
+
+    cache_root = base_cache_root()
+    ctx.log.debug("Scanning Base cache root '%s'.", cache_root)
+    entries = recent_logs(cache_root, command_filter=options.command_filter)
+    if not entries:
+        return report_no_logs(ctx, cache_root, options)
+    return run_with_entries(entries, options)
 
 
-def parse_positive_int(value: str) -> int:
+def parse_positive_int(option: str, value: str) -> int:
     if not value.isdigit():
-        raise argparse.ArgumentTypeError("must be a positive integer")
+        raise ValueError(f"Option '{option}' must be a positive integer.")
     amount = int(value)
     if amount <= 0:
-        raise argparse.ArgumentTypeError("must be greater than zero")
+        raise ValueError(f"Option '{option}' must be greater than zero.")
     return amount
 
 
-def run(args: argparse.Namespace) -> int:
-    selected_actions = sum(1 for name in ("path", "tail", "open") if getattr(args, name))
-    if selected_actions > 1:
-        print("ERROR: Choose only one of --path, --tail, or --open.", file=sys.stderr)
-        return 2
-
-    entries = recent_logs(base_cache_root(), command_filter=args.command)
-    if not entries:
-        return report_no_logs(args)
-    return run_with_entries(args, entries)
-
-
-def report_no_logs(args: argparse.Namespace) -> int:
-    if args.path or args.tail or args.open:
-        print("ERROR: No Base CLI logs found.", file=sys.stderr)
+def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandOptions) -> int:
+    if options.path_only or options.tail or options.open_file:
+        ctx.log.error("No Base CLI logs found.")
         return 1
-    print(f"No Base CLI logs found under {base_cache_root() / 'cli'}.")
+    print(f"No Base CLI logs found under {cache_root / 'cli'}.")
     return 0
 
 
-def run_with_entries(args: argparse.Namespace, entries: list[LogEntry]) -> int:
+def run_with_entries(entries: list[LogEntry], options: LogCommandOptions) -> int:
     newest = entries[0]
-    if args.path:
+    if options.path_only:
         print(newest.path)
         return 0
-    if args.tail:
-        return tail_log(newest.path, args.lines)
-    if args.open:
+    if options.tail:
+        return tail_log(newest.path, options.lines)
+    if options.open_file:
         return open_log(newest.path)
 
-    print_log_table(entries[: args.limit])
+    print_log_table(entries[: options.limit])
     return 0
 
 

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -118,6 +118,17 @@ class BaseLogsTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn("No Base CLI logs found", stdout)
 
+    def test_debug_uses_base_cli_without_creating_self_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            status, stdout, stderr = invoke(["--debug"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertIn("No Base CLI logs found", stdout)
+        self.assertIn(" DEBUG ", stderr)
+        self.assertIn("cli=base_logs", stderr)
+        self.assertFalse((cache_root / "cli" / "base_logs").exists())
+
     def test_path_errors_when_no_log_matches(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             status, stdout, stderr = invoke(["--path"], Path(tmpdir))
@@ -137,3 +148,14 @@ class BaseLogsTests(unittest.TestCase):
         self.assertEqual(stdout, "")
         self.assertIn("Choose only one", stderr)
 
+    def test_invalid_count_options_report_usage_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = invoke(["--limit", "0"], Path(tmpdir))
+            line_status, line_stdout, line_stderr = invoke(["--lines", "abc", "--tail"], Path(tmpdir))
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("Option '--limit' must be greater than zero", stderr)
+        self.assertEqual(line_status, 2)
+        self.assertEqual(line_stdout, "")
+        self.assertIn("Option '--lines' must be a positive integer", line_stderr)

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -77,7 +77,7 @@ ctx.state_dir      # Base cache root / cli / <cli-name>
 ctx.log_dir        # state_dir/logs
 ctx.cache_dir      # state_dir/cache
 ctx.temp_dir       # state_dir/tmp/<run-id>
-ctx.log_file       # log_dir/<run-id>.log
+ctx.log_file       # log_dir/<run-id>.log, or None when persistent logging is disabled
 ctx.config         # dict
 ctx.environment    # str
 ctx.debug          # bool
@@ -130,6 +130,14 @@ Directory lifecycle:
 | `cache/` | before command execution | explicit CLI logic only |
 | `tmp/<run-id>/` | before command execution | after command execution unless kept |
 
+Commands that inspect runtime artifacts can opt out of default persistent log
+creation with `base_cli.App(log_to_file=False)`. That still provides a context
+and the standard user-facing stderr logger, including `--debug`, but leaves
+`ctx.log_file` as `None` and does not create the default `logs/`, `cache/`, or
+`tmp/<run-id>/` directories. `base_logs` uses this mode so `basectl logs` does
+not create a new log entry while listing logs. Passing `--log-file <path>` still
+writes to that explicit file.
+
 ## Logging
 
 Every run gets two streams:
@@ -137,7 +145,7 @@ Every run gets two streams:
 | Stream | Destination | Level | Format |
 |---|---|---|---|
 | user | stderr | INFO by default, DEBUG with `--debug` | Base-style timestamp, level, source, message |
-| persistent | `ctx.log_file` | DEBUG | Base-style timestamp, level, source, message |
+| persistent | `ctx.log_file` when enabled | DEBUG | Base-style timestamp, level, source, message |
 
 Python user-facing logs should visually align with Bash `lib_std.sh` logs:
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -9,7 +9,7 @@ should get by default:
 
 - standard command options such as `--debug`, `--environment`, `--config`,
   `--keep-temp`, and `--log-file`
-- structured logging to stderr and to a persistent per-run log file
+- structured logging to stderr and, by default, to a persistent per-run log file
 - Base project discovery through `base_manifest.yaml`
 - config loading with predictable precedence
 - per-run temp directories, persistent cache directories, and cleanup hooks
@@ -152,7 +152,8 @@ Important fields include:
 - `ctx.log_dir`: persistent log directory.
 - `ctx.cache_dir`: persistent cache directory.
 - `ctx.temp_dir`: per-run temp directory.
-- `ctx.log_file`: persistent log file for this run.
+- `ctx.log_file`: persistent log file for this run, or `None` when persistent
+  logging is disabled.
 - `ctx.config`: merged configuration dictionary.
 - `ctx.environment`: active environment, defaulting to `dev`.
 - `ctx.debug`: whether debug logging is enabled for the stderr stream.
@@ -177,7 +178,14 @@ def helper() -> None:
 `base_cli` configures two handlers:
 
 - a user-facing stderr handler at INFO by default, DEBUG with `--debug`
-- a persistent file handler that always records DEBUG logs
+- a persistent file handler that records DEBUG logs when persistent logging is
+  enabled
+
+Commands that inspect runtime artifacts can use `base_cli.App(log_to_file=False)`
+to keep the standard context and `--debug` behavior without creating default
+`logs/`, `cache/`, or `tmp/<run-id>/` directories. `base_logs` uses this mode so
+`basectl logs` does not appear in its own output. An explicit `--log-file <path>`
+still enables file logging for that invocation.
 
 Logs use the same general shape as Base Bash logs:
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -21,9 +21,10 @@ def _require_click():
 
 
 class App:
-    def __init__(self, name: str | None = None, version: str | None = None) -> None:
+    def __init__(self, name: str | None = None, version: str | None = None, log_to_file: bool = True) -> None:
         self.name = normalize_cli_name(name or sys.argv[0])
         self.version = version
+        self.log_to_file = log_to_file
         self._click_command = None
         self._command_func: Callable[..., Any] | None = None
         self._command_args: tuple[Any, ...] = ()
@@ -97,7 +98,7 @@ class App:
         temp_dir = state_dir / "tmp" / run_id
 
         log_file = Path(standard["log_file"]).expanduser() if standard.get("log_file") else None
-        if dry_run:
+        if dry_run or not self.log_to_file:
             if log_file is not None:
                 log_file.parent.mkdir(parents=True, exist_ok=True)
         else:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -440,6 +440,36 @@ class BaseCliTests(unittest.TestCase):
             self.assertIn("dry run", result.stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_can_disable_default_persistent_logging(self) -> None:
+        app = base_cli.App(name="inspect-logs", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["log_file"] = ctx.log_file
+            seen["state_dir"] = ctx.state_dir
+            seen["cache_dir"] = ctx.cache_dir
+            seen["temp_dir"] = ctx.temp_dir
+            ctx.log.debug("debug without persistent log")
+            ctx.log.info("info without persistent log")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
+                from base_cli.testing import invoke
+
+                result = invoke(app, ["--debug"], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIsNone(seen["log_file"])
+            self.assertFalse(seen["state_dir"].exists())
+            self.assertFalse(seen["cache_dir"].exists())
+            self.assertFalse(seen["temp_dir"].exists())
+            self.assertFalse((home / "Library" / "Caches" / "base").exists())
+            self.assertIn("debug without persistent log", result.stderr)
+            self.assertIn("info without persistent log", result.stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_dry_run_honors_explicit_log_file_without_cache_dirs(self) -> None:
         app = base_cli.App(name="dry-run-log-demo", version="0.1.0")
         seen = {}


### PR DESCRIPTION
## Summary
- Forward `basectl logs -v` to the Python layer as `--debug`.
- Convert `base_logs` from raw argparse to `base_cli.App(log_to_file=False)` so it gets standard Base CLI options without creating a default self-log entry.
- Add framework and logs tests for no-default persistent logging, debug output, and argument validation.
- Document optional persistent logging in `docs/base-cli.md` and the package README.

## Issue Validity
Issue #423 is valid: `logs.sh` parsed `-v` and silently discarded it, unlike other Base subcommands.

Issue #432 is valid: `base_logs` used raw argparse and therefore missed the standard `base_cli.App` options. The blocker was real too: using the default App behavior would create a log entry while listing logs, so this PR adds `log_to_file=False` for inspection-style commands.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/logs.sh`
- `bats cli/bash/commands/basectl/tests/logs.bats`
- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_logs/tests/test_engine.py lib/python/base_cli/tests/test_base_cli.py`
- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_logs lib/python/base_cli`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Closes #423
Closes #432