### PR TITLE
Add export-context command

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -17,6 +17,8 @@ the canonical current command list.
 - `basectl build <project> [target...]` - run declared build targets.
 - `basectl demo [project]` - run a declared interactive demo script.
 - `basectl run <project> <command>` - run a declared project command.
+- `basectl export-context [project]` - export `.ai-context/` as a Markdown or
+  Zip bundle for manual upload or copy/paste into AI tools.
 - `basectl projects list` - list Base-managed projects discovered in the
   workspace.
 - `basectl workspace <status|check|doctor>` - show read-only workspace project
@@ -75,3 +77,6 @@ Important Python packages include:
 - `base_clean` - runtime cache/log/temp cleanup.
 - `base_release` - release check/plan/notes/publish support.
 - `base_dev` - developer profile setup/check/doctor/onboard support.
+- `base_export_context` - deterministic local Markdown and Zip exports from a
+  project's `.ai-context/` directory. Provider uploads are intentionally out of
+  scope.

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -22,6 +22,7 @@ The current command surface covers:
 - GitHub issue, PR, branch, and worktree helpers
 - workspace status/check/doctor reports
 - release readiness inspection and guarded GitHub release publishing
+- local AI context export bundles
 - explicit `ai` prerequisite profile for Codex CLI and Claude Code
 
 ## Active Development Direction
@@ -36,6 +37,7 @@ Recent unreleased work includes:
 - read-only workspace manifest support
 - guarded `basectl release publish`
 - release check, plan, and notes commands
+- local `.ai-context/` export bundles through `basectl export-context`
 - newcomer orientation presentation docs
 - optional project Git remote reachability diagnostics
 - explicit `ai` prerequisite profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   setup, check, doctor, onboard, and shell completion flows.
 - Added first-run seeding of `~/.base.d/config.yaml` with
   `workspace.root: ~/work` during `basectl setup`.
+- Added `basectl export-context` for deterministic local Markdown and Zip
+  bundles from a project's `.ai-context/` directory.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ basectl doctor <project>
 basectl test <project>
 basectl demo [project]
 basectl run <project> <command>
+basectl export-context <project>
 basectl activate <project>
 ```
 
@@ -157,6 +158,7 @@ Current implemented commands include:
 - `basectl test [project]`
 - `basectl build <project> [target...]`
 - `basectl run <project> <command>`
+- `basectl export-context [project]`
 - `basectl onboard`
 - `basectl version`
 
@@ -502,6 +504,21 @@ basectl run example lint -- --fix
 The command name `test` is reserved for the top-level `test` contract, so
 `basectl run example test` delegates to the same command as
 `basectl test example`.
+
+Export a project's AI context pack with:
+
+```bash
+basectl export-context example
+basectl export-context example --format zip --output /tmp/example-ai-context.zip
+basectl export-context --print
+basectl export-context --list-files
+```
+
+`basectl export-context` reads `.ai-context/` from the current or named
+Base-managed project. Markdown exports combine context Markdown files with
+stable source headings, using `.ai-context/INDEX.md` order when available and
+falling back to deterministic filename order for unlisted files. Zip exports
+contain only files from `.ai-context/` so they can be uploaded manually.
 
 Once a project is discoverable, activate it with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -29,6 +29,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `clean`
 - `config`
 - `doctor`
+- `export-context`
 - `gh`
 - `onboard`
 - `repo init/check/configure/agent-guidance/installer-template`
@@ -100,6 +101,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   virtual environment, dry-run, and extra-argument contract as `basectl test`.
   `basectl run <project> test` delegates to the top-level manifest `test`
   contract. Use `basectl run <project> --list` to inspect available commands.
+- `basectl export-context [project]` exports a project's `.ai-context`
+  directory for manual AI tool upload or copy/paste. Markdown exports include
+  stable file headings and use `INDEX.md` ordering when available. Zip exports
+  contain only files from `.ai-context`.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update` updates the Base repository from Git and then runs `basectl setup`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -17,6 +17,8 @@ Commands:
     Verify the local Base CLI environment and optional project artifacts without making changes.
   test [project] [options]
     Run a project's declared test command.
+  export-context [project] [options]
+    Export a project's .ai-context directory as Markdown or Zip.
   build <project> [target...] [options]
     Run a project's declared build targets.
   demo <project> [options]
