### PR TITLE
Add optional repo agent guidance baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Current implemented commands include:
 - `basectl repo init <name>`
 - `basectl repo check [path]`
 - `basectl repo configure [path]`
+- `basectl repo agent-guidance [path]`
 - `basectl activate <project>`
 - `basectl test [project]`
 - `basectl build <project> [target...]`
@@ -376,6 +377,13 @@ Check and repair the repo baseline with:
 ```bash
 basectl repo check ~/work/example
 basectl repo configure ~/work/example --repo codeforester/example
+```
+
+Seed optional repo-local agent guidance with:
+
+```bash
+basectl repo agent-guidance ~/work/example --repo-name example
+basectl repo check ~/work/example --agent-guidance
 ```
 
 `repo configure` is intentionally idempotent. It enables Issues and Projects,

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -31,7 +31,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `doctor`
 - `gh`
 - `onboard`
-- `repo init/check/configure/installer-template`
+- `repo init/check/configure/agent-guidance/installer-template`
 - `test`
 - `build`
 - `update-profile`
@@ -82,6 +82,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   then falls back to the parent directory of `BASE_HOME`.
   `basectl repo check [path]` verifies the local baseline, and
   `basectl repo configure [path]` reapplies the GitHub settings and labels.
+  `basectl repo agent-guidance [path]` seeds optional repo-local agent guidance
+  files and `basectl repo check [path] --agent-guidance` verifies that optional
+  layer for repos that opt in.
   `basectl repo installer-template [path]` prints or writes the maintained
   project installer starter script.
 - `basectl test [project]` runs the project's manifest `test.command` or

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -23,8 +23,8 @@ Commands:
     Run a project's declared interactive demo.
   run <project> <command> [options]
     Run a project's declared command.
-  repo <init|check|configure|installer-template> [options]
-    Create repository baselines and project installer templates.
+  repo <init|check|configure|agent-guidance|installer-template> [options]
+    Create repository baselines, agent guidance, and project installer templates.
   ci <setup|check|doctor> <project> [options]
     Run Base setup, checks, and diagnostics in non-interactive CI.
   clean [--older-than <age>] [--keep-last <count>] [options]

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -17,12 +17,19 @@ BASE_REPO_BASELINE_FILES=(
     .github/workflows/tests.yml
 )
 
+BASE_REPO_AGENT_GUIDANCE_FILES=(
+    AGENTS.md
+    skills.md
+    .github/pull_request_template.md
+)
+
 base_repo_subcommand_usage() {
     cat <<'EOF'
 Usage:
   basectl repo init <name> [options]
   basectl repo check [path] [options]
   basectl repo configure [path] [options]
+  basectl repo agent-guidance [path] [options]
   basectl repo installer-template [path] [options]
 
 Options:
@@ -30,6 +37,10 @@ Options:
   --repo <owner/name>           GitHub repository to configure.
   --description <text>          Repository description for generated README.
   --copyright-holder <name>     Copyright holder for generated LICENSE. Defaults to git config user.name.
+  --repo-name <name>            Repository name for generated agent guidance. Defaults to the target path basename.
+  --default-branch <name>       Default branch for generated agent guidance. Defaults to main.
+  --validation-command <cmd>    Validation command for generated agent guidance. Defaults to ./tests/validate.sh.
+  --agent-guidance              Include optional agent guidance files in repo check.
   --private                     Create a private GitHub repository when needed. This is the default.
   --public                      Create a public GitHub repository when needed.
   --no-configure                Skip GitHub configuration during repo init.
@@ -447,6 +458,139 @@ Closes #
 EOF
 }
 
