### PR TITLE
Verify mise project tool status

### DIFF
--- a/cli/python/base_setup/delegates.py
+++ b/cli/python/base_setup/delegates.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import base_cli
 
@@ -70,17 +72,124 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
             finding_id="BASE-P021",
         )
 
+    project_root = manifest.path.parent.resolve()
+    details = mise_details(project_root, mise_path)
+    trust_problem = check_mise_trust(project_root, mise_path, details)
+    if trust_problem is not None:
+        return trust_problem
+
+    verified_details = details | {"trusted": True, "missing_tools_checked": True}
+    missing_problem = check_mise_missing_tools(manifest, project_root, mise_path, verified_details)
+    if missing_problem is not None:
+        return missing_problem
+
     return ArtifactCheck(
         name="mise",
-        ok=False,
-        message=(
-            f"mise config '{mise_path}' is present and the mise CLI is available, "
-            "but installed mise tools are not verified."
-        ),
-        fix=f"Run 'basectl setup {manifest.project_name}' to install declared mise tools.",
-        status="warn",
+        ok=True,
+        message=f"mise config '{mise_path}' is trusted and mise-managed tools are installed.",
+        fix="",
         finding_id="BASE-P022",
+        details=verified_details,
     )
+
+
+def check_mise_trust(project_root: Path, mise_path: Path, details: dict[str, object]) -> ArtifactCheck | None:
+    trust_check = process.run_capture(["mise", "trust", "--show"], cwd=project_root)
+    trust_text = command_text(trust_check.stdout, trust_check.stderr)
+    if trust_check.returncode != 0:
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=f"mise trust status could not be checked for '{mise_path}'.",
+            fix=f"Run 'mise trust --show' in '{project_root}' for details.",
+            status="warn",
+            finding_id="BASE-P022",
+            details=details | {"returncode": trust_check.returncode},
+        )
+    if mise_config_untrusted(trust_text):
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=f"mise config '{mise_path}' is not trusted by mise.",
+            fix=f"mise trust {mise_path}",
+            finding_id="BASE-P022",
+            details=details | {"trusted": False},
+        )
+    if "trusted" not in trust_text.lower():
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=f"mise trust status for '{mise_path}' could not be determined.",
+            fix=f"Run 'mise trust --show' in '{project_root}' for details.",
+            status="warn",
+            finding_id="BASE-P022",
+            details=details,
+        )
+    return None
+
+
+def check_mise_missing_tools(
+    manifest: BaseManifest,
+    project_root: Path,
+    mise_path: Path,
+    details: dict[str, object],
+) -> ArtifactCheck | None:
+    missing_check = process.run_capture(["mise", "ls", "--missing", "--json"], cwd=project_root)
+    if missing_check.returncode != 0:
+        missing_text = command_text(missing_check.stdout, missing_check.stderr)
+        if mise_config_untrusted(missing_text):
+            return ArtifactCheck(
+                name="mise",
+                ok=False,
+                message=f"mise config '{mise_path}' is not trusted by mise.",
+                fix=f"mise trust {mise_path}",
+                finding_id="BASE-P022",
+                details=details | {"trusted": False, "returncode": missing_check.returncode},
+            )
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=f"mise missing-tool status could not be checked for '{mise_path}'.",
+            fix=f"Run 'mise ls --missing --json' in '{project_root}' for details.",
+            status="warn",
+            finding_id="BASE-P022",
+            details=details | {"returncode": missing_check.returncode},
+        )
+
+    try:
+        missing_payload = json.loads(missing_check.stdout or "{}")
+    except json.JSONDecodeError:
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=f"mise missing-tool output for '{mise_path}' could not be parsed as JSON.",
+            fix=f"Run 'mise ls --missing --json' in '{project_root}' for details.",
+            status="warn",
+            finding_id="BASE-P022",
+            details=details,
+        )
+
+    missing_tools = missing_tool_names(missing_payload)
+    if missing_tools:
+        tool_list = ", ".join(missing_tools)
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=f"mise-managed tools are missing for project config '{mise_path}': {tool_list}.",
+            fix=f"basectl setup {manifest.project_name}",
+            finding_id="BASE-P022",
+            details=details | {"missing_tools": missing_tools},
+        )
+    return None
+
+
+def mise_details(project_root: Path, mise_path: Path) -> dict[str, object]:
+    return {
+        "project_root": str(project_root),
+        "mise_config": str(mise_path),
+        "trust_checked": True,
+        "missing_tools_checked": False,
+    }
 
 
 def reconcile_brewfile(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
@@ -134,6 +243,22 @@ def resolve_brewfile_path(manifest: BaseManifest) -> Path:
     if not brewfile_path.is_file():
         raise ArtifactError(f"{manifest.path}: brewfile '{manifest.brewfile}' does not exist.")
     return brewfile_path
+
+
+def command_text(stdout: str, stderr: str) -> str:
+    return "\n".join(part for part in (stdout, stderr) if part)
+
+
+def mise_config_untrusted(output: str) -> bool:
+    normalized = output.lower()
+    return "untrusted" in normalized or "no trusted config files found" in normalized or "not trusted" in normalized
+
+
+def missing_tool_names(payload: Any) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["unknown"] if payload else []
+    names = [str(name) for name, value in payload.items() if value]
+    return sorted(names)
 
 
 def resolve_mise_path(manifest: BaseManifest) -> Path:

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -56,6 +56,17 @@ def run_check(command: list[str]) -> bool:
     return subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False).returncode == 0
 
 
