### PR TITLE
Improve readonly BASE_HOME recovery guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved Bash startup recovery guidance when an existing shell still has a
+  stale readonly `BASE_HOME` after a Homebrew upgrade.
+
 ## [0.4.1] - 2026-06-10
 
 ### Fixed

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -160,6 +160,32 @@ EOF
     [[ "$output" == *"PATH=$opt_base/bin:/usr/bin:/bin:/usr/sbin:/sbin"* ]]
 }
 
+@test "Base-managed Bash startup explains stale readonly BASE_HOME recovery" {
+    local old_base="$TEST_TMPDIR/homebrew/Cellar/base/0.3.0/libexec"
+    local cellar_base="$TEST_TMPDIR/homebrew/Cellar/base/0.4.1/libexec"
+    local opt_dir="$TEST_TMPDIR/homebrew/opt"
+    local opt_base="$opt_dir/base/libexec"
+
+    mkdir -p "$old_base" "$opt_dir"
+    create_fake_shell_base "$cellar_base"
+    ln -s "../Cellar/base/0.4.1" "$opt_dir/base"
+
+    run env -u BASE_PLATFORM_TOOLS_HOME -u BASE_PLATFORM_TOOLS_BIN_DIR \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -i -c '\
+            readonly BASE_HOME="$1"; \
+            source "$2"' \
+        bash "$old_base" "$opt_base/lib/shell/bashrc"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ERROR: BASE_HOME is readonly and points at '$old_base', not '$opt_base'."* ]]
+    [[ "$output" == *"exec env -u BASE_HOME \\"* ]]
+    [[ "$output" == *"-u BASE_PROJECT_VENV_DIR \\"* ]]
+    [[ "$output" == *'"$SHELL" -l'* ]]
+    [[ "$output" != *"ERROR:   exec env"* ]]
+}
+
 @test "Base-managed Bash startup detects sibling Base Platform Tools without profile rewrite" {
     local workspace="$TEST_TMPDIR/fake-workspace"
     local fake_base="$workspace/base"

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -48,18 +48,30 @@ base_bashrc_var_is_readonly() {
     [[ "$declaration" == declare\ -*r* ]]
 }
 
+base_bashrc_print_stale_base_home_recovery() {
+    printf 'ERROR: Start a fresh shell without stale Base runtime variables:\n' >&2
+    printf '  exec env -u BASE_HOME \\\n' >&2
+    printf '    -u BASE_PROJECT \\\n' >&2
+    printf '    -u BASE_PROJECT_ROOT \\\n' >&2
+    printf '    -u BASE_PROJECT_MANIFEST \\\n' >&2
+    printf '    -u BASE_PROJECT_VENV_DIR \\\n' >&2
+    printf '    "$SHELL" -l\n' >&2
+}
+
 base_bashrc_source_baserc_guard || return $?
 base_baserc_guard_source base_bashrc_debug || return $?
 
 if [[ $- != *i* ]]; then
     base_bashrc_debug "non-interactive shell; skipping"
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
+    unset -f base_bashrc_print_stale_base_home_recovery
     return 0
 fi
 
 if [[ -n "${__base_bashrc_sourced__:-}" ]]; then
     base_bashrc_debug "already sourced; skipping"
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
+    unset -f base_bashrc_print_stale_base_home_recovery
     return 0
 fi
 readonly __base_bashrc_sourced__=1
@@ -81,6 +93,7 @@ base_bashrc_set_base_home() {
         fi
         if base_bashrc_var_is_readonly BASE_HOME; then
             printf "ERROR: BASE_HOME is readonly and points at '%s', not '%s'.\n" "$BASE_HOME" "$base_home" >&2
+            base_bashrc_print_stale_base_home_recovery
             return 1
         fi
     fi
@@ -180,6 +193,7 @@ base_bashrc_source_completions() {
 base_bashrc_set_base_home || {
     printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
+    unset -f base_bashrc_print_stale_base_home_recovery
     return 1
 }
 base_bashrc_configure_path || return $?
@@ -188,6 +202,7 @@ base_bashrc_source_completions || return 1
 base_bashrc_debug "complete"
 
 unset -f base_bashrc_snippet_dir base_bashrc_var_is_readonly base_bashrc_set_base_home
+unset -f base_bashrc_print_stale_base_home_recovery
 unset -f base_bashrc_source_platform_tools_helper base_bashrc_configure_path base_bashrc_source_defaults
 unset -f base_bashrc_source_completions
 unset -f base_bashrc_source_baserc_guard base_bashrc_debug


### PR DESCRIPTION
## Summary
- Print the fresh-shell `env -u` recovery command when Bash startup finds a stale readonly `BASE_HOME`.
- Add a regression test for the Homebrew upgrade stale Cellar-path recovery case.
- Note the user-visible recovery guidance fix in the changelog.

## Issue
Fixes #580

## Validation
- bats --print-output-on-failure --filter "Base-managed Bash startup explains stale readonly BASE_HOME recovery" cli/bash/commands/basectl/tests/update-profile.bats
- bats --print-output-on-failure cli/bash/commands/basectl/tests/update-profile.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None.

## AI Context
- Not updated. This changes a narrow Bash startup recovery message, not Base product shape, architecture, command surface, workflow, manifest model, or durable design decisions.