### PR TITLE
Add build target doctor checks

### DIFF
--- a/cli/python/base_setup/build.py
+++ b/cli/python/base_setup/build.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .checks import ArtifactCheck
+from .manifest import BaseManifest, BuildTargetConfig
+
+
+def check_build(manifest: BaseManifest) -> list[ArtifactCheck]:
+    if manifest.build is None:
+        return []
+
+    checks: list[ArtifactCheck] = []
+    for target_name, target_config in manifest.build.targets.items():
+        checks.append(check_build_target_working_dir(manifest, target_name, target_config))
+    return checks
+
+
+def check_build_target_working_dir(
+    manifest: BaseManifest,
+    target_name: str,
+    target_config: BuildTargetConfig,
+) -> ArtifactCheck:
+    field = f"build.targets.{target_name}.working_dir"
+    working_dir = Path(target_config.working_dir)
+    project_root = manifest.path.parent.resolve()
+
+    if working_dir.is_absolute():
+        return build_target_error(
+            manifest,
+            target_name,
+            f"{manifest.path}: {field} must be relative to the project root.",
+        )
+
+    resolved_working_dir = (project_root / working_dir).resolve()
+    try:
+        resolved_working_dir.relative_to(project_root)
+    except ValueError:
+        return build_target_error(
+            manifest,
+            target_name,
+            f"{manifest.path}: {field} resolves outside the project root: {target_config.working_dir}.",
+        )
+
+    if not resolved_working_dir.exists():
+        return build_target_error(
+            manifest,
+            target_name,
+            f"Build target '{target_name}' working directory '{target_config.working_dir}' does not exist.",
+        )
+    if not resolved_working_dir.is_dir():
+        return build_target_error(
+            manifest,
+            target_name,
+            f"Build target '{target_name}' working directory '{target_config.working_dir}' is not a directory.",
+        )
+
+    return ArtifactCheck(
+        name=f"build.targets.{target_name}",
+        ok=True,
+        message=f"Build target '{target_name}' working directory '{target_config.working_dir}' exists.",
+        fix="",
+        finding_id="BASE-P070",
+    )
+
+
+def build_target_error(manifest: BaseManifest, target_name: str, message: str) -> ArtifactCheck:
+    return ArtifactCheck(
+        name=f"build.targets.{target_name}",
+        ok=False,
+        message=message,
+        fix=f"Create the directory or update build.targets.{target_name}.working_dir in '{manifest.path}'.",
+        finding_id="BASE-P070",
+    )

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -12,6 +12,7 @@ from .artifacts import check_artifact
 from .artifacts import merge_artifacts
 from .artifacts import reconcile_artifacts
 from .artifacts import resolve_artifact_definitions
+from .build import check_build
 from .checks import ArtifactCheck
 from .checks import check_to_doctor_json
 from .checks import check_to_json
@@ -244,6 +245,7 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
 
     checks.extend(check_required_env(effective_manifest))
     checks.extend(check_required_ports(effective_manifest))
+    checks.extend(check_build(effective_manifest))
     checks.extend(check_demo(effective_manifest))
     checks.extend(check_ide_installs(effective_manifest))
     checks.extend(check_ide_extensions(effective_manifest))
@@ -279,4 +281,5 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         commands=manifest.commands,
         activate=manifest.activate,
         demo=manifest.demo,
+        build=manifest.build,
     )