+def run_capture(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+
 def run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = None) -> None:
     stdout_recorder = CommandOutputRecorder()
     stderr_recorder = CommandOutputRecorder()

--- a/cli/python/base_setup/tests/test_mise.py
+++ b/cli/python/base_setup/tests/test_mise.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,6 +10,45 @@ from base_setup import delegates, engine
 from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest
 from base_setup.tests.helpers import fake_context
+
+
+def make_manifest(project_root: Path) -> BaseManifest:
+    (project_root / ".mise.toml").write_text("[tools]\ngo = \"1.22\"\n", encoding="utf-8")
+    return BaseManifest(
+        path=project_root / "base_manifest.yaml",
+        project_name="demo",
+        brewfile=None,
+        mise=".mise.toml",
+        artifacts=(),
+    )
+
+
+def write_fake_mise(bin_dir: Path, log_path: Path, trust_output: str, missing_output: str) -> None:
+    mise = bin_dir / "mise"
+    mise.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                f"printf '%s\\n' \"$PWD $*\" >> {log_path}",
+                "case \"$*\" in",
+                "  'trust --show')",
+                f"    printf '%s\\n' {trust_output!r}",
+                "    ;;",
+                "  'ls --missing --json')",
+                f"    printf '%s\\n' {missing_output!r}",
+                "    ;;",
+                "  *)",
+                "    printf 'unexpected mise args: %s\\n' \"$*\" >&2",
+                "    exit 99",
+                "    ;;",
+                "esac",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    mise.chmod(0o755)
+
 
 class MiseTests(unittest.TestCase):
 
@@ -55,6 +95,97 @@ class MiseTests(unittest.TestCase):
         run_command.assert_called_once_with(ctx, ["mise", "install"], cwd=project_root.resolve())
 
 
