### PR TITLE
Add basectl ci entry point

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,8 +70,16 @@ jobs:
           python -m venv .integration-venv
           .integration-venv/bin/python -m pip install --upgrade pip
           .integration-venv/bin/python -m pip install -r requirements-dev.txt
+          mkdir -p "$HOME/.base.d/base"
+          python -m venv "$HOME/.base.d/base/.venv"
+          "$HOME/.base.d/base/.venv/bin/python" -m pip install --upgrade pip
+          "$HOME/.base.d/base/.venv/bin/python" -m pip install -r requirements-dev.txt
           sudo apt-get update
           sudo apt-get install -y bats
+
+      - name: Run basectl ci smoke check
+        run: |
+          ./bin/basectl ci check base --format json
 
       - name: Run integration tests
         env:

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -25,6 +25,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `activate`
 - `setup`
 - `check`
+- `ci setup/check/doctor`
 - `clean`
 - `config`
 - `doctor`
@@ -54,6 +55,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
   project argument validates `project.name`.
 - `basectl check [project]` verifies the same local requirements without making
   changes and can include project manifest artifacts.
+- `basectl ci setup/check/doctor <project>` runs Base in non-interactive CI
+  mode, sets CI-safe defaults, and supports text or JSON output.
 - `basectl setup/check/doctor --profile <list>` manage opt-in prerequisite
   profiles. `sre` is the first additional built-in profile, and profiles compose
   as comma-separated lists such as `--profile dev,sre`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -25,6 +25,8 @@ Commands:
     Run a project's declared command.
   repo <init|check|configure|installer-template> [options]
     Create repository baselines and project installer templates.
+  ci <setup|check|doctor> <project> [options]
+    Run Base setup, checks, and diagnostics in non-interactive CI.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   logs [options]
@@ -197,6 +199,11 @@ basectl_do_repo() {
     base_repo_subcommand_main "$@"
 }
 
+basectl_do_ci() {
+    basectl_source_subcommand_module ci || return 1
+    base_ci_subcommand_main "$@"
+}
+
 basectl_do_clean() {
     basectl_source_subcommand_module clean || return 1
     base_clean_subcommand_main "$@"
@@ -350,6 +357,7 @@ basectl_main() {
         demo)             basectl_do_demo "$@" ;;
         run)              basectl_do_run "$@" ;;
         repo)             basectl_do_repo "$@" ;;
+        ci)               basectl_do_ci "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         logs)             basectl_do_logs "$@" ;;
         config)           basectl_do_config "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -16,6 +16,7 @@ Usage:
 Options:
   --profile <list>      Include named prerequisite profiles. Known profiles: dev, sre, ai.
   --format <text|json>  Select output format. Defaults to text.
+  --manifest <path>     Use a specific base_manifest.yaml path for project checks.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
 
@@ -74,6 +75,16 @@ base_check_subcommand_main() {
                     base_check_subcommand_usage >&2
                     return 1
                 fi
+                ;;
+            --manifest)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    print_error "Option '--manifest' requires an argument."
+                    base_check_subcommand_usage >&2
+                    return 1
+                fi
+                BASE_SETUP_MANIFEST="$1"
+                export BASE_SETUP_MANIFEST
                 ;;
             -v)
                 setup_enable_debug_logging