+base_repo_write_agent_instructions() {
+    local default_branch="$3"
+    local dry_run="$1"
+    local repo_name="$2"
+    local root="$5"
+    local validation_command="$4"
+
+    base_repo_write_stream "$dry_run" "$root/AGENTS.md" <<EOF
+# Agent Instructions for $repo_name
+
+Use this file for repository-local agent guidance. User instructions still take
+precedence over this baseline.
+
+## Workflow
+
+1. Create or choose a GitHub issue before implementation work.
+2. Use one standard issue label: \`bug\`, \`enhancement\`, \`documentation\`,
+   \`ci\`, or \`security\`.
+3. Branch from the issue with:
+
+   \`\`\`text
+   <category>/<issue>-<YYYYMMDD>-<slug>
+   \`\`\`
+
+4. Use a dedicated worktree for each pull request:
+
+   \`\`\`bash
+   git fetch origin
+   git worktree add -b <branch> ../$repo_name-worktrees/<slug> origin/$default_branch
+   \`\`\`
+
+5. Keep the pull request scoped to the issue and link it with
+   \`Fixes #<issue>\` or \`Closes #<issue>\` when merge should close the issue.
+6. Preserve existing user changes. Do not overwrite project-owned files unless
+   the user explicitly asks for that edit.
+
+## Validation
+
+Run the project validation command before publishing changes:
+
+   \`\`\`bash
+   $validation_command
+   \`\`\`
+
+Also run narrower tests for the files changed when available.
+
+## Documentation
+
+Update docs when behavior, commands, setup, or workflow expectations change.
+Update \`CHANGELOG.md\` only for notable user-visible or release-worthy changes.
+
+## Finish
+
+After merge, sync $default_branch, remove the worktree, and delete merged local
+and remote branches when safe.
+EOF
+}
+
+base_repo_write_agent_skills() {
+    local dry_run="$1"
+    local repo_name="$2"
+    local root="$3"
+
+    base_repo_write_stream "$dry_run" "$root/skills.md" <<EOF
+# Project Skills for $repo_name
+
+Use this file as the repo-local index for project-specific agent workflows.
+Keep entries short, concrete, and owned by this repository.
+
+## Suggested Entries
+
+- Development workflow: issue selection, branch naming, validation, PR creation,
+  merge, and cleanup.
+- Testing workflow: the commands that prove common changes are safe.
+- Release workflow: version, changelog, tag, release, and package manager steps.
+- Domain workflow: product-specific checks or demo expectations that agents
+  should not have to rediscover.
+
+## Boundaries
+
+Do not vendor third-party methodology files here. Link to external guidance or
+copy only repo-owned instructions that the project intends to maintain.
+EOF
+}
+
+base_repo_write_agent_pull_request_template() {
+    local dry_run="$1"
+    local root="$2"
+
+    base_repo_write_stream "$dry_run" "$root/.github/pull_request_template.md" <<'EOF'
+## Summary
+
+<!-- What changed and why. Focus on decisions and user impact, not just the diff. -->
+
+## Issue
+
+Closes #
+
+## Validation
+
+<!-- Commands run and relevant output. Include narrow checks and any broader suite used. -->
+
+## Reviewer Notes
+
+<!-- Optional: tradeoffs, follow-up work, or areas where reviewer attention would help. -->
+
+## Checklist
+
+- [ ] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
+- [ ] Pull request is scoped to one issue, unless a documented multi-issue exception applies.
+- [ ] Pull request body explains what changed and how it was validated.
+- [ ] Relevant project checks pass.
+- [ ] Documentation is updated when behavior or user-facing commands change.
+- [ ] CHANGELOG is updated for notable user-visible or release-worthy changes.
+- [ ] Pull request includes `Fixes #<issue>` or `Closes #<issue>` when merge should close the issue.
+EOF
+}
+
+base_repo_write_agent_guidance() {
+    local default_branch="$3"
+    local dry_run="$1"
+    local repo_name="$2"
+    local root="$5"
+    local status=0
+    local validation_command="$4"
+
+    base_repo_write_agent_instructions "$dry_run" "$repo_name" "$default_branch" "$validation_command" "$root" || status=1
+    base_repo_write_agent_skills "$dry_run" "$repo_name" "$root" || status=1
+    base_repo_write_agent_pull_request_template "$dry_run" "$root" || status=1
+
+    return "$status"
+}
+
 base_repo_write_license() {
     local copyright_holder="$2"
     local dry_run="$1"
@@ -734,6 +878,29 @@ base_repo_check_baseline() {
     return 0
 }
 
+base_repo_check_agent_guidance() {
+    local missing=0
+    local path="$1"
+    local rel
+
+    for rel in "${BASE_REPO_AGENT_GUIDANCE_FILES[@]}"; do
+        if [[ ! -f "$path/$rel" ]]; then
+            log_warn "Missing agent guidance file '$rel'."
+            missing=1
+        else
+            log_info "Agent guidance file '$rel' exists."
+        fi
+    done
+
+    if ((missing)); then
+        log_warn "Agent guidance baseline check found missing requirements."
+        return 1
+    fi
+
+    log_info "Agent guidance baseline check passed."
+    return 0
+}
+
 base_repo_init() {
     local configure=1
     local copyright_holder=""
@@ -861,13 +1028,19 @@ base_repo_init() {
 }
 
 base_repo_check() {
+    local agent_guidance=0
     local path="."
+    local status=0
 
     while (($#)); do
         case "$1" in
             -h|--help|help)
                 base_repo_subcommand_usage
                 return 0
+                ;;
+            --agent-guidance)
+                agent_guidance=1
+                shift
                 ;;
             -v)
                 set_log_level DEBUG
@@ -890,7 +1063,100 @@ base_repo_check() {
     done
 
     path="$(base_repo_target_path "$path")"
-    base_repo_check_baseline "$path"
+    base_repo_check_baseline "$path" || status=1
+    if ((agent_guidance)); then
+        base_repo_check_agent_guidance "$path" || status=1
+    fi
+    return "$status"
+}
+
+base_repo_agent_guidance() {
+    local default_branch="main"
+    local dry_run=0
+    local path="."
+    local repo_name=""
+    local root
+    local validation_command="./tests/validate.sh"
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_repo_subcommand_usage
+                return 0
+                ;;
+            --repo-name)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--repo-name' requires an argument."
+                    return $?
+                }
+                repo_name="$2"
+                shift 2
+                ;;
+            --repo-name=*)
+                repo_name="${1#--repo-name=}"
+                shift
+                ;;
+            --default-branch)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--default-branch' requires an argument."
+                    return $?
+                }
+                default_branch="$2"
+                shift 2
+                ;;
+            --default-branch=*)
+                default_branch="${1#--default-branch=}"
+                shift
+                ;;
+            --validation-command)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--validation-command' requires an argument."
+                    return $?
+                }
+                validation_command="$2"
+                shift 2
+                ;;
+            --validation-command=*)
+                validation_command="${1#--validation-command=}"
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            -v)
+                set_log_level DEBUG
+                export LOG_DEBUG=1
+                shift
+                ;;
+            -*)
+                base_repo_usage_error "Unknown repo agent-guidance option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ "$path" != "." ]]; then
+                    base_repo_usage_error "The 'repo agent-guidance' command accepts at most one path."
+                    return $?
+                fi
+                path="$1"
+                shift
+                ;;
+        esac
+    done
+
+    root="$(base_repo_target_path "$path")"
+    [[ -n "$repo_name" ]] || repo_name="$(basename -- "$root")"
+    [[ -n "$default_branch" ]] || {
+        base_repo_usage_error "Option '--default-branch' requires a non-empty value."
+        return $?
+    }
+    [[ -n "$validation_command" ]] || {
+        base_repo_usage_error "Option '--validation-command' requires a non-empty value."
+        return $?
+    }
+    base_repo_validate_name "$repo_name" || return 2
+
+    base_repo_write_agent_guidance "$dry_run" "$repo_name" "$default_branch" "$validation_command" "$root"
 }
 
 base_repo_configure() {
@@ -1015,6 +1281,10 @@ base_repo_subcommand_main() {
         configure)
             shift
             base_repo_configure "$@"
+            ;;
+        agent-guidance)
+            shift
+            base_repo_agent_guidance "$@"
             ;;
         installer-template)
             shift

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -111,10 +111,18 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "repo_init_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl repo check --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "repo_check_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl repo configure --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "repo_configure_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl repo agent-guidance --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "repo_agent_guidance_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl repo installer-template --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -161,9 +169,11 @@ EOF
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
-    [[ "$output" == *"repo_commands=init check configure installer-template"* ]]
+    [[ "$output" == *"repo_commands=init check configure agent-guidance installer-template"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --dry-run"* ]]
+    [[ "$output" == *"repo_check_options=--agent-guidance"* ]]
     [[ "$output" == *"repo_configure_options=--repo --dry-run"* ]]
+    [[ "$output" == *"repo_agent_guidance_options=--repo-name --default-branch --validation-command --dry-run"* ]]
     [[ "$output" == *"repo_installer_template_options=--dry-run"* ]]
     [[ "$output" == *"ci_commands=setup check doctor"* ]]
     [[ "$output" == *"ci_check_options=--format --manifest --profile"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -13,7 +13,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
-    [[ "$output" == *"repo <init|check|configure|installer-template> [options]"* ]]
+    [[ "$output" == *"repo <init|check|configure|agent-guidance|installer-template> [options]"* ]]
     [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"logs [options]"* ]]
@@ -50,7 +50,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  onboard [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
-    grep -Fqx '  repo <init|check|configure|installer-template> [options]' <<<"$output"
+    grep -Fqx '  repo <init|check|configure|agent-guidance|installer-template> [options]' <<<"$output"
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor> [options]' <<<"$output"

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -11,6 +11,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl repo init <name>"* ]]
     [[ "$output" == *"basectl repo check [path]"* ]]
     [[ "$output" == *"basectl repo configure [path]"* ]]
+    [[ "$output" == *"basectl repo agent-guidance [path]"* ]]
     [[ "$output" == *"basectl repo installer-template [path]"* ]]
 }
 
@@ -53,6 +54,55 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would create executable '$repo_dir/install.sh'."* ]]
     [ ! -e "$repo_dir/install.sh" ]
+}
+
+@test "basectl repo agent-guidance dry-run reports guidance files" {
+    local repo_dir="$TEST_TMPDIR/agent-demo"
+
+    run_basectl repo agent-guidance "$repo_dir" --repo-name base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/AGENTS.md'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/skills.md'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/.github/pull_request_template.md'."* ]]
+    [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo agent-guidance creates optional guidance baseline" {
+    local repo_dir="$TEST_TMPDIR/agent-demo"
+
+    run_basectl repo agent-guidance "$repo_dir" \
+        --repo-name base-demo \
+        --default-branch master \
+        --validation-command "env -u BASE_HOME ./bin/base-test"
+
+    [ "$status" -eq 0 ]
+    [ -f "$repo_dir/AGENTS.md" ]
+    [ -f "$repo_dir/skills.md" ]
+    [ -f "$repo_dir/.github/pull_request_template.md" ]
+    grep -Fq "# Agent Instructions for base-demo" "$repo_dir/AGENTS.md"
+    grep -Fq "git worktree add -b <branch> ../base-demo-worktrees/<slug> origin/master" "$repo_dir/AGENTS.md"
+    grep -Fq "env -u BASE_HOME ./bin/base-test" "$repo_dir/AGENTS.md"
+    grep -Fq '`bug`, `enhancement`, `documentation`,' "$repo_dir/AGENTS.md"
+    grep -Fq '`ci`, or `security`.' "$repo_dir/AGENTS.md"
+    grep -Fq "# Project Skills for base-demo" "$repo_dir/skills.md"
+    grep -Fq "Closes #" "$repo_dir/.github/pull_request_template.md"
+}
+
+@test "basectl repo agent-guidance leaves existing files unchanged" {
+    local repo_dir="$TEST_TMPDIR/custom-guidance"
+
+    mkdir -p "$repo_dir/.github"
+    printf 'custom agents\n' > "$repo_dir/AGENTS.md"
+    printf 'custom skills\n' > "$repo_dir/skills.md"
+    printf 'custom pr\n' > "$repo_dir/.github/pull_request_template.md"
+
+    run_basectl repo agent-guidance "$repo_dir" --repo-name custom-guidance
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$repo_dir/AGENTS.md")" = "custom agents" ]
+    [ "$(cat "$repo_dir/skills.md")" = "custom skills" ]
+    [ "$(cat "$repo_dir/.github/pull_request_template.md")" = "custom pr" ]
 }
 
 @test "basectl repo init dry-run prints baseline and configuration plan" {
@@ -234,6 +284,35 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"Missing repository baseline file 'VERSION'."* ]]
     [[ "$output" == *"Repository baseline check found missing requirements."* ]]
+}
+
+@test "basectl repo check reports missing agent guidance only when opted in" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir" --no-configure
+    [ "$status" -eq 0 ]
+
+    run_basectl repo check "$repo_dir" --agent-guidance
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Missing agent guidance file 'AGENTS.md'."* ]]
+    [[ "$output" == *"Missing agent guidance file 'skills.md'."* ]]
+    [[ "$output" == *"Agent guidance baseline check found missing requirements."* ]]
+}
+
+@test "basectl repo check passes with generated agent guidance when opted in" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir" --no-configure
+    [ "$status" -eq 0 ]
+    run_basectl repo agent-guidance "$repo_dir" --repo-name base-demo
+    [ "$status" -eq 0 ]
+
+    run_basectl repo check "$repo_dir" --agent-guidance
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository baseline check passed."* ]]
+    [[ "$output" == *"Agent guidance baseline check passed."* ]]
 }
 
 @test "basectl repo configure dry-run prints GitHub settings and labels" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,8 +59,9 @@ reference. The filename should answer "what is this about?"
   Python manifest shape and its relationship to current `python-package`
   artifacts.
 - [Repository Baseline](repo-baseline.md) documents `basectl repo init`,
