### PR TITLE
Improve basectl gh auth diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Fixed `basectl gh` authentication diagnostics to include the underlying
+  `gh auth status` output when GitHub access fails.
 - Converted `bootstrap.sh` away from shell strict mode to explicit command
   failure checks that match Base shell standards.
 - Clarified `BASE-H001` required-environment findings as repeated rule

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -50,10 +50,15 @@ base_gh_require_command() {
 }
 
 base_gh_require_auth() {
+    local auth_output line
+
     base_gh_require_command gh || return 1
 
-    gh auth status -h github.com >/dev/null 2>&1 || {
-        base_gh_error "GitHub CLI authentication is not ready."
+    auth_output="$(gh auth status -h github.com 2>&1)" || {
+        base_gh_error "GitHub CLI authentication or GitHub API access is not ready."
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            [[ -n "$line" ]] && base_gh_error "gh auth status: $line"
+        done <<<"$auth_output"
         base_gh_error "Run 'gh auth login -h github.com' and retry."
         return 1
     }

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -68,6 +68,9 @@ EOF
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$*" == "auth status -h github.com" ]]; then
+    printf 'github.com\n' >&2
+    printf '  X failed to reach api.github.com\n' >&2
+    printf '  - check your internet connection or GitHub API access\n' >&2
     exit 1
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -86,7 +89,10 @@ EOF
         '
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"GitHub CLI authentication is not ready."* ]]
+    [[ "$output" == *"GitHub CLI authentication or GitHub API access is not ready."* ]]
+    [[ "$output" == *"gh auth status: github.com"* ]]
+    [[ "$output" == *"gh auth status:   X failed to reach api.github.com"* ]]
+    [[ "$output" == *"gh auth status:   - check your internet connection or GitHub API access"* ]]
     [[ "$output" == *"gh auth login -h github.com"* ]]
     [[ "$output" != *"unexpected gh args"* ]]
 }


### PR DESCRIPTION
## Summary
- Preserve the underlying gh auth status output when basectl gh auth checks fail.
- Broaden the wrapper message to cover authentication or GitHub API access failures.
- Add BATS coverage for network/API-style gh auth status diagnostics.

## Validation
- bats cli/bash/commands/basectl/tests/gh.bats
- git diff --check
- env -u BASE_HOME HOME=/private/tmp/base-gh-auth-diagnostics-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test

## Demo Impact
- None.

Fixes #472