--- a/cli/bash/commands/basectl/subcommands/ci.sh
+++ b/cli/bash/commands/basectl/subcommands/ci.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_ci_subcommand_sourced:-}" ]] && return
+_base_ci_subcommand_sourced=1
+readonly _base_ci_subcommand_sourced
+
+_base_ci_subcommand_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+_base_ci_setup_common_path="$_base_ci_subcommand_dir/setup_common.sh"
+# shellcheck source=/dev/null
+source "$_base_ci_setup_common_path"
+
+base_ci_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl ci setup <project> [options]
+  basectl ci check <project> [options]
+  basectl ci doctor <project> [options]
+
+Options:
+  --format <text|json>  Select output format. Defaults to text.
+  --manifest <path>     Use a specific base_manifest.yaml path.
+  --profile <list>      Include named prerequisite profiles. Known profiles: dev, sre, ai.
+  --recreate-venv       Back up and recreate the project virtual environment during setup.
+  -v                    Enable DEBUG logging for this subcommand.
+  -h, --help            Show this help text.
+
+Purpose:
+  Run Base setup, checks, and diagnostics in a non-interactive CI environment.
+EOF
+}
+
+base_ci_usage_error() {
+    print_error "$*"
+    base_ci_subcommand_usage >&2
+    return 2
+}
+
+base_ci_apply_environment() {
+    export BASE_CI=true
+    export CI=true
+    export BASE_SETUP_NOTIFY=false
+    export BASE_SETUP_ALLOW_SYSTEM_PYTHON=true
+    export BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=false
+}
+
+base_ci_source_subcommand_module() {
+    local module_name="$1"
+    local subcommand_script="$_base_ci_subcommand_dir/${module_name}.sh"
+
+    [[ -f "$subcommand_script" ]] || {
+        print_error "Subcommand module '$subcommand_script' was not found."
+        return 1
+    }
+
+    # shellcheck source=/dev/null
+    source "$subcommand_script"
+}
+
+base_ci_parse_args() {
+    local command="$1"
+    shift
+
+    BASE_CI_FORMAT="text"
+    BASE_CI_MANIFEST=""
+    BASE_CI_PROFILE=""
+    BASE_CI_PROJECT=""
+    BASE_CI_RECREATE_VENV=0
+    BASE_CI_VERBOSE=0
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_ci_subcommand_usage
+                return 10
+                ;;
+            --format)
+                shift
+                [[ -n "${1:-}" ]] || {
+                    base_ci_usage_error "Option '--format' requires an argument."
+                    return $?
+                }
+                case "$1" in
+                    text|json)
+                        BASE_CI_FORMAT="$1"
+                        ;;
+                    *)
+                        base_ci_usage_error "Unsupported ci output format '$1'."
+                        return $?
+                        ;;
+                esac
+                ;;
+            --manifest)
+                shift
+                [[ -n "${1:-}" ]] || {
+                    base_ci_usage_error "Option '--manifest' requires an argument."
+                    return $?
+                }
+                BASE_CI_MANIFEST="$1"
+                ;;
+            --profile)
+                shift
+                [[ -n "${1:-}" ]] || {
+                    base_ci_usage_error "Option '--profile' requires an argument."
+                    return $?
+                }
+                BASE_CI_PROFILE="$1"
+                ;;
+            --recreate-venv)
+                [[ "$command" == setup ]] || {
+                    base_ci_usage_error "Option '--recreate-venv' is only supported for 'ci setup'."
+                    return $?
+                }
+                BASE_CI_RECREATE_VENV=1
+                ;;
+            -v)
+                BASE_CI_VERBOSE=1
+                ;;
+            -*)
+                base_ci_usage_error "Unknown ci $command option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$BASE_CI_PROJECT" ]]; then
+                    base_ci_usage_error "The 'ci $command' command accepts exactly one project name."
+                    return $?
+                fi
+                BASE_CI_PROJECT="$1"
+                ;;
+        esac
+        shift
+    done
+
+    [[ -n "$BASE_CI_PROJECT" ]] || {
+        base_ci_usage_error "The 'ci $command' command requires a project name."
+        return $?
+    }
+}
+
+base_ci_common_delegate_args() {
+    if [[ -n "$BASE_CI_PROFILE" ]]; then
+        printf '%s\n' --profile "$BASE_CI_PROFILE"
+    fi
+    if [[ -n "$BASE_CI_MANIFEST" ]]; then
+        printf '%s\n' --manifest "$BASE_CI_MANIFEST"
+    fi
+    if ((BASE_CI_VERBOSE)); then
+        printf '%s\n' -v
+    fi
+}
+
+base_ci_setup_delegate_args() {
+    base_ci_common_delegate_args
+    if ((BASE_CI_RECREATE_VENV)); then
+        printf '%s\n' --recreate-venv
+    fi
+    printf '%s\n' "$BASE_CI_PROJECT"
+}
+
+base_ci_check_or_doctor_delegate_args() {
+    base_ci_common_delegate_args
+    printf '%s\n' "$BASE_CI_PROJECT" --format "$BASE_CI_FORMAT"
+}
+
+base_ci_print_setup_json() {
+    local command_output="$1"
+    local exit_code="$2"
+    local status="ok"
+
+    if ((exit_code)); then
+        status="error"
+    fi
+
+    printf '{\n'
+    printf '  "schema_version": 1,\n'
+    printf '  "command": "setup",\n'
+    printf '  "status": "%s",\n' "$status"
+    printf '  "project": "%s",\n' "$(setup_json_escape "$BASE_CI_PROJECT")"
+    printf '  "output": "%s"\n' "$(setup_json_escape "$command_output")"
+    printf '}\n'
+}
+
+base_ci_run_setup() {
+    local args=()
+    local command_output
+    local exit_code
+
+    mapfile -t args < <(base_ci_setup_delegate_args)
+    base_ci_source_subcommand_module setup || return 1
+
+    if [[ "$BASE_CI_FORMAT" == json ]]; then
+        command_output="$(base_setup_subcommand_main "${args[@]}" 2>&1)"
+        exit_code=$?
+        base_ci_print_setup_json "$command_output" "$exit_code"
+        return "$exit_code"
+    fi
+
+    base_setup_subcommand_main "${args[@]}"
+}
+
+base_ci_run_check() {
+    local args=()
+
+    mapfile -t args < <(base_ci_check_or_doctor_delegate_args)
+    base_ci_source_subcommand_module check || return 1
+    base_check_subcommand_main "${args[@]}"
+}
+
+base_ci_run_doctor() {
+    local args=()
+
+    mapfile -t args < <(base_ci_check_or_doctor_delegate_args)
+    base_ci_source_subcommand_module doctor || return 1
+    base_doctor_subcommand_main "${args[@]}"
+}
+
+base_ci_subcommand_main() {
+    local command="${1:-}"
+    local parse_status
+
+    case "$command" in
+        -h|--help|help)
+            base_ci_subcommand_usage
+            return 0
+            ;;
+        "")
+            base_ci_usage_error "CI command is required."
+            return $?
+            ;;
+        setup|check|doctor)
+            shift
+            base_ci_parse_args "$command" "$@"
+            parse_status=$?
+            case "$parse_status" in
+                0)
+                    ;;
+                10)
+                    return 0
+                    ;;
+                *)
+                    return "$parse_status"
+                    ;;
+            esac
+            ;;
+        *)
+            base_ci_usage_error "Unknown ci command '$command'."
+            return $?
+            ;;
+    esac
+
+    base_ci_apply_environment
+    case "$command" in
+        setup)
+            base_ci_run_setup
+            ;;
+        check)
+            base_ci_run_check
+            ;;
+        doctor)
+            base_ci_run_doctor
+            ;;
+    esac
+}

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -16,6 +16,7 @@ Usage:
 Options:
   --profile <list>      Include named prerequisite profiles. Known profiles: dev, sre, ai.
   --format <text|json>  Select output format. Defaults to text.
