### PR TITLE
Add Homebrew link conflict guidance

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -163,6 +163,35 @@ Homebrew installs Base's files. `basectl setup` prepares the local Base runtime
 under `~/.base.d/base/.venv` and reconciles other prerequisites that Base needs
 to operate.
 
+### Why can setup fail on a Homebrew `brew link` conflict?
+
+Prerequisite profiles install ordinary Homebrew tools. A tool can pull a
+Homebrew dependency that needs to be linked into Homebrew's prefix. If files such
+as `/usr/local/bin/python3`, `/usr/local/bin/pip3`, or `/usr/local/bin/idle3`
+already point at another Python installation, Homebrew may stop with:
+
+```text
+Error: The `brew link` step did not complete successfully
+```
+
+Base reports Homebrew's suggested dry-run command when it sees this failure.
+Run the dry-run first and inspect the files Homebrew would overwrite:
+
+```bash
+brew link --overwrite python@3.14 --dry-run
+```
+
+If the dry-run only lists stale files you are comfortable replacing, run the
+same command without `--dry-run`, then rerun the Base setup command:
+
+```bash
+brew link --overwrite python@3.14
+basectl setup --profile sre
+```
+
+Do not run the overwrite command blindly on a machine where those Python shims
+are intentionally managed outside Homebrew.
+
 ## Workspace Configuration
 
 ### How should I configure my workspace root?

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -20,6 +20,8 @@ from .errors import ArtifactError
 COMMAND_OUTPUT_TAIL_CHARS = 4000
 SECRET_VALUE_RE = re.compile(r"(?i)\b(token|password|secret|api[-_]?key)=\S+")
 URL_CREDENTIALS_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s:@]+:[^@\s/]+@")
+HOMEBREW_LINK_FAILURE = "The `brew link` step did not complete successfully"
+HOMEBREW_LINK_DRY_RUN_RE = re.compile(r"(?m)^\s*(brew link --overwrite [^\r\n]+ --dry-run)\s*$")
 
 
 @dataclass
@@ -103,6 +105,9 @@ def run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = No
             message = f"{message}\nstdout:\n{stdout_tail}"
         if stderr_tail:
             message = f"{message}\nstderr:\n{stderr_tail}"
+        guidance = command_failure_guidance(stdout_tail, stderr_tail)
+        if guidance:
+            message = f"{message}\n\n{guidance}"
         raise ArtifactError(message)
     if cwd is not None:
         ctx.log.debug("Command succeeded in '%s': %s", cwd, format_command(command))
@@ -124,6 +129,35 @@ def format_command(command: list[str]) -> str:
 def redact_command_output(text: str) -> str:
     text = URL_CREDENTIALS_RE.sub(r"\1[REDACTED]@", text)
     return SECRET_VALUE_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+
+
+def command_failure_guidance(stdout_tail: str, stderr_tail: str) -> str:
+    output = "\n".join(part for part in (stdout_tail, stderr_tail) if part)
+    return homebrew_link_failure_guidance(output)
+
+
+def homebrew_link_failure_guidance(output: str) -> str:
+    if HOMEBREW_LINK_FAILURE not in output:
+        return ""
+
+    match = HOMEBREW_LINK_DRY_RUN_RE.search(output)
+    if match is None:
+        return (
+            "Homebrew reported a link conflict while installing a dependency. "
+            "Review Homebrew's conflicting-file list, repair the link conflict, "
+            "then rerun the Base command."
+        )
+
+    dry_run_command_text = match.group(1)
+    repair_command_text = dry_run_command_text.removesuffix(" --dry-run")
+    return (
+        "Homebrew reported a link conflict while installing a dependency. "
+        "Review the files Homebrew would overwrite before repairing it:\n"
+        f"  {dry_run_command_text}\n"
+        "If the dry-run only lists stale files you are comfortable replacing, run:\n"
+        f"  {repair_command_text}\n"
+        "Then rerun the Base command."
+    )
 
 
 def _write_bytes(target: TextIO, chunk: bytes) -> None:

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -542,6 +542,32 @@ class ProcessTests(unittest.TestCase):
         self.assertIn("stderr:", message)
         self.assertIn("stderr before failure", message)
 
+    def test_run_command_failure_adds_homebrew_link_conflict_guidance(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('Error: The `brew link` step did not complete successfully', file=sys.stderr); "
+                "print('To list all files that would be deleted:', file=sys.stderr); "
+                "print('  brew link --overwrite python@3.14 --dry-run', file=sys.stderr); "
+                "raise SystemExit(1)"
+            ),
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            with self.assertRaises(ArtifactError) as exc:
+                process.run_command(ctx, command)
+
+        message = str(exc.exception)
+        self.assertIn("Homebrew reported a link conflict while installing a dependency.", message)
+        self.assertIn("brew link --overwrite python@3.14 --dry-run", message)
+        self.assertIn("brew link --overwrite python@3.14", message)
+        self.assertIn("Then rerun the Base command.", message)
+
     def test_run_command_redacts_sensitive_output_from_logs_and_failure(self) -> None:
         ctx = fake_context()
         stdout = io.StringIO()


### PR DESCRIPTION
## Summary
- Add setup failure guidance for Homebrew brew link conflicts caused by dependency installs.
- Detect Homebrew suggested dry-run command in captured command output and include a manual repair flow.
- Document the same repair flow in the FAQ.

## Root Cause
The SRE profile can pull Homebrew dependencies such as Python through tools like httpie. On Intel Macs with stale or externally managed shims in /usr/local/bin, Homebrew stops at the link step and Base previously surfaced only the raw command failure.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py -q
- git diff --check
- git diff --cached --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- Setup failures now include a clearer recovery path when Homebrew reports a link conflict.
- No automatic overwrite is performed.

Closes #565