### PR TITLE
Persist setup command output in logs

### DIFF
--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -57,33 +57,33 @@ def run_check(command: list[str]) -> bool:
 
 
 def run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = None) -> None:
-    process = subprocess.Popen(
+    stdout_recorder = CommandOutputRecorder()
+    stderr_recorder = CommandOutputRecorder()
+    with subprocess.Popen(
         command,
         cwd=cwd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-    )
-    stdout_recorder = CommandOutputRecorder()
-    stderr_recorder = CommandOutputRecorder()
-    assert process.stdout is not None
-    assert process.stderr is not None
-    threads = (
-        threading.Thread(
-            target=_tee_stream,
-            args=(ctx, process.stdout, sys.stdout, "stdout", stdout_recorder),
-            daemon=True,
-        ),
-        threading.Thread(
-            target=_tee_stream,
-            args=(ctx, process.stderr, sys.stderr, "stderr", stderr_recorder),
-            daemon=True,
-        ),
-    )
-    for thread in threads:
-        thread.start()
-    returncode = process.wait()
-    for thread in threads:
-        thread.join()
+    ) as process:
+        assert process.stdout is not None
+        assert process.stderr is not None
+        threads = (
+            threading.Thread(
+                target=_tee_stream,
+                args=(ctx, process.stdout, sys.stdout, "stdout", stdout_recorder),
+                daemon=True,
+            ),
+            threading.Thread(
+                target=_tee_stream,
+                args=(ctx, process.stderr, sys.stderr, "stderr", stderr_recorder),
+                daemon=True,
+            ),
+        )
+        for thread in threads:
+            thread.start()
+        returncode = process.wait()
+        for thread in threads:
+            thread.join()
     if returncode:
         message = f"Command failed with exit {returncode}: {redact_command_output(format_command(command))}"
         stdout_tail = stdout_recorder.text()

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -1,13 +1,51 @@
 from __future__ import annotations
 
+import os
+import re
 import shlex
 import shutil
 import subprocess
+import sys
+import threading
+from collections import deque
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import BinaryIO, TextIO
 
 import base_cli
 
 from .errors import ArtifactError
+
+
+COMMAND_OUTPUT_TAIL_CHARS = 4000
+SECRET_VALUE_RE = re.compile(r"(?i)\b(token|password|secret|api[-_]?key)=\S+")
+URL_CREDENTIALS_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s:@]+:[^@\s/]+@")
+
+
+@dataclass
+class CommandOutputRecorder:
+    limit: int = COMMAND_OUTPUT_TAIL_CHARS
+    _chunks: deque[str] = field(default_factory=deque)
+    _length: int = 0
+
+    def append(self, text: str) -> None:
+        if not text:
+            return
+        redacted = redact_command_output(text)
+        self._chunks.append(redacted)
+        self._length += len(redacted)
+        while self._length > self.limit and len(self._chunks) > 1:
+            removed = self._chunks.popleft()
+            self._length -= len(removed)
+        if self._length > self.limit and self._chunks:
+            self._chunks[0] = self._chunks[0][-self.limit :]
+            self._length = self.limit
+
+    def text(self) -> str:
+        value = "".join(self._chunks)
+        if len(value) <= self.limit:
+            return value.strip()
+        return value[-self.limit:].strip()
 
 
 def command_exists(name: str) -> bool:
@@ -19,13 +57,41 @@ def run_check(command: list[str]) -> bool:
 
 
 def run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = None) -> None:
-    # Keep stdout live for installer progress; capture stderr for persistent failure logs.
-    completed = subprocess.run(command, cwd=cwd, stderr=subprocess.PIPE, text=True, check=False)
-    if completed.returncode:
-        stderr = (completed.stderr or "").strip()
-        message = f"Command failed with exit {completed.returncode}: {format_command(command)}"
-        if stderr:
-            message = f"{message}\n{stderr}"
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout_recorder = CommandOutputRecorder()
+    stderr_recorder = CommandOutputRecorder()
+    assert process.stdout is not None
+    assert process.stderr is not None
+    threads = (
+        threading.Thread(
+            target=_tee_stream,
+            args=(ctx, process.stdout, sys.stdout, "stdout", stdout_recorder),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_tee_stream,
+            args=(ctx, process.stderr, sys.stderr, "stderr", stderr_recorder),
+            daemon=True,
+        ),
+    )
+    for thread in threads:
+        thread.start()
+    returncode = process.wait()
+    for thread in threads:
+        thread.join()
+    if returncode:
+        message = f"Command failed with exit {returncode}: {redact_command_output(format_command(command))}"
+        stdout_tail = stdout_recorder.text()
+        stderr_tail = stderr_recorder.text()
+        if stdout_tail:
+            message = f"{message}\nstdout:\n{stdout_tail}"
+        if stderr_tail:
+            message = f"{message}\nstderr:\n{stderr_tail}"
         raise ArtifactError(message)
     if cwd is not None:
         ctx.log.debug("Command succeeded in '%s': %s", cwd, format_command(command))