-  `basectl repo check`, and `basectl repo configure` for standardizing new
-  Base-managed repositories.
+  `basectl repo check`, `basectl repo configure`, and the optional
+  `basectl repo agent-guidance` layer for standardizing new Base-managed
+  repositories.
 - [Remote Installer Policy](remote-installer-policy.md) defines the allowed
   remote shell installer URLs, opt-in boundaries, dry-run behavior, and logging
   expectations for setup paths.

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -38,6 +38,12 @@ Check the local baseline:
 basectl repo check ~/work/base-demo
 ```
 
+Seed optional repo-local agent guidance:
+
+```bash
+basectl repo agent-guidance ~/work/base-demo --repo-name base-demo
+```
+
 Reapply GitHub-side repository settings and labels:
 
 ```bash
@@ -84,6 +90,35 @@ test:
 The generated validation script checks for the required baseline files. It is
 not a replacement for project tests; it is the seed contract that lets
 `basectl test <project>` work immediately.
+
+## Optional Agent Guidance
+
+`repo agent-guidance` creates repo-local guidance files for agent-assisted
+development when they do not already exist:
+
+- `AGENTS.md`
+- `skills.md`
+- `.github/pull_request_template.md`
+
+The command accepts `--repo-name <name>`, `--default-branch <name>`, and
+`--validation-command <command>` so generated examples match the repository.
+Defaults are inferred from the target path, `main`, and `./tests/validate.sh`.
+
+Existing files are left unchanged. This keeps the guidance layer safe for repos
+that already have their own instructions or pull request template.
+
+Preview the files without writing them:
+
+```bash
+basectl repo agent-guidance ~/work/base-demo --repo-name base-demo --dry-run
+```
+
+Include the optional guidance files in local baseline checks only when the repo
+has opted into this layer:
+
+```bash
+basectl repo check ~/work/base-demo --agent-guidance
+```
 
 ## Git Workflow
 
