### PR TITLE
Standardize check JSON diagnostics

### DIFF
--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -55,29 +55,7 @@ base_doctor_print_json_finding() {
 }
 
 base_doctor_base_finding_id() {
-    case "$1" in
-        homebrew)
-            printf '%s\n' "BASE-D001"
-            ;;
-        xcode_command_line_tools)
-            printf '%s\n' "BASE-D002"
-            ;;
-        python)
-            printf '%s\n' "BASE-D003"
-            ;;
-        base_virtualenv)
-            printf '%s\n' "BASE-D004"
-            ;;
-        pyyaml)
-            printf '%s\n' "BASE-D005"
-            ;;
-        click)
-            printf '%s\n' "BASE-D006"
-            ;;
-        *)
-            printf '%s\n' "BASE-D000"
-            ;;
-    esac
+    setup_base_check_finding_id "$1"
 }
 
 base_doctor_print_check_json_results() {
@@ -214,9 +192,11 @@ base_doctor_run_json() {
     local errors=0 profile_errors=0 profile_json="[]"
     local project="$1"
     local project_errors=0 project_json="[]"
+    local status="ok"
 
     setup_collect_base_check_results warn || true
     errors="$(base_doctor_count_check_errors)"
+    status="$(setup_check_results_status)"
 
     if setup_profiles_enabled; then
         if profile_json="$(setup_run_base_dev_layer doctor --format json)"; then
@@ -226,6 +206,7 @@ base_doctor_run_json() {
             [[ -n "$profile_json" ]] || profile_json="[]"
             errors=$((errors + profile_errors))
         fi
+        status="$(setup_merge_diagnostic_status "$status" "$(setup_json_payload_status "$profile_json")")"
     fi
 
     if [[ -n "$project" ]]; then
@@ -236,10 +217,12 @@ base_doctor_run_json() {
             [[ -n "$project_json" ]] || project_json="[]"
             errors=$((errors + project_errors))
         fi
+        status="$(setup_merge_diagnostic_status "$status" "$(setup_json_payload_status "$project_json")")"
     fi
 
     printf '{\n'
-    printf '  "ok": %s' "$([[ "$errors" -eq 0 ]] && printf true || printf false)"
+    printf '  "schema_version": 1,\n'
+    printf '  "status": "%s"' "$(setup_json_escape "$status")"
     if [[ -n "$project" ]]; then
         printf ',\n'
         printf '  "project": "%s"' "$(setup_json_escape "$project")"

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -765,11 +765,21 @@ setup_print_project_venv_check_json() {
     local ok="$1"
     local message="$2"
     local fix="$3"
+    local project="$4"
+    local status
 
-    printf '[{"name":"project_virtualenv","ok":%s,"message":"%s","fix":"%s"}]\n' \
-        "$ok" \
+    status="$(setup_diagnostic_status_from_ok "$ok")"
+    printf '{\n'
+    printf '  "schema_version": 1,\n'
+    printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
+    printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
+    printf '  "checks": [\n'
+    printf '    {"id":"BASE-P050","status":"%s","name":"project_virtualenv","message":"%s","fix":"%s"}\n' \
+        "$(setup_json_escape "$status")" \
         "$(setup_json_escape "$message")" \
         "$(setup_json_escape "$fix")"
+    printf '  ]\n'
+    printf '}\n'
 }
 
 setup_print_project_venv_doctor_json() {
@@ -897,7 +907,8 @@ setup_run_project_artifact_layer() {
                 setup_print_project_venv_check_json \
                     false \
                     "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
-                    "$(setup_recovery_project_venv "$project")"
+                    "$(setup_recovery_project_venv "$project")" \
+                    "$project"
             fi
         elif [[ "$action" == doctor ]]; then
             printf 'error  %-9s  %-26s  %s\n' "BASE-P050" "Project virtualenv" "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
@@ -1181,21 +1192,95 @@ setup_json_escape() {
     printf '%s' "$output"
 }
 
+setup_diagnostic_status_from_ok() {
+    if [[ "$1" == true ]]; then
+        printf '%s\n' "ok"
+    else
+        printf '%s\n' "error"
+    fi
+}
+
+setup_merge_diagnostic_status() {
+    local current="$1"
+    local next="$2"
+
+    if [[ "$current" == error || "$next" == error ]]; then
+        printf '%s\n' "error"
+    elif [[ "$current" == warn || "$next" == warn ]]; then
+        printf '%s\n' "warn"
+    else
+        printf '%s\n' "ok"
+    fi
+}
+
+setup_json_payload_status() {
+    local payload="$1"
+
+    if [[ "$payload" == *'"status":"error"'* || "$payload" == *'"status": "error"'* ]]; then
+        printf '%s\n' "error"
+    elif [[ "$payload" == *'"status":"warn"'* || "$payload" == *'"status": "warn"'* ]]; then
+        printf '%s\n' "warn"
+    else
+        printf '%s\n' "ok"
+    fi
+}
+
+setup_check_results_status() {
+    local count i status="ok"
+
+    count="${#_BASE_SETUP_CHECK_NAMES[@]}"
+    for ((i = 0; i < count; i++)); do
+        status="$(setup_merge_diagnostic_status "$status" "$(setup_diagnostic_status_from_ok "${_BASE_SETUP_CHECK_OK[$i]}")")"
+    done
+
+    printf '%s\n' "$status"
+}
+
+setup_base_check_finding_id() {
+    case "$1" in
+        homebrew)
+            printf '%s\n' "BASE-D001"
+            ;;
+        xcode_command_line_tools)
+            printf '%s\n' "BASE-D002"
+            ;;
+        python)
+            printf '%s\n' "BASE-D003"
+            ;;
+        base_virtualenv)
+            printf '%s\n' "BASE-D004"
+            ;;
+        pyyaml)
+            printf '%s\n' "BASE-D005"
+            ;;
+        click)
+            printf '%s\n' "BASE-D006"
+            ;;
+        *)
+            printf '%s\n' "BASE-D000"
+            ;;
+    esac
+}
+
 setup_print_check_json_item() {
     local trailing_comma="$1"
-    local name="$2"
-    local ok="$3"
-    local message="$4"
+    local finding_id="$2"
+    local status="$3"
+    local name="$4"
+    local message="$5"
+    local fix="${6:-}"
 
-    printf '    {"name":"%s","ok":%s,"message":"%s"}%s\n' \
+    printf '    {"id":"%s","status":"%s","name":"%s","message":"%s","fix":"%s"}%s\n' \
+        "$(setup_json_escape "$finding_id")" \
+        "$(setup_json_escape "$status")" \
         "$(setup_json_escape "$name")" \
-        "$ok" \
         "$(setup_json_escape "$message")" \
+        "$(setup_json_escape "$fix")" \
         "$trailing_comma"
 }
 
 setup_print_check_json_results() {
-    local count i trailing_comma
+    local count fix i status trailing_comma
 
     count="${#_BASE_SETUP_CHECK_NAMES[@]}"
     for ((i = 0; i < count; i++)); do
@@ -1203,11 +1288,18 @@ setup_print_check_json_results() {
         if ((i == count - 1)); then
             trailing_comma=""
         fi
+        status="$(setup_diagnostic_status_from_ok "${_BASE_SETUP_CHECK_OK[$i]}")"
+        fix="${_BASE_SETUP_CHECK_RECOVERIES[$i]}"
+        if [[ "$status" == ok ]]; then
+            fix=""
+        fi
         setup_print_check_json_item \
             "$trailing_comma" \
+            "$(setup_base_check_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
+            "$status" \
             "${_BASE_SETUP_CHECK_NAMES[$i]}" \
-            "${_BASE_SETUP_CHECK_OK[$i]}" \
-            "${_BASE_SETUP_CHECK_MESSAGES[$i]}"
+            "${_BASE_SETUP_CHECK_MESSAGES[$i]}" \
+            "$fix"
     done
 }
 
@@ -1229,29 +1321,35 @@ setup_print_json_property_value() {
 }
 
 setup_run_check_json() {
-    local missing=0
-    local profile_json="[]"
+    local profile_json=""
+    local profile_status="ok"
     local project="${BASE_SETUP_PROJECT_NAME:-}"
-    local project_json="[]"
+    local project_json=""
+    local project_status="ok"
+    local status
 
-    setup_collect_base_check_results warn || missing=1
+    setup_collect_base_check_results warn || true
+    status="$(setup_check_results_status)"
 
     if setup_profiles_enabled; then
         if ! profile_json="$(setup_run_base_dev_layer check --format json)"; then
-            missing=1
-            [[ -n "$profile_json" ]] || profile_json="[]"
+            [[ -n "$profile_json" ]] || profile_json='{"schema_version":1,"status":"error","profiles":[],"checks":[]}'
         fi
+        profile_status="$(setup_json_payload_status "$profile_json")"
+        status="$(setup_merge_diagnostic_status "$status" "$profile_status")"
     fi
 
     if [[ -n "$project" ]]; then
         if ! project_json="$(setup_run_project_artifact_check_json)"; then
-            missing=1
-            [[ -n "$project_json" ]] || project_json="[]"
+            [[ -n "$project_json" ]] || project_json='{"schema_version":1,"status":"error","checks":[]}'
         fi
+        project_status="$(setup_json_payload_status "$project_json")"
+        status="$(setup_merge_diagnostic_status "$status" "$project_status")"
     fi
 
     printf '{\n'
-    printf '  "ok": %s,\n' "$([[ "$missing" -eq 0 ]] && printf true || printf false)"
+    printf '  "schema_version": 1,\n'
+    printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
     if [[ -n "$project" ]]; then
         printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
     fi
@@ -1276,7 +1374,7 @@ setup_run_check_json() {
     fi
     printf '}\n'
 
-    [[ "$missing" -eq 0 ]]
+    [[ "$status" != error ]]
 }
 
 setup_run_install() {

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -217,12 +217,14 @@ load ./setup_helpers.bash
         "$BASE_REPO_ROOT/bin/basectl" check --format json
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *'"ok": true'* ]]
-    [[ "$output" == *'"name":"homebrew","ok":true'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "ok"'* ]]
+    [[ "$output" == *'"id":"BASE-D001","status":"ok","name":"homebrew"'* ]]
     [[ "$output" != *'"name":"bats"'* ]]
-    [[ "$output" == *'"name":"pyyaml","ok":true'* ]]
-    [[ "$output" == *'"name":"click","ok":true'* ]]
-    [[ "$output" == *'"name":"base_virtualenv","ok":true'* ]]
+    [[ "$output" == *'"id":"BASE-D005","status":"ok","name":"pyyaml"'* ]]
+    [[ "$output" == *'"id":"BASE-D006","status":"ok","name":"click"'* ]]
+    [[ "$output" == *'"id":"BASE-D004","status":"ok","name":"base_virtualenv"'* ]]
+    [[ "$output" != *'"ok":'* ]]
     venv_line="$(printf '%s\n' "$output" | grep -n '"name":"base_virtualenv"' | cut -d: -f1)"
     pyyaml_line="$(printf '%s\n' "$output" | grep -n '"name":"pyyaml"' | cut -d: -f1)"
     click_line="$(printf '%s\n' "$output" | grep -n '"name":"click"' | cut -d: -f1)"
@@ -258,8 +260,10 @@ load ./setup_helpers.bash
         "$BASE_REPO_ROOT/bin/basectl" check --format json
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *'"ok": false'* ]]
-    [[ "$output" == *'"name":"base_virtualenv","ok":false'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "error"'* ]]
+    [[ "$output" == *'"id":"BASE-D004","status":"error","name":"base_virtualenv"'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
     [ "${stderr:-}" = "" ]
 }
@@ -326,9 +330,13 @@ load ./setup_helpers.bash
         "$BASE_REPO_ROOT/bin/basectl" check demo --format json
 
     [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "ok"'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
-    [[ "$output" == *'"name":"demo-artifact","ok":true'* || "$output" == *'"name": "demo-artifact"'* ]]
+    [[ "$output" == *'"schema_version":1,"status":"ok","project":"demo","checks"'* ]]
+    [[ "$output" == *'"id":"BASE-P040","status":"ok","name":"demo-artifact"'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [ "${stderr:-}" = "" ]
 }
 
@@ -363,10 +371,12 @@ load ./setup_helpers.bash
         "$BASE_REPO_ROOT/bin/basectl" check demo --format json
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "error"'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
-    [[ "$output" == *'"name":"project_virtualenv","ok":false'* ]]
+    [[ "$output" == *'"id":"BASE-P050","status":"error","name":"project_virtualenv"'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
     [[ "$output" == *"Run 'basectl setup demo --recreate-venv' to back up and recreate the project virtual environment."* ]]
     [ "${stderr:-}" = "" ]
@@ -396,13 +406,15 @@ load ./setup_helpers.bash
         "$BASE_REPO_ROOT/bin/basectl" check --profile dev --format json
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "error"'* ]]
     [[ "$output" == *'"profile_checks":'* ]]
     [[ "$output" != *'"dev_checks":'* ]]
     [[ "$output" == *"bats-core"* ]]
     [[ "$output" == *"gh"* ]]
-    [[ "$output" == *'"name":"pyyaml","ok":true'* ]]
-    [[ "$output" == *'"name":"click","ok":true'* ]]
+    [[ "$output" == *'"id":"BASE-D005","status":"ok","name":"pyyaml"'* ]]
+    [[ "$output" == *'"id":"BASE-D006","status":"ok","name":"click"'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [ "$(cat "$TEST_STATE_DIR/dev-args")" = "$(printf '%s\n' check --format json --profile dev)" ]
     [ "${stderr:-}" = "" ]
 }
@@ -452,11 +464,13 @@ load ./setup_helpers.bash
         "$BASE_REPO_ROOT/bin/basectl" check --format json
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *'"ok": false'* ]]
-    [[ "$output" == *'"name":"homebrew","ok":false'* ]]
-    [[ "$output" == *'"name":"pyyaml","ok":false'* ]]
-    [[ "$output" == *'"name":"click","ok":false'* ]]
-    [[ "$output" == *'"name":"base_virtualenv","ok":false'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "error"'* ]]
+    [[ "$output" == *'"id":"BASE-D001","status":"error","name":"homebrew"'* ]]
+    [[ "$output" == *'"id":"BASE-D005","status":"error","name":"pyyaml"'* ]]
+    [[ "$output" == *'"id":"BASE-D006","status":"error","name":"click"'* ]]
+    [[ "$output" == *'"id":"BASE-D004","status":"error","name":"base_virtualenv"'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [ "${stderr:-}" = "" ]
 }

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -254,8 +254,10 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" doctor --format json
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "error"'* ]]
     [[ "$output" == *'"findings":'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *'"id":"BASE-D001","status":"error","name":"homebrew","message":"Homebrew is not installed.","fix":"Run '\''basectl setup'\'' to install Homebrew, or install it manually from https://brew.sh/."'* ]]
     [[ "$output" == *'"id":"BASE-D002","status":"error","name":"xcode_command_line_tools"'* ]]
     [[ "$output" == *'"id":"BASE-D003","status":"error","name":"python"'* ]]
@@ -425,9 +427,11 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" doctor demo --format json
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *'"ok": true'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "warn"'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_findings":'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *'"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"'* ]]
     [[ "$output" != *"Running Python project doctor layer."* ]]
     [ "${stderr:-}" = "" ]
@@ -498,9 +502,11 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" doctor demo --format json
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *'"ok": false'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "error"'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_findings":'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *'"id":"BASE-P050","status":"error","name":"project_virtualenv"'* ]]
     [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
     [[ "$output" == *"Run 'basectl setup demo --recreate-venv' to back up and recreate the project virtual environment."* ]]

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -175,7 +175,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
             ;;
         check)
             if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
-                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]\n'
+                printf '{"schema_version":1,"status":"error","profiles":["dev"],"checks":[{"id":"BASE-D104","status":"error","name":"bats-core","message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"id":"BASE-D104","status":"error","name":"gh","message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]}\n'
             else
                 printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
                 printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
@@ -222,7 +222,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
             ;;
         check)
             if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
-                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]\n'
+                printf '{"schema_version":1,"status":"error","profiles":["dev"],"checks":[{"id":"BASE-D104","status":"error","name":"bats-core","message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"id":"BASE-D104","status":"error","name":"gh","message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]}\n'
             else
                 printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
                 printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
@@ -323,7 +323,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
             ;;
         check)
             if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
-                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]\n'
+                printf '{"schema_version":1,"status":"error","profiles":["dev"],"checks":[{"id":"BASE-D104","status":"error","name":"bats-core","message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"id":"BASE-D104","status":"error","name":"gh","message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]}\n'
             else
                 printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
                 printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
@@ -455,7 +455,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
     case "${1:-}" in
         check)
             if [[ "${2:-}" == "--format" && "${3:-}" == "json" ]]; then
-                printf '[{"name":"bats-core","ok":false,"message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"name":"gh","ok":false,"message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]\n'
+                printf '{"schema_version":1,"status":"error","profiles":["dev"],"checks":[{"id":"BASE-D104","status":"error","name":"bats-core","message":"Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.","fix":"basectl setup --profile dev"},{"id":"BASE-D104","status":"error","name":"gh","message":"Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.","fix":"basectl setup --profile dev"}]}\n'
             else
                 printf 'Artifact '\''bats-core'\'' is not installed via Homebrew package '\''bats-core'\''.\n' >&2
                 printf 'Artifact '\''gh'\'' is not installed via Homebrew package '\''gh'\''.\n' >&2
@@ -506,7 +506,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
         shift || true
     done
     if [[ "$action" == "check" && "$output_format" == "json" ]]; then
-        printf '[{"name":"demo-artifact","ok":true,"message":"Project artifact check passed.","fix":""}]\n'
+        printf '{"schema_version":1,"status":"ok","project":"demo","checks":[{"id":"BASE-P040","status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""}]}\n'
     elif [[ "$action" == "check" ]]; then
         printf 'Project artifact check passed.\n' >&2
     elif [[ "$action" == "doctor" ]]; then

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.artifacts import reconcile_artifact, resolve_artifact_definitions
 from base_setup.errors import ArtifactError
 from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError, read_manifest
@@ -269,7 +270,12 @@ def check_profile_manifests(
             profile=profile_manifest.name,
         )
     )
-    return print_check_results(ctx, checks, output_format=output_format)
+    return print_check_results(
+        ctx,
+        checks,
+        output_format=output_format,
+        profiles=tuple(profile_manifest.name for profile_manifest in profile_manifests),
+    )
 
 
 def check_profiles(
@@ -279,7 +285,7 @@ def check_profiles(
     output_format: str,
 ) -> int:
     checks = collect_profile_checks(profiles, profile_manifests)
-    return print_check_results(ctx, checks, output_format=output_format)
+    return print_check_results(ctx, checks, output_format=output_format, profiles=profiles)
 
 
 def check_dev_artifacts(
@@ -289,12 +295,27 @@ def check_dev_artifacts(
     output_format: str,
 ) -> int:
     checks = dev_checks(artifacts, definitions, profile="dev")
-    return print_check_results(ctx, checks, output_format=output_format)
+    return print_check_results(ctx, checks, output_format=output_format, profiles=("dev",))
 
 
-def print_check_results(ctx: base_cli.Context, checks: tuple[DevCheck, ...], output_format: str) -> int:
+def print_check_results(
+    ctx: base_cli.Context,
+    checks: tuple[DevCheck, ...],
+    output_format: str,
+    profiles: tuple[str, ...],
+) -> int:
     if output_format == "json":
-        print(json.dumps([check_to_json(check) for check in checks], indent=2))
+        print(
+            json.dumps(
+                {
+                    "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
+                    "status": checks_status(checks),
+                    "profiles": list(profiles),
+                    "checks": [check_to_json(check) for check in checks],
+                },
+                indent=2,
+            )
+        )
     elif output_format == "text":
         for check in checks:
             if check.ok:
@@ -305,7 +326,7 @@ def print_check_results(ctx: base_cli.Context, checks: tuple[DevCheck, ...], out
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
         return 2
 
-    return 0 if all(check.ok for check in checks) else 1
+    return 0 if all(doctor_status(check) != "error" for check in checks) else 1
 
 
 def doctor_profile_manifests(
@@ -535,16 +556,7 @@ def check_github_cli_auth() -> DevCheck:
     )
 
 
-def check_to_json(check: DevCheck) -> dict[str, str | bool]:
-    return {
-        "name": check.name,
-        "ok": check.ok,
-        "message": check.message,
-        "fix": check.fix,
-    }
-
-
-def check_to_doctor_json(check: DevCheck) -> dict[str, str]:
+def check_to_json(check: DevCheck) -> dict[str, str]:
     return {
         "id": check.finding_id,
         "status": doctor_status(check),
@@ -552,6 +564,19 @@ def check_to_doctor_json(check: DevCheck) -> dict[str, str]:
         "message": check.message,
         "fix": check.fix,
     }
+
+
+def check_to_doctor_json(check: DevCheck) -> dict[str, str]:
+    return check_to_json(check)
+
+
+def checks_status(checks: tuple[DevCheck, ...]) -> str:
+    statuses = tuple(doctor_status(check) for check in checks)
+    if "error" in statuses:
+        return "error"
+    if "warn" in statuses:
+        return "warn"
+    return "ok"
 
 
 def doctor_status(check: DevCheck) -> str:

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -145,10 +145,17 @@ class DevManifestTests(unittest.TestCase):
         ):
             status, stdout, stderr = run_engine(["check", "--profile", "sre", "--format", "json"])
 
-        findings = json.loads(stdout)
+        payload = json.loads(stdout)
+        findings = payload["checks"]
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["profiles"], ["sre"])
         self.assertEqual(findings[0]["name"], "kubectl")
+        self.assertEqual(findings[0]["id"], "BASE-D104")
+        self.assertEqual(findings[0]["status"], "error")
+        self.assertNotIn("ok", findings[0])
         self.assertEqual(findings[0]["fix"], "basectl setup --profile sre")
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
@@ -159,9 +166,13 @@ class DevManifestTests(unittest.TestCase):
                 extra_env={"PATH": bin_dir},
             )
 
-        findings = json.loads(stdout)
+        payload = json.loads(stdout)
+        findings = payload["checks"]
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["profiles"], ["ai"])
         self.assertEqual([finding["name"] for finding in findings], ["codex", "claude"])
         self.assertEqual(findings[0]["fix"], "basectl setup --profile ai")
         self.assertEqual(findings[1]["fix"], "basectl setup --profile ai")