@@ -42,3 +108,54 @@ def dry_run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None 
 
 def format_command(command: list[str]) -> str:
     return shlex.join(command)
+
+
+def redact_command_output(text: str) -> str:
+    text = URL_CREDENTIALS_RE.sub(r"\1[REDACTED]@", text)
+    return SECRET_VALUE_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+
+
+def _write_bytes(target: TextIO, chunk: bytes) -> None:
+    buffer = getattr(target, "buffer", None)
+    if buffer is not None:
+        buffer.write(chunk)
+    else:
+        target.write(chunk.decode(errors="replace"))
+    target.flush()
+
+
+def _log_lines(ctx: base_cli.Context, label: str, text: str, pending: str) -> str:
+    pending += text
+    lines = pending.splitlines(keepends=True)
+    if lines and not lines[-1].endswith(("\n", "\r")):
+        pending = lines.pop()
+    else:
+        pending = ""
+    for line in lines:
+        stripped = line.strip()
+        if stripped:
+            ctx.log.debug("Command %s: %s", label, redact_command_output(stripped))
+    return pending
+
+
+def _tee_stream(
+    ctx: base_cli.Context,
+    stream: BinaryIO,
+    target: TextIO,
+    label: str,
+    recorder: CommandOutputRecorder,
+) -> None:
+    pending = ""
+    try:
+        while True:
+            chunk = os.read(stream.fileno(), 4096)
+            if not chunk:
+                break
+            _write_bytes(target, chunk)
+            text = chunk.decode(errors="replace")
+            recorder.append(text)
+            pending = _log_lines(ctx, label, text, pending)
+        if pending.strip():
+            ctx.log.debug("Command %s: %s", label, redact_command_output(pending.strip()))
+    finally:
+        stream.close()

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import io
 import importlib.util
 import os
+import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -478,26 +481,126 @@ class ProcessTests(unittest.TestCase):
 
     def test_run_command_includes_stderr_on_failure(self) -> None:
         ctx = fake_context()
+        command = [
+            sys.executable,
+            "-c",
+            "import sys; print('installer exploded', file=sys.stderr); raise SystemExit(17)",
+        ]
+        stderr = io.StringIO()
 
-        with mock.patch(
-            "base_setup.process.subprocess.run",
-            return_value=mock.Mock(returncode=17, stderr="installer exploded\n"),
-        ):
+        with redirect_stderr(stderr):
             with self.assertRaisesRegex(ArtifactError, "installer exploded"):
-                process.run_command(ctx, ["installer", "--bad"])
+                process.run_command(ctx, command)
+
+    def test_run_command_streams_and_logs_stdout_and_stderr(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('install stdout'); "
+                "print('install stderr', file=sys.stderr)"
+            ),
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            process.run_command(ctx, command)
+
+        self.assertIn("install stdout", stdout.getvalue())
+        self.assertIn("install stderr", stderr.getvalue())
+        debug_messages = [call.args[0] % call.args[1:] for call in ctx.log.debug.call_args_list]
+        self.assertIn("Command stdout: install stdout", debug_messages)
+        self.assertIn("Command stderr: install stderr", debug_messages)
 
 
+    def test_run_command_failure_includes_bounded_stdout_and_stderr_tail(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('stdout before failure'); "
+                "print('stderr before failure', file=sys.stderr); "
+                "raise SystemExit(17)"
+            ),
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            with self.assertRaises(ArtifactError) as exc:
+                process.run_command(ctx, command)
+
+        message = str(exc.exception)
+        self.assertIn("Command failed with exit 17", message)
+        self.assertIn("stdout:", message)
+        self.assertIn("stdout before failure", message)
+        self.assertIn("stderr:", message)
+        self.assertIn("stderr before failure", message)
+
+    def test_run_command_redacts_sensitive_output_from_logs_and_failure(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('url=https://user:secret@example.invalid/pkg.whl'); "
+                "print('token=super-secret', file=sys.stderr); "
+                "raise SystemExit(9)"
+            ),
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            with self.assertRaises(ArtifactError) as exc:
+                process.run_command(ctx, command)
+
+        message = str(exc.exception)
+        debug_text = "\n".join(str(call.args) for call in ctx.log.debug.call_args_list)
+        self.assertNotIn("super-secret", message)
+        self.assertNotIn("super-secret", debug_text)
+        self.assertNotIn("user:secret", message)
+        self.assertNotIn("user:secret", debug_text)
+        self.assertIn("[REDACTED]", message)
+        self.assertIn("[REDACTED]", debug_text)
+
+    def test_run_command_failure_truncates_large_single_chunk_tail(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "sys.stdout.write('x' * 5000 + 'tail-marker'); "
+                "raise SystemExit(17)"
+            ),
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+            with self.assertRaises(ArtifactError) as exc:
+                process.run_command(ctx, command)
+
+        message = str(exc.exception)
+        self.assertLessEqual(
+            len(message.split("stdout:\n", 1)[1]),
+            process.COMMAND_OUTPUT_TAIL_CHARS,
+        )
+        self.assertIn("tail-marker", message)
 
     def test_run_command_logs_success_at_debug(self) -> None:
         ctx = fake_context()
