### PR TITLE
Fix build workspace usage guard

### DIFF
--- a/cli/bash/commands/basectl/subcommands/build.sh
+++ b/cli/bash/commands/basectl/subcommands/build.sh
@@ -116,12 +116,12 @@ base_build_subcommand_main() {
         esac
     done
 
-    [[ -n "$project" ]] || {
-        base_build_usage_error "Project name is required."
-        return $?
-    }
     [[ -n "$project" || "$workspace_requested" != "1" ]] || {
         base_build_usage_error "Option '--workspace' requires an explicit project name."
+        return $?
+    }
+    [[ -n "$project" ]] || {
+        base_build_usage_error "Project name is required."
         return $?
     }
 

--- a/cli/bash/commands/basectl/tests/build.bats
+++ b/cli/bash/commands/basectl/tests/build.bats
@@ -10,6 +10,24 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl build <project> [target...]"* ]]
 }
 
+@test "basectl build reports invalid arguments as usage errors" {
+    run_basectl build
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Project name is required."* ]]
+
+    run_basectl build --workspace
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--workspace' requires an argument."* ]]
+
+    run_basectl build --workspace "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--workspace' requires an explicit project name."* ]]
+
+    run_basectl build --unknown demo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unknown build option '--unknown'."* ]]
+}
+
 @test "basectl build runs default targets from target working directories" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"


### PR DESCRIPTION
## Summary

- Move the `basectl build --workspace`-without-project guard before the generic project-required guard.
- Add Bats coverage for `basectl build` usage errors, including the `--workspace` regression from #487.

## Issue

Closes #487

## Validation

- `bats cli/bash/commands/basectl/tests/build.bats`
- `./bin/basectl build --workspace /Users/rameshhp/work --dry-run`
- `./bin/base-test`
- `git diff --check`

## Demo Impact

None. This changes build command usage-error selection only; project demos are unchanged.

## Notes

The direct CLI check now exits with status 2 and prints `ERROR: Option '--workspace' requires an explicit project name.` for `basectl build --workspace <path>` without a project.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Relevant BATS and Python tests pass.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`