### PR TITLE
Clarify Base install coexistence guidance

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -45,7 +45,8 @@ basectl update-profile
 ```
 
 Use a source checkout when you are contributing to Base or want to inspect and
-run the repository directly:
+run the repository directly. This is the preferred mode for a Base development
+machine:
 
 ```bash
 git clone https://github.com/codeforester/base.git ~/work/base
@@ -73,13 +74,33 @@ then an existing source checkout, and otherwise defaults to source mode.
 ### Can Homebrew-installed Base and source-cloned Base coexist?
 
 Yes. They can coexist because the active `basectl` is whichever executable your
-shell resolves first. A source checkout can always be run explicitly:
+shell resolves first. Coexistence is not dangerous, but it can make validation
+ambiguous because both installs normally share user state under `~/.base.d`.
+
+For a Base contributor machine, prefer one active owner: the source checkout.
+Use Homebrew-installed Base when validating the consumer install or upgrade
+experience, preferably in a test account, on a separate machine, or with an
+isolated `HOME`.
+
+A source checkout can always be run explicitly:
 
 ```bash
 ~/work/base/bin/basectl version
 ```
 
 That does not require it to be first on `PATH`.
+
+On Apple Silicon, a Homebrew install is usually available as:
+
+```bash
+/opt/homebrew/bin/basectl version
+```
+
+On Intel macOS, it is usually available as:
+
+```bash
+/usr/local/bin/basectl version
+```
 
 ### How do I know which basectl is active?
 
@@ -92,6 +113,8 @@ type -a basectl
 
 `command -v basectl` shows the command your shell will run by default.
 `type -a basectl` shows every matching command your shell can see.
+When testing a specific install route, use the absolute `basectl` path for that
+route instead of relying on `PATH`.
 
 ### If I have both installs, which one should bootstrap prefer?
 

--- a/README.md
+++ b/README.md
@@ -756,6 +756,13 @@ your shell startup path. When installed through Homebrew, update Base with:
 brew upgrade codeforester/base/base
 ```
 
+For a Base development machine, prefer the source checkout as the active
+`basectl`. Homebrew-installed Base and source-cloned Base can coexist, but the
+active command is whichever executable wins on `PATH`, and both normally share
+state under `~/.base.d`. Use Homebrew-managed Base for consumer install or
+upgrade validation in a test account, separate machine, isolated `HOME`, or with
+explicit paths such as `/opt/homebrew/bin/basectl` or `~/work/base/bin/basectl`.
+
 When Base is installed through Homebrew, `BASE_HOME` points to the physical
 Homebrew install location. It does not point to your project workspace. Configure
 `workspace.root` in `~/.base.d/config.yaml` so commands such as

--- a/docs/homebrew-upgrade-rehearsal.md
+++ b/docs/homebrew-upgrade-rehearsal.md
@@ -12,6 +12,10 @@ upgrade without losing local Base state.
 - Start from an existing released Homebrew install of Base.
 - Use a test `HOME` when possible so shell startup and `~/.base.d` preservation
   can be checked without mutating a personal account.
+- Avoid using a day-to-day Base development checkout as the active `basectl`
+  for this rehearsal. If a source checkout is present, use explicit Homebrew
+  paths and record `command -v basectl` plus `type -a basectl` before and after
+  the upgrade.
 - Use a scratch workspace with a Base-managed project such as `base-demo`.
 - Confirm Homebrew health before starting:
 

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -64,6 +64,12 @@ Before starting either install path:
 5. Choose a scratch workspace that does not contain production project changes.
 6. If both Homebrew and source checkouts are present, write down which
    `basectl` executable should win on `PATH`.
+7. On a Base development machine, prefer the source checkout as the active
+   `basectl`. Use Homebrew-managed Base for consumer install and upgrade
+   validation only when that is the run's purpose.
+8. When both installs exist, use explicit paths such as `~/work/base/bin/basectl`
+   and `/opt/homebrew/bin/basectl` or `/usr/local/bin/basectl` so the run does
+   not accidentally test the wrong install route.
 
 The run is acceptable only when failures are actionable and tied to the chosen
 route. For example, an Xcode Command Line Tools prompt is acceptable only if the


### PR DESCRIPTION
## Summary
- Clarify that source checkout Base is the preferred active mode on Base development machines.
- Explain that Homebrew-managed Base should be used for consumer install/upgrade validation with isolation or explicit paths.
- Reinforce PATH ownership checks in the FAQ, README, macOS validation checklist, and Homebrew upgrade rehearsal docs.

## Validation
- git diff --check

Closes #538