+        command = [sys.executable, "-c", ""]
 
-        with mock.patch(
-            "base_setup.process.subprocess.run",
-            return_value=mock.Mock(returncode=0, stderr=""),
-        ):
-            process.run_command(ctx, ["installer", "--good", "two words"])
+        process.run_command(ctx, command)
 
         ctx.log.debug.assert_called_once_with(
             "Command succeeded: %s",
-            "installer --good 'two words'",
+            format_command(command),
         )

--- a/docs/superpowers/plans/2026-06-09-setup-output-logs.md
+++ b/docs/superpowers/plans/2026-06-09-setup-output-logs.md
@@ -1,0 +1,333 @@
+# Setup Output Logs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist useful external setup command stdout/stderr in Base logs while keeping live terminal progress.
+
+**Architecture:** Keep the behavior centralized in `cli/python/base_setup/process.py`, because project artifacts, Brewfile/mise delegates, IDE setup, and prerequisite profiles already use `run_command()`. Add a tee-style subprocess helper that streams stdout/stderr live, logs redacted chunks, and retains bounded redacted tails for failure summaries.
+
+**Tech Stack:** Python standard library `subprocess`, `threading`, `os`, `sys`, `re`, and existing `base_cli.Context` logging.
+
+---
+
+## File Structure
+
+- Modify `cli/python/base_setup/process.py`: subprocess tee helper, redaction, bounded tails, updated `run_command()`.
+- Modify `cli/python/base_setup/tests/test_artifacts.py`: focused process tests for streaming, logging, failure tails, and redaction.
+- Add `docs/superpowers/specs/2026-06-09-setup-output-logs-design.md`: design record.
+- Add `docs/superpowers/plans/2026-06-09-setup-output-logs.md`: this implementation plan.
+
+## Task 1: Failing Process Tests
+
+**Files:**
+- Modify: `cli/python/base_setup/tests/test_artifacts.py`
+
+- [ ] **Step 1: Add tests for streamed and logged command output**
+
+Add imports near the top:
+
+```python
+import io
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+```
+
+Add these tests to `ProcessTests`:
+
+```python
+    def test_run_command_streams_and_logs_stdout_and_stderr(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('install stdout'); "
+                "print('install stderr', file=sys.stderr)"
+            ),
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            process.run_command(ctx, command)
+
+        self.assertIn("install stdout", stdout.getvalue())
+        self.assertIn("install stderr", stderr.getvalue())
+        debug_messages = [call.args[0] % call.args[1:] for call in ctx.log.debug.call_args_list]
+        self.assertIn("Command stdout: install stdout", debug_messages)
+        self.assertIn("Command stderr: install stderr", debug_messages)
+```
+
+- [ ] **Step 2: Add failure-tail and redaction tests**
+
+Add these tests to `ProcessTests`:
+
+```python
+    def test_run_command_failure_includes_bounded_stdout_and_stderr_tail(self) -> None:
+        ctx = fake_context()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('stdout before failure'); "
+                "print('stderr before failure', file=sys.stderr); "
+                "raise SystemExit(17)"
+            ),
+        ]
+
+        with self.assertRaises(ArtifactError) as exc:
+            process.run_command(ctx, command)
+
+        message = str(exc.exception)
+        self.assertIn("Command failed with exit 17", message)
+        self.assertIn("stdout:", message)
+        self.assertIn("stdout before failure", message)
+        self.assertIn("stderr:", message)
+        self.assertIn("stderr before failure", message)
+
+    def test_run_command_redacts_sensitive_output_from_logs_and_failure(self) -> None:
+        ctx = fake_context()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('url=https://user:secret@example.invalid/pkg.whl'); "
+                "print('token=super-secret', file=sys.stderr); "
+                "raise SystemExit(9)"
+            ),
+        ]
+
+        with self.assertRaises(ArtifactError) as exc:
+            process.run_command(ctx, command)
+
+        message = str(exc.exception)
+        debug_text = "\n".join(str(call.args) for call in ctx.log.debug.call_args_list)
+        self.assertNotIn("super-secret", message)
+        self.assertNotIn("super-secret", debug_text)
+        self.assertNotIn("user:secret", message)
+        self.assertNotIn("user:secret", debug_text)
+        self.assertIn("[REDACTED]", message)
+        self.assertIn("[REDACTED]", debug_text)
+```
+
+- [ ] **Step 3: Run tests and verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_setup/tests/test_artifacts.py
+```
+
+Expected: FAIL because current `run_command()` does not log stdout, does not capture stdout tails, and has no output redaction.
+
+## Task 2: Tee Executor Implementation
+
+**Files:**
+- Modify: `cli/python/base_setup/process.py`
+
+- [ ] **Step 1: Add imports and constants**
+
+Add:
+
+```python
+import os
+import re
+import sys
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from typing import BinaryIO, TextIO
+```
+
+Add constants:
+
+```python
+COMMAND_OUTPUT_TAIL_CHARS = 4000
+SECRET_VALUE_RE = re.compile(r"(?i)\b(token|password|secret|api[-_]?key)=\S+")
+URL_CREDENTIALS_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s:@]+:[^@\s/]+@")
+```
+
+- [ ] **Step 2: Add bounded output recorder**
+
+Add:
+
+```python
+@dataclass
+class CommandOutputRecorder:
+    limit: int = COMMAND_OUTPUT_TAIL_CHARS
+    _chunks: deque[str] = field(default_factory=deque)
+    _length: int = 0
+
+    def append(self, text: str) -> None:
+        if not text:
+            return
+        redacted = redact_command_output(text)
+        self._chunks.append(redacted)
+        self._length += len(redacted)
+        while self._length > self.limit and self._chunks:
+            removed = self._chunks.popleft()
+            self._length -= len(removed)
+
+    def text(self) -> str:
+        value = "".join(self._chunks)
+        if len(value) <= self.limit:
+            return value.strip()
+        return value[-self.limit:].strip()
+```
+
+- [ ] **Step 3: Add output redaction**
+
+Add:
+
+```python
+def redact_command_output(text: str) -> str:
+    text = URL_CREDENTIALS_RE.sub(r"\1[REDACTED]@", text)
+    return SECRET_VALUE_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+```
+
+- [ ] **Step 4: Add stream helpers**
+
+Add:
+
+```python
+def _write_bytes(target: TextIO, chunk: bytes) -> None:
+    buffer = getattr(target, "buffer", None)
+    if buffer is not None:
+        buffer.write(chunk)
+    else:
+        target.write(chunk.decode(errors="replace"))
+    target.flush()
+
+
+def _log_lines(ctx: base_cli.Context, label: str, text: str, pending: str) -> str:
+    pending += text
+    lines = pending.splitlines(keepends=True)
+    if lines and not lines[-1].endswith(("\n", "\r")):
+        pending = lines.pop()
+    else:
+        pending = ""
+    for line in lines:
+        stripped = line.strip()
+        if stripped:
+            ctx.log.debug("Command %s: %s", label, redact_command_output(stripped))
+    return pending
+```
+
+Add:
+
+```python
+def _tee_stream(
+    ctx: base_cli.Context,
+    stream: BinaryIO,
+    target: TextIO,
+    label: str,
+    recorder: CommandOutputRecorder,
+) -> None:
+    pending = ""
+    while True:
+        chunk = os.read(stream.fileno(), 4096)
+        if not chunk:
+            break
+        _write_bytes(target, chunk)
+        text = chunk.decode(errors="replace")
+        recorder.append(text)
+        pending = _log_lines(ctx, label, text, pending)
+    if pending.strip():
+        ctx.log.debug("Command %s: %s", label, redact_command_output(pending.strip()))
+```
+
+- [ ] **Step 5: Replace `run_command()` subprocess call**
+
+Replace the current implementation with:
+
+```python
+def run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = None) -> None:
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout_recorder = CommandOutputRecorder()
+    stderr_recorder = CommandOutputRecorder()
+    assert process.stdout is not None
+    assert process.stderr is not None
+    threads = (
+        threading.Thread(
+            target=_tee_stream,
+            args=(ctx, process.stdout, sys.stdout, "stdout", stdout_recorder),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_tee_stream,
+            args=(ctx, process.stderr, sys.stderr, "stderr", stderr_recorder),
+            daemon=True,
+        ),
+    )
+    for thread in threads:
+        thread.start()
+    returncode = process.wait()
+    for thread in threads:
+        thread.join()
+    if returncode:
+        message = f"Command failed with exit {returncode}: {format_command(command)}"
+        stdout_tail = stdout_recorder.text()
+        stderr_tail = stderr_recorder.text()
+        if stdout_tail:
+            message = f"{message}\nstdout:\n{stdout_tail}"
+        if stderr_tail:
+            message = f"{message}\nstderr:\n{stderr_tail}"
+        raise ArtifactError(message)
+    if cwd is not None:
+        ctx.log.debug("Command succeeded in '%s': %s", cwd, format_command(command))
+    else:
+        ctx.log.debug("Command succeeded: %s", format_command(command))
+```
+
+- [ ] **Step 6: Run tests and verify GREEN**
+
+Run:
+
+```bash
+PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_setup/tests/test_artifacts.py
+```
+
+Expected: PASS.
+
+## Task 3: Validation and Commit
+
+**Files:**
+- All changed files
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_setup/tests/test_artifacts.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full validation**
+
+Run:
+
+```bash
+env -u BASE_HOME ./bin/base-test
+git diff --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add cli/python/base_setup/process.py cli/python/base_setup/tests/test_artifacts.py docs/superpowers/specs/2026-06-09-setup-output-logs-design.md docs/superpowers/plans/2026-06-09-setup-output-logs.md
+git commit -m "Persist setup command output in logs"
+```

--- a/docs/superpowers/specs/2026-06-09-setup-output-logs-design.md
+++ b/docs/superpowers/specs/2026-06-09-setup-output-logs-design.md
@@ -1,0 +1,77 @@
+# Setup Output Logs Design
+
+Issue: #508
+
+## Goal
+
+When Base runs external setup commands, users should still see live command
+progress, and Base's persistent logs should contain enough stdout/stderr context
+to debug failures without rerunning setup with shell redirection.
+
+## Scope
+
+This change is limited to the Python setup execution path centered on
+`base_setup.process.run_command()`. That function is already used by project
+artifact installs, Brewfile/mise delegates, IDE installs/extensions, and
+developer prerequisite profile setup. Dry-run behavior and read-only check
+commands are out of scope.
+
+## Design
+
+Replace the current `subprocess.run(..., stderr=PIPE)` call with a small
+tee-style executor in `base_setup.process`.
+
+The executor will:
+
+- start the child process with stdout and stderr piped
+- read stdout and stderr concurrently
+- write stdout chunks to the current process stdout and stderr chunks to stderr
+- log redacted stdout/stderr chunks through `ctx.log.debug(...)`
+- retain a bounded redacted tail for each stream
+- raise `ArtifactError` with the command, exit code, and available bounded
+  stdout/stderr tails on failure
+- keep the existing success debug message
+
+Logging command output at debug level matches Base's existing persistent-log
+model: normal terminal output remains the child process output, while file logs
+record debug messages. If the user runs with `--debug`, debug log lines may also
+be visible on stderr; the primary live progress stream remains unchanged.
+
+## Redaction
+
+The first implementation will redact obvious secret-shaped output before it
+enters logs or failure messages:
+
+- URL credentials such as `https://user:secret@example.invalid/path`
+- key/value fragments whose key looks like `token`, `password`, `secret`,
+  `api-key`, or `api_key`
+
+The live terminal stream is not modified. Redaction is a safety net for
+persistent logs and error summaries, not a substitute for tools avoiding secret
+output.
+
+## Failure Message
+
+On nonzero exit, `ArtifactError` will include:
+
+```text
+Command failed with exit 17: installer --bad
+stdout:
+...
+stderr:
+...
+```
+
+Empty streams are omitted. Tails are bounded by characters, not by process
+runtime, so large installer logs do not explode the error message.
+
+## Tests
+
+Add focused unit tests in `cli/python/base_setup/tests/test_artifacts.py` for:
+
+- stdout and stderr are streamed to the caller and logged
+- failure messages include bounded stdout and stderr tails
+- sensitive output is redacted from logs and failure messages
+
+Run the focused test file first, then the full `env -u BASE_HOME ./bin/base-test`
+suite.


### PR DESCRIPTION
## Summary
- Document the #508 design and execution plan for setup output logging.
- Stream setup subprocess stdout/stderr live while writing redacted debug log lines.
- Include bounded redacted stdout/stderr tails in setup command failure messages.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_setup/tests/test_artifacts.py
- PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc\n- env -u BASE_HOME ./bin/base-test\n- git diff --check\n\nCloses #508