+  --manifest <path>     Use a specific base_manifest.yaml path for project diagnostics.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
 
@@ -100,6 +101,72 @@ base_doctor_count_check_errors() {
     done
 
     printf '%s\n' "$errors"
+}
+
+base_doctor_print_collected_check_results() {
+    local count fix i status
+
+    count="${#_BASE_SETUP_CHECK_NAMES[@]}"
+    for ((i = 0; i < count; i++)); do
+        fix="${_BASE_SETUP_CHECK_RECOVERIES[$i]}"
+        if [[ "${_BASE_SETUP_CHECK_OK[$i]}" == true ]]; then
+            status="ok"
+            fix=""
+            if [[ -n "${_BASE_SETUP_CHECK_DEBUG_MESSAGES[$i]}" ]]; then
+                log_debug "${_BASE_SETUP_CHECK_DEBUG_MESSAGES[$i]}"
+            fi
+        else
+            status="error"
+        fi
+
+        base_doctor_print_finding \
+            "$status" \
+            "$(base_doctor_base_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
+            "${_BASE_SETUP_CHECK_NAMES[$i]}" \
+            "${_BASE_SETUP_CHECK_MESSAGES[$i]}" \
+            "$fix"
+    done
+}
+
+base_doctor_run_ci_runtime_text() {
+    local errors=0 profile_errors=0 project="$1"
+
+    setup_collect_base_check_results warn || true
+    errors="$(base_doctor_count_check_errors)"
+
+    if [[ -n "$project" ]]; then
+        printf "Base CI doctor for project '%s'\n\n" "$project"
+    else
+        printf 'Base CI doctor\n\n'
+    fi
+
+    base_doctor_print_collected_check_results
+    if setup_profiles_enabled; then
+        setup_run_base_dev_layer doctor
+        profile_errors=$?
+        errors=$((errors + profile_errors))
+    fi
+    if [[ -n "$project" ]]; then
+        setup_run_project_artifact_doctor
+        errors=$((errors + $?))
+    fi
+
+    printf '\n'
+    if ((errors == 0)); then
+        if [[ -n "$project" ]]; then
+            printf "Base CI doctor found no blocking issues for project '%s'.\n" "$project"
+        else
+            printf 'Base CI doctor found no blocking issues.\n'
+        fi
+        return 0
+    fi
+
+    if [[ -n "$project" ]]; then
+        printf "Base CI doctor found %s blocking issue(s) for project '%s'.\n" "$errors" "$project"
+    else
+        printf 'Base CI doctor found %s blocking issue(s).\n' "$errors"
+    fi
+    return 1
 }
 
 base_doctor_check_homebrew() {
@@ -294,6 +361,16 @@ base_doctor_subcommand_main() {
                         ;;
                 esac
                 ;;
+            --manifest)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    print_error "Option '--manifest' requires an argument."
+                    base_doctor_subcommand_usage >&2
+                    return 2
+                fi
+                BASE_SETUP_MANIFEST="$1"
+                export BASE_SETUP_MANIFEST
+                ;;
             -v)
                 setup_enable_debug_logging
                 ;;
