### PR TITLE
Document issue Project status workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ them.
   or `security`.
 - Do not create or apply `type:*` issue labels.
 - Assign Codex-created issues to `codeforester` when GitHub allows it.
+- For issues tracked in Base Roadmap, set Project `Status` to `In Progress`
+  before implementation starts, move it to `In Review` when the PR opens, and
+  verify `Done` after merge/closure. If Project V2 access or item state
+  prevents an update, mention that in the work summary.
 - Prefer `basectl gh` for supported issue, branch, PR, check, and cleanup
   operations.
 - Fall back to the GitHub connector, raw `gh`, or `git` when `basectl gh` does

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,10 @@ for issue-backed work, validation, and design-only sessions.
    - `ci` for GitHub Actions, tests, release automation, or CI reliability.
    - `security` for security hardening, dependency pinning, static analysis, or
      permission tightening.
-3. Create a branch from the issue using this convention:
+3. When the issue is tracked in Base Roadmap, set its Project `Status` to
+   `In Progress` before branch or worktree work begins. Move it to `In Review`
+   when the PR opens, and verify it is `Done` after merge/closure.
+4. Create a branch from the issue using this convention:
 
    ```text
    <category>/<issue>-<YYYYMMDD>-<slug>
@@ -32,18 +35,18 @@ for issue-backed work, validation, and design-only sessions.
    enhancement/179-20260528-projects-list-json
    ```
 
-4. Use an isolated Git worktree for each pull request:
+5. Use an isolated Git worktree for each pull request:
 
    ```bash
    git fetch origin master
    git worktree add -b <branch> ~/work/base-worktrees/<slug> origin/master
    ```
 
-5. Keep the PR scoped to the issue. Avoid unrelated refactors.
-6. Link the PR back to the issue with `Fixes #<issue>` or `Closes #<issue>`.
-7. Use the standard PR body and fill in Summary, Issue, Validation, Demo
+6. Keep the PR scoped to the issue. Avoid unrelated refactors.
+7. Link the PR back to the issue with `Fixes #<issue>` or `Closes #<issue>`.
+8. Use the standard PR body and fill in Summary, Issue, Validation, Demo
    Impact, and Notes.
-8. After merge, sync `master`, remove the worktree, and delete the local and
+9. After merge, sync `master`, remove the worktree, and delete the local and
    remote branches:
 
    ```bash

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -37,6 +37,23 @@ assigned to `codeforester`.
 If assignment fails, the automation should mention that in its summary instead
 of silently leaving the issue unassigned.
 
+## Issue Project Status
+
+When an issue is tracked in the `Base Roadmap` Project, keep the issue's
+`Status` field aligned with the implementation train:
+
+- Set `Status` to `In Progress` before creating the implementation branch or
+  starting work in a worktree.
+- Set `Status` to `In Review` when the pull request opens.
+- After the pull request merges and the issue closes, verify `Status` is
+  `Done`; update it explicitly if automation did not.
+- If Project V2 access is unavailable, the issue is not in the Project, or the
+  status update fails, mention that in the work summary instead of silently
+  skipping it.
+
+Do not add pull requests as separate Project items by default. The issue owns
+milestone and Project tracking so roadmap views do not double count the work.
+
 ## Preferred GitHub Interface
 
 Use `basectl gh` as the preferred interface for Base repository GitHub
@@ -194,8 +211,8 @@ When a PR is opened for an issue, inherit metadata selectively:
 
 Do not copy milestone or GitHub Project fields to the PR by default. Keep those
 on the issue so release planning and Project views do not double count the same
-work. When a PR opens, move the issue's Project status to `In Review` instead
-of adding a separate PR item to the Project.
+work. Follow the issue Project status transitions above instead of adding a
+separate PR item to the Project.
 
 PR reviewers are PR-specific and should be selected from the implementation
 surface, ownership, and risk of the change rather than copied from the issue.


### PR DESCRIPTION
## Summary
- Add an explicit Base Roadmap issue status lifecycle to the GitHub workflow docs.
- Mirror the In Progress / In Review / Done rule in contributor and agent checklists.
- Clarify that issues, not pull requests, own Project tracking by default.

## Issue
Fixes #533

## Validation
- git diff --check
- git diff --cached --check

## Demo Impact
None. Documentation-only change.

## Notes
Issue #533 was moved to In Progress before implementation work began.