### PR TITLE
Fix build target argument errors

### DIFF
--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -27,8 +27,8 @@ def build_targets_project_from_args(
     workspace: str | None,
     resolve_project: ProjectResolver,
 ) -> int:
-    if not 1 <= len(arguments) <= 1000:
-        ctx.log.error("Command 'build-targets' expects between 1 and 1000 arguments; got %d.", len(arguments))
+    if len(arguments) < 1:
+        ctx.log.error("Command 'build-targets' requires at least 1 argument (project name); got %d.", len(arguments))
         return 2
     return build_targets_project_command(ctx, arguments[0], arguments[1:], workspace, resolve_project)
 
@@ -40,7 +40,7 @@ def list_build_targets_from_args(
     resolve_project: ProjectResolver,
 ) -> int:
     if len(arguments) != 1:
-        ctx.log.error("Command 'build-target-list' expects between 1 and 1 arguments; got %d.", len(arguments))
+        ctx.log.error("Command 'build-target-list' requires exactly 1 argument (project name); got %d.", len(arguments))
         return 2
     return list_build_targets_command(ctx, arguments[0], workspace, resolve_project)
 

--- a/cli/python/base_projects/tests/test_build_targets.py
+++ b/cli/python/base_projects/tests/test_build_targets.py
@@ -84,6 +84,57 @@ def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
 
 
 class BuildTargetTests(unittest.TestCase):
+    def test_projects_build_targets_requires_project_argument(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+
+            status, stdout, stderr = run_engine(["build-targets"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("requires at least 1 argument (project name); got 0", stderr)
+
+    def test_projects_build_targets_does_not_cap_target_arguments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_build_manifest(workspace / "demo", "demo")
+            targets = [f"target-{index}" for index in range(1001)]
+
+            status, stdout, stderr = run_engine(["build-targets", "demo", *targets], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("does not declare build target 'target-0'", stderr)
+        self.assertNotIn("expects between 1 and 1000 arguments", stderr)
+
+    def test_projects_build_target_list_requires_exactly_one_project_argument(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+
+            status, stdout, stderr = run_engine(["build-target-list"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("requires exactly 1 argument (project name); got 0", stderr)
+
+    def test_projects_build_target_list_rejects_extra_arguments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+
+            status, stdout, stderr = run_engine(["build-target-list", "demo", "api"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("requires exactly 1 argument (project name); got 2", stderr)
+
     def test_projects_build_targets_prints_default_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Replace confusing build-target parser usage text with exact/at-least argument wording.
- Remove the artificial 1000-argument ceiling from `build-targets` so only the required project name is validated at this layer.
- Add Python regression coverage for missing project names, extra `build-target-list` arguments, and many explicit build targets.

## Issue

Closes #488

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_build_targets.py`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m base_projects build-targets`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m base_projects build-target-list demo extra`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact

None. This only changes internal build-target resolver usage errors and tests.

## Notes

The first full-suite attempt inherited `BASE_HOME=/Users/rameshhp/work/base`, which made pytest import the main checkout while running this worktree's tests. A second attempt with `BASE_HOME` pointed at the worktree fixed imports but changed bootstrap's default source install path. The passing full-suite invocation was `env -u BASE_HOME ./bin/base-test`, letting the test script use the current worktree for imports while preserving bootstrap's test assumptions.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Relevant BATS and Python tests pass.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`