### PR TITLE
Add doctor findings to documentation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ Key starting points:
 - [Architecture](docs/architecture.md)
 - [Execution Model](docs/execution-model.md)
 - [Tool Boundaries](docs/tool-boundaries.md)
+- [Doctor Finding IDs](docs/doctor-findings.md)
 - [IDE Bootstrapping](docs/ide-bootstrapping.md)
 - [Local Config](docs/local-config.md)
 - [Project Demo Workflow](docs/project-demo-workflow.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,9 @@ reference. The filename should answer "what is this about?"
   point and its relationship to Linux support.
 - [`basectl check` parallelism](check-parallelism.md) records the evaluation and
   implementation constraints for parallel check probes.
+- [Doctor Finding IDs](doctor-findings.md) is the stable reference for
+  `BASE-D*`, `BASE-P*`, and `BASE-H*` finding identifiers emitted by
+  `basectl doctor --format json`.
 - [Base-managed demo project](base-managed-demo-project.md) defines the proof
   project criteria for showing Base's complete workspace workflow.
 - [Project Demo Workflow](project-demo-workflow.md) documents `demo.script`,


### PR DESCRIPTION
## Summary
- Add `docs/doctor-findings.md` to the docs map.
- Link the doctor finding reference from the top-level README documentation section.

## Validation
- git diff --check

## Demo Impact
- None. Documentation-only change.

Closes #445