### PR TITLE
Refresh execution model subcommand list

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -157,7 +157,8 @@ The umbrella command implementation lives at:
 $BASE_HOME/cli/bash/commands/basectl/basectl.sh
 ```
 
-It owns the current Base subcommands:
+It owns the current Base subcommands. The canonical, always-current command
+list is `basectl --help`; this list summarizes the shipped public surface:
 
 - `setup`
 - `check`
@@ -166,6 +167,14 @@ It owns the current Base subcommands:
 - `activate`
 - `test`
 - `run`
+- `demo`
+- `repo`
+- `logs`
+- `workspace`
+- `onboard`
+- `gh`
+- `config`
+- `update`
 - `projects list`
 - `update-profile`
 - `version`


### PR DESCRIPTION
## Summary
- Refresh the execution-model `basectl` subcommand list to match the current CLI surface.
- Point readers to `basectl --help` as the canonical runtime command list.

## Validation
- git diff --check

## Demo Impact
- None. Documentation-only change.

Closes #444