--- a/cli/python/base_setup/tests/test_build.py
+++ b/cli/python/base_setup/tests/test_build.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from base_setup import build, engine
+from base_setup.manifest import BaseManifest, BuildConfig, BuildTargetConfig
+
+
+def default_manifest(path: Path) -> BaseManifest:
+    return BaseManifest(
+        path=path,
+        project_name="base-defaults",
+        brewfile=None,
+        artifacts=(),
+    )
+
+
+def build_manifest(
+    manifest_path: Path,
+    targets: dict[str, BuildTargetConfig],
+) -> BaseManifest:
+    return BaseManifest(
+        path=manifest_path,
+        project_name="demo",
+        brewfile=None,
+        artifacts=(),
+        build=BuildConfig(default=tuple(targets), targets=targets),
+    )
+
+
+class BuildDiagnosticsTests(unittest.TestCase):
+    def test_check_build_returns_no_checks_without_build_config(self) -> None:
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+
+        self.assertEqual(build.check_build(manifest), [])
+
+    def test_check_build_target_working_dir_reports_existing_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "services" / "api").mkdir(parents=True)
+            manifest = build_manifest(
+                project_root / "base_manifest.yaml",
+                {"api": BuildTargetConfig(command="go build ./cmd/api", working_dir="services/api")},
+            )
+
+            check = build.check_build(manifest)[0]
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P070")
+        self.assertEqual(check.name, "build.targets.api")
+        self.assertIn("working directory 'services/api' exists", check.message)
+
+    def test_check_build_target_working_dir_reports_missing_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = build_manifest(
+                project_root / "base_manifest.yaml",
+                {"api": BuildTargetConfig(command="go build ./cmd/api", working_dir="services/api")},
+            )
+
+            check = build.check_build(manifest)[0]
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P070")
+        self.assertIn("working directory 'services/api' does not exist", check.message)
+        self.assertIn("build.targets.api.working_dir", check.fix)
+
+    def test_check_build_target_working_dir_reports_file_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "services").mkdir()
+            (project_root / "services" / "api").write_text("not a directory\n", encoding="utf-8")
+            manifest = build_manifest(
+                project_root / "base_manifest.yaml",
+                {"api": BuildTargetConfig(command="go build ./cmd/api", working_dir="services/api")},
+            )
+
+            check = build.check_build(manifest)[0]
+
+        self.assertFalse(check.ok)
+        self.assertIn("working directory 'services/api' is not a directory", check.message)
+
+    def test_check_build_target_working_dir_rejects_absolute_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = build_manifest(
+                project_root / "base_manifest.yaml",
+                {"api": BuildTargetConfig(command="go build ./cmd/api", working_dir=str(project_root))},
+            )
+
+            check = build.check_build(manifest)[0]
+
+        self.assertFalse(check.ok)
+        self.assertIn("must be relative to the project root", check.message)
+
+    def test_check_build_target_working_dir_rejects_escaping_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = build_manifest(
+                project_root / "base_manifest.yaml",
+                {"api": BuildTargetConfig(command="go build ./cmd/api", working_dir="../api")},
+            )
+
+            check = build.check_build(manifest)[0]
+
+        self.assertFalse(check.ok)
+        self.assertIn("resolves outside the project root", check.message)
+
+    def test_manifest_checks_include_build_target_working_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "services" / "api").mkdir(parents=True)
+            manifest = build_manifest(
+                project_root / "base_manifest.yaml",
+                {"api": BuildTargetConfig(command="go build ./cmd/api", working_dir="services/api")},
+            )
+
+            checks = engine.manifest_checks(default_manifest(Path(tmpdir) / "default.yaml"), manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P070"])
+        self.assertTrue(checks[0].ok)
+
+    def test_doctor_manifest_reports_build_target_finding_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = build_manifest(
+                project_root / "base_manifest.yaml",
+                {"api": BuildTargetConfig(command="go build ./cmd/api", working_dir="services/api")},
+            )
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                status = engine.doctor_manifest(default_manifest(Path(tmpdir) / "default.yaml"), manifest, "json")
+
+        findings = json.loads(stdout.getvalue())
+        self.assertEqual(status, 1)
+        self.assertEqual([finding["id"] for finding in findings], ["BASE-P070"])
+        self.assertEqual([finding["name"] for finding in findings], ["build.targets.api"])
+        self.assertEqual([finding["status"] for finding in findings], ["error"])

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -66,6 +66,7 @@ part of the doctor workflow.
 | `BASE-P050` | Project virtual environment readiness |
 | `BASE-P060` | Project demo declaration |
 | `BASE-P061` | Project demo script path and executable status |
+| `BASE-P070` | Build target working directory status |
 | `BASE-P100` | User config disables all IDE setup and checks |
 | `BASE-P101` | User config disables setup and checks for one IDE |
 | `BASE-P102` | User IDE setting conflicts with a project manifest setting |


### PR DESCRIPTION
## Summary

- Add project doctor/check coverage for manifest build target working directories.
- Report `BASE-P070` for each build target, including missing, non-directory, absolute, and project-escaping working directories.
- Preserve `build` when applying effective user config so manifest checks can see build declarations.
- Document the new doctor finding ID in `docs/doctor-findings.md`.

## Issue

Closes #489

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_build.py cli/python/base_setup/tests/test_demo.py`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -c 'from pathlib import Path; from base_setup.engine import doctor_manifest; from base_setup.manifest import BaseManifest, BuildConfig, BuildTargetConfig; default=BaseManifest(path=Path("default.yaml"), project_name="base", brewfile=None, artifacts=()); manifest=BaseManifest(path=Path("/tmp/demo/base_manifest.yaml"), project_name="demo", brewfile=None, artifacts=(), build=BuildConfig(targets={"api": BuildTargetConfig(command="go build ./cmd/api", working_dir="services/api")})); raise SystemExit(doctor_manifest(default, manifest, "text"))'`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`
- `git diff --cached --check`

## Demo Impact

None. This changes project doctor/check diagnostics for build configuration; demos are unchanged.

## Notes

`env -u BASE_HOME` is used for full-suite worktree validation so `bin/base-test` imports this worktree's Python code without changing bootstrap tests that intentionally depend on the default `BASE_HOME` behavior.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Relevant BATS and Python tests pass.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`