@@ -179,6 +181,11 @@ basectl_do_check() {
 basectl_do_test() {
     basectl_source_subcommand_module test || return 1
     base_test_subcommand_main "$@"
+}
+
+basectl_do_export_context() {
+    basectl_source_subcommand_module export_context || return 1
+    base_export_context_subcommand_main "$@"
 }
 
 basectl_do_build() {
@@ -360,6 +367,7 @@ basectl_main() {
         activate)         basectl_do_activate "$@" ;;
         check)            basectl_do_check "$@" ;;
         test)             basectl_do_test "$@" ;;
+        export-context)   basectl_do_export_context "$@" ;;
         build)            basectl_do_build "$@" ;;
         demo)             basectl_do_demo "$@" ;;
         run)              basectl_do_run "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/export_context.sh
+++ b/cli/bash/commands/basectl/subcommands/export_context.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_export_context_subcommand_sourced:-}" ]] && return
+_base_export_context_subcommand_sourced=1
+readonly _base_export_context_subcommand_sourced
+
+base_export_context_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl export-context [project] [options]
+
+Options:
+  --workspace <path>       Workspace directory to scan for a named project.
+  --format <markdown|zip>  Export format. Defaults to markdown.
+  --output <path>          Write the export bundle to this path.
+  --print                  Print the Markdown export bundle to stdout.
+  --list-files             Print the files in export order without writing a bundle.
+  -v                       Enable DEBUG logging for this subcommand.
+  -h, --help               Show this help text.
+
+Export a Base-managed project's .ai-context directory for manual upload or
+copy/paste into AI tools.
+EOF
+}
+
+base_export_context_usage_error() {
+    base_export_context_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_export_context_subcommand_main() {
+    local project="" wrapper resolve_output resolved_name project_root manifest_path
+    local output_format="markdown" output_path="" print_bundle=0 list_files=0 workspace_requested=0
+    local resolve_args=() exporter_args=()
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_export_context_subcommand_usage
+                return 0
+                ;;
+            -v)
+                exporter_args+=(--debug)
+                shift
+                ;;
+            --workspace)
+                [[ -n "${2:-}" ]] || {
+                    base_export_context_usage_error "Option '--workspace' requires an argument."
+                    return $?
+                }
+                workspace_requested=1
+                resolve_args+=(--workspace "$2")
+                shift 2
+                ;;
+            --workspace=*)
+                workspace_requested=1
+                resolve_args+=("$1")
+                shift
+                ;;
+            --format)
+                [[ -n "${2:-}" ]] || {
+                    base_export_context_usage_error "Option '--format' requires an argument."
+                    return $?
+                }
+                output_format="$2"
+                shift 2
+                ;;
+            --format=*)
+                output_format="${1#--format=}"
+                shift
+                ;;
+            --output)
+                [[ -n "${2:-}" ]] || {
+                    base_export_context_usage_error "Option '--output' requires an argument."
+                    return $?
+                }
+                output_path="$2"
+                shift 2
+                ;;
+            --output=*)
+                output_path="${1#--output=}"
+                shift
+                ;;
+            --print)
+                print_bundle=1
+                shift
+                ;;
+            --list-files)
+                list_files=1
+                shift
+                ;;
+            -*)
+                base_export_context_usage_error "Unknown export-context option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$project" ]]; then
+                    base_export_context_usage_error "The 'export-context' command accepts exactly one project name."
+                    return $?
+                fi
+                project="$1"
+                shift
+                ;;
+        esac
+    done
+
+    case "$output_format" in
+        markdown|zip) ;;
+        *)
+            base_export_context_usage_error "Unsupported export-context format '$output_format'. Expected markdown or zip."
+            return $?
+            ;;
+    esac
+    [[ -n "$project" || "$workspace_requested" != "1" ]] || {
+        base_export_context_usage_error "Option '--workspace' requires an explicit project name."
+        return $?
+    }
+    [[ "$print_bundle" != "1" || "$output_format" == "markdown" ]] || {
+        base_export_context_usage_error "Option '--print' only supports markdown exports."
+        return $?
+    }
+    [[ "$print_bundle" != "1" || -z "$output_path" ]] || {
+        base_export_context_usage_error "Options '--print' and '--output' cannot be combined."
+        return $?
+    }
+    [[ "$list_files" != "1" || ( "$print_bundle" != "1" && -z "$output_path" ) ]] || {
+        base_export_context_usage_error "Option '--list-files' cannot be combined with '--print' or '--output'."
+        return $?
+    }
+
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    if [[ -n "$project" ]]; then
+        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${resolve_args[@]}")" || return $?
+    else
+        resolve_output="$("$wrapper" --project base base_projects current)" || return $?
+    fi
+    IFS=$'\t' read -r resolved_name project_root manifest_path <<<"$resolve_output"
+
+    [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
+        fatal_error "Unable to resolve project for export-context."
+    }
+
+    exporter_args+=(
+        --project-name "$resolved_name"
+        --project-root "$project_root"
+        --format "$output_format"
+    )
+    [[ -z "$output_path" ]] || exporter_args+=(--output "$output_path")
+    [[ "$print_bundle" != "1" ]] || exporter_args+=(--print)
+    [[ "$list_files" != "1" ]] || exporter_args+=(--list-files)
+
+    "$wrapper" --project base base_export_context "${exporter_args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -55,6 +55,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "run_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl export-context ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "export_context_projects=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl check --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -75,6 +79,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "run_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl export-context demo --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "export_context_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl projects list --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -157,11 +165,13 @@ EOF
     [[ "$output" == *"test_projects=base demo"* ]]
     [[ "$output" == *"build_projects=base demo"* ]]
     [[ "$output" == *"run_projects=base demo"* ]]
