### PR TITLE
Require artifact finding IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Removed the placeholder `BASE-P000` default from `ArtifactCheck` so project
+  doctor findings must declare explicit stable IDs.
 - Updated the README status section to match the current `0.2.0` release.
 - Fixed `basectl repo init` to create new repositories under the configured
   workspace root instead of the caller's current directory.

--- a/cli/python/base_setup/checks.py
+++ b/cli/python/base_setup/checks.py
@@ -9,8 +9,8 @@ class ArtifactCheck:
     ok: bool
     message: str
     fix: str
+    finding_id: str
     status: str = ""
-    finding_id: str = "BASE-P000"
 
 
 def check_to_json(check: ArtifactCheck) -> dict[str, str | bool]:

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -118,11 +118,12 @@ class ProjectCheckTests(unittest.TestCase):
             ok=False,
             message="Optional project artifact is not installed.",
             fix="basectl setup demo",
+            finding_id="BASE-P033",
             status="warn",
         )
 
         self.assertEqual(engine.doctor_status(check), "warn")
-        self.assertEqual(setup_checks.check_to_doctor_json(check)["id"], "BASE-P000")
+        self.assertEqual(setup_checks.check_to_doctor_json(check)["id"], "BASE-P033")
         self.assertEqual(setup_checks.check_to_doctor_json(check)["status"], "warn")
 
         default_manifest = BaseManifest(
@@ -144,6 +145,17 @@ class ProjectCheckTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("warn", stdout.getvalue())
+
+    def test_artifact_check_requires_explicit_finding_id(self) -> None:
+        kwargs = {
+            "name": "optional-artifact",
+            "ok": False,
+            "message": "Optional project artifact is not installed.",
+            "fix": "basectl setup demo",
+        }
+
+        with self.assertRaises(TypeError):
+            setup_checks.ArtifactCheck(**kwargs)
 
 
 

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -6,6 +6,9 @@ human-readable names or messages.
 
 Finding IDs are never reused after they ship. A finding may change its message,
 fix text, or severity over time, but its ID keeps the same meaning.
+Every doctor finding implementation must provide an explicit ID; placeholder
+IDs such as `BASE-P000` are invalid because they cannot support automation or
+suppression policies.
 
 ## Principles
 


### PR DESCRIPTION
## Summary
- Remove the placeholder `BASE-P000` default from `ArtifactCheck`.
- Require every project doctor finding to pass an explicit stable `finding_id`.
- Update diagnostics tests and doctor finding docs to treat `BASE-P000` as invalid placeholder text only.

## Issue Validity
Issue #424 is valid, but partly stale: most artifact, delegate, IDE, demo, health, and workspace checks already had explicit `BASE-P###` or `BASE-H###` IDs. The remaining bug was the default itself, plus a test that still blessed `BASE-P000`.

## Validation
- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_projects/tests/test_workspace_checks.py`
- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/checks.py cli/python/base_setup/tests/test_diagnostics.py`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-review-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

Closes #424