### PR TITLE
Prune migrated TODO backlog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,18 +14,5 @@ branch named:
 See [docs/github-workflow.md](docs/github-workflow.md) for the current label,
 milestone, Project, issue assignment, branch, and worktree policy.
 
-The previous public TODO backlog was migrated to GitHub Issues on 2026-05-28:
-
-- #118 Add first-class mise integration
-- #119 Implement basectl test project execution
-- #120 Consider a structured python manifest section
-- #121 Decide whether setup hooks belong in the manifest
-- #122 Implement basectl onboard
-- #123 Decide whether basectl onboard project belongs in Base or project installers
-- #124 Implement future docker-service artifact support when a real project needs it
-- #125 Add initial Linux support plan
-- #126 Design basectl ci
-- #127 Add a real Base-managed project demonstration
-- #128 Evaluate parallelizing independent basectl check probes
-- #129 Harden GitHub Actions Python file discovery
-- #130 Pin CI development dependencies and add security scanners
+The original public TODO backlog was migrated to GitHub Issues in 2026. Use
+open GitHub Issues for current product and documentation work.


### PR DESCRIPTION
## Summary
- Remove the stale TODO migration table.
- Point current backlog readers to GitHub Issues as the source of truth.

## Validation
- git diff --check

## Demo Impact
- None. Documentation-only change.

Closes #452