### PR TITLE
docs: add reproducible debugging guidance

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,38 @@ Run the full command/library suite through:
 basectl test base
 ```
 
+## Reproducible debugging and completion checks
+
+Before changing behavior, capture a reproducible failure path:
+
+1. Save the exact failing command, args, and environment assumptions.
+2. Re-run once with full command output visible.
+3. Test one hypothesis at a time and stop when evidence confirms or rejects it.
+
+Start with narrow diagnostics in this order:
+
+```bash
+basectl check <project>
+basectl doctor <project>
+basectl test <project>
+```
+
+When failures cross boundaries, map each symptom to ownership:
+
+- Shell startup/profile changes: `lib/bash/` and `cli/bash/`.
+- Manifest and project-discovery behavior: `base_manifest.yaml`, `tests/integration/`, and command mapping code.
+- Runtime orchestration changes: `bin/basectl` and `lib/shell/runtime/`.
+- Python behavior changes: `cli/python/` and `lib/python/`.
+
+Use this completion gate before marking a change complete:
+
+- Run `git diff --check` and capture the command output.
+- Run the narrowest validation commands for the changed layer and capture successful
+  command transcripts in the PR.
+- Re-run the repro command(s) that previously failed to show the fix.
+- Record whether `basectl check` / `basectl doctor` output and exit status changed, and why.
+- If checks cannot run in the current environment, call that out explicitly in the PR notes.
+
 ## Integration Tests
 
 Integration tests live under `tests/integration/`. They run real `basectl`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,14 +45,18 @@ basectl test <project>
 ```
 
 `basectl check` and `basectl doctor` should be treated as read-only,
-non-mutating diagnostics. Use them to inspect the current workspace state
-before running setup, cleanup, or other commands that intentionally change it.
+non-mutating diagnostics. They should not install dependencies, rewrite shell
+profiles, change manifests, or mutate repositories. Use them to inspect the
+current workspace state before running setup, cleanup, or other commands that
+intentionally change it.
 
 When failures cross boundaries, map each symptom to ownership:
 
 - Shell startup/profile changes: `lib/bash/` and `cli/bash/`.
 - Manifest and project-discovery behavior: `base_manifest.yaml`, `tests/integration/`, and command mapping code.
-- Runtime orchestration changes: `bin/basectl`, `lib/bash/runtime/`, and `lib/shell/` for startup/profile snippets.
+- Runtime orchestration changes: `bin/basectl` and `lib/bash/runtime/` for
+  runtime shell code, plus `lib/shell/` only for shell startup/profile
+  snippets.
 - Python behavior changes: `cli/python/` and `lib/python/`.
 
 Use this completion gate before marking a change complete:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,11 +44,15 @@ basectl doctor <project>
 basectl test <project>
 ```
 
+`basectl check` and `basectl doctor` should be treated as read-only,
+non-mutating diagnostics. Use them to inspect the current workspace state
+before running setup, cleanup, or other commands that intentionally change it.
+
 When failures cross boundaries, map each symptom to ownership:
 
 - Shell startup/profile changes: `lib/bash/` and `cli/bash/`.
 - Manifest and project-discovery behavior: `base_manifest.yaml`, `tests/integration/`, and command mapping code.
-- Runtime orchestration changes: `bin/basectl` and `lib/shell/runtime/`.
+- Runtime orchestration changes: `bin/basectl`, `lib/bash/runtime/`, and `lib/shell/` for startup/profile snippets.
 - Python behavior changes: `cli/python/` and `lib/python/`.
 
 Use this completion gate before marking a change complete:


### PR DESCRIPTION
## Summary
- Add a Base-specific reproducible debugging workflow to `docs/testing.md`.
- Document completion checks that require fresh validation evidence before merge.

## Issue
Closes codeforester/base#500

## Validation
- `git diff --check`

## Demo Impact
None. Documentation/process only.

## Notes
Documentation-only change. Maintainer review is requesting a couple of small doc corrections before merge.