### PR TITLE
Seed Base user config on first setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   `basectl check|doctor <project> --remote-network`.
 - Added an explicit `ai` prerequisite profile for Codex CLI and Claude Code
   setup, check, doctor, onboard, and shell completion flows.
+- Added first-run seeding of `~/.base.d/config.yaml` with
+  `workspace.root: ~/work` during `basectl setup`.
 
 ### Changed
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -196,21 +196,22 @@ are intentionally managed outside Homebrew.
 
 ### How should I configure my workspace root?
 
-If repositories live side by side under a directory such as `~/work`, configure:
+On first setup, Base creates `~/.base.d/config.yaml` with:
 
 ```yaml
 workspace:
   root: ~/work
 ```
 
-in:
+If repositories live side by side under a different directory, edit:
 
 ```text
 ~/.base.d/config.yaml
 ```
 
-This helps commands such as `basectl projects list`, `basectl activate
-<project>`, and `basectl test <project>` find participating repositories.
+Base does not overwrite existing config files or symlinks. The workspace root
+helps commands such as `basectl projects list`, `basectl activate <project>`,
+and `basectl test <project>` find participating repositories.
 
 ### What belongs in Base versus a project-owned installer?
 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ For mode selection, dry-run behavior, and contributor setup details, see
 [First-Mile Bootstrap](docs/bootstrap.md).
 
 For Homebrew installs, Base itself lives under Homebrew's prefix rather than in
-your project workspace. If your repositories live under a shared directory such
-as `~/work`, set the workspace root in `~/.base.d/config.yaml` after running
-`basectl setup`:
+your project workspace. On first setup, Base creates `~/.base.d/config.yaml`
+with the default workspace root:
 
 ```yaml
 workspace:
   root: ~/work
 ```
+
+Edit that value if your repositories live under a different shared directory.
 
 Or install directly through Homebrew when Homebrew is already available:
 