@@ -183,10 +194,15 @@ class DevManifestTests(unittest.TestCase):
                 extra_env={"PATH": bin_dir},
             )
 
-        findings = json.loads(stdout)
+        payload = json.loads(stdout)
+        findings = payload["checks"]
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertTrue(all(finding["ok"] for finding in findings))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["profiles"], ["ai"])
+        self.assertTrue(all(finding["status"] == "ok" for finding in findings))
+        self.assertTrue(all("ok" not in finding for finding in findings))
         self.assertIn(str(bin_path / "codex"), findings[0]["message"])
         self.assertIn("codex 1.2.3", findings[0]["message"])
         self.assertIn(str(bin_path / "claude"), findings[1]["message"])
@@ -205,15 +221,20 @@ class DevManifestTests(unittest.TestCase):
                 extra_env={"PATH": bin_dir},
             )
 
-        findings = json.loads(stdout)
+        payload = json.loads(stdout)
+        findings = payload["checks"]
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["profiles"], ["ai"])
         self.assertEqual(findings[0]["name"], "codex")
-        self.assertFalse(findings[0]["ok"])
+        self.assertEqual(findings[0]["status"], "error")
+        self.assertNotIn("ok", findings[0])
         self.assertEqual(findings[0]["fix"], "basectl setup --profile ai")
         self.assertIn("Codex CLI version check failed with exit 7", findings[0]["message"])
         self.assertIn("codex crashed", findings[0]["message"])