+    [[ "$output" == *"export_context_projects=base demo"* ]]
     [[ "$output" == *"check_options=--profile --format"* ]]
     [[ "$output" == *"check_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"test_options=--workspace --dry-run"* ]]
     [[ "$output" == *"build_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
+    [[ "$output" == *"export_context_options=--workspace --format --output --print --list-files"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"workspace_commands=status check doctor"* ]]
     [[ "$output" == *"workspace_options=--workspace --manifest --format"* ]]

--- a/cli/bash/commands/basectl/tests/export-context.bats
+++ b/cli/bash/commands/basectl/tests/export-context.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl export-context prints help without requiring the Base Python venv" {
+    run_basectl export-context --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl export-context [project] [options]"* ]]
+    [[ "$output" == *"--format <markdown|zip>"* ]]
+    [[ "$output" == *"--list-files"* ]]
+}
+
+@test "basectl export-context resolves current project when omitted" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/export-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "current" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_export_context" ]]; then
+    shift 2
+    printf '%s\n' "$*" > "${BASE_TEST_EXPORT_STATE:?}"
+    printf 'exported current\n'
+    exit 0
+fi
+printf 'unexpected export-context python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_EXPORT_STATE="$state_file" \
+        bash -c '
+            cd "$1"
+            shift
+            "$@"
+        ' bash "$workspace/demo" "$BASE_REPO_ROOT/bin/basectl" export-context --print
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exported current"* ]]
+    [ "$(cat "$state_file")" = "--project-name demo --project-root $workspace/demo --format markdown --print" ]
+}
+
+@test "basectl export-context resolves named project and forwards output options" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/export-state"
+    local output_path="$TEST_TMPDIR/base-ai-context.zip"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" && "${5:-}" == "--workspace" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_export_context" ]]; then
+    shift 2
+    printf '%s\n' "$*" > "${BASE_TEST_EXPORT_STATE:?}"
+    printf 'exported named\n'
+    exit 0
+fi
+printf 'unexpected export-context python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_EXPORT_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" export-context demo --workspace "$workspace" --format zip --output "$output_path"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exported named"* ]]
+    [ "$(cat "$state_file")" = "--project-name demo --project-root $workspace/demo --format zip --output $output_path" ]
+}
+
+@test "basectl export-context reports invalid arguments as usage errors" {
+    run_basectl export-context demo extra
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"basectl export-context [project] [options]"* ]]
+    [[ "$output" == *"The 'export-context' command accepts exactly one project name."* ]]
+}

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -12,6 +12,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"setup [options]"* ]]
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"test [project] [options]"* ]]
+    [[ "$output" == *"export-context [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
     [[ "$output" == *"repo <init|check|configure|agent-guidance|installer-template> [options]"* ]]
     [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
@@ -51,6 +52,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  onboard [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
+    grep -Fqx '  export-context [project] [options]' <<<"$output"
     grep -Fqx '  repo <init|check|configure|agent-guidance|installer-template> [options]' <<<"$output"
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"

--- a/cli/python/base_export_context/__init__.py
+++ b/cli/python/base_export_context/__init__.py
@@ -1,0 +1,1 @@
+"""AI context export command package."""

--- a/cli/python/base_export_context/__main__.py
+++ b/cli/python/base_export_context/__main__.py
@@ -1,0 +1,5 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_export_context/engine.py
+++ b/cli/python/base_export_context/engine.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+import base_cli
+
+
+app = base_cli.App(name="base_export_context")
+
+CONTEXT_DIR_NAME = ".ai-context"
+MARKDOWN_FORMAT = "markdown"
+ZIP_FORMAT = "zip"
+SUPPORTED_FORMATS = (MARKDOWN_FORMAT, ZIP_FORMAT)
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+MARKDOWN_CODE_RE = re.compile(r"`([^`]+)`")
+
+
+@dataclass(frozen=True)
+class ContextFile:
+    path: Path
+    relative_path: PurePosixPath
+
+    @property
+    def display_path(self) -> str:
+        return f"{CONTEXT_DIR_NAME}/{self.relative_path.as_posix()}"
+
+
+class ExportContextError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ExportContextOptions:
+    project_name: str
+    project_root: Path
+    output_format: str
+    output_path: str | None
+    print_bundle: bool
+    list_files: bool
+
+
+def main(argv: list[str] | None = None) -> int:
+    result = app.click_command.main(args=argv, standalone_mode=False)
+    return int(result or 0)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.option("--project-name", required=True, help="Resolved Base project name.")
+@base_cli.option("--project-root", required=True, help="Resolved Base project root.")
+@base_cli.option("--format", "output_format", default=MARKDOWN_FORMAT, help="Output format: markdown or zip.")
+@base_cli.option("--output", "output_path", help="Output path for the export bundle.")
+@base_cli.option("--print", "print_bundle", is_flag=True, help="Print the Markdown bundle to stdout.")
+@base_cli.option("--list-files", is_flag=True, help="Print the files in export order without writing a bundle.")
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def run(
+    ctx: base_cli.Context,
+    project_name: str,
+    project_root: str,
+    output_format: str,
+    output_path: str | None,
+    print_bundle: bool,
+    list_files: bool,
+) -> int:
+    options = ExportContextOptions(
+        project_name=project_name,
+        project_root=Path(project_root).expanduser().resolve(),
+        output_format=output_format.lower(),
+        output_path=output_path,
+        print_bundle=print_bundle,
+        list_files=list_files,
+    )
+    validation_error = validate_options(options, raw_output_format=output_format)
+    if validation_error is not None:
+        ctx.log.error(validation_error)
+        return 2
+
+    try:
+        return export_context(options)
+    except ExportContextError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+
+def validate_options(options: ExportContextOptions, raw_output_format: str) -> str | None:
+    if options.output_format not in SUPPORTED_FORMATS:
+        return f"Unsupported export format '{raw_output_format}'. Expected one of: markdown, zip."
+    if options.print_bundle and options.output_format != MARKDOWN_FORMAT:
+        return "Option '--print' only supports markdown exports."
+    if options.print_bundle and options.output_path:
+        return "Options '--print' and '--output' cannot be combined."
+    if options.list_files and (options.print_bundle or options.output_path):
+        return "Option '--list-files' cannot be combined with '--print' or '--output'."
+    return None
+
+
+def export_context(options: ExportContextOptions) -> int:
+    if options.list_files:
+        files = ordered_context_files(
+            options.project_name,
+            options.project_root,
+            include_all=options.output_format == ZIP_FORMAT,
+        )
+        for context_file in files:
+            print(context_file.display_path)
+        return 0
+
+    if options.output_format == MARKDOWN_FORMAT:
+        return export_markdown_context(options)
+
+    files = ordered_context_files(options.project_name, options.project_root, include_all=True)
+    destination = resolve_output_path(options.project_name, options.output_path, "zip")
+    write_zip_file(destination, files)
+    print(f"Wrote Zip AI context export for project '{options.project_name}' to {destination}")
+    return 0
+
+
+def export_markdown_context(options: ExportContextOptions) -> int:
+    files = ordered_context_files(options.project_name, options.project_root, include_all=False)
+    content = render_markdown_bundle(options.project_name, files)
+    if options.print_bundle:
+        print(content, end="")
+        return 0
+    destination = resolve_output_path(options.project_name, options.output_path, "md")
+    write_text_file(destination, content)
+    print(f"Wrote Markdown AI context export for project '{options.project_name}' to {destination}")
+    return 0
+
+
+def resolve_output_path(project_name: str, output_path: str | None, extension: str) -> Path:
+    if output_path:
+        return Path(output_path).expanduser()
+    return Path.cwd() / f"{project_name}-ai-context.{extension}"
+
+
+def ordered_context_files(project_name: str, project_root: Path, include_all: bool) -> tuple[ContextFile, ...]:
+    context_dir = project_root / CONTEXT_DIR_NAME
+    if not context_dir.exists():
+        raise ExportContextError(
+            f"Project '{project_name}' does not have an .ai-context directory. "
+            "Add .ai-context/README.md before exporting AI context."
+        )
+    if not context_dir.is_dir():
+        raise ExportContextError(f"Project '{project_name}' has .ai-context, but it is not a directory.")
+
+    files = discover_context_files(context_dir, include_all=include_all)
+    if not files:
+        if include_all:
+            detail = "does not contain files"
+        else:
+            detail = "does not contain Markdown files"
+        raise ExportContextError(f"Project '{project_name}' .ai-context directory {detail}.")
+
+    by_relative_path = {context_file.relative_path.as_posix(): context_file for context_file in files}
+    ordered_paths: list[str] = []
+    for referenced_path in index_references(context_dir, by_relative_path):
+        if referenced_path not in ordered_paths:
+            ordered_paths.append(referenced_path)
+    ordered_paths.extend(path for path in sorted(by_relative_path) if path not in ordered_paths)
+    return tuple(by_relative_path[path] for path in ordered_paths)
+
+
+def discover_context_files(context_dir: Path, include_all: bool) -> tuple[ContextFile, ...]:
+    files: list[ContextFile] = []
+    for path in context_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        if not include_all and path.suffix.lower() != ".md":
+            continue
+        relative_path = PurePosixPath(path.relative_to(context_dir).as_posix())
+        files.append(ContextFile(path=path, relative_path=relative_path))
+    return tuple(sorted(files, key=lambda context_file: context_file.relative_path.as_posix()))
+
+
+def index_references(context_dir: Path, known_paths: dict[str, ContextFile]) -> tuple[str, ...]:
+    index_path = context_dir / "INDEX.md"
+    if "INDEX.md" not in known_paths or not index_path.is_file():
+        return ()
+
+    try:
+        content = index_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ExportContextError("Unable to read .ai-context/INDEX.md as UTF-8.") from exc
+
+    references: list[str] = []
+    for _, raw_reference in sorted(markdown_reference_matches(content), key=lambda item: item[0]):
+        normalized = normalize_index_reference(raw_reference)
+        if normalized is not None and normalized in known_paths and normalized not in references:
+            references.append(normalized)
+    return tuple(references)
+
+
+def markdown_reference_matches(content: str) -> tuple[tuple[int, str], ...]:
+    matches: list[tuple[int, str]] = []
+    matches.extend((match.start(1), match.group(1)) for match in MARKDOWN_LINK_RE.finditer(content))
+    matches.extend((match.start(1), match.group(1)) for match in MARKDOWN_CODE_RE.finditer(content))
+    return tuple(matches)
+
+
+def normalize_index_reference(raw_reference: str) -> str | None:
+    reference = raw_reference.strip().strip("<>")
+    if not reference or "://" in reference or reference.startswith(("/", "#")):
+        return None
+    reference = reference.split("#", 1)[0].split("?", 1)[0]
+    if not reference:
+        return None
+    pure_path = PurePosixPath(reference)
+    if pure_path.is_absolute() or any(part == ".." for part in pure_path.parts):
+        return None
+    return pure_path.as_posix()
+
+
+def render_markdown_bundle(project_name: str, files: tuple[ContextFile, ...]) -> str:
+    parts = [
+        f"# AI Context Export: {project_name}",
+        "",
+        "Files are exported from `.ai-context/` in deterministic order.",
+        "",
+    ]
+
+    for context_file in files:
+        parts.append(f"## `{context_file.display_path}`")
+        parts.append("")
+        try:
+            content = context_file.path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise ExportContextError(f"Unable to read {context_file.display_path} as UTF-8.") from exc
+        parts.append(content.rstrip("\n"))
+        parts.append("")
+        parts.append("")
+
+    return "\n".join(parts)
+
+
+def write_text_file(destination: Path, content: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(content, encoding="utf-8")
+
+
+def write_zip_file(destination: Path, files: tuple[ContextFile, ...]) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for context_file in files:
+            info = zipfile.ZipInfo(context_file.relative_path.as_posix(), ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, context_file.path.read_bytes())

--- a/cli/python/base_export_context/tests/test_engine.py
+++ b/cli/python/base_export_context/tests/test_engine.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+import zipfile
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_export_context import engine
+
+
+def write_context_file(project_root: Path, relative_path: str, content: str) -> None:
+    path = project_root / ".ai-context" / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def invoke_engine(args: list[str], project_root: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    env = {
+        "BASE_HOME": str(project_root),
+        "HOME": str(project_root / "home"),
+    }
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class ExportContextTests(unittest.TestCase):
+    def test_markdown_print_uses_index_order_then_remaining_markdown_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            write_context_file(
+                project_root,
+                "INDEX.md",
+                "# Index\n\n1. `B.md`\n2. [A](A.md)\n3. `../README.md`\n",
+            )
+            write_context_file(project_root, "A.md", "Alpha\n")
+            write_context_file(project_root, "B.md", "Bravo\n")
+            write_context_file(project_root, "C.md", "Charlie")
+            (project_root / "README.md").write_text("not context\n", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "--project-name",
+                    "demo",
+                    "--project-root",
+                    str(project_root),
+                    "--print",
+                ],
+                project_root,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("# AI Context Export: demo\n", stdout)
+        headings = [line for line in stdout.splitlines() if line.startswith("## `")]
+        self.assertEqual(
+            headings,
+            [
+                "## `.ai-context/B.md`",
+                "## `.ai-context/A.md`",
+                "## `.ai-context/C.md`",
+                "## `.ai-context/INDEX.md`",
+            ],
+        )
+        self.assertIn("Bravo\n", stdout)
+        self.assertIn("Charlie\n", stdout)
+        self.assertNotIn("not context", stdout)
+
+    def test_list_files_prints_export_order_without_writing_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            write_context_file(project_root, "INDEX.md", "Read `PROJECT.md` first.\n")
+            write_context_file(project_root, "PROJECT.md", "Project\n")
+            write_context_file(project_root, "STATUS.md", "Status\n")
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "--project-name",
+                    "demo",
+                    "--project-root",
+                    str(project_root),
+                    "--list-files",
+                ],
+                project_root,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            ".ai-context/PROJECT.md\n.ai-context/INDEX.md\n.ai-context/STATUS.md\n",
+        )
+
+    def test_output_writes_markdown_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            output_path = Path(tmpdir) / "bundle.md"
+            write_context_file(project_root, "PROJECT.md", "Project\n")
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "--project-name",
+                    "demo",
+                    "--project-root",
+                    str(project_root),
+                    "--output",
+                    str(output_path),
+                ],
+                project_root,
+            )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(stderr, "")
+            self.assertEqual(stdout, f"Wrote Markdown AI context export for project 'demo' to {output_path}\n")
+            self.assertIn("## `.ai-context/PROJECT.md`\n", output_path.read_text(encoding="utf-8"))
+
+    def test_missing_context_directory_reports_actionable_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+
+            status, stdout, stderr = invoke_engine(
+                ["--project-name", "demo", "--project-root", str(project_root), "--print"],
+                project_root,
+            )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("Project 'demo' does not have an .ai-context directory", stderr)
+        self.assertIn("Add .ai-context/README.md", stderr)
+
+    def test_zip_export_contains_context_files_only_and_is_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            first_zip = Path(tmpdir) / "first.zip"
+            second_zip = Path(tmpdir) / "second.zip"
+            write_context_file(project_root, "INDEX.md", "Read `PROJECT.md` first.\n")
+            write_context_file(project_root, "PROJECT.md", "Project\n")
+            write_context_file(project_root, "notes/raw.txt", "Raw context\n")
+            (project_root / "README.md").write_text("not context\n", encoding="utf-8")
+
+            first_status, first_stdout, first_stderr = invoke_engine(
+                [
+                    "--project-name",
+                    "demo",
+                    "--project-root",
+                    str(project_root),
+                    "--format",
+                    "zip",
+                    "--output",
+                    str(first_zip),
+                ],
+                project_root,
+            )
+            second_status, _, _ = invoke_engine(
+                [
+                    "--project-name",
+                    "demo",
+                    "--project-root",
+                    str(project_root),
+                    "--format",
+                    "zip",
+                    "--output",
+                    str(second_zip),
+                ],
+                project_root,
+            )
+
+            self.assertEqual(first_status, 0)
+            self.assertEqual(second_status, 0)
+            self.assertEqual(first_stderr, "")
+            self.assertEqual(first_stdout, f"Wrote Zip AI context export for project 'demo' to {first_zip}\n")
+            self.assertEqual(first_zip.read_bytes(), second_zip.read_bytes())
+            with zipfile.ZipFile(first_zip) as archive:
+                self.assertEqual(
+                    archive.namelist(),
+                    ["PROJECT.md", "INDEX.md", "notes/raw.txt"],
+                )
+                for info in archive.infolist():
+                    self.assertEqual(info.date_time, (1980, 1, 1, 0, 0, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -63,7 +63,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test build demo run repo ci release clean logs config doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test export-context build demo run repo ci release clean logs config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -106,6 +106,9 @@ _base_basectl_completion() {
             ;;
         test)
             _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
+            ;;
+        export-context)
+            _base_basectl_completion_project_or_options "--workspace --format --output --print --list-files -v -h --help" "$cur"
             ;;
         build)
             _base_basectl_completion_project_or_options "--workspace --dry-run --list -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -18,6 +18,7 @@ _base_basectl_completion() {
         'setup:Install and bootstrap the local Base CLI environment'
         'check:Verify the local Base CLI environment'
         'test:Run a project test command'
+        'export-context:Export a project AI context bundle'
         'build:Run project build targets'
         'demo:Run a project interactive demo'
         'run:Run a project command'
@@ -90,6 +91,19 @@ _base_basectl_completion() {
         test)
             _arguments '--workspace[Workspace directory to scan]:path:_files' \
                 '--dry-run[Print the resolved test command without running it]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
+            ;;
+        export-context)
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--format[Export format]:format:(markdown zip)' \
+                '--output[Output path]:path:_files' \
+                '--print[Print the Markdown export to stdout]' \
+                '--list-files[List files in export order]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then


### PR DESCRIPTION
## Summary

- Add `basectl export-context` through the normal Bash dispatch layer for current or named Base-managed projects.
- Add the `base_export_context` Python package for deterministic Markdown and Zip exports from `.ai-context/`.
- Update help, Bash/Zsh completions, README/changelog docs, and `.ai-context/` command/status context.

## Issue

Closes #569

## Validation

- RED: `env -u BASE_HOME PYTHONPATH="$PWD/lib/python:$PWD/cli/python" "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_export_context/tests/test_engine.py` failed before `base_export_context` existed.
- RED: `env -u BASE_HOME bats cli/bash/commands/basectl/tests/export-context.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats` failed before dispatch/help/completions existed.
- `env -u BASE_HOME PYTHONPATH="$PWD/lib/python:$PWD/cli/python" "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_export_context/tests/test_engine.py`
- `env -u BASE_HOME bats cli/bash/commands/basectl/tests/export-context.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `bash -n cli/bash/commands/basectl/subcommands/export_context.sh cli/bash/commands/basectl/basectl.sh lib/shell/completions/basectl_completion.sh lib/shell/completions/basectl_completion.zsh`
- `env BASE_CACHE_DIR=/tmp/base-cache-569 ./bin/basectl export-context --list-files`
- `env BASE_CACHE_DIR=/tmp/base-cache-569 ./bin/basectl export-context --print`
- `env BASE_CACHE_DIR=/tmp/base-cache-569 ./bin/basectl export-context --format zip --output /tmp/base-ai-context-569.zip`
- `python3 -m zipfile -l /tmp/base-ai-context-569.zip`
- `env PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint --rcfile=.pylintrc cli/python/base_export_context`
- `find cli/python lib/python -name '*.py' -print0 | xargs -0 "$HOME/.base.d/base/.venv/bin/python" -m pylint --rcfile=.pylintrc`
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD`
- `env -u BASE_HOME ./bin/base-test` after rebasing onto current `master`
  (`375 passed, 1 skipped`; BATS `1..402`, all ok)

## Demo Impact

None. This adds a local export command and does not change the demo workflow.

## Notes

- Provider upload is intentionally out of scope; this command only writes local Markdown/Zip bundles or prints Markdown to stdout.
- A sandboxed smoke run needed `BASE_CACHE_DIR=/tmp/base-cache-569` because the default user cache path is outside the writable sandbox.
- Rebased over #573 and kept both Unreleased changelog entries.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
