### PR TITLE
Preserve Homebrew opt paths after upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,9 +813,10 @@ state under `~/.base.d`. Use Homebrew-managed Base for consumer install or
 upgrade validation in a test account, separate machine, isolated `HOME`, or with
 explicit paths such as `/opt/homebrew/bin/basectl` or `~/work/base/bin/basectl`.
 
-When Base is installed through Homebrew, `BASE_HOME` points to the physical
-Homebrew install location. It does not point to your project workspace. Configure
-`workspace.root` in `~/.base.d/config.yaml` so commands such as
+When Base is installed through Homebrew, `BASE_HOME` points to the stable
+Homebrew install location, such as `/usr/local/opt/base/libexec` or
+`/opt/homebrew/opt/base/libexec`. It does not point to your project workspace.
+Configure `workspace.root` in `~/.base.d/config.yaml` so commands such as
 `basectl projects list`, `basectl activate <project>`, and
 `basectl test <project>` can find your repositories:
 

--- a/base_init.sh
+++ b/base_init.sh
@@ -82,7 +82,7 @@ base_init_resolve_home() {
             base_init_error "BASE_HOME '$BASE_HOME' is not a directory or is not accessible."
             return 1
         }
-        (cd -- "$BASE_HOME" && pwd -P)
+        (cd -L -- "$BASE_HOME" && pwd -L)
         return $?
     fi
 

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -64,6 +64,43 @@ EOF
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_ZSH_DEFAULTS=false"* ]]
 }
 