-        self.assertTrue(findings[1]["ok"])
+        self.assertEqual(findings[1]["status"], "ok")
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_check_multiple_profiles_combines_results_once_per_profile(self) -> None:
@@ -225,9 +246,13 @@ class DevManifestTests(unittest.TestCase):
                 ["check", "--profile", "dev,sre", "--format", "json"]
             )
 
-        findings = json.loads(stdout)
+        payload = json.loads(stdout)
+        findings = payload["checks"]
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["profiles"], ["dev", "sre"])
         names = [finding["name"] for finding in findings]
         self.assertIn("bats-core", names)
         self.assertIn("kubectl", names)
@@ -259,11 +284,16 @@ class DevManifestTests(unittest.TestCase):
             status, stdout, stderr = run_engine(["check", "--format", "json"])
 
         self.assertEqual(status, 1)
-        self.assertIn('"name": "bats-core"', stdout)
-        self.assertIn('"ok": false', stdout)
-        self.assertIn('"name": "gh"', stdout)
-        self.assertIn('"name": "shellcheck"', stdout)
         self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        findings = payload["checks"]
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["profiles"], ["dev"])
+        self.assertIn("bats-core", [finding["name"] for finding in findings])
+        self.assertIn("gh", [finding["name"] for finding in findings])
+        self.assertIn("shellcheck", [finding["name"] for finding in findings])
+        self.assertTrue(all("ok" not in finding for finding in findings))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_check_json_reports_invalid_github_auth_when_gh_is_installed(self) -> None:
@@ -284,13 +314,15 @@ class DevManifestTests(unittest.TestCase):
         ):
             status, stdout, stderr = run_engine(["check", "--format", "json"])
 
