### PR TITLE
Fix activate BASE_SHELL readonly warning

### DIFF
--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -118,7 +118,6 @@ base_activate_subcommand_main() {
     export BASE_PROJECT_MANIFEST="$manifest_path"
     export BASE_PROJECT_VENV_DIR="$venv_dir"
     export BASE_HOME
-    export BASE_SHELL=1
 
     if [[ "$preserve_cwd" != "1" ]]; then
         cd "$project_root" || fatal_error "Unable to enter project root '$project_root'."

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -43,6 +43,7 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" activate demo
 
     [ "$status" -eq 0 ]
+    [[ "$output" != *"BASE_SHELL: readonly variable"* ]]
     [[ "$output" == *"args=--rcfile $BASE_REPO_ROOT/lib/bash/runtime/bashrc"* ]]
     [[ "$output" == *"BASE_PROJECT=demo"* ]]
     [[ "$output" == *"BASE_PROJECT_ROOT=$workspace/demo"* ]]


### PR DESCRIPTION
## Summary
- Remove the redundant `BASE_SHELL=1` export from `basectl activate`.
- Add activation BATS coverage so the readonly warning cannot reappear silently.

## Root Cause
`base_init.sh` already exports `BASE_SHELL` and marks it readonly during command startup. `basectl activate` tried to assign it again before launching the runtime shell, which printed `BASE_SHELL: readonly variable` even though activation continued.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/activate.sh`
- `env -u BASE_HOME -u BASE_SHELL bats cli/bash/commands/basectl/tests/activate.bats lib/bash/runtime/tests/runtime_bashrc.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`
- `git diff --cached --check`

## Demo Impact
Activation output is cleaner for Base-managed demo projects; no behavior change to the runtime shell.

Closes #564