+@test "basectl update-profile writes stable Homebrew opt-style paths" {
+    local cellar_parent="$TEST_TMPDIR/homebrew/Cellar/base/0.4.0"
+    local opt_dir="$TEST_TMPDIR/homebrew/opt"
+    local opt_base="$opt_dir/base/libexec"
+
+    mkdir -p "$cellar_parent" "$opt_dir"
+    ln -s "$BASE_REPO_ROOT" "$cellar_parent/libexec"
+    ln -s "../Cellar/base/0.4.0" "$opt_dir/base"
+
+    run env \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$opt_base" \
+        PATH="$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$TEST_BASH_BIN_DIR/bash" -c '\
+            source "$BASE_HOME/base_init.sh"; \
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"; \
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update_profile.sh"; \
+            base_update_profile_subcommand_main'
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$TEST_HOME/.bash_profile")" == *"source \"$opt_base/lib/shell/bash_profile\""* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"source \"$opt_base/lib/shell/bashrc\""* ]]
+    [[ "$(cat "$TEST_HOME/.zprofile")" == *"source \"$opt_base/lib/shell/zprofile\""* ]]
+    [[ "$(cat "$TEST_HOME/.zshrc")" == *"source \"$opt_base/lib/shell/zshrc\""* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" != *"/Cellar/base/0.4.0"* ]]
+}
+
 @test "basectl update-profile preserves non-Base dotfile content and is idempotent" {
     printf '%s
 ' 'user line before' > "$TEST_HOME/.bashrc"
@@ -98,6 +135,29 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"$BASE_REPO_ROOT/bin/basectl"* ]]
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
+}
+
+@test "Base-managed Bash startup preserves Homebrew opt-style symlink paths" {
+    local cellar_base="$TEST_TMPDIR/homebrew/Cellar/base/0.4.0/libexec"
+    local opt_dir="$TEST_TMPDIR/homebrew/opt"
+    local opt_base="$opt_dir/base/libexec"
+
+    mkdir -p "$opt_dir"
+    create_fake_shell_base "$cellar_base"
+    ln -s "../Cellar/base/0.4.0" "$opt_dir/base"
+
+    run env -u BASE_HOME -u BASE_PLATFORM_TOOLS_HOME -u BASE_PLATFORM_TOOLS_BIN_DIR \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash --rcfile "$opt_base/lib/shell/bashrc" -i -c '\
+            printf "BASE_HOME=%s\n" "$BASE_HOME"; \
+            printf "BASE_BIN=%s\n" "$(command -v basectl)"; \
+            printf "PATH=%s\n" "$PATH"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_HOME=$opt_base"* ]]
+    [[ "$output" == *"BASE_BIN=$opt_base/bin/basectl"* ]]
+    [[ "$output" == *"PATH=$opt_base/bin:/usr/bin:/bin:/usr/sbin:/sbin"* ]]
 }
 
 @test "Base-managed Bash startup detects sibling Base Platform Tools without profile rewrite" {
@@ -296,6 +356,29 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"$BASE_REPO_ROOT/bin/basectl"* ]]
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
+}
+
+@test "Base-managed Zsh startup preserves Homebrew opt-style symlink paths" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
+    local cellar_base="$TEST_TMPDIR/homebrew/Cellar/base/0.4.0/libexec"
+    local opt_dir="$TEST_TMPDIR/homebrew/opt"
+    local opt_base="$opt_dir/base/libexec"
+
+    mkdir -p "$opt_dir"
+    create_fake_shell_base "$cellar_base"
+    ln -s "../Cellar/base/0.4.0" "$opt_dir/base"
+
+    run env -u BASE_HOME -u BASE_PLATFORM_TOOLS_HOME -u BASE_PLATFORM_TOOLS_BIN_DIR \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        zsh -f -i -c 'source "$1"; printf "BASE_HOME=%s\n" "$BASE_HOME"; printf "BASE_BIN=%s\n" "$(command -v basectl)"; printf "PATH=%s\n" "$PATH"' \
+        zsh "$opt_base/lib/shell/zshrc"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_HOME=$opt_base"* ]]
+    [[ "$output" == *"BASE_BIN=$opt_base/bin/basectl"* ]]
+    [[ "$output" == *"PATH=$opt_base/bin:/usr/bin:/bin:/usr/sbin:/sbin"* ]]
 }
 
 @test "Base-managed Zsh startup detects sibling Base Platform Tools without profile rewrite" {

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -30,11 +30,13 @@ does not require `$BASE_HOME` to be the root of a Git repository. That keeps the
 same runtime model usable when Base is checked out as its own repo or embedded
 inside a larger repository.
 
-`BASE_HOME` is always the physical Base installation root. It is not the
-developer workspace root, and it is not changed by `~/.base.d/config.yaml`.
-Project-discovery commands use the configured `workspace.root` from
-`~/.base.d/config.yaml` when present, then fall back to `BASE_HOME`'s parent for
-source-checkout layouts.
+`BASE_HOME` is the selected Base installation root. For Homebrew installs this
+should remain on Homebrew's stable `opt` path, such as
+`/usr/local/opt/base/libexec` or `/opt/homebrew/opt/base/libexec`, rather than a
+versioned Cellar path. It is not the developer workspace root, and it is not
+changed by `~/.base.d/config.yaml`. Project-discovery commands use the
+configured `workspace.root` from `~/.base.d/config.yaml` when present, then fall
+back to `BASE_HOME`'s parent for source-checkout layouts.
 
 The Base home check validates the expected Base files instead of checking for a
 `.git` directory.

--- a/docs/homebrew-upgrade-rehearsal.md
+++ b/docs/homebrew-upgrade-rehearsal.md
@@ -76,6 +76,13 @@ path, and archive checksum used for the rehearsal.
 Verify the upgraded install:
 
 ```bash
+env -u BASE_HOME \
+  -u BASE_PROJECT \
+  -u BASE_PROJECT_ROOT \
+  -u BASE_PROJECT_MANIFEST \
+  -u BASE_PROJECT_VENV_DIR \
+  HOME="$TEST_ROOT/home" PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  /usr/local/bin/basectl update-profile
 env HOME="$TEST_ROOT/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
   bash -lc 'command -v basectl && basectl version'
 env HOME="$TEST_ROOT/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -101,6 +108,8 @@ Accept the rehearsal only when:
 - The `~/.base.d/config.yaml` checksum is unchanged.
 - The Base virtual environment still exists and `basectl check` accepts it.
 - Fresh Bash and Zsh login shells resolve `basectl` to the Homebrew install.
+- Fresh Bash and Zsh login shells report `BASE_HOME` on the stable Homebrew
+  `opt` path, not on a versioned `Cellar/base/<version>` path.
 - `basectl projects list` still discovers the scratch project.
 - `basectl setup`, `check`, `doctor`, and `test` pass for the scratch project.
 
@@ -162,3 +171,48 @@ Update Command Line Tools on the rehearsal host, or rerun this checklist on a
 host where `brew doctor` does not block package installation. Issue #526 should
 remain open until the actual Homebrew upgrade command and post-upgrade checks
 complete successfully.
+
+## 2026-06-10 Run Record
+
+Issue: #526, with follow-up #576.
+
+Result: upgrade succeeded, but shell startup exposed a stale Cellar path problem.
+
+Observed result:
+
+- `brew upgrade codeforester/base/base` exited zero and upgraded Base from
+  `0.3.0` to `0.4.0`.
+- Homebrew cleanup removed `/usr/local/Cellar/base/0.3.0`.
+- The active shell still attempted to run the removed
+  `/usr/local/Cellar/base/0.3.0/libexec/bin/basectl` until Bash command hashing
+  was cleared.
+- A subsequent login-shell handoff still inherited a readonly `BASE_HOME`
+  pointing at `/usr/local/Cellar/base/0.3.0/libexec`, while the refreshed
+  profile snippet pointed at `/usr/local/Cellar/base/0.4.0/libexec`.
+
+Immediate recovery:
+
+```bash
+hash -r
+env -u BASE_HOME \
+  -u BASE_PROJECT \
+  -u BASE_PROJECT_ROOT \
+  -u BASE_PROJECT_MANIFEST \
+  -u BASE_PROJECT_VENV_DIR \
+  /usr/local/bin/basectl update-profile
+exec env -u BASE_HOME \
+  -u BASE_PROJECT \
+  -u BASE_PROJECT_ROOT \
+  -u BASE_PROJECT_MANIFEST \
+  -u BASE_PROJECT_VENV_DIR \
+  "$SHELL" -l
+```
+
+Expected fixed behavior:
+
+- Homebrew-managed Base startup preserves `/usr/local/opt/base/libexec` or
+  `/opt/homebrew/opt/base/libexec` when launched through the Homebrew formula.
+- `basectl update-profile` refreshes managed shell snippets with the stable
+  Homebrew install path.
+- Fresh Bash and Zsh login shells no longer depend on a versioned Cellar path
+  that `brew cleanup` can remove during the next upgrade.

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -95,7 +95,8 @@ Project discovery uses this order:
 This distinction matters for Homebrew installs. In a source checkout,
 `BASE_HOME` is usually the `base` repository inside a shared directory such as
 `~/work/base`, so `BASE_HOME`'s parent is a reasonable fallback. In a Homebrew
-install, `BASE_HOME` points to the physical Homebrew install location, not the
+install, `BASE_HOME` points to the stable Homebrew install location, such as
+`/usr/local/opt/base/libexec` or `/opt/homebrew/opt/base/libexec`, not the
 developer's workspace. The first-run default sets `workspace.root` to `~/work`;
 edit that value to make commands such as
 `basectl projects list`, `basectl activate <project>`, and

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -23,7 +23,7 @@ base_bash_profile_debug() {
 }
 
 base_bash_profile_snippet_dir() {
-    cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
+    cd -L -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -L
 }
 
 base_bash_profile_source_baserc_guard() {

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -22,7 +22,7 @@ base_bashrc_debug() {
 }
 
 base_bashrc_snippet_dir() {
-    cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
+    cd -L -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -L
 }
 
 base_bashrc_source_baserc_guard() {
@@ -70,7 +70,7 @@ base_bashrc_set_base_home() {
     local base_home
 
     snippet_dir="$(base_bashrc_snippet_dir)" || return 1
-    base_home="$(cd -- "$snippet_dir/../.." && pwd -P)" || return 1
+    base_home="$(cd -L -- "$snippet_dir/../.." && pwd -L)" || return 1
 
     [[ -f "$base_home/base_init.sh" ]] || return 1
     if [[ -n "${BASE_HOME+x}" ]]; then

--- a/lib/shell/zprofile
+++ b/lib/shell/zprofile
@@ -26,7 +26,7 @@ base_zprofile_snippet_dir() {
     source_path="$(eval 'printf "%s\n" "${(%):-%x}"')" || return 1
     [[ -n "$source_path" ]] || return 1
 
-    cd -- "$(dirname -- "$source_path")" && pwd -P
+    cd -L -- "$(dirname -- "$source_path")" && pwd -L
 }
 
 base_zprofile_source_baserc_guard() {

--- a/lib/shell/zshrc
+++ b/lib/shell/zshrc
@@ -27,7 +27,7 @@ base_zshrc_snippet_dir() {
     source_path="$(eval 'printf "%s\n" "${(%):-%x}"')" || return 1
     [[ -n "$source_path" ]] || return 1
 
-    cd -- "$(dirname -- "$source_path")" && pwd -P
+    cd -L -- "$(dirname -- "$source_path")" && pwd -L
 }
 
 base_zshrc_source_baserc_guard() {
@@ -67,7 +67,7 @@ base_zshrc_set_base_home() {
     local base_home
 
     snippet_dir="$(base_zshrc_snippet_dir)" || return 1
-    base_home="$(cd -- "$snippet_dir/../.." && pwd -P)" || return 1
+    base_home="$(cd -L -- "$snippet_dir/../.." && pwd -L)" || return 1
 
     [[ -f "$base_home/base_init.sh" ]] || return 1
     export BASE_HOME="$base_home"

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -69,6 +69,38 @@ run_base_init_script() {
     [[ "$output" == *"BASE_SHELL_DIR=$TEST_BASE_HOME/lib/shell"* ]]
 }
 
+@test "base_init preserves explicit symlinked BASE_HOME paths" {
+    local cellar_base="$TEST_TMPDIR/homebrew/Cellar/base/0.4.0/libexec"
+    local opt_dir="$TEST_TMPDIR/homebrew/opt"
+    local opt_base="$opt_dir/base/libexec"
+
+    mkdir -p "$opt_dir"
+    create_minimal_base_home "$cellar_base"
+    ln -s "../Cellar/base/0.4.0" "$opt_dir/base"
+
+    run env \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        BASE_HOME="$opt_base" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            printf "BASE_HOME=%s\n" "$BASE_HOME"
+            printf "BASE_BIN_DIR=%s\n" "$BASE_BIN_DIR"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_HOME=$opt_base"* ]]
+    [[ "$output" == *"BASE_BIN_DIR=$opt_base/bin"* ]]
+}
+
 @test "base_init exports host operating system and shell metadata" {
     run_base_init_script '
         base_home="$1"


### PR DESCRIPTION
## Summary
- Preserve logical Homebrew `opt` symlink paths when `BASE_HOME` is explicitly set.
- Keep Bash and Zsh managed startup snippets on stable Homebrew paths instead of versioned Cellar paths.
- Document the Intel Mac recovery path for stale readonly Base environment exported by an already-running shell.

## Root Cause
Base normalized `BASE_HOME` and shell snippet paths with physical `pwd -P` resolution. For Homebrew installs, that turned `/usr/local/opt/base/libexec` into `/usr/local/Cellar/base/<version>/libexec`, so profile snippets could keep pointing at a Cellar version that `brew cleanup` later removed.

## Validation
- `bats tests/base_init.bats`
- `bats cli/bash/commands/basectl/tests/update-profile.bats`
- `bats lib/bash/runtime/tests/runtime_bashrc.bats`
- `bats cli/bash/commands/basectl/tests/runtime-shell.bats`
- `bats tests/bootstrap.bats tests/install.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

Closes #576