### PR TITLE
Update architecture GitHub conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Replaced stale pre-1.0 rewrite guidance in the architecture repository
+  conventions with current GitHub release and Homebrew tap ownership.
 - Removed a hardcoded issue number from the 1.0 Homebrew upgrade reminder in
   `basectl release`.
 - Kept `basectl ci setup --format json` output focused on a clean setup summary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -650,15 +650,16 @@ through managed workstation provisioning before invoking `basectl setup`.
 
 ## GitHub and Repository Conventions
 
-- Base is a public GitHub repository
-- Issues are the official communication channel for bug reports and feedback
-- The README contains a clear "Issues and Feedback" section pointing users to GitHub
-  Issues
-- A stable release tag (e.g. `v0.9.0`) marks the last version of the old Base design
-  before the current rewrite begins
-- The README includes a notice that active development is happening on master and the
-  API is changing significantly
-- Users who want stability should pin to the stable release tag
+- Base uses a public GitHub repository at `codeforester/base`.
+- GitHub Issues are the official product backlog for bugs, feature requests,
+  release work, maintenance, and documentation follow-up.
+- `basectl release` manages annotated tags and GitHub Releases for Base using
+  the manifest-owned release metadata in `base_manifest.yaml`.
+- The Homebrew tap at `codeforester/homebrew-base` owns the formula that installs
+  published Base releases.
+- Homebrew tap updates happen after each GitHub Release and remain a manual
+  handoff. `basectl release` prints the required tap follow-up when the project
+  manifest declares Homebrew metadata.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace stale pre-1.0 rewrite guidance in `docs/architecture.md` with current GitHub backlog, release, and Homebrew tap ownership.
- Add a changelog note for the architecture docs correction.

## Validation
- `git diff --check`
- `rg -n "v0\.9\.0|old Base design|API is changing significantly|pin to the stable release" docs/architecture.md` returned no matches
- `env -u BASE_HOME ./bin/base-test`

Closes #561