+    def test_mise_check_passes_when_trusted_and_no_tools_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            project_root = tmp / "demo"
+            project_root.mkdir()
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            log_path = tmp / "mise.log"
+            manifest = make_manifest(project_root)
+            write_fake_mise(bin_dir, log_path, f"{project_root.resolve()}: trusted", "{}")
+
+            with mock.patch.dict(os.environ, {"PATH": f"{bin_dir}:{os.environ['PATH']}"}):
+                check = delegates.check_mise(manifest)
+            log_lines = log_path.read_text(encoding="utf-8").splitlines()
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.status, "")
+        self.assertIn("mise-managed tools are installed", check.message)
+        self.assertEqual(check.fix, "")
+        self.assertEqual(
+            log_lines,
+            [
+                f"{project_root.resolve()} trust --show",
+                f"{project_root.resolve()} ls --missing --json",
+            ],
+        )
+
+
+    def test_mise_check_reports_untrusted_project_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            project_root = tmp / "demo"
+            project_root.mkdir()
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            log_path = tmp / "mise.log"
+            manifest = make_manifest(project_root)
+            write_fake_mise(bin_dir, log_path, f"{project_root.resolve()}: untrusted", "{}")
+
+            with mock.patch.dict(os.environ, {"PATH": f"{bin_dir}:{os.environ['PATH']}"}):
+                check = delegates.check_mise(manifest)
+            log_lines = log_path.read_text(encoding="utf-8").splitlines()
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "")
+        self.assertIn("is not trusted by mise", check.message)
+        self.assertEqual(check.fix, f"mise trust {project_root.resolve() / '.mise.toml'}")
+        self.assertEqual(log_lines, [f"{project_root.resolve()} trust --show"])
+
+
+    def test_mise_check_reports_missing_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            project_root = tmp / "demo"
+            project_root.mkdir()
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            log_path = tmp / "mise.log"
+            manifest = make_manifest(project_root)
+            write_fake_mise(bin_dir, log_path, f"{project_root.resolve()}: trusted", '{"go":[{"version":"1.22"}]}')
+
+            with mock.patch.dict(os.environ, {"PATH": f"{bin_dir}:{os.environ['PATH']}"}):
+                check = delegates.check_mise(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "")
+        self.assertIn("mise-managed tools are missing", check.message)
+        self.assertIn("go", check.message)
+        self.assertEqual(check.fix, "basectl setup demo")
+
+
+    def test_mise_check_warns_when_missing_tool_output_is_not_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            project_root = tmp / "demo"
+            project_root.mkdir()
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            log_path = tmp / "mise.log"
+            manifest = make_manifest(project_root)
+            write_fake_mise(bin_dir, log_path, f"{project_root.resolve()}: trusted", "not json")
+
+            with mock.patch.dict(os.environ, {"PATH": f"{bin_dir}:{os.environ['PATH']}"}):
+                check = delegates.check_mise(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertIn("could not be parsed", check.message)
+        self.assertEqual(check.fix, f"Run 'mise ls --missing --json' in '{project_root.resolve()}' for details.")
+
+
 
     def test_mise_missing_file_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -92,29 +223,27 @@ class MiseTests(unittest.TestCase):
 
     def test_manifest_checks_include_mise_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            project_root = Path(tmpdir) / "demo"
+            tmp = Path(tmpdir)
+            project_root = tmp / "demo"
             project_root.mkdir()
-            (project_root / ".mise.toml").write_text("[tools]\n", encoding="utf-8")
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            log_path = tmp / "mise.log"
             default_manifest = BaseManifest(
-                path=Path(tmpdir) / "default.yaml",
+                path=tmp / "default.yaml",
                 project_name="base",
                 brewfile=None,
                 artifacts=(),
             )
-            manifest = BaseManifest(
-                path=project_root / "base_manifest.yaml",
-                project_name="demo",
-                brewfile=None,
-                mise=".mise.toml",
-                artifacts=(),
-            )
+            manifest = make_manifest(project_root)
+            write_fake_mise(bin_dir, log_path, f"{project_root.resolve()}: trusted", "{}")
 
-            with mock.patch("base_setup.process.command_exists", return_value=True):
+            with mock.patch.dict(os.environ, {"PATH": f"{bin_dir}:{os.environ['PATH']}"}):
                 checks = engine.manifest_checks(default_manifest, manifest)
 
         self.assertIn("mise", [check.name for check in checks])
         mise_check = next(check for check in checks if check.name == "mise")
-        self.assertFalse(mise_check.ok)
-        self.assertEqual(mise_check.status, "warn")
-        self.assertIn("installed mise tools are not verified", mise_check.message)
-        self.assertEqual(mise_check.fix, "Run 'basectl setup demo' to install declared mise tools.")
+        self.assertTrue(mise_check.ok)
+        self.assertEqual(mise_check.status, "")
+        self.assertIn("mise-managed tools are installed", mise_check.message)
+        self.assertEqual(mise_check.fix, "")

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -98,7 +98,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P012` | Brewfile dependency status |
 | `BASE-P020` | mise config path validity |
 | `BASE-P021` | mise CLI availability |
-| `BASE-P022` | mise tool verification status |
+| `BASE-P022` | mise trust and missing-tool status |
 | `BASE-P030` | Unsupported artifact manager |
 | `BASE-P031` | Unsupported Homebrew artifact version |
 | `BASE-P032` | Homebrew unavailable for artifact checks |


### PR DESCRIPTION
## Summary
- Replace the static mise warning with project-root checks for mise trust and missing tools.
- Report actionable fixes for untrusted configs, missing tools, and unverifiable mise output.
- Update BASE-P022 docs and add fake-mise unit coverage for trusted, untrusted, missing-tool, and malformed-output cases.

## Validation
- env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/fix-530-20260609-mise-project-checks/lib/python:/Users/rameshhp/work/base-worktrees/fix-530-20260609-mise-project-checks/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_mise.py cli/python/base_setup/tests/test_diagnostics.py -q
- env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/fix-530-20260609-mise-project-checks/lib/python:/Users/rameshhp/work/base-worktrees/fix-530-20260609-mise-project-checks/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files "*.py")
- /Users/rameshhp/work/base-worktrees/fix-530-20260609-mise-project-checks/bin/base-wrapper --project banyanlabs base_setup --action check --format json --manifest /Users/rameshhp/work/banyanlabs/base_manifest.yaml banyanlabs
- env -u BASE_HOME ./bin/base-test
- git diff --check
- git diff --cached --check

## Demo Impact
- Project checks no longer keep warning after mise setup has succeeded.

Fixes #530