-        findings = json.loads(stdout)
+        payload = json.loads(stdout)
+        findings = payload["checks"]
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
         self.assertIn(
             {
+                "id": "BASE-D106",
+                "status": "error",
                 "name": "gh-auth",
-                "ok": False,
                 "message": "GitHub CLI authentication is not ready.",
                 "fix": "gh auth login -h github.com",
             },

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -17,8 +17,10 @@ from base_cli.paths import discover_manifest
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
 from base_setup.checks import ArtifactCheck
+from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.checks import check_to_doctor_json
 from base_setup.checks import check_to_json
+from base_setup.checks import checks_status
 from base_setup.checks import doctor_status
 from base_setup.checks import print_doctor_finding
 from base_setup.demo import resolve_demo_script_path
@@ -672,15 +674,6 @@ def project_venv_check(project_name: str) -> ArtifactCheck:
     )
 
 
-def checks_status(checks: tuple[ArtifactCheck, ...]) -> str:
-    statuses = tuple(doctor_status(check) for check in checks)
-    if "error" in statuses:
-        return "error"
-    if "warn" in statuses:
-        return "warn"
-    return "ok"
-
-
 def workspace_error_count(results: tuple[WorkspaceProjectCheckResult, ...]) -> int:
     return sum(1 for result in results for check in result.checks if doctor_status(check) == "error")
 
