### PR TITLE
Add project installer template

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -30,7 +30,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `doctor`
 - `gh`
 - `onboard`
-- `repo init/check/configure`
+- `repo init/check/configure/installer-template`
 - `test`
 - `build`
 - `update-profile`
@@ -79,6 +79,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
   then falls back to the parent directory of `BASE_HOME`.
   `basectl repo check [path]` verifies the local baseline, and
   `basectl repo configure [path]` reapplies the GitHub settings and labels.
+  `basectl repo installer-template [path]` prints or writes the maintained
+  project installer starter script.
 - `basectl test [project]` runs the project's manifest `test.command` or
   `test.mise` from the project root with Base project environment variables
   exported. Use `basectl test <project> -- <args...>` to pass extra arguments

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -23,8 +23,8 @@ Commands:
     Run a project's declared interactive demo.
   run <project> <command> [options]
     Run a project's declared command.
-  repo <init|check|configure> [options]
-    Create, check, and configure a standard Base-managed repository baseline.
+  repo <init|check|configure|installer-template> [options]
+    Create repository baselines and project installer templates.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   logs [options]

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -23,6 +23,7 @@ Usage:
   basectl repo init <name> [options]
   basectl repo check [path] [options]
   basectl repo configure [path] [options]
+  basectl repo installer-template [path] [options]
 
 Options:
   --path <path>                 Target path for repo init. Defaults to workspace root plus <name>.
@@ -36,7 +37,8 @@ Options:
   -v                            Enable DEBUG logging for this subcommand.
   -h, --help                    Show this help text.
 
-Create, check, and configure a standard Base-managed repository baseline.
+Create, check, and configure a standard Base-managed repository baseline, or
+write a reusable project installer template.
 EOF
 }
 
