### PR TITLE
Fix self-demo readonly BASE_HOME warning

### DIFF
--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -263,6 +263,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Base Self-Demo"* ]]
     [[ "$output" == *"Base self-demo complete."* ]]
+    [[ "$output" != *"BASE_HOME: readonly variable"* ]]
     grep -Fqx "basectl projects list --workspace $(dirname "$BASE_REPO_ROOT")" "$state_file"
     grep -Fqx "basectl check base" "$state_file"
     grep -Fqx "basectl doctor base" "$state_file"

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -14,11 +14,13 @@ base_demo_home() {
     cd -- "$(base_demo_script_dir)/.." && pwd -P
 }
 
-BASE_HOME="$(base_demo_home)" || {
-    printf 'ERROR: Unable to resolve Base home for demo.\n' >&2
-    exit 1
-}
-export BASE_HOME
+if [[ -z "${BASE_HOME:-}" ]]; then
+    BASE_HOME="$(base_demo_home)" || {
+        printf 'ERROR: Unable to resolve Base home for demo.\n' >&2
+        exit 1
+    }
+    export BASE_HOME
+fi
 
 # shellcheck source=/dev/null
 source "$BASE_HOME/base_init.sh" || {


### PR DESCRIPTION
## Summary

- Stop `demo/demo.sh` from reassigning `BASE_HOME` after `basectl` has already established the readonly Base runtime contract.
- Add a self-demo regression assertion so `basectl demo base -- --non-interactive` cannot reintroduce the readonly warning.

## Issue

Closes #490

## Validation

- `bats cli/bash/commands/basectl/tests/demo.bats`
- `/Users/rameshhp/work/base-worktrees/fix-490-20260607-demo-readonly-base-home/bin/basectl demo base -- --non-interactive`
- `./bin/base-test`
- `git diff --check`

## Demo Impact

The Base self-demo now starts cleanly without printing `BASE_HOME: readonly variable`. The walkthrough content and command flow are unchanged.

## Notes

The first real-demo validation attempt inside Codex sandbox was blocked from writing Base's normal cache directory under `~/Library/Caches`; rerunning the same command with approved filesystem access passed.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Relevant BATS and Python tests pass.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`