@@ -144,6 +179,8 @@ Dry-run mode does not require authentication because it only prints the planned
 
 The MVP does not configure branch protection, manage repository secrets, create
 teams, add CODEOWNERS, or force Base-specific PR sections such as `Demo Impact`.
-Those are separate workflow and policy decisions. Base can grow those
-capabilities once the baseline command has proven useful for real repos such as
-the Base demo project.
+The optional agent guidance baseline also does not install Superpowers, manage
+`~/.codex/config.toml`, or vendor third-party methodology files. Those are
+separate workflow and policy decisions. Base can grow those capabilities once
+the baseline command has proven useful for real repos such as the Base demo
+project.

--- a/docs/superpowers/plans/2026-06-09-agent-guidance-baseline.md
+++ b/docs/superpowers/plans/2026-06-09-agent-guidance-baseline.md
@@ -1,0 +1,145 @@
+# Agent Guidance Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `basectl repo agent-guidance` command and opt-in
+`repo check --agent-guidance` validation for repo-local agent guidance files.
+
+**Architecture:** Reuse the existing `basectl repo` shell implementation and
+no-overwrite writer helpers. Keep generated guidance separate from the default
+repository baseline, and make checks enforce it only when the caller passes an
+explicit flag.
+
+**Tech Stack:** Bash, existing `basectl repo` helpers, BATS, ShellCheck, Zsh
+syntax checks, and Markdown docs.
+
+---
+
+## File Structure
+
+- Modify `cli/bash/commands/basectl/subcommands/repo.sh`: add command usage,
+  guidance file writers, opt-in baseline check, option parsing, and dispatcher
+  support.
+- Modify `cli/bash/commands/basectl/tests/repo.bats`: add RED tests for help,
+  dry-run, file creation, preservation, and opt-in check behavior.
+- Modify `cli/bash/commands/basectl/tests/help.bats`: update umbrella help
+  expectations.
+- Modify `cli/bash/commands/basectl/tests/completions.bats`: add Bash
+  completion expectations for the new command and option flag.
+- Modify `lib/shell/completions/basectl_completion.sh`: complete
+  `repo agent-guidance` and `repo check --agent-guidance`.
+- Modify `lib/shell/completions/basectl_completion.zsh`: add the same Zsh
+  completion surface.
+- Modify `docs/repo-baseline.md`, `docs/README.md`,
+  `cli/bash/commands/basectl/README.md`, and `README.md`: document the optional
+  agent guidance layer.
+- Add `docs/superpowers/specs/2026-06-09-agent-guidance-baseline-design.md`:
+  design record.
+- Add `docs/superpowers/plans/2026-06-09-agent-guidance-baseline.md`: this plan.
+
+## Task 1: RED Tests
+
+- [ ] Add help assertions for `basectl repo agent-guidance [path]`.
+- [ ] Add a dry-run test that expects planned creation of `AGENTS.md`,
+  `skills.md`, and `.github/pull_request_template.md`, with no files written.
+- [ ] Add a write test that checks generated files contain the repo name,
+  default branch, worktree path, labels, and validation command.
+- [ ] Add a preservation test that pre-creates guidance files and confirms
+  content stays unchanged.
+- [ ] Add `repo check --agent-guidance` tests for missing guidance files and
+  successful guidance checks after generation.
+- [ ] Add completion/help expectations for `agent-guidance` and
+  `--agent-guidance`.
+- [ ] Run focused BATS and verify RED.
+
+Command:
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats
+```
+
+Expected RED result: new tests fail because `agent-guidance` and
+`--agent-guidance` are not implemented.
+
+## Task 2: Repo Command Implementation
+
+- [ ] Define the optional agent guidance file list in `repo.sh`.
+- [ ] Add writers for `AGENTS.md`, `skills.md`, and the PR template, reusing
+  `base_repo_write_stream`.
+- [ ] Add `base_repo_write_agent_guidance()` to write all three files and
+  preserve existing files.
+- [ ] Add `base_repo_check_agent_guidance()` to warn on missing files and pass
+  when all optional guidance files exist.
+- [ ] Add `base_repo_agent_guidance()` parser with optional path, `--repo-name`,
+  `--default-branch`, `--validation-command`, `--dry-run`, `-v`, and help.
+- [ ] Extend `base_repo_check()` to accept `--agent-guidance` and combine its
+  status with the standard baseline check.
+- [ ] Extend dispatcher support for `agent-guidance`.
+- [ ] Run focused BATS and verify GREEN.
+
+Command:
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats
+```
+
+## Task 3: Help, Completions, And Docs
+
+- [ ] Update umbrella help and command README surfaces.
+- [ ] Update Bash and Zsh completions for the new command and flag.
+- [ ] Document usage and boundaries in `docs/repo-baseline.md`.
+- [ ] Update docs maps where command summaries mention `repo`.
+- [ ] Run focused help/completion tests.
+
+Commands:
+
+```bash
+bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats
+zsh -n lib/shell/completions/basectl_completion.zsh
+```
+
+## Task 4: Validation
+
+- [ ] Run focused repo tests:
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats
+```
+
+- [ ] Run help and completion tests:
+
+```bash
+bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats
+```
+
+- [ ] Run shell checks:
+
+```bash
+shellcheck -S error cli/bash/commands/basectl/subcommands/repo.sh lib/shell/completions/basectl_completion.sh
+zsh -n lib/shell/completions/basectl_completion.zsh
+```
+
+- [ ] Run whitespace validation:
+
+```bash
+git diff --check
+```
+
+- [ ] Run full Base validation:
+
+```bash
+env -u BASE_HOME ./bin/base-test
+```
+
+## Task 5: Publish
+
+- [ ] Commit implementation.
+- [ ] Push `enhancement/522-20260609-agent-guidance`.
+- [ ] Open a PR closing #522.
+- [ ] Watch CI.
+- [ ] Merge when checks are green.
+- [ ] Sync local `master`.
+- [ ] Remove the #522 worktree and local branch.

--- a/docs/superpowers/specs/2026-06-09-agent-guidance-baseline-design.md
+++ b/docs/superpowers/specs/2026-06-09-agent-guidance-baseline-design.md
@@ -1,0 +1,70 @@
+# Agent Guidance Baseline Design
+
+## Context
+
+Issue #522 asks Base to seed an optional repo-local guidance layer for
+agent-assisted development. Base already owns a small repository hygiene
+baseline through `basectl repo init`, but that baseline intentionally avoids
+agent-specific files. The new layer should be opt-in, preserve existing project
+guidance, and stay separate from user-local Codex or Superpowers configuration.
+
+## Command Shape
+
+Add a focused command:
+
+```bash
+basectl repo agent-guidance [path] [options]
+```
+
+The command defaults to the current directory and accepts:
+
+- `--repo-name <name>` to fill repo-specific examples. Defaults to the basename
+  of the target path.
+- `--default-branch <name>` to fill branch-sync examples. Defaults to `main`.
+- `--validation-command <command>` to fill validation guidance. Defaults to
+  `./tests/validate.sh`.
+- `--dry-run` to print the files that would be created without writing them.
+
+The command creates these files when they do not already exist:
+
+- `AGENTS.md`
+- `skills.md`
+- `.github/pull_request_template.md`
+
+Existing files are left unchanged. This mirrors `repo init` and keeps project
+ownership clear.
+
+## Generated Guidance
+
+`AGENTS.md` seeds repository-wide agent instructions: issue-first work,
+branch/worktree naming, validation, documentation expectations, and cleanup.
+It uses generated values for repository name, default branch, worktree path,
+standard labels, and validation command.
+
+`skills.md` seeds a repo-local skill index for project-specific workflows. It
+does not vendor third-party methodology files or install any tool.
+
+`.github/pull_request_template.md` seeds a lightweight PR template with summary,
+issue link, validation, reviewer notes, and checklist items that match the Base
+repo workflow.
+
+## Check Behavior
+
+`basectl repo check [path]` remains unchanged by default.
+
+Add `basectl repo check [path] --agent-guidance` to include the optional
+guidance files in the check. Missing files are warnings and produce a non-zero
+exit, consistent with the existing repository baseline check.
+
+## Boundaries
+
+This change does not install Superpowers, manage `~/.codex/config.toml`, infer
+agent policy from global machine settings, overwrite existing guidance, or make
+agent guidance part of the default repository baseline.
+
+## Validation
+
+Add Bats coverage for command help, dry-run output, file creation, existing-file
+preservation, opt-in check failures, and opt-in check success. Update Bash and
+Zsh completions and docs, then run the targeted Bats suites, shell syntax
+checks, and the full Base test suite.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -119,16 +119,19 @@ _base_basectl_completion() {
         repo)
             case "${COMP_WORDS[2]:-}" in
                 "")
-                    _base_basectl_completion_compgen "init check configure installer-template" "$cur"
+                    _base_basectl_completion_compgen "init check configure agent-guidance installer-template" "$cur"
                     ;;
                 init)
                     _base_basectl_completion_compgen "--path --repo --description --copyright-holder --private --public --no-configure --dry-run -v -h --help" "$cur"
                     ;;
                 check)
-                    _base_basectl_completion_compgen "-v -h --help" "$cur"
+                    _base_basectl_completion_compgen "--agent-guidance -v -h --help" "$cur"
                     ;;
                 configure)
                     _base_basectl_completion_compgen "--repo --dry-run -v -h --help" "$cur"
+                    ;;
+                agent-guidance)
+                    _base_basectl_completion_compgen "--repo-name --default-branch --validation-command --dry-run -v -h --help" "$cur"
                     ;;
                 installer-template)
                     _base_basectl_completion_compgen "--dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -130,7 +130,7 @@ _base_basectl_completion() {
         repo)
             case "${words[3]:-}" in
                 init)
-                    _arguments '1:repo command:(init check configure installer-template)' \
+                    _arguments '1:repo command:(init check configure agent-guidance installer-template)' \
                         '2:repository name:' \
                         '--path[Target path]:path:_files' \
                         '--repo[GitHub repository]:repo:' \
@@ -144,28 +144,39 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 check)
-                    _arguments '1:repo command:(init check configure installer-template)' \
+                    _arguments '1:repo command:(init check configure agent-guidance installer-template)' \
                         '2:path:_files' \
+                        '--agent-guidance[Include optional agent guidance files]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 configure)
-                    _arguments '1:repo command:(init check configure installer-template)' \
+                    _arguments '1:repo command:(init check configure agent-guidance installer-template)' \
                         '2:path:_files' \
                         '--repo[GitHub repository]:repo:' \
                         '--dry-run[Print planned changes]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
+                agent-guidance)
+                    _arguments '1:repo command:(init check configure agent-guidance installer-template)' \
+                        '2:path:_files' \
+                        '--repo-name[Repository name for generated guidance]:name:' \
+                        '--default-branch[Default branch for generated guidance]:branch:' \
+                        '--validation-command[Validation command for generated guidance]:command:' \
+                        '--dry-run[Print planned changes]' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
                 installer-template)
-                    _arguments '1:repo command:(init check configure installer-template)' \
+                    _arguments '1:repo command:(init check configure agent-guidance installer-template)' \
                         '2:path:_files' \
                         '--dry-run[Print planned changes]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)
-                    _arguments '1:repo command:(init check configure installer-template)'
+                    _arguments '1:repo command:(init check configure agent-guidance installer-template)'
                     ;;
             esac
             ;;


### PR DESCRIPTION
## Summary
- Add basectl repo agent-guidance as an opt-in writer for AGENTS.md, skills.md, and .github/pull_request_template.md.
- Add basectl repo check --agent-guidance for repos that opt into that optional guidance layer.
- Update help, Bash/Zsh completions, tests, and docs for the new repo guidance surface.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats
- bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats
- shellcheck -S error cli/bash/commands/basectl/subcommands/repo.sh lib/shell/completions/basectl_completion.sh
- zsh -n lib/shell/completions/basectl_completion.zsh
- git diff --check
- env -u BASE_HOME ./bin/base-test

Closes #522