@@ -718,6 +711,7 @@ def workspace_checks_to_json(
     doctor: bool,
 ) -> dict[str, Any]:
     return {
+        "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
         "workspace": str(workspace_root),
         "status": checks_status(tuple(check for result in results for check in result.checks)),
         "project_count": len(results),
@@ -735,13 +729,10 @@ def workspace_checks_to_json(
     }
 
 
-def workspace_check_item_to_json(check: ArtifactCheck, doctor: bool) -> dict[str, str | bool]:
+def workspace_check_item_to_json(check: ArtifactCheck, doctor: bool) -> dict[str, str]:
     if doctor:
         return check_to_doctor_json(check)
-    payload = check_to_json(check)
-    payload["id"] = check.finding_id
-    payload["status"] = doctor_status(check)
-    return payload
+    return check_to_json(check)
 
 
 def print_workspace_status(workspace_root: Path, statuses: tuple[WorkspaceProjectStatus, ...]) -> None:

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -94,6 +94,7 @@ class WorkspaceCheckTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["workspace"], str(workspace.resolve()))
         self.assertEqual(payload["status"], "error")
         self.assertEqual(payload["project_count"], 1)
@@ -101,7 +102,7 @@ class WorkspaceCheckTests(unittest.TestCase):
         self.assertEqual(payload["projects"][0]["status"], "error")
         self.assertEqual(payload["projects"][0]["checks"][0]["id"], "BASE-P050")
         self.assertEqual(payload["projects"][0]["checks"][0]["status"], "error")
-        self.assertEqual(payload["projects"][0]["checks"][0]["ok"], False)
+        self.assertNotIn("ok", payload["projects"][0]["checks"][0])
 
     def test_workspace_doctor_supports_json_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -123,6 +124,7 @@ class WorkspaceCheckTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["workspace"], str(workspace.resolve()))
         self.assertEqual(payload["projects"][0]["checks"][0]["id"], "BASE-P050")
         self.assertEqual(payload["projects"][0]["checks"][0]["status"], "error")

--- a/cli/python/base_setup/checks.py
+++ b/cli/python/base_setup/checks.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Any
+
+
+DIAGNOSTIC_JSON_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -13,22 +18,36 @@ class ArtifactCheck:
     status: str = ""
 
 
-def check_to_json(check: ArtifactCheck) -> dict[str, str | bool]:
-    return {
-        "name": check.name,
-        "ok": check.ok,
-        "message": check.message,
-        "fix": check.fix,
-    }
-
-
-def check_to_doctor_json(check: ArtifactCheck) -> dict[str, str]:
+def check_to_json(check: ArtifactCheck) -> dict[str, str]:
     return {
         "id": check.finding_id,
         "status": doctor_status(check),
         "name": check.name,
         "message": check.message,
         "fix": check.fix,
+    }
+
+
+def check_to_doctor_json(check: ArtifactCheck) -> dict[str, str]:
+    return check_to_json(check)
+
+
+def checks_status(checks: Iterable[ArtifactCheck]) -> str:
+    statuses = tuple(doctor_status(check) for check in checks)
+    if "error" in statuses:
+        return "error"
+    if "warn" in statuses:
+        return "warn"
+    return "ok"
+
+
+def checks_payload_to_json(checks: Iterable[ArtifactCheck], **metadata: Any) -> dict[str, Any]:
+    check_tuple = tuple(checks)
+    return {
+        "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
+        "status": checks_status(check_tuple),
+        **metadata,
+        "checks": [check_to_json(check) for check in check_tuple],
     }
 
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -15,7 +15,7 @@ from .artifacts import resolve_artifact_definitions
 from .build import check_build
 from .checks import ArtifactCheck
 from .checks import check_to_doctor_json
-from .checks import check_to_json
+from .checks import checks_payload_to_json
 from .checks import doctor_status
 from .checks import print_doctor_finding
 from .demo import check_demo
@@ -193,7 +193,7 @@ def check_manifest(
 ) -> int:
     checks = manifest_checks(default_manifest, manifest)
     if output_format == "json":
-        print(json.dumps([check_to_json(check) for check in checks], indent=2))
+        print(json.dumps(checks_payload_to_json(checks, project=manifest.project_name), indent=2))
     elif output_format == "text":
         ctx.log.info("Checking project '%s' manifest requirements.", manifest.project_name)
         for check in checks:

--- a/cli/python/base_setup/tests/test_demo.py
+++ b/cli/python/base_setup/tests/test_demo.py
@@ -109,10 +109,15 @@ class DemoDiagnosticsTests(unittest.TestCase):
             with redirect_stdout(stdout):
                 status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
 
-        checks = json.loads(stdout.getvalue())
+        payload = json.loads(stdout.getvalue())
+        checks = payload["checks"]
         self.assertEqual(status, 0)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["project"], "demo")
         self.assertEqual([check["name"] for check in checks], ["demo declaration", "demo script"])
-        self.assertTrue(all(check["ok"] for check in checks))
+        self.assertTrue(all(check["status"] == "ok" for check in checks))
+        self.assertTrue(all("ok" not in check for check in checks))
 
     def test_doctor_manifest_reports_demo_finding_ids(self) -> None:
         default_manifest = BaseManifest(

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -46,10 +46,17 @@ class ProjectCheckTests(unittest.TestCase):
                 ["--action", "check", "--format", "json", "--manifest", str(manifest_path), "demo"]
             )
 
+        payload = json.loads(stdout)
+        checks = payload["checks"]
         self.assertEqual(status, 1)
