### PR TITLE
Document release Homebrew tap update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,9 @@ For contribution workflow, branch naming, tests, and PR expectations, see
 For GitHub labels, milestones, Projects, issue assignment, branch names, and
 worktree-based PR trains, see [GitHub Workflow](github-workflow.md).
 
+For release preparation, tagging, GitHub Releases, and the Homebrew tap update,
+see [Release Process](release-process.md).
+
 ## Naming Convention
 
 Use stable topic names for documentation files:
@@ -35,6 +38,8 @@ reference. The filename should answer "what is this about?"
   support plan and bootstrap boundaries.
 - [Runtime Environment](runtime-environment.md) is the canonical reference for
   Base-managed environment variables, `~/.baserc`, and mutability rules.
+- [Release Process](release-process.md) defines the Base release ceremony,
+  version-file policy, GitHub Release flow, and Homebrew tap follow-up.
 - [Testing](testing.md) explains Base's Python, BATS, and hermetic integration
   test layers.
 - [Tool Boundaries](tool-boundaries.md) records ecosystem decisions for tools

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -292,6 +292,10 @@ Suggested Base milestones:
 Every issue does not need a milestone. Use milestones when the issue contributes
 to a concrete release goal.
 
+For the release checklist itself, including `VERSION`, changelog, tags, GitHub
+Releases, and the follow-up `codeforester/homebrew-base` tap update, see
+[Release Process](release-process.md).
+
 ## Projects
 
 Use one GitHub Project first: `Base Roadmap`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,101 @@
+# Release Process
+
+Base releases are explicit release ceremonies, not automatic side effects of
+ordinary pull requests.
+
+Use this checklist when preparing and publishing a new Base release such as
+`0.3.1` or `0.4.0`.
+
+## Ownership
+
+The release spans two repositories:
+
+- `codeforester/base` owns Base source, release notes, `VERSION`, Git tags, and
+  GitHub Releases.
+- `codeforester/homebrew-base` owns the Homebrew formula that installs published
+  Base releases.
+
+The Homebrew tap update happens after the Base tag and GitHub Release exist.
+The formula points at a versioned tag archive and records that archive's
+`sha256`, so the archive must be available before the formula can be updated and
+validated.
+
+## Version Policy
+
+Do not update `VERSION` on every merged pull request.
+
+`VERSION` records the latest published Base release. Ordinary feature, fix,
+documentation, and maintenance PRs leave it unchanged. A release-prep PR updates
+`VERSION` once the next release number has been chosen.
+
+Keep upcoming changes under the `Unreleased` section in `CHANGELOG.md` until a
+release-prep PR moves them into a dated release section.
+
+## Base Release Checklist
+
+Complete these steps in `codeforester/base`:
+
+1. Choose the release version and create or use a GitHub issue for the release
+   artifact work.
+2. Create a release-prep branch and worktree from `origin/master`.
+3. Update release metadata:
+   - `VERSION`
+   - README version badge and current-release text
+   - `CHANGELOG.md`, moving relevant `Unreleased` entries into the new release
+     section
+4. Validate the release-prep PR:
+
+   ```bash
+   git diff --check
+   bin/base-test
+   ```
+
+5. Merge the release-prep PR into `master`.
+6. Sync local `master`.
+7. Create an annotated tag from the merged release commit:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+8. Publish the GitHub Release from the corresponding changelog section.
+9. Confirm the release tag and GitHub Release are visible on GitHub.
+
+## Homebrew Tap Checklist
+
+Complete these steps in `codeforester/homebrew-base` after the Base tag exists:
+
+1. Create a Homebrew tap update issue or PR for the new Base version.
+2. Update `Formula/base.rb`:
+   - `url` to the new Base tag archive
+   - `sha256` to the checksum of that archive
+   - `version` to the new Base version
+3. Compute the archive checksum from the published tag:
+
+   ```bash
+   curl -fsSL https://github.com/codeforester/base/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+   ```
+
+4. Validate the formula from the tap repository:
+
+   ```bash
+   brew install --build-from-source Formula/base.rb
+   brew test codeforester/base
+   brew audit --new --formula Formula/base.rb
+   ```
+
+5. Open and merge the tap PR.
+6. Smoke-test the consumer upgrade path:
+
+   ```bash
+   brew update
+   brew upgrade codeforester/base/base
+   ```
+
+## Cleanup
+
+After the Base release PR and Homebrew tap PR are merged, clean up their
+worktrees and branches. Keep the release issue or linked issue comments updated
+with the Base release URL and Homebrew tap PR URL so the release record has both
+halves of the ceremony.


### PR DESCRIPTION
## Summary
- Add `docs/release-process.md` with the Base release checklist, version policy, and Homebrew tap follow-up.
- Link the release process from the docs map and GitHub workflow guidance.

## Issue
Closes #516

## Validation
- `git diff --check`

## Demo Impact
None. Documentation/process only.

## Notes
Full test suite not run; this is a documentation-only change.