@@ -563,8 +564,10 @@ basectl config show
 basectl config doctor
 ```
 
-Base owns the meaning of `~/.base.d/config.yaml`, but users own how that file is
-edited, backed up, or synced. See [docs/local-config.md](docs/local-config.md).
+Base creates `~/.base.d/config.yaml` with a small first-run default when the file
+is missing, then leaves user edits and symlinks alone. Base owns the meaning of
+that file, but users own how it is edited, backed up, or synced. See
+[docs/local-config.md](docs/local-config.md).
 
 Inspect release readiness for a Base-managed repository with:
 

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -34,6 +34,7 @@ Setup does:
   5. Create ~/.base.d/base/.venv if it does not already exist.
   6. Install Base Python bootstrap packages into the Base virtual environment.
   7. Invoke the Python project setup layer for base_manifest.yaml artifacts.
+  8. Create ~/.base.d/config.yaml with workspace.root: ~/work if missing.
 
 Notes:
   - This command is intentionally idempotent.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -759,6 +759,49 @@ setup_project_venv_dir() {
     printf '%s\n' "$HOME/.base.d/$project/.venv"
 }
 
+setup_user_config_path() {
+    printf '%s\n' "$HOME/.base.d/config.yaml"
+}
+
+setup_seed_user_config() {
+    local config_dir config_path temp_file
+
+    config_path="$(setup_user_config_path)"
+    if [[ -e "$config_path" || -L "$config_path" ]]; then
+        return 0
+    fi
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Would create Base user config at '$config_path'."
+        return 0
+    fi
+
+    config_dir="$(dirname "$config_path")"
+    safe_mkdir -p "$config_dir"
+    if [[ -e "$config_path" || -L "$config_path" ]]; then
+        return 0
+    fi
+
+    temp_file="$(mktemp "$config_path.XXXXXX")" ||
+        fatal_error "Unable to create temporary Base user config for '$config_path'."
+    {
+        printf 'workspace:\n'
+        printf '  root: ~/work\n'
+    } > "$temp_file" || {
+        rm -f -- "$temp_file"
+        fatal_error "Unable to write Base user config '$config_path'."
+    }
+    mv -n -- "$temp_file" "$config_path" || {
+        rm -f -- "$temp_file"
+        fatal_error "Unable to create Base user config '$config_path'."
+    }
+    if [[ -e "$temp_file" ]]; then
+        rm -f -- "$temp_file"
+        return 0
+    fi
+    log_info "Created Base user config at '$config_path'."
+}
+
 setup_project_venv_python_bin() {
     local project="$1"
     local venv_dir
@@ -1765,6 +1808,7 @@ setup_run_install() {
         fi
     fi
     setup_run_project_artifact_setup || return $?
+    setup_seed_user_config
 
     if setup_is_dry_run; then
         log_info "[DRY-RUN] Base CLI setup check is complete."

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -15,6 +15,7 @@ load ./setup_helpers.bash
     [[ "$output" == *"--no-notify"* ]]
     [[ "$output" == *"--recreate-venv"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on macOS."* ]]
+    [[ "$output" == *"Create ~/.base.d/config.yaml with workspace.root: ~/work if missing."* ]]
 }
 
 @test "basectl setup fails on unsupported operating systems" {
@@ -124,6 +125,79 @@ EOF
     [ -f "$TEST_STATE_DIR/click-install-ran" ]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ -f "$venv_dir/pyvenv.cfg" ]
+}
+
+@test "basectl setup seeds missing user config with workspace root" {
+    local config_path="$TEST_HOME/.base.d/config.yaml"
+    local installer
+
+    create_xcode_stubs
+    installer="$(create_homebrew_installer_stub)"
+
+    run_base_command \
+        BASE_SETUP_NOTIFY_MIN_SECONDS=999999 \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
+        setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Created Base user config at '$config_path'."* ]]
+    [ -f "$config_path" ]
+    [ "$(cat "$config_path")" = $'workspace:\n  root: ~/work' ]
+}
+
+@test "basectl setup leaves existing user config unchanged" {
+    local config_path="$TEST_HOME/.base.d/config.yaml"
+    local installer
+
+    mkdir -p "$(dirname "$config_path")"
+    printf 'workspace:\n  root: ~/src\n' > "$config_path"
+    create_xcode_stubs
+    installer="$(create_homebrew_installer_stub)"
+
+    run_base_command \
+        BASE_SETUP_NOTIFY_MIN_SECONDS=999999 \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
+        setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Created Base user config"* ]]
+    [ "$(cat "$config_path")" = $'workspace:\n  root: ~/src' ]
+}
+
+@test "basectl setup leaves user config symlinks unchanged" {
+    local config_path="$TEST_HOME/.base.d/config.yaml"
+    local config_target="$TEST_TMPDIR/synced-config.yaml"
+    local installer
+
+    mkdir -p "$(dirname "$config_path")"
+    printf 'workspace:\n  root: ~/synced-work\n' > "$config_target"
+    ln -s "$config_target" "$config_path"
+    create_xcode_stubs
+    installer="$(create_homebrew_installer_stub)"
+
+    run_base_command \
+        BASE_SETUP_NOTIFY_MIN_SECONDS=999999 \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_SCRIPT="$installer" \
+        setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Created Base user config"* ]]
+    [ -L "$config_path" ]
+    [ "$(readlink "$config_path")" = "$config_target" ]
+    [ "$(cat "$config_target")" = $'workspace:\n  root: ~/synced-work' ]
+}
+
+@test "basectl setup dry-run reports user config seed without writing it" {
+    local config_path="$TEST_HOME/.base.d/config.yaml"
+
+    run_base_command setup --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create Base user config at '$config_path'."* ]]
+    [ ! -e "$config_path" ]
 }
 
 @test "basectl setup rejects Homebrew installer override outside test mode" {

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -6,8 +6,16 @@ Base reads machine-local user configuration from:
 ~/.base.d/config.yaml
 ```
 
