### PR TITLE
Add project Git remote diagnostics

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -766,6 +766,48 @@ setup_recovery_project_venv() {
     printf "Run 'basectl setup %s --recreate-venv' to back up and recreate the project virtual environment.\n" "$project"
 }
 
+setup_json_array_items() {
+    local value="$1"
+
+    value="${value//$'\n'/}"
+    value="${value//$'\r'/}"
+    value="${value#\[}"
+    value="${value%\]}"
+    printf '%s' "$value"
+}
+
+setup_print_project_check_json_with_venv() {
+    local precheck_json="$1"
+    local ok="$2"
+    local message="$3"
+    local fix="$4"
+    local project="$5"
+    local items precheck_status status venv_status
+
+    venv_status="$(setup_diagnostic_status_from_ok "$ok")"
+    precheck_status="$(setup_json_payload_status "$precheck_json")"
+    status="$(setup_merge_diagnostic_status "$precheck_status" "$venv_status")"
+    items="$(setup_json_array_items "$precheck_json")"
+
+    printf '{\n'
+    printf '  "schema_version": 1,\n'
+    printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
+    printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
+    printf '  "checks": [\n'
+    if [[ -n "$items" ]]; then
+        printf '    %s,\n' "$items"
+    fi
+    setup_print_check_json_item \
+        "" \
+        "BASE-P050" \
+        "$venv_status" \
+        "project_virtualenv" \
+        "$message" \
+        "$fix"
+    printf '  ]\n'
+    printf '}\n'
+}
+
 setup_print_project_venv_check_json() {
     local ok="$1"
     local message="$2"
@@ -788,14 +830,42 @@ setup_print_project_venv_check_json() {
 }
 
 setup_print_project_venv_doctor_json() {
-    local status="$1"
-    local message="$2"
-    local fix="$3"
+    local precheck_json="$1"
+    local status="$2"
+    local message="$3"
+    local fix="$4"
+    local items
 
-    printf '[{"id":"BASE-P050","status":"%s","name":"project_virtualenv","message":"%s","fix":"%s"}]\n' \
+    items="$(setup_json_array_items "$precheck_json")"
+
+    printf '['
+    if [[ -n "$items" ]]; then
+        printf '%s,' "$items"
+    fi
+    printf '{"id":"BASE-P050","status":"%s","name":"project_virtualenv","message":"%s","fix":"%s"}]\n' \
         "$(setup_json_escape "$status")" \
         "$(setup_json_escape "$message")" \
         "$(setup_json_escape "$fix")"
+}
+
+setup_run_project_pre_venv_layer() {
+    local action="$1"
+    local output_format="$2"
+    local manifest_path="$3"
+    local project="$4"
+    local python_bin venv_dir
+    local args=()
+
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
+
+    args+=(--manifest "$manifest_path")
+    args+=(--action "$action")
+    args+=(--format "$output_format")
+    args+=("$project")
+
+    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" "$python_bin" -m base_setup "${args[@]}"
 }
 
 setup_run_project_artifact_setup() {
@@ -834,7 +904,7 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path project project_venv_dir python_bin resolved_name resolved_root resolve_output venv_dir
+    local exit_code manifest_path precheck_json project project_venv_dir python_bin resolved_name resolved_root resolve_output venv_dir
     local args=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
@@ -904,20 +974,31 @@ setup_run_project_artifact_layer() {
         fi
         if [[ "$output_format" == json ]]; then
             if [[ "$action" == doctor ]]; then
+                precheck_json="$(setup_run_project_pre_venv_layer predoctor json "$manifest_path" "$project")" || true
+                [[ -n "$precheck_json" ]] || precheck_json="[]"
                 setup_print_project_venv_doctor_json \
+                    "$precheck_json" \
                     "error" \
                     "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
                     "$(setup_recovery_project_venv "$project")"
             else
-                setup_print_project_venv_check_json \
+                precheck_json="$(setup_run_project_pre_venv_layer precheck json "$manifest_path" "$project")" || true
+                [[ -n "$precheck_json" ]] || precheck_json="[]"
+                setup_print_project_check_json_with_venv \
+                    "$precheck_json" \
                     false \
                     "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
                     "$(setup_recovery_project_venv "$project")" \
                     "$project"
             fi
         elif [[ "$action" == doctor ]]; then
+            setup_run_project_pre_venv_layer predoctor text "$manifest_path" "$project" || true
             printf 'error  %-9s  %-26s  %s\n' "BASE-P050" "Project virtualenv" "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
             printf '       Fix: %s\n' "$(setup_recovery_project_venv "$project")"
+        elif [[ "$action" == check ]]; then
+            setup_run_project_pre_venv_layer precheck text "$manifest_path" "$project" || true
+            log_warn "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+            log_warn "$(setup_recovery_project_venv "$project")"
         else
             log_warn "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
             log_warn "$(setup_recovery_project_venv "$project")"

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -450,6 +450,7 @@ load ./setup_helpers.bash
     [[ "$output" == *'"status": "error"'* ]]
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
+    [[ "$output" == *'"id":"BASE-P080","status":"ok","name":"git_repository"'* ]]
     [[ "$output" == *'"id":"BASE-P050","status":"error","name":"project_virtualenv"'* ]]
     [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -482,6 +482,28 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
     printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    shift 2
+    action="setup"
+    output_format="text"
+    while (($#)); do
+        case "$1" in
+            --action)
+                shift
+                action="${1:-}"
+                ;;
+            --format)
+                shift
+                output_format="${1:-}"
+                ;;
+        esac
+        shift || true
+    done
+    if [[ "$action" == "predoctor" && "$output_format" == "json" ]]; then
+        printf '[{"id":"BASE-P080","status":"ok","name":"git_repository","message":"Project is inside a Git repository.","fix":""}]\n'
+        exit 0
+    fi
+fi
 printf 'unexpected doctor project broken venv python args: %s\n' "$*" >&2
 exit 1
 EOF
@@ -507,6 +529,7 @@ EOF
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_findings":'* ]]
     [[ "$output" != *'"ok":'* ]]
+    [[ "$output" == *'"id":"BASE-P080","status":"ok","name":"git_repository"'* ]]
     [[ "$output" == *'"id":"BASE-P050","status":"error","name":"project_virtualenv"'* ]]
     [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
     [[ "$output" == *"Run 'basectl setup demo --recreate-venv' to back up and recreate the project virtual environment."* ]]

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -514,7 +514,15 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
         esac
         shift || true
     done
-    if [[ "$action" == "check" && "$output_format" == "json" ]]; then
+    if [[ "$action" == "precheck" && "$output_format" == "json" ]]; then
+        printf '[{"id":"BASE-P080","status":"ok","name":"git_repository","message":"Project is inside a Git repository.","fix":""}]\n'
+    elif [[ "$action" == "precheck" ]]; then
+        printf 'Project is inside a Git repository.\n' >&2
+    elif [[ "$action" == "predoctor" && "$output_format" == "json" ]]; then
+        printf '[{"id":"BASE-P080","status":"ok","name":"git_repository","message":"Project is inside a Git repository.","fix":""}]\n'
+    elif [[ "$action" == "predoctor" ]]; then
+        printf 'ok     BASE-P080  git_repository            Project is inside a Git repository.\n'
+    elif [[ "$action" == "check" && "$output_format" == "json" ]]; then
         printf '{"schema_version":1,"status":"ok","project":"demo","checks":[{"id":"BASE-P040","status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""}]}\n'
     elif [[ "$action" == "check" ]]; then
         printf 'Project artifact check passed.\n' >&2

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -25,6 +25,7 @@ from base_setup.checks import doctor_status
 from base_setup.checks import print_doctor_finding
 from base_setup.demo import resolve_demo_script_path
 from base_setup.engine import manifest_checks
+from base_setup.engine import pre_venv_manifest_checks
 from base_setup.engine import read_default_manifest
 from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest, ManifestError, TestConfig, read_manifest
@@ -628,9 +629,11 @@ def workspace_project_check_result(
             checks=checks,
         )
 
-    checks = (project_venv_check(manifest.project_name),)
-    if checks[0].ok:
-        checks += manifest_checks(default_manifest, manifest)
+    venv_check = project_venv_check(manifest.project_name)
+    if venv_check.ok:
+        checks = (venv_check,) + manifest_checks(default_manifest, manifest)
+    else:
+        checks = pre_venv_manifest_checks(manifest) + (venv_check,)
 
     return WorkspaceProjectCheckResult(
         name=manifest.project_name,

--- a/cli/python/base_setup/checks.py
+++ b/cli/python/base_setup/checks.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from collections.abc import Mapping
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 
 
@@ -16,19 +18,23 @@ class ArtifactCheck:
     fix: str
     finding_id: str
     status: str = ""
+    details: Mapping[str, Any] = field(default_factory=dict)
 
 
-def check_to_json(check: ArtifactCheck) -> dict[str, str]:
-    return {
+def check_to_json(check: ArtifactCheck) -> dict[str, Any]:
+    payload: dict[str, Any] = {
         "id": check.finding_id,
         "status": doctor_status(check),
         "name": check.name,
         "message": check.message,
         "fix": check.fix,
     }
+    if check.details:
+        payload["details"] = dict(check.details)
+    return payload
 
 
-def check_to_doctor_json(check: ArtifactCheck) -> dict[str, str]:
+def check_to_doctor_json(check: ArtifactCheck) -> dict[str, Any]:
     return check_to_json(check)
 
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -15,6 +15,7 @@ from .artifacts import resolve_artifact_definitions
 from .build import check_build
 from .checks import ArtifactCheck
 from .checks import check_to_doctor_json
+from .checks import check_to_json
 from .checks import checks_payload_to_json
 from .checks import doctor_status
 from .checks import print_doctor_finding
@@ -24,6 +25,7 @@ from .delegates import check_mise
 from .delegates import reconcile_brewfile
 from .delegates import reconcile_mise
 from .errors import ArtifactError
+from .git_remote import check_git_remote
 from .health import check_required_env
 from .health import check_required_ports
 from .ide import check_ide_extensions
@@ -116,7 +118,14 @@ def run_manifest_action(
         return check_manifest(ctx, default_manifest, base_manifest, output_format=manifest_action.output_format)
     if action == "doctor":
         return doctor_manifest(default_manifest, base_manifest, output_format=manifest_action.output_format)
-    ctx.log.error("Unsupported base_setup action '%s'. Expected setup, bootstrap, check, or doctor.", action)
+    if action == "precheck":
+        return check_pre_venv_manifest(ctx, base_manifest, output_format=manifest_action.output_format)
+    if action == "predoctor":
+        return doctor_pre_venv_manifest(base_manifest, output_format=manifest_action.output_format)
+    ctx.log.error(
+        "Unsupported base_setup action '%s'. Expected setup, bootstrap, check, doctor, precheck, or predoctor.",
+        action,
+    )
     return 2
 
 
@@ -209,6 +218,24 @@ def check_manifest(
     return 0 if all(check.ok or doctor_status(check) == "warn" for check in checks) else 1
 
 
+def check_pre_venv_manifest(ctx: base_cli.Context, manifest: BaseManifest, output_format: str) -> int:
+    checks = pre_venv_manifest_checks(manifest)
+    if output_format == "json":
+        print(json.dumps([check_to_json(check) for check in checks], separators=(",", ":")))
+    elif output_format == "text":
+        for check in checks:
+            if check.ok:
+                ctx.log.info(check.message)
+            else:
+                ctx.log.warning(check.message)
+                if check.fix:
+                    ctx.log.warning("Fix: %s", check.fix)
+    else:
+        ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
+        return 2
+    return 0 if all(check.ok or doctor_status(check) == "warn" for check in checks) else 1
+
+
 def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest, output_format: str) -> int:
     checks = manifest_checks(default_manifest, manifest)
     if output_format == "json":
@@ -230,13 +257,37 @@ def doctor_manifest(default_manifest: BaseManifest, manifest: BaseManifest, outp
     return min(error_count, 125)
 
 
+def doctor_pre_venv_manifest(manifest: BaseManifest, output_format: str) -> int:
+    checks = pre_venv_manifest_checks(manifest)
+    if output_format == "json":
+        print(json.dumps([check_to_doctor_json(check) for check in checks], separators=(",", ":")))
+        return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
+    if output_format != "text":
+        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
+        return 2
+
+    error_count = 0
+    for check in checks:
+        status = doctor_status(check)
+        print_doctor_finding(status, check.finding_id, check.name, check.message, check.fix)
+        if status == "error":
+            error_count += 1
+    return min(error_count, 125)
+
+
+def pre_venv_manifest_checks(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+    return check_git_remote(manifest)
+
+
 def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+    pre_venv_checks: list[ArtifactCheck] = []
     checks: list[ArtifactCheck] = []
     user_config = read_user_config()
     effective_manifest = effective_manifest_with_user_config(manifest, user_config)
     artifacts = merge_artifacts(default_manifest.artifacts, effective_manifest.artifacts)
     definitions = resolve_artifact_definitions(artifacts)
 
+    pre_venv_checks.extend(pre_venv_manifest_checks(effective_manifest))
     checks.extend(ide_preference_warning_checks(manifest, user_config))
 
     if effective_manifest.brewfile is not None:
@@ -266,7 +317,7 @@ def manifest_checks(default_manifest: BaseManifest, manifest: BaseManifest) -> t
                 finding_id="BASE-P001",
             )
         )
-    return tuple(checks)
+    return tuple(pre_venv_checks + checks)
 
 
 def effective_manifest_with_user_config(manifest: BaseManifest, user_config: UserConfig) -> BaseManifest:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -110,23 +110,25 @@ def run_manifest_action(
     action = manifest_action.action
     if action == "setup":
         reconcile_manifest(ctx, default_manifest, base_manifest, dry_run=manifest_action.dry_run)
-        return 0
-    if action == "bootstrap":
+        status = 0
+    elif action == "bootstrap":
         reconcile_bootstrap_artifacts(ctx, default_manifest, base_manifest, dry_run=manifest_action.dry_run)
-        return 0
-    if action == "check":
-        return check_manifest(ctx, default_manifest, base_manifest, output_format=manifest_action.output_format)
-    if action == "doctor":
-        return doctor_manifest(default_manifest, base_manifest, output_format=manifest_action.output_format)
-    if action == "precheck":
-        return check_pre_venv_manifest(ctx, base_manifest, output_format=manifest_action.output_format)
-    if action == "predoctor":
-        return doctor_pre_venv_manifest(base_manifest, output_format=manifest_action.output_format)
-    ctx.log.error(
-        "Unsupported base_setup action '%s'. Expected setup, bootstrap, check, doctor, precheck, or predoctor.",
-        action,
-    )
-    return 2
+        status = 0
+    elif action == "check":
+        status = check_manifest(ctx, default_manifest, base_manifest, output_format=manifest_action.output_format)
+    elif action == "doctor":
+        status = doctor_manifest(default_manifest, base_manifest, output_format=manifest_action.output_format)
+    elif action == "precheck":
+        status = check_pre_venv_manifest(ctx, base_manifest, output_format=manifest_action.output_format)
+    elif action == "predoctor":
+        status = doctor_pre_venv_manifest(base_manifest, output_format=manifest_action.output_format)
+    else:
+        ctx.log.error(
+            "Unsupported base_setup action '%s'. Expected setup, bootstrap, check, doctor, precheck, or predoctor.",
+            action,
+        )
+        status = 2
+    return status
 
 
 def validate_project_name(manifest: BaseManifest, expected_project: str | None) -> None:

--- a/cli/python/base_setup/git_remote.py
+++ b/cli/python/base_setup/git_remote.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+from urllib.parse import urlunparse
+from urllib.parse import urlparse
+
+from . import process
+from .checks import ArtifactCheck
+from .manifest import BaseManifest
+
+
+GITHUB_HOST = "github.com"
+SCP_REMOTE_RE = re.compile(r"^(?:(?P<user>[^@\s]+)@)?(?P<host>[^:\s/]+):(?P<path>.+)$")
+
+
+@dataclass(frozen=True)
+class RemoteInfo:
+    valid: bool
+    provider: str
+    transport: str
+    sanitized_url: str
+    host: str = ""
+    repository: str = ""
+    local_path: Path | None = None
+    reachable: bool | None = None
+    error: str = ""
+
+
+def check_git_remote(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+    if not manifest.path.is_absolute() or not manifest.path.is_file():
+        return ()
+
+    project_root = manifest.path.parent.resolve()
+    repository_check, _git_root = check_git_repository(project_root)
+    checks = [repository_check]
+    if not repository_check.ok:
+        if repository_check.details.get("inside_work_tree") is False:
+            return ()
+        return tuple(checks)
+
+    origin_check, remote_info = check_origin_remote(project_root)
+    checks.append(origin_check)
+    if not origin_check.ok or remote_info is None:
+        return tuple(checks)
+
+    if remote_info.provider == "github":
+        checks.append(check_github_cli_auth(remote_info))
+    return tuple(checks)
+
+
+def check_git_repository(project_root: Path) -> tuple[ArtifactCheck, Path | None]:
+    if not process.command_exists("git"):
+        return (
+            ArtifactCheck(
+                name="git_repository",
+                ok=False,
+                message="Git was not found, so project repository diagnostics could not run.",
+                fix="Install Git or Xcode Command Line Tools.",
+                finding_id="BASE-P080",
+                details={"project_root": str(project_root), "git_available": False},
+            ),
+            None,
+        )
+
+    inside = run_git(project_root, ["rev-parse", "--is-inside-work-tree"])
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return (
+            ArtifactCheck(
+                name="git_repository",
+                ok=False,
+                message=f"Project directory '{project_root}' is not inside a Git repository.",
+                fix="Clone the project repository or initialize Git before using project Git remote workflows.",
+                finding_id="BASE-P080",
+                details={
+                    "project_root": str(project_root),
+                    "git_available": True,
+                    "inside_work_tree": False,
+                },
+            ),
+            None,
+        )
+
+    top_level = run_git(project_root, ["rev-parse", "--show-toplevel"])
+    git_root = Path(top_level.stdout.strip()).resolve() if top_level.returncode == 0 else project_root
+    return (
+        ArtifactCheck(
+            name="git_repository",
+            ok=True,
+            message=f"Project is inside a Git repository at '{git_root}'.",
+            fix="",
+            finding_id="BASE-P080",
+            details={
+                "project_root": str(project_root),
+                "git_root": str(git_root),
+                "git_available": True,
+                "inside_work_tree": True,
+            },
+        ),
+        git_root,
+    )
+
+
+def check_origin_remote(project_root: Path) -> tuple[ArtifactCheck, RemoteInfo | None]:
+    completed = run_git(project_root, ["remote", "get-url", "origin"])
+    if completed.returncode != 0:
+        return (
+            ArtifactCheck(
+                name="git_origin_remote",
+                ok=False,
+                message="Project Git repository does not have an 'origin' remote.",
+                fix="Add an origin remote with Git, for example: git remote add origin <url>",
+                finding_id="BASE-P081",
+                details={
+                    "remote": "origin",
+                    "present": False,
+                    "network_checked": False,
+                },
+            ),
+            None,
+        )
+
+    remote_url = completed.stdout.strip()
+    remote_info = parse_origin_remote(remote_url, project_root)
+    if not remote_info.valid:
+        return (
+            ArtifactCheck(
+                name="git_origin_remote",
+                ok=False,
+                message=f"Project Git origin remote is malformed: {remote_info.error}",
+                fix="Update origin with a valid Git remote URL.",
+                finding_id="BASE-P081",
+                details=remote_details(remote_info),
+            ),
+            remote_info,
+        )
+
+    if remote_info.provider == "local" and remote_info.reachable is False:
+        return (
+            ArtifactCheck(
+                name="git_origin_remote",
+                ok=False,
+                message=f"Project Git origin remote path does not exist: {remote_info.sanitized_url}",
+                fix="Update origin to an existing local repository path.",
+                finding_id="BASE-P081",
+                details=remote_details(remote_info),
+            ),
+            remote_info,
+        )
+
+    return (
+        ArtifactCheck(
+            name="git_origin_remote",
+            ok=True,
+            message=origin_remote_message(remote_info),
+            fix="",
+            finding_id="BASE-P081",
+            details=remote_details(remote_info),
+        ),
+        remote_info,
+    )
+
+
+def check_github_cli_auth(remote_info: RemoteInfo) -> ArtifactCheck:
+    details = {
+        "remote": "origin",
+        "provider": "github",
+        "host": remote_info.host,
+        "repository": remote_info.repository,
+        "gh_auth_checked": True,
+    }
+    if not process.command_exists("gh"):
+        return ArtifactCheck(
+            name="github_cli_auth",
+            ok=False,
+            message="GitHub CLI 'gh' was not found; GitHub authentication for origin was not checked.",
+            fix="Install GitHub CLI or run 'basectl setup --profile dev'.",
+            finding_id="BASE-P082",
+            status="warn",
+            details=details | {"gh_available": False},
+        )
+
+    if process.run_check(["gh", "auth", "status", "-h", GITHUB_HOST]):
+        return ArtifactCheck(
+            name="github_cli_auth",
+            ok=True,
+            message="GitHub CLI authentication is ready for github.com.",
+            fix="",
+            finding_id="BASE-P082",
+            details=details | {"gh_available": True, "authenticated": True},
+        )
+
+    return ArtifactCheck(
+        name="github_cli_auth",
+        ok=False,
+        message="GitHub CLI authentication is not ready for github.com.",
+        fix="gh auth login -h github.com",
+        finding_id="BASE-P082",
+        status="warn",
+        details=details | {"gh_available": True, "authenticated": False},
+    )
+
+
+def parse_origin_remote(remote_url: str, project_root: Path) -> RemoteInfo:
+    remote_url = remote_url.strip()
+    if not remote_url:
+        return malformed_remote("Origin remote URL is empty.")
+
+    if "://" in remote_url:
+        return parse_url_remote(remote_url)
+
+    scp_match = SCP_REMOTE_RE.match(remote_url)
+    if scp_match and not remote_url.startswith(("/", "./", "../", "~")):
+        return parse_scp_remote(scp_match)
+
+    return parse_local_remote(remote_url, project_root)
+
+
+def parse_url_remote(remote_url: str) -> RemoteInfo:
+    parsed = urlparse(remote_url)
+    scheme = parsed.scheme.lower()
+    if not scheme:
+        return malformed_remote("Remote URL is missing a scheme.")
+
+    if scheme == "file":
+        path = unquote(parsed.path)
+        if not path:
+            return malformed_remote("file remote is missing a path.")
+        local_path = Path(path)
+        return RemoteInfo(
+            valid=True,
+            provider="local",
+            transport="file",
+            sanitized_url=urlunparse(("file", "", parsed.path, "", "", "")),
+            local_path=local_path,
+            reachable=local_path.exists(),
+        )
+
+    host = (parsed.hostname or "").lower()
+    if not host or not parsed.path or parsed.path == "/":
+        return malformed_remote("Remote URL is missing a host or repository path.")
+
+    sanitized_netloc = host
+    if parsed.port is not None:
+        sanitized_netloc = f"{sanitized_netloc}:{parsed.port}"
+    sanitized_url = urlunparse((scheme, sanitized_netloc, parsed.path, "", "", ""))
+    provider = "github" if host == GITHUB_HOST else "other"
+    repository = ""
+    error = ""
+    valid = True
+    if provider == "github":
+        repository = github_repository(parsed.path)
+        if not repository:
+            valid = False
+            error = "GitHub remote must include owner and repository."
+
+    return RemoteInfo(
+        valid=valid,
+        provider=provider,
+        transport=scheme,
+        sanitized_url=sanitized_url,
+        host=host,
+        repository=repository,
+        error=error,
+    )
+
+
+def parse_scp_remote(match: re.Match[str]) -> RemoteInfo:
+    host = match.group("host").lower()
+    path = match.group("path").strip()
+    if not host or not path:
+        return malformed_remote("SSH remote is missing a host or repository path.")
+
+    sanitized_url = f"{host}:{path}"
+    provider = "github" if host == GITHUB_HOST else "other"
+    repository = ""
+    error = ""
+    valid = True
+    if provider == "github":
+        repository = github_repository(path)
+        if not repository:
+            valid = False
+            error = "GitHub remote must include owner and repository."
+
+    return RemoteInfo(
+        valid=valid,
+        provider=provider,
+        transport="ssh",
+        sanitized_url=sanitized_url,
+        host=host,
+        repository=repository,
+        error=error,
+    )
+
+
+def parse_local_remote(remote_url: str, project_root: Path) -> RemoteInfo:
+    local_path = Path(remote_url).expanduser()
+    resolved_path = local_path if local_path.is_absolute() else (project_root / local_path).resolve()
+    return RemoteInfo(
+        valid=True,
+        provider="local",
+        transport="local_path",
+        sanitized_url=remote_url,
+        local_path=resolved_path,
+        reachable=resolved_path.exists(),
+    )
+
+
+def malformed_remote(error: str) -> RemoteInfo:
+    return RemoteInfo(
+        valid=False,
+        provider="unknown",
+        transport="unknown",
+        sanitized_url="",
+        error=error,
+    )
+
+
+def github_repository(path: str) -> str:
+    normalized = path.strip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized.removesuffix(".git")
+    parts = normalized.split("/")
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        return ""
+    return f"{parts[0]}/{parts[1]}"
+
+
+def origin_remote_message(remote_info: RemoteInfo) -> str:
+    if remote_info.provider == "github":
+        return (
+            "Project Git origin remote points to GitHub repository "
+            f"'{remote_info.repository}' over {remote_info.transport}."
+        )
+    if remote_info.provider == "local":
+        return f"Project Git origin remote points to local repository path '{remote_info.sanitized_url}'."
+    if remote_info.host:
+        return f"Project Git origin remote points to host '{remote_info.host}' over {remote_info.transport}."
+    return "Project Git origin remote is configured."
+
+
+def remote_details(remote_info: RemoteInfo) -> dict[str, object]:
+    details: dict[str, object] = {
+        "remote": "origin",
+        "provider": remote_info.provider,
+        "transport": remote_info.transport,
+        "network_checked": False,
+    }
+    if remote_info.sanitized_url:
+        details["sanitized_url"] = remote_info.sanitized_url
+    if remote_info.host:
+        details["host"] = remote_info.host
+    if remote_info.repository:
+        details["repository"] = remote_info.repository
+    if remote_info.reachable is not None:
+        details["reachable"] = remote_info.reachable
+    if remote_info.error:
+        details["error"] = remote_info.error
+    return details
+
+
+def run_git(project_root: Path, arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(project_root), *arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )

--- a/cli/python/base_setup/tests/test_git_remote.py
+++ b/cli/python/base_setup/tests/test_git_remote.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from base_setup.checks import check_to_json
+from base_setup.checks import doctor_status
+from base_setup.git_remote import check_git_remote
+from base_setup.manifest import BaseManifest
+
+
+def manifest_for(project_root: Path) -> BaseManifest:
+    manifest_path = project_root / "base_manifest.yaml"
+    manifest_path.write_text("project:\n  name: demo\nartifacts: []\n", encoding="utf-8")
+    return BaseManifest(path=manifest_path, project_name="demo", brewfile=None, artifacts=())
+
+
+def git(project_root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(project_root), *args],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+
+
+@unittest.skipUnless(shutil.which("git"), "Git is not installed")
+class GitRemoteCheckTests(unittest.TestCase):
+    def test_skips_project_directory_outside_git_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = manifest_for(Path(tmpdir))
+
+            checks = check_git_remote(manifest)
+
+        self.assertEqual(checks, ())
+
+    def test_reports_git_repository_without_origin_remote(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            git(project_root, "init")
+            manifest = manifest_for(project_root)
+
+            checks = check_git_remote(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P080", "BASE-P081"])
+        self.assertTrue(checks[0].ok)
+        self.assertFalse(checks[1].ok)
+        self.assertIn("does not have an 'origin' remote", checks[1].message)
+        self.assertEqual(checks[1].details["network_checked"], False)
+
+    def test_reports_github_remote_with_unavailable_auth_as_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            git(project_root, "init")
+            git(project_root, "remote", "add", "origin", "git@github.com:codeforester/base.git")
+            manifest = manifest_for(project_root)
+
+            with (
+                mock.patch("base_setup.git_remote.process.command_exists", return_value=True),
+                mock.patch("base_setup.git_remote.process.run_check", return_value=False) as run_check,
+            ):
+                checks = check_git_remote(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P080", "BASE-P081", "BASE-P082"])
+        self.assertTrue(checks[1].ok)
+        self.assertEqual(checks[1].details["provider"], "github")
+        self.assertEqual(checks[1].details["transport"], "ssh")
+        self.assertEqual(checks[1].details["repository"], "codeforester/base")
+        self.assertFalse(checks[2].ok)
+        self.assertEqual(doctor_status(checks[2]), "warn")
+        self.assertEqual(checks[2].fix, "gh auth login -h github.com")
+        run_check.assert_called_once_with(["gh", "auth", "status", "-h", "github.com"])
+
+    def test_non_github_remote_does_not_check_github_cli_auth(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            git(project_root, "init")
+            git(project_root, "remote", "add", "origin", "https://example.com/team/demo.git")
+            manifest = manifest_for(project_root)
+
+            def command_exists(name: str) -> bool:
+                if name == "git":
+                    return True
+                raise AssertionError(f"unexpected command lookup: {name}")
+
+            with (
+                mock.patch("base_setup.git_remote.process.command_exists", side_effect=command_exists),
+                mock.patch("base_setup.git_remote.process.run_check") as run_check,
+            ):
+                checks = check_git_remote(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P080", "BASE-P081"])
+        self.assertTrue(checks[1].ok)
+        self.assertEqual(checks[1].details["provider"], "other")
+        self.assertEqual(checks[1].details["host"], "example.com")
+        run_check.assert_not_called()
+
+    def test_reports_missing_local_origin_path_without_network_probe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            git(project_root, "init")
+            git(project_root, "remote", "add", "origin", "../missing-remote.git")
+            manifest = manifest_for(project_root)
+
+            checks = check_git_remote(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P080", "BASE-P081"])
+        self.assertFalse(checks[1].ok)
+        self.assertEqual(checks[1].details["provider"], "local")
+        self.assertEqual(checks[1].details["network_checked"], False)
+        self.assertEqual(checks[1].details["reachable"], False)
+
+    def test_reports_malformed_github_remote(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            git(project_root, "init")
+            git(project_root, "config", "remote.origin.url", "https://github.com")
+            manifest = manifest_for(project_root)
+
+            checks = check_git_remote(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P080", "BASE-P081"])
+        self.assertFalse(checks[1].ok)
+        self.assertIn("malformed", checks[1].message)
+        self.assertEqual(checks[1].details["network_checked"], False)
+
+    def test_sanitizes_credential_bearing_github_remote(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            git(project_root, "init")
+            git(project_root, "remote", "add", "origin", "https://token:secret@github.com/codeforester/base.git")
+            manifest = manifest_for(project_root)
+
+            with (
+                mock.patch("base_setup.git_remote.process.command_exists", return_value=True),
+                mock.patch("base_setup.git_remote.process.run_check", return_value=True),
+            ):
+                checks = check_git_remote(manifest)
+
+        payload = json.dumps([check_to_json(check) for check in checks])
+        self.assertNotIn("token", payload)
+        self.assertNotIn("secret", payload)
+        self.assertIn("https://github.com/codeforester/base.git", payload)
+        self.assertEqual(checks[1].details["sanitized_url"], "https://github.com/codeforester/base.git")

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -108,6 +108,9 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P060` | Project demo declaration |
 | `BASE-P061` | Project demo script path and executable status |
 | `BASE-P070` | Build target working directory status |
+| `BASE-P080` | Project Git repository status |
+| `BASE-P081` | Project Git `origin` remote status |
+| `BASE-P082` | GitHub CLI authentication status for a GitHub-hosted project remote |
 | `BASE-P100` | User config disables all IDE setup and checks |
 | `BASE-P101` | User config disables setup and checks for one IDE |
 | `BASE-P102` | User IDE setting conflicts with a project manifest setting |
@@ -139,6 +142,12 @@ Base only inspects the `pyproject.toml` file beside the active
 configuration source and do not cause Base to install Python dependencies.
 Warnings in this range should guide users toward a valid Python project file
 without failing the Base manifest check by themselves.
+
+`BASE-P080` through `BASE-P082` are read-only project Git remote diagnostics.
+They report whether the project directory is inside a Git repository, whether
+`origin` is configured and parseable, and whether GitHub CLI authentication is
+ready when `origin` points at GitHub. Default project check and doctor do not
+probe network remote reachability; that belongs behind an explicit opt-in path.
 
 ## Health Findings
 


### PR DESCRIPTION
## Summary
- Add read-only project Git diagnostics for Git worktree, origin remote, and GitHub CLI auth readiness.
- Include sanitized structured details in project check/doctor JSON without default network reachability probes.
- Run pre-venv Git diagnostics when project venv health blocks the normal project layer, and document new BASE-P080 through BASE-P082 findings.

## Validation
- env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/feat-395-20260609-project-git-remote-health/lib/python:/Users/rameshhp/work/base-worktrees/feat-395-20260609-project-git-remote-health/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_git_remote.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_projects/tests/test_workspace_checks.py -q
- env -u BASE_HOME bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats
- env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/feat-395-20260609-project-git-remote-health/lib/python:/Users/rameshhp/work/base-worktrees/feat-395-20260609-project-git-remote-health/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python -q
- env -u BASE_HOME ./bin/base-test
- git diff --check
- git diff --cached --check

## Demo Impact
- Project check/doctor now surface Git remote readiness for repositories with an origin remote; no demo script changes.

Fixes #395