### PR TITLE
Add basectl build target orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Current implemented commands include:
 - `basectl repo configure [path]`
 - `basectl activate <project>`
 - `basectl test [project]`
+- `basectl build <project> [target...]`
 - `basectl run <project> <command>`
 - `basectl onboard`
 - `basectl version`
@@ -408,6 +409,46 @@ basectl test example -- -k focused_case
 ```
 
 For `test.mise`, Base passes those arguments after `mise run <task> --`.
+
+Run a discovered project's declared build targets with:
+
+```bash
+basectl build example
+basectl build example api worker
+```
+
+The `build` contract is intentionally declarative. Base does not infer how to
+compile Go, Java, C++, Node.js, or any other language. The project declares the
+targets it owns:
+
+```yaml
+build:
+  default:
+    - api
+    - worker
+  targets:
+    api:
+      description: Build the API service.
+      working_dir: services/api
+      command: go build ./cmd/api
+    worker:
+      description: Build the worker service.
+      working_dir: services/worker
+      command: go build ./cmd/worker
+```
+
+`basectl build <project>` runs `build.default` sequentially. `basectl build
+<project> <target> [target...]` runs only the named targets. Base exports the
+same project environment variables as `basectl test`, prepends the project
+virtual environment when it exists, changes into each target's `working_dir`,
+and returns the first failing build command's exit status.
+
+Use `--list` or `--dry-run` to inspect the manifest contract:
+
+```bash
+basectl build example --list
+basectl build example --dry-run
+```
 
 Run other manifest-declared project commands with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -33,6 +33,7 @@ that delegate to `basectl`.
 - `onboard`
 - `repo init/check/configure`
 - `test`
+- `build`
 - `update-profile`
 - `update`
 - `projects list`
@@ -83,6 +84,10 @@ that delegate to `basectl`.
   `test.mise` from the project root with Base project environment variables
   exported. Use `basectl test <project> -- <args...>` to pass extra arguments
   to the delegated test command.
+- `basectl build <project> [target...]` runs manifest `build.targets` from
+  each target's `working_dir`. With no targets, it runs `build.default`
+  sequentially. Use `basectl build <project> --list` to inspect targets and
+  `--dry-run` to preview commands without running them.
 - `basectl run <project> <command>` runs a named command from the project's
   manifest `commands` map with the same project root, environment variables,
   virtual environment, dry-run, and extra-argument contract as `basectl test`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -17,6 +17,8 @@ Commands:
     Verify the local Base CLI environment and optional project artifacts without making changes.
   test [project] [options]
     Run a project's declared test command.
+  build <project> [target...] [options]
+    Run a project's declared build targets.
   demo <project> [options]
     Run a project's declared interactive demo.
   run <project> <command> [options]
@@ -173,6 +175,11 @@ basectl_do_check() {
 basectl_do_test() {
     basectl_source_subcommand_module test || return 1
     base_test_subcommand_main "$@"
+}
+
+basectl_do_build() {
+    basectl_source_subcommand_module build || return 1
+    base_build_subcommand_main "$@"
 }
 
 basectl_do_demo() {
@@ -339,6 +346,7 @@ basectl_main() {
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
         test)             basectl_do_test "$@" ;;
+        build)            basectl_do_build "$@" ;;
         demo)             basectl_do_demo "$@" ;;
         run)              basectl_do_run "$@" ;;
         repo)             basectl_do_repo "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/build.sh
+++ b/cli/bash/commands/basectl/subcommands/build.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_build_subcommand_sourced:-}" ]] && return
+_base_build_subcommand_sourced=1
+readonly _base_build_subcommand_sourced
+
+_base_project_command_helpers_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/project_command_helpers.sh"
+# shellcheck source=/dev/null
+source "$_base_project_command_helpers_path"
+
+base_build_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl build <project> [target...] [options] [-- extra args...]
+  basectl build <project> --list [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --dry-run           Print resolved build commands without running them.
+  --list              List build targets for a project.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Run a project's declared build targets from their configured working directories.
+When no target is provided, Base runs build.default from the project manifest.
+Use -- to pass additional arguments to each delegated build command.
+EOF
+}
+
+base_build_usage_error() {
+    base_build_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_build_list_targets() {
+    local project="$1"
+    shift
+    local args=("$@")
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local list_output line resolved_name project_root manifest_path target_name working_dir build_command description
+    local printed_header=0
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    list_output="$("$wrapper" --project base base_projects build-target-list "$project" "${args[@]}")" || return $?
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description <<<"$line"
+        [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" ]] || {
+            fatal_error "Unable to parse build targets for project '$project'."
+        }
+        if ((printed_header == 0)); then
+            printf "Build targets for project '%s'\n\n" "$resolved_name"
+            printed_header=1
+        fi
+        printf '%-20s %-40s %s\n' "$target_name" "$working_dir" "${description:-$build_command}"
+    done <<<"$list_output"
+}
+
+base_build_subcommand_main() {
+    local project="" wrapper resolve_output line resolved_name project_root manifest_path target_name working_dir build_command description
+    local venv_dir command_to_run display_command
+    local dry_run=0 list_targets=0 workspace_requested=0
+    local args=() extra_args=() targets=()
+
+    while (($#)); do
+        case "$1" in
+            --)
+                shift
+                extra_args=("$@")
+                break
+                ;;
+            -h|--help|help)
+                base_build_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --workspace)
+                [[ -n "${2:-}" ]] || {
+                    base_build_usage_error "Option '--workspace' requires an argument."
+                    return $?
+                }
+                workspace_requested=1
+                args+=(--workspace "$2")
+                shift 2
+                ;;
+            --workspace=*)
+                workspace_requested=1
+                args+=("$1")
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            --list)
+                list_targets=1
+                shift
+                ;;
+            -*)
+                base_build_usage_error "Unknown build option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -z "$project" ]]; then
+                    project="$1"
+                else
+                    targets+=("$1")
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$project" ]] || {
+        base_build_usage_error "Project name is required."
+        return $?
+    }
+    [[ -n "$project" || "$workspace_requested" != "1" ]] || {
+        base_build_usage_error "Option '--workspace' requires an explicit project name."
+        return $?
+    }
+
+    if [[ "$list_targets" == "1" ]]; then
+        [[ ${#targets[@]} -eq 0 ]] || {
+            base_build_usage_error "Option '--list' cannot be combined with build targets."
+            return $?
+        }
+        [[ ${#extra_args[@]} -eq 0 ]] || {
+            base_build_usage_error "Option '--list' cannot be combined with extra build arguments."
+            return $?
+        }
+        base_build_list_targets "$project" "${args[@]}"
+        return $?
+    fi
+
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    resolve_output="$("$wrapper" --project base base_projects build-targets "$project" "${targets[@]}" "${args[@]}")" || return $?
+    [[ -n "$resolve_output" ]] || fatal_error "Unable to resolve build targets for project '$project'."
+
+    resolved_name=""
+    venv_dir=""
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description <<<"$line"
+        [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" && -n "$build_command" ]] || {
+            fatal_error "Unable to parse build target '$target_name' for project '$project'."
+        }
+
+        if [[ -z "$venv_dir" ]]; then
+            venv_dir="$(base_project_venv_dir "$resolved_name")"
+            export BASE_PROJECT="$resolved_name"
+            export BASE_PROJECT_ROOT="$project_root"
+            export BASE_PROJECT_MANIFEST="$manifest_path"
+            export BASE_PROJECT_VENV_DIR="$venv_dir"
+
+            if [[ -d "$venv_dir/bin" ]]; then
+                PATH="$venv_dir/bin:$PATH"
+                export PATH
+            elif [[ "$dry_run" != "1" ]]; then
+                log_warn "Project virtual environment was not found at '$venv_dir'. Run 'basectl setup $resolved_name' first."
+            fi
+        fi
+
+        command_to_run="$(base_command_with_extra_args "$build_command" "${extra_args[@]}")"
+        display_command="$(base_display_command "$build_command" "${extra_args[@]}")"
+
+        if [[ "$dry_run" == "1" ]]; then
+            printf '[DRY-RUN] Would build target %q for project %q in %q: %s\n' \
+                "$target_name" "$resolved_name" "$working_dir" "$display_command"
+            continue
+        fi
+
+        log_info "Building target '$target_name' for project '$resolved_name': $display_command"
+        (cd "$working_dir" && bash -c "$command_to_run" basectl-build "${extra_args[@]}") || return $?
+    done <<<"$resolve_output"
+}

--- a/cli/bash/commands/basectl/tests/build.bats
+++ b/cli/bash/commands/basectl/tests/build.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl build prints help" {
+    run_basectl build --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl build <project> [target...]"* ]]
+}
+
+@test "basectl build runs default targets from target working directories" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/build-state"
+
+    mkdir -p "$(dirname "$python_bin")" \
+        "$workspace/demo/services/api" \
+        "$workspace/demo/services/worker" \
+        "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'printf "api:%s:%s:%s:%s:%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" >> "$BASE_TEST_BUILD_STATE"' 'Build API'
+    printf 'demo\t%s\t%s\tworker\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/worker" 'printf "worker:%s:%s\n" "$BASE_PROJECT" "$PWD" >> "$BASE_TEST_BUILD_STATE"' 'Build worker'
+    exit 0
+fi
+printf 'unexpected build python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    touch "$TEST_HOME/.base.d/demo/.venv/bin/go"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_BUILD_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$state_file")" == *"api:demo:$workspace/demo:$workspace/demo/base_manifest.yaml:$TEST_HOME/.base.d/demo/.venv:$workspace/demo/services/api"* ]]
+    [[ "$(cat "$state_file")" == *"worker:demo:$workspace/demo/services/worker"* ]]
+}
+
+@test "basectl build passes explicit targets and extra args" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/build-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" && "${5:-}" == "api" ]]; then
+    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'fake-build ./cmd/api' 'Build API'
+    exit 0
+fi
+printf 'unexpected build python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$TEST_HOME/.base.d/demo/.venv/bin/fake-build" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${BASE_TEST_BUILD_STATE:?}"
+EOF
+    chmod +x "$python_bin" "$TEST_HOME/.base.d/demo/.venv/bin/fake-build"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_BUILD_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo api -- --release "name with spaces"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state_file")" = $'./cmd/api\n--release\nname with spaces' ]
+}
+
+@test "basectl build dry-run prints resolved targets without running them" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/build-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'touch "$BASE_TEST_BUILD_STATE"; exit 7' 'Build API'
+    exit 0
+fi
+printf 'unexpected build python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_BUILD_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo --dry-run -- --release
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would build target api for project demo"* ]]
+    [[ "$output" == *'touch "$BASE_TEST_BUILD_STATE"; exit 7 --release'* ]]
+    [ ! -e "$state_file" ]
+}
+
+@test "basectl build --list prints project build targets" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-target-list" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'go build ./cmd/api' 'Build API'
+    exit 0
+fi
+printf 'unexpected build python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Build targets for project 'demo'"* ]]
+    [[ "$output" == *"api"* ]]
+    [[ "$output" == *"Build API"* ]]
+}
+
+@test "basectl build reports resolver errors" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
+    printf "ERROR: Project 'demo' does not declare build targets in '%s/base_manifest.yaml'.\n" "${BASE_TEST_PROJECT_ROOT:?}" >&2
+    exit 1
+fi
+printf 'unexpected build python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not declare build targets"* ]]
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -47,6 +47,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "test_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl build ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "build_projects=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl run ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -63,6 +67,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "test_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl build demo --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "build_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl run demo --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -127,10 +135,12 @@ EOF
     [[ "$output" == *"check_projects=base demo"* ]]
     [[ "$output" == *"doctor_projects=base demo"* ]]
     [[ "$output" == *"test_projects=base demo"* ]]
+    [[ "$output" == *"build_projects=base demo"* ]]
     [[ "$output" == *"run_projects=base demo"* ]]
     [[ "$output" == *"check_options=--profile --format"* ]]
     [[ "$output" == *"check_profiles=dev sre dev,sre"* ]]
     [[ "$output" == *"test_options=--workspace --dry-run"* ]]
+    [[ "$output" == *"build_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"workspace_commands=status check doctor"* ]]

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
+
+import base_cli
+from base_setup.manifest import BaseManifest, BuildTargetConfig, ManifestError, read_manifest
+
+
+class ProjectLike(Protocol):
+    name: str
+    root: Path
+    manifest_path: Path
+
+
+class BuildTargetError(RuntimeError):
+    pass
+
+
+ProjectResolver = Callable[[base_cli.Context, str, str | None], ProjectLike]
+
+
+def build_targets_project_from_args(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    workspace: str | None,
+    resolve_project: ProjectResolver,
+) -> int:
+    if not 1 <= len(arguments) <= 1000:
+        ctx.log.error("Command 'build-targets' expects between 1 and 1000 arguments; got %d.", len(arguments))
+        return 2
+    return build_targets_project_command(ctx, arguments[0], arguments[1:], workspace, resolve_project)
+
+
+def list_build_targets_from_args(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    workspace: str | None,
+    resolve_project: ProjectResolver,
+) -> int:
+    if len(arguments) != 1:
+        ctx.log.error("Command 'build-target-list' expects between 1 and 1 arguments; got %d.", len(arguments))
+        return 2
+    return list_build_targets_command(ctx, arguments[0], workspace, resolve_project)
+
+
+def build_targets_project_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    target_names: tuple[str, ...],
+    workspace: str | None,
+    resolve_project: ProjectResolver,
+) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+
+    try:
+        project = resolve_project(ctx, project_name, workspace)
+        manifest = read_manifest(project.manifest_path)
+        targets = selected_build_targets(project, manifest, target_names)
+    except (RuntimeError, ManifestError, BuildTargetError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    for target_name, target_config, working_dir in targets:
+        print_build_target(project, target_name, target_config, working_dir)
+    return 0
+
+
+def list_build_targets_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    workspace: str | None,
+    resolve_project: ProjectResolver,
+) -> int:
+    if not project_name:
+        ctx.log.error("Project name is required.")
+        return 2
+
+    try:
+        project = resolve_project(ctx, project_name, workspace)
+        manifest = read_manifest(project.manifest_path)
+        targets = all_build_targets(project, manifest)
+    except (RuntimeError, ManifestError, BuildTargetError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    for target_name, target_config, working_dir in targets:
+        print_build_target(project, target_name, target_config, working_dir)
+    return 0
+
+
+def print_build_target(
+    project: ProjectLike,
+    target_name: str,
+    target_config: BuildTargetConfig,
+    working_dir: Path,
+) -> None:
+    print(
+        f"{project.name}\t{project.root}\t{project.manifest_path}\t{target_name}\t"
+        f"{working_dir}\t{target_config.command}\t{target_config.description or ''}"
+    )
+
+
+def selected_build_targets(
+    project: ProjectLike,
+    manifest: BaseManifest,
+    target_names: tuple[str, ...],
+) -> tuple[tuple[str, BuildTargetConfig, Path], ...]:
+    build = manifest.build
+    if build is None or not build.targets:
+        raise BuildTargetError(f"Project '{project.name}' does not declare build targets in '{manifest.path}'.")
+
+    selected_names = target_names or build.default
+    if not selected_names:
+        raise BuildTargetError(
+            f"Project '{project.name}' does not declare build.default in '{manifest.path}'. "
+            "Pass one or more build targets explicitly."
+        )
+
+    targets: list[tuple[str, BuildTargetConfig, Path]] = []
+    for target_name in selected_names:
+        try:
+            target_config = build.targets[target_name]
+        except KeyError as exc:
+            raise BuildTargetError(
+                f"Project '{project.name}' does not declare build target '{target_name}' in '{manifest.path}'."
+            ) from exc
+        working_dir = resolve_build_target_working_dir(project, target_name, target_config)
+        targets.append((target_name, target_config, working_dir))
+    return tuple(targets)
+
+
+def all_build_targets(
+    project: ProjectLike,
+    manifest: BaseManifest,
+) -> tuple[tuple[str, BuildTargetConfig, Path], ...]:
+    build = manifest.build
+    if build is None or not build.targets:
+        raise BuildTargetError(f"Project '{project.name}' does not declare build targets in '{manifest.path}'.")
+
+    return tuple(
+        (
+            target_name,
+            target_config,
+            resolve_build_target_working_dir(project, target_name, target_config),
+        )
+        for target_name, target_config in build.targets.items()
+    )
+
+
+def resolve_build_target_working_dir(
+    project: ProjectLike,
+    target_name: str,
+    target_config: BuildTargetConfig,
+) -> Path:
+    field = f"build.targets.{target_name}.working_dir"
+    project_root = project.root.resolve()
+    declared_path = Path(target_config.working_dir)
+    if declared_path.is_absolute():
+        raise BuildTargetError(f"{project.manifest_path}: {field} must be a relative path inside the project root.")
+
+    candidate = (project_root / declared_path).resolve()
+    try:
+        candidate.relative_to(project_root)
+    except ValueError as exc:
+        raise BuildTargetError(
+            f"{project.manifest_path}: {field} resolves outside the project root: {target_config.working_dir}."
+        ) from exc
+
+    if not candidate.exists():
+        raise BuildTargetError(
+            f"{project.manifest_path}: {field} directory '{target_config.working_dir}' does not exist."
+        )
+    if not candidate.is_dir():
+        raise BuildTargetError(
+            f"{project.manifest_path}: {field} path '{target_config.working_dir}' is not a directory."
+        )
+    return candidate

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -14,6 +14,8 @@ import base_cli
 from base_cli.config import read_user_config
 from base_cli.paths import base_cache_root, base_state_root
 from base_cli.paths import discover_manifest
+from base_projects.build_targets import build_targets_project_from_args
+from base_projects.build_targets import list_build_targets_from_args
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import check_to_doctor_json
 from base_setup.checks import check_to_json
@@ -97,6 +99,7 @@ def dispatch_projects_command(
 ) -> int:
     command = arguments[0] if arguments else "list"
     command_arguments = arguments[1:] if arguments else ()
+    resolver = resolve_named_project
     handlers = {
         "list": lambda: list_projects_from_args(ctx, command_arguments, workspace, output_format),
         "status": lambda: workspace_status_from_args(ctx, command_arguments, workspace, output_format),
@@ -114,6 +117,8 @@ def dispatch_projects_command(
         "activation-sources": lambda: activation_sources_project_from_args(ctx, command_arguments, workspace),
         "run-command": lambda: run_command_project_from_args(ctx, command_arguments, workspace),
         "run-commands": lambda: list_run_commands_from_args(ctx, command_arguments, workspace),
+        "build-targets": lambda: build_targets_project_from_args(ctx, command_arguments, workspace, resolver),
+        "build-target-list": lambda: list_build_targets_from_args(ctx, command_arguments, workspace, resolver),
     }
     handler = handlers.get(command)
     if handler is not None:
@@ -121,7 +126,8 @@ def dispatch_projects_command(
 
     ctx.log.error(
         "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
-        "status, check, doctor, test-command, demo-script, activation-sources, run-command, run-commands.",
+        "status, check, doctor, test-command, demo-script, activation-sources, run-command, run-commands, "
+        "build-targets, build-target-list.",
         command,
     )
     return 2

--- a/cli/python/base_projects/tests/test_build_targets.py
+++ b/cli/python/base_projects/tests/test_build_targets.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_projects import engine
+
+
+def write_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
+def write_build_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "services" / "api").mkdir(parents=True)
+    (project_root / "services" / "worker").mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        "\n".join(
+            [
+                "project:",
+                f"  name: {name}",
+                "build:",
+                "  default:",
+                "    - api",
+                "    - worker",
+                "  targets:",
+                "    api:",
+                "      description: Build the API service.",
+                "      working_dir: services/api",
+                "      command: go build ./cmd/api",
+                "    worker:",
+                "      description: Build the worker service.",
+                "      working_dir: services/worker",
+                "      command: go build ./cmd/worker",
+                "artifacts: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_build_manifest_without_default(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "services" / "api").mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        "\n".join(
+            [
+                "project:",
+                f"  name: {name}",
+                "build:",
+                "  targets:",
+                "    api:",
+                "      working_dir: services/api",
+                "      command: go build ./cmd/api",
+                "artifacts: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    env = {
+        "HOME": str(base_home.parent / "home"),
+        "BASE_HOME": str(base_home),
+        "BASE_PROJECT": "",
+        "BASE_PROJECT_MANIFEST": "",
+    }
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class BuildTargetTests(unittest.TestCase):
+    def test_projects_build_targets_prints_default_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_build_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["build-targets", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\tapi\t{(project_root / 'services' / 'api').resolve()}\tgo build ./cmd/api\tBuild the API service.\n"
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\tworker\t{(project_root / 'services' / 'worker').resolve()}\tgo build ./cmd/worker"
+            "\tBuild the worker service.\n",
+        )
+
+    def test_projects_build_targets_prints_explicit_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_build_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["build-targets", "demo", "worker"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\tworker\t{(project_root / 'services' / 'worker').resolve()}\tgo build ./cmd/worker"
+            "\tBuild the worker service.\n",
+        )
+
+    def test_projects_build_target_list_prints_all_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_build_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["build-target-list", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("\tapi\t", stdout)
+        self.assertIn("\tworker\t", stdout)
+
+    def test_projects_build_targets_requires_build_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, _stdout, stderr = run_engine(["build-targets", "demo"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("does not declare build targets", stderr)
+
+    def test_projects_build_targets_requires_default_when_no_targets_are_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_build_manifest_without_default(workspace / "demo", "demo")
+
+            status, _stdout, stderr = run_engine(["build-targets", "demo"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("does not declare build.default", stderr)
+
+    def test_projects_build_targets_reports_unknown_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_build_manifest(workspace / "demo", "demo")
+
+            status, _stdout, stderr = run_engine(["build-targets", "demo", "web"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertIn("does not declare build target 'web'", stderr)

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -58,6 +58,19 @@ class DemoConfig:
 
 
 @dataclass(frozen=True)
+class BuildTargetConfig:
+    command: str
+    working_dir: str = "."
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class BuildConfig:
+    default: tuple[str, ...] = ()
+    targets: dict[str, BuildTargetConfig] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class PortHealthConfig:
     port: int
     state: str
@@ -90,6 +103,7 @@ class BaseManifest:
     commands: dict[str, str] = field(default_factory=dict)
     activate: ActivateConfig = field(default_factory=ActivateConfig)
     demo: DemoConfig | None = None
+    build: BuildConfig | None = None
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -121,6 +135,7 @@ def read_manifest(path: Path) -> BaseManifest:
         "commands",
         "activate",
         "demo",
+        "build",
     }
     unknown_top_level = sorted(set(data) - allowed_top_level)
     if unknown_top_level:
@@ -136,6 +151,7 @@ def read_manifest(path: Path) -> BaseManifest:
     commands = _read_commands(path, data.get("commands"))
     activate = _read_activate(path, data.get("activate"))
     demo = _read_demo(path, data.get("demo"))
+    build = _read_build(path, data.get("build"))
     artifacts = _read_artifacts(path, data.get("artifacts", []))
 
     return BaseManifest(
@@ -151,6 +167,7 @@ def read_manifest(path: Path) -> BaseManifest:
         commands=commands,
         activate=activate,
         demo=demo,
+        build=build,
     )
 
 
@@ -269,6 +286,110 @@ def _read_demo(path: Path, demo_data: Any) -> DemoConfig | None:
         description = description.strip()
 
     return DemoConfig(script=script, description=description)
+
+
+def _read_build(path: Path, build_data: Any) -> BuildConfig | None:
+    if build_data is None:
+        return None
+    if not isinstance(build_data, dict):
+        raise ManifestError(f"{path}: build must be a mapping when provided.")
+
+    allowed_keys = {"default", "targets"}
+    unknown_keys = sorted(set(build_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: build has unsupported keys: {', '.join(unknown_keys)}.")
+
+    targets = _read_build_targets(path, build_data.get("targets", {}))
+    default = _read_build_default(path, build_data.get("default", []), targets)
+    return BuildConfig(default=default, targets=targets)
+
+
+def _read_build_default(
+    path: Path,
+    default_data: Any,
+    targets: dict[str, BuildTargetConfig],
+) -> tuple[str, ...]:
+    if default_data is None:
+        return ()
+    if not isinstance(default_data, list):
+        raise ManifestError(f"{path}: build.default must be a list when provided.")
+
+    default: list[str] = []
+    seen: set[str] = set()
+    for index, target_data in enumerate(default_data, start=1):
+        if not isinstance(target_data, str) or not target_data.strip():
+            raise ManifestError(f"{path}: build.default[{index}] must be a non-empty string.")
+        target_name = target_data.strip()
+        if not COMMAND_NAME_RE.fullmatch(target_name):
+            raise ManifestError(f"{path}: build.default[{index}] must be a valid target name.")
+        if target_name in seen:
+            raise ManifestError(f"{path}: build.default[{index}] duplicates '{target_name}'.")
+        if target_name not in targets:
+            raise ManifestError(f"{path}: build.default[{index}] references unknown target '{target_name}'.")
+        seen.add(target_name)
+        default.append(target_name)
+    return tuple(default)
+
+
+def _read_build_targets(path: Path, targets_data: Any) -> dict[str, BuildTargetConfig]:
+    if targets_data is None:
+        return {}
+    if not isinstance(targets_data, dict):
+        raise ManifestError(f"{path}: build.targets must be a mapping when provided.")
+
+    targets: dict[str, BuildTargetConfig] = {}
+    for target_name_data, target_data in targets_data.items():
+        if not isinstance(target_name_data, str) or not target_name_data.strip():
+            raise ManifestError(f"{path}: build.targets keys must be non-empty strings.")
+        target_name = target_name_data.strip()
+        if not COMMAND_NAME_RE.fullmatch(target_name):
+            raise ManifestError(f"{path}: build.targets.{target_name} must be a valid target name.")
+        if target_name in targets:
+            raise ManifestError(f"{path}: build.targets duplicates '{target_name}'.")
+        targets[target_name] = _read_build_target(path, target_name, target_data)
+    return targets
+
+
+def _read_build_target(path: Path, target_name: str, target_data: Any) -> BuildTargetConfig:
+    if not isinstance(target_data, dict):
+        raise ManifestError(f"{path}: build.targets.{target_name} must be a mapping.")
+
+    allowed_keys = {"command", "working_dir", "description"}
+    unknown_keys = sorted(set(target_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(
+            f"{path}: build.targets.{target_name} has unsupported keys: {', '.join(unknown_keys)}."
+        )
+
+    command = target_data.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise ManifestError(f"{path}: build.targets.{target_name}.command must be a non-empty string.")
+    command = command.strip()
+    if _has_control_line_break(command):
+        raise ManifestError(f"{path}: build.targets.{target_name}.command must not contain control line breaks.")
+
+    working_dir = target_data.get("working_dir", ".")
+    if not isinstance(working_dir, str) or not working_dir.strip():
+        raise ManifestError(f"{path}: build.targets.{target_name}.working_dir must be a non-empty string.")
+    working_dir = working_dir.strip()
+    if _has_control_line_break(working_dir):
+        raise ManifestError(
+            f"{path}: build.targets.{target_name}.working_dir must not contain control line breaks."
+        )
+
+    description = target_data.get("description")
+    if description is not None:
+        if not isinstance(description, str) or not description.strip():
+            raise ManifestError(
+                f"{path}: build.targets.{target_name}.description must be a non-empty string when provided."
+            )
+        description = description.strip()
+        if _has_control_line_break(description):
+            raise ManifestError(
+                f"{path}: build.targets.{target_name}.description must not contain control line breaks."
+            )
+
+    return BuildTargetConfig(command=command, working_dir=working_dir, description=description)
 
 
 def _read_health(path: Path, health_data: Any) -> HealthConfig:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,6 +105,7 @@ layers. This keeps the product name and the control-plane action separate:
 - `basectl activate`
 - `basectl run`
 - `basectl test`
+- `basectl build`
 - `basectl demo`
 - `basectl logs`
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -166,6 +166,7 @@ list is `basectl --help`; this list summarizes the shipped public surface:
 - `doctor`
 - `activate`
 - `test`
+- `build`
 - `run`
 - `demo`
 - `repo`

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -59,7 +59,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test demo run repo clean logs config doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test build demo run repo clean logs config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -102,6 +102,9 @@ _base_basectl_completion() {
             ;;
         test)
             _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
+            ;;
+        build)
+            _base_basectl_completion_project_or_options "--workspace --dry-run --list -v -h --help" "$cur"
             ;;
         demo)
             _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -18,6 +18,7 @@ _base_basectl_completion() {
         'setup:Install and bootstrap the local Base CLI environment'
         'check:Verify the local Base CLI environment'
         'test:Run a project test command'
+        'build:Run project build targets'
         'demo:Run a project interactive demo'
         'run:Run a project command'
         'repo:Create, check, and configure repository baseline'
@@ -88,6 +89,17 @@ _base_basectl_completion() {
                 '--dry-run[Print the resolved test command without running it]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
+            ;;
+        build)
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--dry-run[Print resolved build commands without running them]' \
+                '--list[List build targets]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects' '*:Build target:'
             if [[ "$state" == projects ]]; then
                 project_names=("${(@f)$(_base_basectl_completion_project_names)}")
                 _describe -t projects 'Base project' project_names


### PR DESCRIPTION
## Summary
- Add manifest schema support for `build.default` and `build.targets`.
- Add `base_projects` build target resolution plus the new `basectl build` subcommand with `--list`, `--dry-run`, target selection, and extra argument forwarding.
- Document the build contract and add Bash/Python tests plus completion coverage.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_projects/engine.py cli/python/base_projects/build_targets.py cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_build_targets.py cli/python/base_setup/manifest.py`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_build_targets cli.python.base_projects.tests.test_engine`
- `git diff --check`
- `env -u BASE_HOME HOME=/private/tmp/base-build-home BASE_TEST_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bin/base-test`

## Demo Impact
- None in this PR. This adds the Base build command contract; base-demo and Banyan Labs can adopt it in follow-up project manifests.

Closes #474