@@ -223,7 +225,7 @@ base_repo_write_stream() {
     local target_dir
 
     if [[ -e "$target" ]]; then
-        log_info "Repository baseline file already exists at '$target'; leaving it unchanged."
+        log_info "File already exists at '$target'; leaving it unchanged."
         return 0
     fi
 
@@ -246,7 +248,7 @@ base_repo_write_executable_stream() {
     local target_dir
 
     if [[ -e "$target" ]]; then
-        log_info "Repository baseline file already exists at '$target'; leaving it unchanged."
+        log_info "File already exists at '$target'; leaving it unchanged."
         return 0
     fi
 
@@ -265,6 +267,41 @@ base_repo_write_executable_stream() {
         log_error "Failed to make '$target' executable."
         return 1
     fi
+}
+
+base_repo_installer_template_path() {
+    [[ -n "${BASE_HOME:-}" ]] || {
+        log_error "BASE_HOME is required to locate the project installer template."
+        return 1
+    }
+
+    printf '%s/templates/project-install.sh\n' "$BASE_HOME"
+}
+
+base_repo_print_installer_template() {
+    local template
+
+    template="$(base_repo_installer_template_path)" || return 1
+    [[ -f "$template" ]] || {
+        log_error "Project installer template was not found at '$template'."
+        return 1
+    }
+
+    cat "$template"
+}
+
+base_repo_write_installer_template() {
+    local dry_run="$1"
+    local target="$2"
+    local template
+
+    template="$(base_repo_installer_template_path)" || return 1
+    [[ -f "$template" ]] || {
+        log_error "Project installer template was not found at '$template'."
+        return 1
+    }
+
+    base_repo_write_executable_stream "$dry_run" "$target" < "$template"
 }
 
 base_repo_write_readme() {
@@ -916,6 +953,49 @@ base_repo_configure() {
     base_repo_configure_github "$dry_run" "$github_repo"
 }
 
+base_repo_installer_template() {
+    local dry_run=0
+    local path=""
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_repo_subcommand_usage
+                return 0
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            -v)
+                set_log_level DEBUG
+                export LOG_DEBUG=1
+                shift
+                ;;
+            -*)
+                base_repo_usage_error "Unknown repo installer-template option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$path" ]]; then
+                    base_repo_usage_error "The 'repo installer-template' command accepts at most one path."
+                    return $?
+                fi
+                path="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$path" ]]; then
+        base_repo_print_installer_template
+        return $?
+    fi
+
+    path="$(base_repo_target_path "$path")"
+    base_repo_write_installer_template "$dry_run" "$path"
+}
+
 base_repo_subcommand_main() {
     local command="${1:-}"
 
@@ -935,6 +1015,10 @@ base_repo_subcommand_main() {
         configure)
             shift
             base_repo_configure "$@"
+            ;;
+        installer-template)
+            shift
+            base_repo_installer_template "$@"
             ;;
         *)
             base_repo_usage_error "Unknown repo command '$command'."

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -115,6 +115,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "repo_configure_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl repo installer-template --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "repo_installer_template_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl gh ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -149,9 +153,10 @@ EOF
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
-    [[ "$output" == *"repo_commands=init check configure"* ]]
+    [[ "$output" == *"repo_commands=init check configure installer-template"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --dry-run"* ]]
     [[ "$output" == *"repo_configure_options=--repo --dry-run"* ]]
+    [[ "$output" == *"repo_installer_template_options=--dry-run"* ]]
     [[ "$output" == *"gh_areas=issue pr branch worktree todo"* ]]
     [[ "$output" == *"gh_worktree_commands=prune"* ]]
     [[ "$output" == *"gh_worktree_prune_options=--dry-run --yes"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -13,7 +13,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
-    [[ "$output" == *"repo <init|check|configure> [options]"* ]]
+    [[ "$output" == *"repo <init|check|configure|installer-template> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"logs [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
@@ -49,7 +49,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  onboard [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
-    grep -Fqx '  repo <init|check|configure> [options]' <<<"$output"
+    grep -Fqx '  repo <init|check|configure|installer-template> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -11,6 +11,48 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl repo init <name>"* ]]
     [[ "$output" == *"basectl repo check [path]"* ]]
     [[ "$output" == *"basectl repo configure [path]"* ]]
+    [[ "$output" == *"basectl repo installer-template [path]"* ]]
+}
+
+@test "basectl repo installer-template prints the maintained template" {
+    run_basectl repo installer-template
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'PROJECT_NAME="${PROJECT_NAME:-example-project}"'* ]]
+    [[ "$output" == *'PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/example/example-project.git}"'* ]]
+    [[ "$output" == *'basectl" setup --manifest "$PROJECT_DIR/base_manifest.yaml" "$PROJECT_NAME"'* ]]
+}
+
+@test "basectl repo installer-template writes an executable template" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo installer-template "$repo_dir/install.sh"
+
+    [ "$status" -eq 0 ]
+    [ -x "$repo_dir/install.sh" ]
+    grep -Fq 'PROJECT_NAME="${PROJECT_NAME:-example-project}"' "$repo_dir/install.sh"
+}
+
+@test "basectl repo installer-template leaves existing files unchanged" {
+    local repo_dir="$TEST_TMPDIR/custom"
+
+    mkdir -p "$repo_dir"
+    printf 'custom\n' > "$repo_dir/install.sh"
+
+    run_basectl repo installer-template "$repo_dir/install.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$repo_dir/install.sh")" = "custom" ]
+}
+
+@test "basectl repo installer-template dry-run reports executable creation" {
+    local repo_dir="$TEST_TMPDIR/dry-run"
+
+    run_basectl repo installer-template "$repo_dir/install.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create executable '$repo_dir/install.sh'."* ]]
+    [ ! -e "$repo_dir/install.sh" ]
 }
 
 @test "basectl repo init dry-run prints baseline and configuration plan" {

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -49,42 +49,36 @@ The installer should not reimplement Base's setup logic. It should call Base.
 
 ## Recommended Flow
 
-A project installer should be a thin Bash script with a predictable sequence:
+Start from Base's maintained template, then customize the project-owned copy:
 
 ```bash
-#!/usr/bin/env bash
-
-project_name="banyanlabs"
-workspace_dir="${HOME}/work"
-base_dir="${workspace_dir}/base"
-project_dir="${workspace_dir}/${project_name}"
-
-installer="${TMPDIR:-/tmp}/base-install.sh"
-
-mkdir -p "$workspace_dir" || {
-    printf 'ERROR: Unable to create workspace directory %s.\n' "$workspace_dir" >&2
-    exit 1
-}
-
-if [[ ! -d "$base_dir/.git" ]]; then
-    curl -fsSL -o "$installer" https://raw.githubusercontent.com/codeforester/base/master/install.sh || exit 1
-    BASE_INSTALL_DIR="$base_dir" bash "$installer" || exit 1
-else
-    git -C "$base_dir" pull --ff-only || exit 1
-fi
-
-if [[ ! -d "$project_dir/.git" ]]; then
-    git clone https://github.com/codeforester/banyanlabs.git "$project_dir" || exit 1
-else
-    git -C "$project_dir" pull --ff-only || exit 1
-fi
-
-"$base_dir/bin/basectl" setup --manifest "$project_dir/base_manifest.yaml" "$project_name" || exit 1
-"$base_dir/bin/basectl" update-profile || exit 1
+basectl repo installer-template
+basectl repo installer-template install.sh
 ```
 
-This is only a sketch. A real installer should add friendlier output, better
-error handling, and project-specific next steps.
+With no path, the command prints the template to stdout. With a path, it writes
+an executable script and leaves an existing file unchanged so project
+customizations are not overwritten.
+
+For a project such as Banyan Labs, the generated script should change the
+project-owned values at the top:
+
+```bash
+PROJECT_NAME="${PROJECT_NAME:-banyanlabs}"
+PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/codeforester/banyanlabs.git}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/work}"
+BASE_DIR="${BASE_DIR:-$WORKSPACE_DIR/base}"
+PROJECT_DIR="${PROJECT_DIR:-$WORKSPACE_DIR/$PROJECT_NAME}"
+RUN_UPDATE_PROFILE="${RUN_UPDATE_PROFILE:-true}"
+```
+
+It should also replace the generic success text with project-specific next
+steps, for example:
+
+```bash
+log "Banyan Labs setup is complete."
+log "Next: open the project README and run the first Banyan Labs smoke test."
+```
 
 If a project installer uses Base's standalone installer, it should still avoid
 reimplementing Base setup. Use `BASE_INSTALL_DIR` or `install.sh --dir <path>` to

--- a/docs/superpowers/plans/2026-06-09-project-installer-template.md
+++ b/docs/superpowers/plans/2026-06-09-project-installer-template.md
@@ -1,0 +1,159 @@
+# Project Installer Template Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a maintained reusable project installer template that projects can
+print or write through `basectl repo installer-template`.
+
+**Architecture:** Keep the template source in `templates/project-install.sh`.
+Extend the existing Bash `repo` subcommand with a small printer/writer command
+that reuses Base's current idempotent executable file writer. Document project
+customization in `docs/project-installers.md`.
+
+**Tech Stack:** Bash, existing `basectl repo` shell helpers, BATS, ShellCheck,
+and Markdown docs.
+
+---
+
+## File Structure
+
+- Create `templates/project-install.sh`: maintained copyable starter installer.
+- Modify `cli/bash/commands/basectl/subcommands/repo.sh`: add
+  `installer-template` usage, printer, writer, parser, and dispatcher entry.
+- Modify `cli/bash/commands/basectl/tests/repo.bats`: add RED tests for the new
+  command.
+- Modify `docs/project-installers.md`: replace the sketch with the template
+  command and customization guidance.
+- Add `docs/superpowers/specs/2026-06-09-project-installer-template-design.md`:
+  design record.
+- Add `docs/superpowers/plans/2026-06-09-project-installer-template.md`: this
+  plan.
+
+## Task 1: RED Command Tests
+
+**Files:**
+- Modify `cli/bash/commands/basectl/tests/repo.bats`
+
+- [ ] Add a help assertion for `basectl repo installer-template [path]`.
+- [ ] Add a test that runs `basectl repo installer-template` and asserts stdout
+  contains:
+  - `PROJECT_NAME="${PROJECT_NAME:-example-project}"`
+  - `PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/example/example-project.git}"`
+  - `basectl" setup --manifest "$PROJECT_DIR/base_manifest.yaml" "$PROJECT_NAME"`
+- [ ] Add a test that runs `basectl repo installer-template "$repo_dir/install.sh"`
+  and asserts the file exists and is executable.
+- [ ] Add a test that pre-creates `install.sh`, runs the command, and asserts
+  the custom content is unchanged.
+- [ ] Add a dry-run test that asserts no file is written.
+- [ ] Run focused BATS and verify RED.
+
+Command:
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats
+```
+
+Expected RED result: new tests fail because `installer-template` is not a known
+repo subcommand.
+
+## Task 2: Template File
+
+**Files:**
+- Create `templates/project-install.sh`
+
+- [ ] Add a Bash script with editable defaults for project name, repo URL,
+  workspace, Base directory, project directory, Base install URL, and profile
+  update behavior.
+- [ ] Add helpers for logging, command execution, failure handling, temporary
+  installer cleanup, workspace creation, Base install/update, project
+  clone/update, setup, optional profile update, and success output.
+- [ ] Make the script call Base's maintained `install.sh` rather than
+  reimplementing Base setup.
+- [ ] Run ShellCheck on the template and fix any findings.
+
+Command:
+
+```bash
+shellcheck -S error templates/project-install.sh
+```
+
+## Task 3: Repo Command Implementation
+
+**Files:**
+- Modify `cli/bash/commands/basectl/subcommands/repo.sh`
+
+- [ ] Add `basectl repo installer-template [path] [options]` to usage.
+- [ ] Add `base_repo_print_installer_template()` that prints
+  `templates/project-install.sh` from `BASE_HOME`.
+- [ ] Add `base_repo_write_installer_template()` that writes an executable copy
+  to a requested path using the existing no-overwrite semantics.
+- [ ] Add `base_repo_installer_template()` option parsing for:
+  - optional path
+  - `--dry-run`
+  - `-v`
+  - help
+- [ ] Add dispatcher support for `installer-template`.
+- [ ] Run focused BATS and verify GREEN.
+
+Command:
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats
+```
+
+## Task 4: Documentation
+
+**Files:**
+- Modify `docs/project-installers.md`
+
+- [ ] Replace the old sketch with commands for printing or writing the template.
+- [ ] Add a Banyan Labs customization example that changes `PROJECT_NAME`,
+  `PROJECT_REPO_URL`, and project-specific next-step messaging.
+- [ ] Keep the product boundary language: Base provides mechanics, the project
+  owns narrative and final instructions.
+- [ ] Run Markdown whitespace validation.
+
+Command:
+
+```bash
+git diff --check -- docs/project-installers.md
+```
+
+## Task 5: Validation
+
+- [ ] Run focused repo BATS:
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats
+```
+
+- [ ] Run ShellCheck:
+
+```bash
+shellcheck -S error templates/project-install.sh cli/bash/commands/basectl/subcommands/repo.sh
+```
+
+- [ ] Run full Base validation:
+
+```bash
+env -u BASE_HOME ./bin/base-test
+```
+
+- [ ] Run whitespace validation:
+
+```bash
+git diff --check
+```
+
+## Task 6: Publish
+
+- [ ] Commit implementation.
+- [ ] Push `enhancement/512-20260609-project-installer-template`.
+- [ ] Open a PR closing #512.
+- [ ] Watch CI.
+- [ ] Merge when checks are green.
+- [ ] Sync local `master`.
+- [ ] Remove the #512 worktree and local branch.

--- a/docs/superpowers/specs/2026-06-09-project-installer-template-design.md
+++ b/docs/superpowers/specs/2026-06-09-project-installer-template-design.md
@@ -1,0 +1,94 @@
+# Project Installer Template Design
+
+Issue: #512
+
+## Goal
+
+Give Base-managed projects a maintained starter installer they can copy or
+generate, while keeping project-specific language, credentials, and final
+onboarding steps inside the project repository.
+
+## Selected Approach
+
+Use a command-backed template:
+
+- add a checked-in `templates/project-install.sh`
+- add `basectl repo installer-template [path]`
+- print the template to stdout when no path is provided
+- write an executable script when a path is provided
+
+This is narrower than adding a full project installer generator with many
+project-specific flags, but stronger than documentation-only guidance. Base owns
+the reusable mechanics and a stable starting point; each project owns the copy
+it publishes.
+
+## Alternatives Considered
+
+1. **Checked-in template only.** Lowest implementation cost, but users have to
+   know where to find it and how to copy it correctly.
+2. **`basectl repo init --installer`.** Convenient for new repos, but less
+   useful for existing repos and expands `repo init` option scope.
+3. **`basectl repo installer-template`.** Discoverable, works for existing and
+   new repos, and keeps installer generation separate from baseline generation.
+
+The third option is the chosen slice.
+
+## Template Behavior
+
+The template will be a valid Bash script with editable defaults at the top:
+
+- `PROJECT_NAME`
+- `PROJECT_REPO_URL`
+- `WORKSPACE_DIR`
+- `BASE_DIR`
+- `PROJECT_DIR`
+- `BASE_INSTALL_URL`
+- `RUN_UPDATE_PROFILE`
+
+The script will:
+
+1. create or locate the workspace directory
+2. install or update Base using Base's maintained `install.sh`
+3. clone or update the target project repository
+4. run `basectl setup --manifest "$PROJECT_DIR/base_manifest.yaml" "$PROJECT_NAME"`
+5. optionally run `basectl update-profile`
+6. run or recommend `basectl doctor "$PROJECT_NAME"` when project setup fails
+7. leave success messaging and next steps as project-owned text
+
+The template will preserve underlying command output by running commands
+directly and printing the command before it runs. It will not reimplement
+Homebrew, Python, virtualenv, or artifact reconciliation logic.
+
+## Command Behavior
+
+`basectl repo installer-template` with no path writes the template to stdout.
+
+`basectl repo installer-template <path>` writes an executable file, creating
+parent directories as needed. Like other repo baseline writers, it leaves an
+existing file unchanged rather than overwriting local project customizations.
+
+`--dry-run` with a path reports the planned executable creation and writes no
+file.
+
+## Documentation
+
+Update `docs/project-installers.md` so the recommended flow points to the
+template command first, then shows the kind of customization a project such as
+Banyan Labs should make: project name, repo URL, workspace default, friendly
+success message, and project-specific next steps.
+
+Update `docs/README.md` only if needed; the existing Project Installers entry is
+already present.
+
+## Tests
+
+Add BATS coverage for:
+
+- repo help lists `installer-template`
+- printing the template to stdout
+- writing an executable installer template to a requested path
+- leaving an existing installer unchanged
+- dry-run not writing the file
+
+Run ShellCheck on the checked-in template, then the full `env -u BASE_HOME
+./bin/base-test` suite.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -119,7 +119,7 @@ _base_basectl_completion() {
         repo)
             case "${COMP_WORDS[2]:-}" in
                 "")
-                    _base_basectl_completion_compgen "init check configure" "$cur"
+                    _base_basectl_completion_compgen "init check configure installer-template" "$cur"
                     ;;
                 init)
                     _base_basectl_completion_compgen "--path --repo --description --copyright-holder --private --public --no-configure --dry-run -v -h --help" "$cur"
@@ -129,6 +129,9 @@ _base_basectl_completion() {
                     ;;
                 configure)
                     _base_basectl_completion_compgen "--repo --dry-run -v -h --help" "$cur"
+                    ;;
+                installer-template)
+                    _base_basectl_completion_compgen "--dry-run -v -h --help" "$cur"
                     ;;
             esac
             ;;

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -129,7 +129,7 @@ _base_basectl_completion() {
         repo)
             case "${words[3]:-}" in
                 init)
-                    _arguments '1:repo command:(init check configure)' \
+                    _arguments '1:repo command:(init check configure installer-template)' \
                         '2:repository name:' \
                         '--path[Target path]:path:_files' \
                         '--repo[GitHub repository]:repo:' \
@@ -143,21 +143,28 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 check)
-                    _arguments '1:repo command:(init check configure)' \
+                    _arguments '1:repo command:(init check configure installer-template)' \
                         '2:path:_files' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 configure)
-                    _arguments '1:repo command:(init check configure)' \
+                    _arguments '1:repo command:(init check configure installer-template)' \
                         '2:path:_files' \
                         '--repo[GitHub repository]:repo:' \
                         '--dry-run[Print planned changes]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
+                installer-template)
+                    _arguments '1:repo command:(init check configure installer-template)' \
+                        '2:path:_files' \
+                        '--dry-run[Print planned changes]' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
                 *)
-                    _arguments '1:repo command:(init check configure)'
+                    _arguments '1:repo command:(init check configure installer-template)'
                     ;;
             esac
             ;;

--- a/templates/project-install.sh
+++ b/templates/project-install.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Project-owned values. Copy this template into your project and customize them.
+PROJECT_NAME="${PROJECT_NAME:-example-project}"
+PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/example/example-project.git}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/work}"
+BASE_DIR="${BASE_DIR:-$WORKSPACE_DIR/base}"
+PROJECT_DIR="${PROJECT_DIR:-$WORKSPACE_DIR/$PROJECT_NAME}"
+BASE_INSTALL_URL="${BASE_INSTALL_URL:-https://raw.githubusercontent.com/codeforester/base/master/install.sh}"
+RUN_UPDATE_PROFILE="${RUN_UPDATE_PROFILE:-true}"
+
+INSTALLER_TMP=""
+
+log() {
+    printf '%s\n' "$*"
+}
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+run() {
+    printf '+'
+    printf ' %q' "$@"
+    printf '\n'
+    "$@"
+}
+
+cleanup() {
+    if [[ -n "$INSTALLER_TMP" && -f "$INSTALLER_TMP" ]]; then
+        rm -f "$INSTALLER_TMP"
+    fi
+}
+trap cleanup EXIT
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "Required command '$1' was not found."
+}
+
+ensure_workspace() {
+    run mkdir -p "$WORKSPACE_DIR"
+}
+
+install_or_update_base() {
+    require_command git
+
+    if [[ -d "$BASE_DIR/.git" ]]; then
+        log "Updating Base at '$BASE_DIR'."
+        run git -C "$BASE_DIR" pull --ff-only
+        return 0
+    fi
+
+    if [[ -e "$BASE_DIR" ]]; then
+        die "Base path '$BASE_DIR' exists but is not a Git checkout."
+    fi
+
+    require_command curl
+    INSTALLER_TMP="$(mktemp "${TMPDIR:-/tmp}/base-install.XXXXXX")"
+    log "Installing Base into '$BASE_DIR'."
+    run curl -fsSL -o "$INSTALLER_TMP" "$BASE_INSTALL_URL"
+    run bash "$INSTALLER_TMP" --dir "$BASE_DIR" --no-profile
+}
+
+clone_or_update_project() {
+    require_command git
+
+    if [[ -d "$PROJECT_DIR/.git" ]]; then
+        log "Updating $PROJECT_NAME at '$PROJECT_DIR'."
+        run git -C "$PROJECT_DIR" pull --ff-only
+        return 0
+    fi
+
+    if [[ -e "$PROJECT_DIR" ]]; then
+        die "Project path '$PROJECT_DIR' exists but is not a Git checkout."
+    fi
+
+    log "Cloning $PROJECT_NAME into '$PROJECT_DIR'."
+    run git clone "$PROJECT_REPO_URL" "$PROJECT_DIR"
+}
+
+run_project_setup() {
+    local manifest="$PROJECT_DIR/base_manifest.yaml"
+
+    [[ -f "$manifest" ]] || die "Project manifest was not found at '$manifest'."
+    [[ -x "$BASE_DIR/bin/basectl" ]] || die "Base CLI was not found at '$BASE_DIR/bin/basectl'."
+
+    if ! run "$BASE_DIR/bin/basectl" setup --manifest "$PROJECT_DIR/base_manifest.yaml" "$PROJECT_NAME"; then
+        log "Project setup failed. Running Base doctor for more detail."
+        run "$BASE_DIR/bin/basectl" doctor "$PROJECT_NAME" || true
+        die "Project setup failed."
+    fi
+}
+
+maybe_update_profile() {
+    case "$RUN_UPDATE_PROFILE" in
+        true|1|yes)
+            run "$BASE_DIR/bin/basectl" update-profile
+            ;;
+        false|0|no)
+            log "Skipping shell profile update."
+            ;;
+        *)
+            die "RUN_UPDATE_PROFILE must be true or false."
+            ;;
+    esac
+}
+
+main() {
+    log "Installing $PROJECT_NAME workspace."
+    log "Workspace: $WORKSPACE_DIR"
+
+    ensure_workspace
+    install_or_update_base
+    clone_or_update_project
+    run_project_setup
+    maybe_update_profile
+
+    log "$PROJECT_NAME setup is complete."
+    log "Project-specific next steps belong here."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `templates/project-install.sh` as Base's maintained starter script for project-owned installers.
- Add `basectl repo installer-template [path]` to print the template or write an executable copy without overwriting existing customizations.
- Update project-installer docs, help text, completions, and BATS coverage for the new command.

## Validation

- `bats cli/bash/commands/basectl/tests/repo.bats`
- `bats cli/bash/commands/basectl/tests/help.bats`
- `bats cli/bash/commands/basectl/tests/completions.bats`
- `shellcheck -S error templates/project-install.sh cli/bash/commands/basectl/subcommands/repo.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

Closes #512