-This file is optional. When it is missing, Base behaves as though the user
-config is an empty YAML mapping.
+`basectl setup` creates this file with a small first-run default when it is
+missing:
+
+```yaml
+workspace:
+  root: ~/work
+```
+
+Base still treats a missing file as an empty YAML mapping so read-only commands
+and partial installations can run before setup has seeded the file.
 
 Inspect it with:
 
@@ -26,10 +34,12 @@ the path is a symlink.
 
 Base owns the meaning of `~/.base.d/config.yaml`.
 
-The user owns how that file is edited, backed up, copied, or synced.
+The user owns how that file is edited, backed up, copied, or synced. After Base
+creates the first-run default, Base does not overwrite existing config files or
+symlinks.
 
-Base does not edit the file for the user, and Base does not automate iCloud,
-dotfile, or backup setup. Developers can edit the YAML directly.
+Base does not automate iCloud, dotfile, or backup setup. Developers can edit the
+YAML directly.
 
 Good ways to keep this file across machines include:
 
@@ -86,13 +96,14 @@ This distinction matters for Homebrew installs. In a source checkout,
 `BASE_HOME` is usually the `base` repository inside a shared directory such as
 `~/work/base`, so `BASE_HOME`'s parent is a reasonable fallback. In a Homebrew
 install, `BASE_HOME` points to the physical Homebrew install location, not the
-developer's workspace. Set `workspace.root` to make commands such as
+developer's workspace. The first-run default sets `workspace.root` to `~/work`;
+edit that value to make commands such as
 `basectl projects list`, `basectl activate <project>`, and
 `basectl test <project>` independent of how Base itself was installed.
 
 `workspace.root` must be an absolute path or start with `~`. Base does not
-create the directory automatically; `basectl config doctor` reports whether the
-configured path exists.
+create the workspace directory automatically; `basectl config doctor` reports
+whether the configured path exists.
 
 ## IDE Preferences
 
@@ -155,10 +166,10 @@ Supported IDE preference keys are intentionally narrow:
 Unknown IDE names and unsupported keys are rejected. Settings values must be
 JSON-serializable because Base writes them to IDE `settings.json` files.
 
-Base does not edit this file. There is no `basectl config set` or IDE preference
-editor command by design; developers can edit YAML directly, and Base keeps the
-runtime behavior inspectable through `basectl config show` and
-`basectl config doctor`.
+Aside from the first-run seed, Base does not edit this file. There is no
+`basectl config set` or IDE preference editor command by design; developers can
+edit YAML directly, and Base keeps the runtime behavior inspectable through
+`basectl config show` and `basectl config doctor`.
 
 ## Sync Guidance
 

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -6,7 +6,7 @@ bats_require_minimum_version 1.5.0
 setup() {
     setup_test_tmpdir
     TEST_HOME="$TEST_TMPDIR/home"
-    TEST_WORKSPACE="$TEST_TMPDIR/workspace"
+    TEST_WORKSPACE="$TEST_HOME/work"
     TEST_STATE_DIR="$TEST_TMPDIR/state"
     TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
     TEST_XCODE_DIR="$TEST_TMPDIR/CommandLineTools"


### PR DESCRIPTION
## Summary

- Seed `~/.base.d/config.yaml` during local `basectl setup` when the file is missing.
- Use the conservative first-run default `workspace.root: ~/work`.
- Preserve existing config files and symlinks, and report the seed action during dry-run without writing.
- Update README, FAQ, local config docs, setup help, changelog, and integration fixtures for the new default.

## Why

Homebrew installs place `BASE_HOME` under Homebrew's prefix, so project discovery falls back to the wrong parent directory unless the user manually creates `~/.base.d/config.yaml`. A first-run seed gives new installs the expected workspace root while keeping user-owned config editable and non-overwritten.

## Validation

- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats tests/integration/base_workflows.bats`
- `bash -n cli/bash/commands/basectl/subcommands/setup.sh cli/bash/commands/basectl/subcommands/setup_common.sh`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact

First-time setup now leaves brewed Base installs with a usable default workspace root for project discovery. Existing user configs and symlinks are left unchanged.

Closes #571