@@ -317,6 +394,15 @@ base_doctor_subcommand_main() {
     BASE_SETUP_PROJECT_NAME="$project"
     export BASE_SETUP_PROJECT_NAME
     log_debug "Running 'basectl doctor'."
+    if setup_ci_runtime_only; then
+        if [[ "$output_format" == json ]]; then
+            base_doctor_run_json "$project"
+        else
+            base_doctor_run_ci_runtime_text "$project"
+        fi
+        return $?
+    fi
+
     setup_require_macos
 
     if [[ "$output_format" == json ]]; then

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -331,6 +331,10 @@ setup_allow_system_python() {
     [[ "${BASE_SETUP_ALLOW_SYSTEM_PYTHON:-false}" == true ]]
 }
 
+setup_ci_runtime_only() {
+    [[ "${BASE_CI:-false}" == true && "$OSTYPE" != darwin* ]]
+}
+
 setup_allow_test_hooks() {
     [[ "${BASE_TEST_MODE:-false}" == true || "${CI:-false}" == true ]]
 }
@@ -364,6 +368,10 @@ setup_recovery_venv() {
 
 setup_recovery_base_python_package() {
     printf "%s\n" "Run 'basectl setup' to install Base Python bootstrap packages."
+}
+
+setup_recovery_ci_python() {
+    printf "%s\n" "Install Python 3.13 or set BASE_SETUP_PYTHON_BIN, then rerun 'basectl ci'."
 }
 
 setup_recovery_project_layer() {
@@ -1296,7 +1304,7 @@ setup_wait_for_base_check_probes() {
     return "$failed"
 }
 
-setup_collect_base_check_results() {
+setup_collect_macos_base_check_results() {
     local click_package
     local missing=0
     local probe_pids=()
@@ -1339,6 +1347,78 @@ setup_collect_base_check_results() {
     rm -rf "$tmpdir"
 
     return "$missing"
+}
+
+setup_collect_ci_runtime_check_results() {
+    local click_package
+    local missing=0
+    local pyyaml_package
+    local python_bin
+
+    setup_clear_check_results
+    click_package="$(setup_click_package)"
+    pyyaml_package="$(setup_pyyaml_package)"
+    setup_ensure_cached_paths
+
+    if python_bin="$(setup_find_python_bin)"; then
+        setup_add_check_result \
+            "python" \
+            true \
+            "Python is available for CI runtime checks." \
+            "" \
+            "Resolved Python binary: $python_bin"
+    else
+        setup_add_check_result \
+            "python" \
+            false \
+            "Python is not available for CI runtime checks." \
+            "$(setup_recovery_ci_python)"
+        missing=1
+    fi
+
+    if setup_virtualenv_healthy; then
+        setup_add_check_result "base_virtualenv" true "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+    else
+        setup_add_check_result \
+            "base_virtualenv" \
+            false \
+            "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
+            "$(setup_recovery_venv)"
+        missing=1
+    fi
+
+    if setup_base_python_package_installed "$pyyaml_package"; then
+        setup_add_check_result "pyyaml" true "$(setup_base_python_package_check_message "$pyyaml_package" true)"
+    else
+        setup_add_check_result \
+            "pyyaml" \
+            false \
+            "$(setup_base_python_package_check_message "$pyyaml_package" false)" \
+            "$(setup_recovery_base_python_package)"
+        missing=1
+    fi
+
+    if setup_base_python_package_installed "$click_package"; then
+        setup_add_check_result "click" true "$(setup_base_python_package_check_message "$click_package" true)"
+    else
+        setup_add_check_result \
+            "click" \
+            false \
+            "$(setup_base_python_package_check_message "$click_package" false)" \
+            "$(setup_recovery_base_python_package)"
+        missing=1
+    fi
+
+    return "$missing"
+}
+
+setup_collect_base_check_results() {
+    if setup_ci_runtime_only; then
+        setup_collect_ci_runtime_check_results
+        return $?
+    fi
+
+    setup_collect_macos_base_check_results "$@"
 }
 
 setup_print_check_text_results() {
@@ -1626,7 +1706,32 @@ setup_run_check_json() {
     [[ "$status" != error ]]
 }
 
+setup_run_ci_runtime_install() {
+    setup_create_virtualenv
+    setup_install_pyyaml
+    setup_install_click
+    if setup_profiles_enabled; then
+        if setup_is_dry_run; then
+            setup_run_base_dev_layer setup --dry-run || fatal_error "Python prerequisite profile layer failed."
+        else
+            setup_run_base_dev_layer setup || fatal_error "Python prerequisite profile layer failed."
+        fi
+    fi
+    setup_run_project_artifact_setup || return $?
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Base CI setup check is complete."
+    else
+        log_info "Base CI setup is complete."
+    fi
+}
+
 setup_run_install() {
+    if setup_ci_runtime_only; then
+        setup_run_ci_runtime_install
+        return $?
+    fi
+
     setup_require_macos
     setup_install_homebrew
     setup_install_xcode_tools

--- a/cli/bash/commands/basectl/tests/ci.bats
+++ b/cli/bash/commands/basectl/tests/ci.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+load ./setup_helpers.bash
+
+
+create_ci_project() {
+    local workspace="$1"
+    local project="${2:-demo}"
+    local project_dir="$workspace/$project"
+
+    mkdir -p "$project_dir"
+    cat > "$project_dir/base_manifest.yaml" <<EOF
+schema_version: 1
+
+project:
+  name: $project
+EOF
+}
+
+prepare_ci_runtime() {
+    local workspace="$1"
+
+    create_xcode_stubs
+    create_brew_stub
+    create_ci_project "$workspace" demo
+    touch "$TEST_STATE_DIR/xcode-installed"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$TEST_HOME/.base.d/base/.venv"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$TEST_HOME/.base.d/demo/.venv"
+}
+
+@test "basectl ci prints help" {
+    run_base_command ci --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl ci setup <project>"* ]]
+    [[ "$output" == *"basectl ci check <project>"* ]]
+    [[ "$output" == *"basectl ci doctor <project>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
+}
+
+@test "basectl ci requires a command and project" {
+    run_base_command ci
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"CI command is required."* ]]
+
+    run_base_command ci check --format json
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"The 'ci check' command requires a project name."* ]]
+}
+
+@test "basectl ci check delegates with CI defaults and JSON output" {
+    local workspace="$TEST_TMPDIR/workspace"
+
+    prepare_ci_runtime "$workspace"
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" ci check demo --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "ok"'* ]]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"project_checks":'* ]]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format json demo)" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-base-ci")" = "true" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-ci")" = "true" ]
+}
+
+@test "basectl ci setup disables notifications and writes JSON when requested" {
+    local workspace="$TEST_TMPDIR/workspace"
+
+    prepare_ci_runtime "$workspace"
+    create_osascript_stub
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" ci setup demo --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"command": "setup"'* ]]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"status": "ok"'* ]]
+    [[ "$output" == *'"output":'* ]]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-base-ci")" = "true" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-ci")" = "true" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-notify")" = "false" ]
+    [ ! -f "$TEST_STATE_DIR/osascript-args" ]
+}
+
+@test "basectl ci check supports Linux runtime-only JSON checks" {
+    create_system_python3_stub
+    create_project_setup_venv_stub "$TEST_HOME/.base.d/base/.venv"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+
+    run_base_command OSTYPE=linux-gnu ci check base --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status": "ok"'* ]]
+    [[ "$output" == *'"name":"python","message":"Python is available for CI runtime checks."'* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -119,6 +119,14 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "repo_installer_template_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "ci_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci check --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci_check_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl gh ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -157,6 +165,8 @@ EOF
     [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --dry-run"* ]]
     [[ "$output" == *"repo_configure_options=--repo --dry-run"* ]]
     [[ "$output" == *"repo_installer_template_options=--dry-run"* ]]
+    [[ "$output" == *"ci_commands=setup check doctor"* ]]
+    [[ "$output" == *"ci_check_options=--format --manifest --profile"* ]]
     [[ "$output" == *"gh_areas=issue pr branch worktree todo"* ]]
     [[ "$output" == *"gh_worktree_commands=prune"* ]]
     [[ "$output" == *"gh_worktree_prune_options=--dry-run --yes"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -14,6 +14,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
     [[ "$output" == *"repo <init|check|configure|installer-template> [options]"* ]]
+    [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"logs [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
@@ -50,6 +51,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  repo <init|check|configure|installer-template> [options]' <<<"$output"
+    grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -498,6 +498,9 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     shift 2
     printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-args"
     printf '%s\n' "${BASE_PROJECT:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-project"
+    printf '%s\n' "${BASE_CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-base-ci"
+    printf '%s\n' "${CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-ci"
+    printf '%s\n' "${BASE_SETUP_NOTIFY:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-notify"
     touch "$BASE_SETUP_TEST_STATE_DIR/project-setup-ran"
     action="setup"
     output_format="text"

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,8 +70,8 @@ reference. The filename should answer "what is this about?"
   arbitrary manifest setup hooks yet.
 - [`basectl onboard`](basectl-onboard.md) captures the guided setup experience
   and its relationship to project installers.
-- [`basectl ci`](basectl-ci.md) defines the future non-interactive CI entry
-  point and its relationship to Linux support.
+- [`basectl ci`](basectl-ci.md) defines the non-interactive CI entry point and
+  its relationship to Linux runtime support.
 - [`basectl check` parallelism](check-parallelism.md) records the evaluation and
   implementation constraints for parallel check probes.
 - [Doctor Finding IDs](doctor-findings.md) is the stable reference for

--- a/docs/basectl-ci.md
+++ b/docs/basectl-ci.md
@@ -1,9 +1,9 @@
 # basectl ci
 
-`basectl ci` is a future non-interactive entry point for running Base in CI
-systems. It should reuse the same setup, check, doctor, and project manifest
-logic as local development, but it should avoid user-facing prompts and
-macOS-specific UI behaviors.
+`basectl ci` is the non-interactive entry point for running Base in CI systems.
+It reuses the same setup, check, doctor, and project manifest logic as local
+development, while avoiding user-facing prompts and macOS-specific UI
+behaviors.
 
 ## Goals
 
@@ -12,7 +12,7 @@ macOS-specific UI behaviors.
 - Reuse project manifests rather than adding a CI-only manifest format.
 - Make Linux support useful before Base has a complete Linux bootstrap story.
 
-## Proposed Interface
+## Interface
 
 ```bash
 basectl ci setup <project> [--format text|json]
@@ -20,8 +20,12 @@ basectl ci check <project> [--format text|json]
 basectl ci doctor <project> [--format text|json]
 ```
 
-The default mode should be non-interactive. If a required action cannot be
-performed without prompting, `basectl ci` should fail with a clear fix message.
+All commands also accept `--manifest <path>` for CI jobs that know the manifest
+path directly, plus `--profile <list>` for opt-in prerequisite profiles.
+`basectl ci setup` additionally accepts `--recreate-venv`.
+
+The default mode is non-interactive. If a required action cannot be performed
+without prompting, `basectl ci` fails with a clear fix message.
 
 ## Behavior
 
@@ -32,11 +36,12 @@ performed without prompting, `basectl ci` should fail with a clear fix message.
 - disable macOS notifications
 - avoid Xcode or UI installer prompts
 - run project artifact setup through the same manifest path as `basectl setup`
+- emit a small JSON wrapper when `--format json` is requested
 
 `basectl ci check <project>` should:
 
 - run read-only Base and project checks
-- prefer JSON output when `--format json` is supplied
+- emit JSON output when `--format json` is supplied
 - exit non-zero only for errors, not warnings
 
 `basectl ci doctor <project>` should:
@@ -47,11 +52,13 @@ performed without prompting, `basectl ci` should fail with a clear fix message.
 
 ## Linux Relationship
 
-The first useful version can support "runtime-only Linux":
+The first useful version supports "runtime-only Linux":
 
 - Base commands run under Linux when prerequisites already exist.
 - Bootstrap/install remains documented as manual.
 - Project checks and Python artifact reconciliation work in CI.
+- Linux CI checks validate Python availability, the Base virtual environment,
+  and Base Python bootstrap packages without requiring Homebrew or Xcode.
 
 Full Linux bootstrap can come later through the Linux support plan.
 
@@ -70,3 +77,17 @@ Full Linux bootstrap can come later through the Linux support plan.
 - The command works in GitHub Actions on Ubuntu when Python and project
   prerequisites are already installed.
 - The implementation has tests for non-interactive behavior and exit codes.
+
+## Example GitHub Actions Step
+
+```yaml
+- name: Prepare Base runtime
+  run: |
+    mkdir -p "$HOME/.base.d/base"
+    python -m venv "$HOME/.base.d/base/.venv"
+    "$HOME/.base.d/base/.venv/bin/python" -m pip install --upgrade pip
+    "$HOME/.base.d/base/.venv/bin/python" -m pip install -r requirements-dev.txt
+
+- name: Check Base project
+  run: ./bin/basectl ci check base --format json
+```

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -342,7 +342,7 @@ Suggested Base milestones:
   Project test execution, mise integration, manifest refinement, and a real
   Base-managed demo project.
 - `v0.4.0 - CI and Linux foundation`
-  Linux runtime support, CI-oriented behavior, and `basectl ci` planning.
+  Linux runtime support and CI-oriented `basectl ci` behavior.
 - `v1.0.0 - Stable public release`
   Stable manifest contracts, compatibility expectations, and upgrade policy.
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -81,12 +81,14 @@ basectl ci check base --format json
 basectl ci doctor base --format json
 ```
 
-The first CI-compatible milestone can document manual prerequisite setup in the
-workflow before invoking Base.
+The first CI-compatible milestone documents manual prerequisite setup in the
+workflow before invoking Base. `basectl ci` then runs runtime checks without
+requiring Homebrew or Xcode on Linux.
 
 ## Implementation Phases
 
-1. Split macOS-only setup checks from portable runtime checks.
+1. Split macOS-only setup checks from portable runtime checks. Initial support
+   exists through `basectl ci`.
 2. Add Linux platform detection and explicit unsupported-platform messages.
 3. Make `basectl check` and `doctor` report Linux prerequisite status without
    requiring Homebrew or Xcode.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -63,7 +63,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test build demo run repo clean logs config doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test build demo run repo ci clean logs config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -132,6 +132,19 @@ _base_basectl_completion() {
                     ;;
                 installer-template)
                     _base_basectl_completion_compgen "--dry-run -v -h --help" "$cur"
+                    ;;
+            esac
+            ;;
+        ci)
+            case "${COMP_WORDS[2]:-}" in
+                "")
+                    _base_basectl_completion_compgen "setup check doctor" "$cur"
+                    ;;
+                setup)
+                    _base_basectl_completion_project_profiles_or_options "$cur" "--format --manifest --profile --recreate-venv -v -h --help"
+                    ;;
+                check|doctor)
+                    _base_basectl_completion_project_profiles_or_options "$cur" "--format --manifest --profile -v -h --help"
                     ;;
             esac
             ;;

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -22,6 +22,7 @@ _base_basectl_completion() {
         'demo:Run a project interactive demo'
         'run:Run a project command'
         'repo:Create, check, and configure repository baseline'
+        'ci:Run Base setup, checks, and diagnostics in CI'
         'clean:Remove old Base CLI runtime artifacts'
         'logs:List and open recent Base CLI runtime logs'
         'config:Inspect Base machine-local user config'
@@ -167,6 +168,36 @@ _base_basectl_completion() {
                     _arguments '1:repo command:(init check configure installer-template)'
                     ;;
             esac
+            ;;
+        ci)
+            case "${words[3]:-}" in
+                setup)
+                    _arguments '1:ci command:(setup check doctor)' \
+                        '--format[Output format]:format:(text json)' \
+                        '--manifest[Use a specific manifest]:path:_files' \
+                        '--profile[Include prerequisite profiles]:profile:(dev sre ai dev,sre dev,ai sre,ai dev,sre,ai)' \
+                        '--recreate-venv[Recreate the project virtual environment]' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]' \
+                        '2:Base project:->projects'
+                    ;;
+                check|doctor)
+                    _arguments '1:ci command:(setup check doctor)' \
+                        '--format[Output format]:format:(text json)' \
+                        '--manifest[Use a specific manifest]:path:_files' \
+                        '--profile[Include prerequisite profiles]:profile:(dev sre ai dev,sre dev,ai sre,ai dev,sre,ai)' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]' \
+                        '2:Base project:->projects'
+                    ;;
+                *)
+                    _arguments '1:ci command:(setup check doctor)'
+                    ;;
+            esac
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
             ;;
         clean)
             _arguments '--older-than[Artifact age]:age:' \


### PR DESCRIPTION
## Summary

- Add `basectl ci setup/check/doctor <project>` with CI-safe defaults and text/json output handling.
- Add Linux runtime-only CI checks that validate Python, the Base venv, and Base Python bootstrap packages without requiring Homebrew or Xcode.
- Update CI docs, shell completions, tests, and the GitHub Actions integration smoke path.

## Validation

- `bats cli/bash/commands/basectl/tests/ci.bats`
- `bats cli/bash/commands/basectl/tests/check.bats`
- `bats cli/bash/commands/basectl/tests/doctor.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `shellcheck -S error cli/bash/commands/basectl/subcommands/ci.sh cli/bash/commands/basectl/subcommands/check.sh cli/bash/commands/basectl/subcommands/doctor.sh cli/bash/commands/basectl/subcommands/setup_common.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-ci-cache OSTYPE=linux-gnu ./bin/basectl ci check base --format json`

Closes #525