-        self.assertIn('"name": "requests"', stdout)
-        self.assertIn('"ok": false', stdout)
-        self.assertIn('"fix": "basectl setup demo"', stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["project"], "demo")
+        request_checks = [check for check in checks if check["name"] == "requests"]
+        self.assertEqual(len(request_checks), 1)
+        self.assertEqual(request_checks[0]["status"], "error")
+        self.assertNotIn("ok", request_checks[0])
+        self.assertEqual(request_checks[0]["fix"], "basectl setup demo")
 
 
 
@@ -208,9 +215,13 @@ class ProjectCheckTests(unittest.TestCase):
                 doctor_status = engine.doctor_manifest(default_manifest, manifest, output_format="json")
 
         output = stdout.getvalue()
-        parsed_checks = json.loads(output)
+        payload = json.loads(output)
+        parsed_checks = payload["checks"]
         doctor_findings = json.loads(doctor_stdout.getvalue())
         self.assertEqual(status, 1)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["project"], "demo")
         self.assertEqual(doctor_status, 2)
         self.assertEqual(
             [check["name"] for check in parsed_checks],
@@ -232,9 +243,8 @@ class ProjectCheckTests(unittest.TestCase):
                 "BASE_TEST_REQUIRED_EMPTY",
             ],
         )
-        self.assertTrue(parsed_checks[0]["ok"])
-        self.assertFalse(parsed_checks[1]["ok"])
-        self.assertFalse(parsed_checks[2]["ok"])
+        self.assertEqual([check["status"] for check in parsed_checks], ["ok", "error", "error"])
+        self.assertTrue(all("ok" not in check for check in parsed_checks))
         self.assertEqual(
             parsed_checks[1]["message"],
             "Environment variable 'BASE_TEST_REQUIRED_MISSING' is not set or is empty.",
@@ -293,15 +303,18 @@ class ProjectCheckTests(unittest.TestCase):
                     output_format="json",
                 )
 
-        parsed_checks = json.loads(stdout.getvalue())
+        payload = json.loads(stdout.getvalue())
+        parsed_checks = payload["checks"]
         self.assertEqual(status, 1)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["project"], "demo")
         self.assertEqual(
             [check["name"] for check in parsed_checks],
             ["postgres", "app", "busy-app"],
         )
-        self.assertTrue(parsed_checks[0]["ok"])
-        self.assertTrue(parsed_checks[1]["ok"])
-        self.assertFalse(parsed_checks[2]["ok"])
+        self.assertEqual([check["status"] for check in parsed_checks], ["ok", "ok", "error"])
+        self.assertTrue(all("ok" not in check for check in parsed_checks))
         self.assertIn("already listening", parsed_checks[2]["message"])
         self.assertEqual(
             parsed_checks[2]["fix"],
@@ -446,11 +459,15 @@ class ProjectCheckTests(unittest.TestCase):
                     output_format="json",
                 )
 
-        checks = json.loads(stdout.getvalue())
+        payload = json.loads(stdout.getvalue())
+        checks = payload["checks"]
         self.assertEqual(status, 0)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "warn")
+        self.assertEqual(payload["project"], "demo")
         self.assertEqual([check["name"] for check in checks], ["pyproject.toml", "pyproject dependencies"])
-        self.assertTrue(checks[0]["ok"])
-        self.assertFalse(checks[1]["ok"])
+        self.assertEqual([check["status"] for check in checks], ["ok", "warn"])
+        self.assertTrue(all("ok" not in check for check in checks))
         self.assertIn("does not reconcile yet", checks[1]["message"])
 
 
@@ -521,13 +538,18 @@ class IdeDiagnosticsTests(unittest.TestCase):
                 with redirect_stdout(stdout_buffer):
                     status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
 
-        checks = json.loads(stdout_buffer.getvalue())
+        payload = json.loads(stdout_buffer.getvalue())
+        checks = payload["checks"]
         self.assertEqual(status, 0)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["project"], "demo")
         self.assertEqual(
             [check["name"] for check in checks],
             ["VS Code app", "ms-python.python", "VS Code setting: editor.formatOnSave"],
         )
-        self.assertTrue(all(check["ok"] for check in checks))
+        self.assertTrue(all(check["status"] == "ok" for check in checks))
+        self.assertTrue(all("ok" not in check for check in checks))
 
 
 

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -21,6 +21,46 @@ needs stable IDs, statuses, names, messages, and fix guidance.
 explicit, reviewable, and paired with dry-run behavior before Base offers it as
 part of the doctor workflow.
 
+## Diagnostic JSON Contract
+
+Base diagnostic JSON uses `schema_version: 1` for object-shaped payloads. This
+contract was introduced before Base 1.0 and intentionally replaces the earlier
+experimental check JSON shape that used per-item `ok` booleans.
+
+Every diagnostic item emitted by `basectl check --format json` and
+`basectl doctor --format json` has the same fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable finding ID, such as `BASE-D001` or `BASE-P050` |
+| `status` | One of `ok`, `warn`, or `error` |
+| `name` | Short machine-readable finding subject |
+| `message` | Human-readable diagnostic detail |
+| `fix` | Suggested remediation, or an empty string when no fix is needed |
+
+Check commands that return an object include an aggregate `status` and a
+`checks` array of diagnostic items:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "checks": []
+}
+```
+
+`basectl check <project> --format json` and
+`basectl check --profile <list> --format json` embed project/profile layer
+results as nested diagnostic payload objects under `project_checks` and
+`profile_checks`. Workspace check and doctor JSON keep their workspace/project
+object shape and use the same diagnostic item fields inside each project's
+`checks` array.
+
+Doctor commands use the same diagnostic item fields. The top-level
+`basectl doctor --format json` wrapper includes `schema_version` and aggregate
+`status`, and keeps doctor-specific arrays named `findings`,
+`profile_findings`, and `project_findings`.
+
 ## Namespaces
 
 | Prefix | Scope |

--- a/docs/superpowers/plans/2026-06-08-check-json-contract.md
+++ b/docs/superpowers/plans/2026-06-08-check-json-contract.md
@@ -1,0 +1,150 @@
+# Check JSON Contract Implementation Plan
+
+Issue: #507
+Design: `docs/superpowers/specs/2026-06-08-check-json-contract-design.md`
+
+## Goal
+
+Normalize Base check JSON output to a v1 diagnostic contract before 1.0:
+
+- Every diagnostic item has `id`, `status`, `name`, `message`, and `fix`.
+- Check JSON no longer emits per-item `ok`.
+- Object payloads include `schema_version: 1` and aggregate `status`.
+- Project and profile check output embedded by `basectl check --format json`
+  becomes an object payload rather than a bare array.
+- Text output stays unchanged.
+
+## Contract
+
+Diagnostic item:
+
+```json
+{
+  "id": "BASE-D001",
+  "status": "ok",
+  "name": "homebrew",
+  "message": "Homebrew is installed.",
+  "fix": ""
+}
+```
+
+Check payload:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "checks": []
+}
+```
+
+`basectl check demo --format json`:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "project": "demo",
+  "checks": [],
+  "project_checks": {
+    "schema_version": 1,
+    "status": "ok",
+    "project": "demo",
+    "checks": []
+  }
+}
+```
+
+`basectl check --profile dev --format json`:
+
+```json
+{
+  "schema_version": 1,
+  "status": "error",
+  "checks": [],
+  "profile_checks": {
+    "schema_version": 1,
+    "status": "error",
+    "profiles": ["dev"],
+    "checks": []
+  }
+}
+```
+
+Workspace check JSON keeps its existing workspace/project object shape, but adds
+`schema_version: 1` and emits v1 items without `ok`.
+
+## Implementation Steps
+
+1. Add failing tests for the new contract.
+   - Update `cli/bash/commands/basectl/tests/check.bats` JSON assertions:
+     expect `schema_version`, aggregate `status`, item `id/status/fix`, no
+     per-item `ok`, and nested object payloads for `profile_checks` and
+     `project_checks`.
+   - Update `cli/python/base_setup/tests/test_diagnostics.py`,
+     `cli/python/base_dev/tests/test_engine.py`, and
+     `cli/python/base_projects/tests/test_workspace_checks.py` to assert the v1
+     check payload shape.
+   - Keep doctor item tests intact except where object payloads gain
+     `schema_version` and aggregate `status`.
+
+2. Implement shared project diagnostic helpers in `cli/python/base_setup/checks.py`.
+   - Add `DIAGNOSTIC_JSON_SCHEMA_VERSION = 1`.
+   - Change `check_to_json()` to return the v1 item shape.
+   - Keep `check_to_doctor_json()` as the same item shape for existing imports.
+   - Add `checks_status(checks)` with error > warn > ok precedence.
+   - Add `checks_payload_to_json(checks, **metadata)` returning
+     `schema_version`, `status`, metadata, and `checks`.
+
+3. Normalize project check JSON in `cli/python/base_setup/engine.py`.
+   - `check_manifest(..., --format json)` prints
+     `checks_payload_to_json(checks, project=manifest.project_name)`.
+   - `doctor_manifest(..., --format json)` can keep its bare findings array
+     because it is nested as doctor findings, not check payload.
+
+4. Normalize profile check JSON in `cli/python/base_dev/engine.py`.
+   - Change local `check_to_json()` to emit v1 items.
+   - Add local payload helpers mirroring the shared status logic.
+   - `print_check_results(..., --format json)` prints an object with
+     `profiles` and `checks`.
+   - Leave direct doctor JSON as a findings array of v1 items.
+
+5. Normalize workspace check JSON in `cli/python/base_projects/engine.py`.
+   - Import and reuse the shared `checks_status()`.
+   - Add `schema_version: 1` to workspace check/doctor object payloads.
+   - Make workspace check items use `check_to_json()` directly, with no `ok`.
+
+6. Normalize Bash wrapper JSON in
+   `cli/bash/commands/basectl/subcommands/setup_common.sh`.
+   - Base check items use `BASE-D` IDs and `status`.
+   - Top-level `basectl check --format json` emits `schema_version`, aggregate
+     `status`, and `checks`.
+   - Project virtualenv fallback check JSON emits a check payload object.
+   - Nested `profile_checks` and `project_checks` are embedded as object
+     payloads.
+   - Aggregate status accounts for base checks and nested payload statuses.
+
+7. Add matching schema metadata to object-shaped doctor JSON in
+   `cli/bash/commands/basectl/subcommands/doctor.sh`.
+   - Replace top-level `ok` with `schema_version` and aggregate `status`.
+   - Keep `findings`, `profile_findings`, and `project_findings`.
+
+8. Update tests fixtures/stubs.
+   - Update `cli/bash/commands/basectl/tests/setup_helpers.bash` stubbed JSON
+     emitted by fake Python layers.
+   - Preserve text-mode stubs and assertions.
+
+9. Update docs.
+   - Add a v1 diagnostic JSON contract section to `docs/doctor-findings.md`.
+   - Mention that the pre-1.0 check JSON shape is intentionally breaking and
+     that `check` and `doctor` share diagnostic item fields.
+
+10. Validate.
+    - Run focused tests for changed Python modules.
+    - Run Bats check/doctor tests.
+    - Run `env -u BASE_HOME ./bin/base-test`.
+    - Run `git diff --check`.
+
+## Completion
+
+Commit the implementation and open a PR that closes #507.

--- a/docs/superpowers/specs/2026-06-08-check-json-contract-design.md
+++ b/docs/superpowers/specs/2026-06-08-check-json-contract-design.md
@@ -1,0 +1,229 @@
+# Check JSON Contract Design
+
+Issue: #507
+
+## Summary
+
+Base should expose one stable diagnostic item shape across check and doctor JSON
+output before 1.0. The current check JSON output mixes shapes across Bash base
+environment checks, Python project checks, prerequisite profile checks, and
+workspace checks. That makes automation brittle because callers cannot depend
+on the same fields appearing everywhere.
+
+Base is still pre-1.0 and has no external compatibility contract yet, so this
+issue should make a clean breaking change instead of carrying legacy `ok` fields
+forward indefinitely.
+
+## Goals
+
+- Define the v1 JSON contract for diagnostic check and doctor output.
+- Use one diagnostic item shape everywhere: `id`, `status`, `name`, `message`,
+  and `fix`.
+- Normalize project and prerequisite-profile check JSON into object payloads
+  instead of bare arrays.
+- Keep top-level command payloads machine-readable with `schema_version`,
+  `status`, and command-specific context.
+- Preserve deterministic output ordering.
+- Document that pre-1.0 JSON output may still change until Base declares the
+  1.0 contract stable.
+
+## Non-Goals
+
+- Do not change text output.
+- Do not change finding IDs or add new diagnostic meanings.
+- Do not change check or doctor exit-status rules except where tests need to
+  assert the current behavior explicitly.
+- Do not add suppression, filtering, or JSON Schema files in this issue.
+- Do not parallelize checks in this issue.
+
+## Contract
+
+Every diagnostic item emitted by check or doctor JSON should have this shape:
+
+```json
+{
+  "id": "BASE-P050",
+  "status": "error",
+  "name": "project_virtualenv",
+  "message": "Virtual environment is missing.",
+  "fix": "Run 'basectl setup demo --recreate-venv'."
+}
+```
+
+`status` is the machine-readable result and replaces per-item `ok`.
+
+Allowed statuses:
+
+- `ok`: the diagnostic passed
+- `warn`: Base found a non-blocking or advisory issue
+- `error`: Base found a failing requirement
+
+`fix` should always be present. Use an empty string when no fix guidance applies.
+
+## Top-Level Payloads
+
+Object-shaped command payloads should include:
+
+- `schema_version`: integer `1`
+- `status`: aggregate status for the command payload
+
+Aggregate status should be:
+
+- `error` when any diagnostic item is `error`
+- `warn` when there are no errors and at least one diagnostic item is `warn`
+- `ok` when all diagnostic items are `ok`
+
+`basectl check --format json`:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "checks": []
+}
+```
+
+`basectl check <project> --format json`:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "project": "demo",
+  "checks": [],
+  "project_checks": {
+    "schema_version": 1,
+    "status": "ok",
+    "project": "demo",
+    "checks": []
+  }
+}
+```
+
+`basectl check --profile dev --format json`:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "checks": [],
+  "profile_checks": {
+    "schema_version": 1,
+    "status": "ok",
+    "profiles": ["dev"],
+    "checks": []
+  }
+}
+```
+
+`basectl workspace check --format json` should keep its workspace-oriented
+object shape and ensure each project diagnostic item uses the same v1 item
+shape:
+
+```json
+{
+  "schema_version": 1,
+  "workspace": "/Users/example/work",
+  "status": "error",
+  "project_count": 1,
+  "projects": [
+    {
+      "name": "demo",
+      "status": "error",
+      "path": "/Users/example/work/demo",
+      "manifest_path": "/Users/example/work/demo/base_manifest.yaml",
+      "manifest": "valid",
+      "checks": []
+    }
+  ]
+}
+```
+
+Doctor JSON should use the same diagnostic item shape. Existing doctor payloads
+already mostly have the right item fields; this issue should align check output
+with that model and add `schema_version` where the command returns an object.
+
+## Architecture
+
+Keep the existing `ArtifactCheck` and `DevCheck` data classes. Replace the
+current split between `check_to_json()` and `check_to_doctor_json()` with shared
+diagnostic-item serializers that produce the v1 item shape.
+
+The Python project layer should expose object payload helpers for check output
+so direct `python -m base_setup --action check --format json` invocations and
+Bash-wrapped `basectl check <project> --format json` receive the same contract.
+
+The prerequisite profile layer should do the same for `base_dev check
+--format json`.
+
+The Bash base-environment check path should stop hand-assembling a legacy item
+shape. It can keep Bash JSON emission for now, but its JSON item helper should
+accept `id`, `status`, `name`, `message`, and `fix`, then render the same v1
+diagnostic object as the Python serializers.
+
+Workspace check JSON should no longer patch `id` and `status` into legacy check
+items. It should call the shared v1 item serializer directly.
+
+## Compatibility
+
+This is intentionally backward-incompatible:
+
+- per-item `ok` is removed
+- Python project check JSON changes from a bare array to an object
+- prerequisite profile check JSON changes from a bare array to an object
+
+This is acceptable because Base has not declared a 1.0 compatibility contract.
+The documentation should call out that the v1 diagnostic JSON contract is the
+target shape for 1.0, while pre-1.0 JSON may still change as Base hardens.
+
+## Error Handling
+
+JSON emission must remain valid when diagnostic messages include quotes,
+backslashes, newlines, C0 control characters, or DEL. Existing Bash JSON escaping
+tests should be updated to assert the new item fields, not just the old `ok`
+field.
+
+If a nested project or profile layer fails without producing JSON, the Bash
+wrapper should preserve the current fallback behavior of reporting an empty
+nested payload and failing the top-level check command. If the nested layer
+does produce a valid object payload with `status`, the top-level status should
+reflect that nested status.
+
+## Documentation
+
+Add a diagnostics JSON section to the docs, likely in `docs/doctor-findings.md`
+or a dedicated diagnostics-output page linked from the docs map. The docs
+should cover:
+
+- v1 diagnostic item fields
+- allowed statuses
+- aggregate status rules
+- the intentional pre-1.0 breaking change
+- the relationship between check and doctor JSON
+
+## Testing
+
+Add or update tests for:
+
+- `basectl check --format json` base-environment output
+- `basectl check <project> --format json`
+- `basectl check --profile dev --format json`
+- direct `base_setup` project check JSON
+- direct `base_dev` profile check JSON
+- `basectl workspace check --format json`
+- `basectl doctor --format json` remains aligned with the item shape
+- JSON escaping for diagnostic strings with control characters
+
+Run:
+
+```bash
+env -u BASE_HOME ./bin/base-test
+git diff --check
+```
+
+## Implementation Notes
+
+The implementation should happen in one PR for issue #507 because the public
+contract needs to change coherently across Bash, project, profile, and workspace
+surfaces. Keep the change focused on shape and tests; leave check parallelism
+and workspace-manifest behavior to their own issues.

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -190,18 +190,21 @@ run_basectl_separate_stderr() {
     run_basectl_separate_stderr check demo --format json
     [ "$status" -eq 0 ]
     [ "${stderr:-}" = "" ]
-    [[ "$output" == *'"ok": true'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "ok"'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
+    [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *'"name": "click"'* ]]
 
     run_basectl_separate_stderr doctor demo --format json
     [ "$status" -eq 0 ]
     [ "${stderr:-}" = "" ]
-    [[ "$output" == *'"ok": true'* ]]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "ok"'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_findings":'* ]]
-    [[ "$output" == *'"status": "ok"'* ]]
+    [[ "$output" != *'"ok":'* ]]
 }
 
 @test "basectl test delegates from the project root with project environment" {


### PR DESCRIPTION
## Summary
- Normalize check JSON diagnostic items to the v1 `id`/`status`/`name`/`message`/`fix` contract and remove per-item `ok`.
- Wrap project and profile check JSON as versioned diagnostic payload objects, and add schema metadata to workspace/doctor object JSON.
- Document the diagnostic JSON contract and update Python, Bats, and integration coverage.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_demo.py cli/python/base_dev/tests/test_engine.py cli/python/base_projects/tests/test_workspace_checks.py`
- `bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats`
- `bats tests/integration/base_workflows.bats`
- `env -u BASE_HOME ./bin/base-test`
- `bats cli/bash/commands/basectl/tests/doctor.bats`
- `git diff --check`

Closes #507