### PR TITLE
Remove redundant setup doctor JSON alias

### DIFF
--- a/cli/python/base_projects/workspace_reports.py
+++ b/cli/python/base_projects/workspace_reports.py
@@ -13,7 +13,6 @@ from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_manifest import read_workspace_manifest
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
-from base_setup.checks import check_to_doctor_json
 from base_setup.checks import check_to_json
 from base_setup.checks import checks_status
 from base_setup.checks import doctor_status
@@ -537,7 +536,7 @@ def workspace_check_to_json(
     results: tuple[WorkspaceProjectCheckResult, ...],
     workspace_manifest: WorkspaceManifest | None = None,
 ) -> dict[str, Any]:
-    return workspace_checks_to_json(workspace_root, results, doctor=False, workspace_manifest=workspace_manifest)
+    return workspace_checks_to_json(workspace_root, results, workspace_manifest=workspace_manifest)
 
 
 def workspace_doctor_to_json(
@@ -545,13 +544,12 @@ def workspace_doctor_to_json(
     results: tuple[WorkspaceProjectCheckResult, ...],
     workspace_manifest: WorkspaceManifest | None = None,
 ) -> dict[str, Any]:
-    return workspace_checks_to_json(workspace_root, results, doctor=True, workspace_manifest=workspace_manifest)
+    return workspace_checks_to_json(workspace_root, results, workspace_manifest=workspace_manifest)
 
 
 def workspace_checks_to_json(
     workspace_root: Path,
     results: tuple[WorkspaceProjectCheckResult, ...],
-    doctor: bool,
     workspace_manifest: WorkspaceManifest | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -559,7 +557,7 @@ def workspace_checks_to_json(
         "workspace": str(workspace_root),
         "status": checks_status(tuple(check for result in results for check in result.checks)),
         "project_count": workspace_project_count(results, workspace_manifest),
-        "projects": [workspace_check_result_to_json(result, doctor, workspace_manifest) for result in results],
+        "projects": [workspace_check_result_to_json(result, workspace_manifest) for result in results],
     }
     add_workspace_manifest_json(payload, results, workspace_manifest)
     return payload
@@ -567,7 +565,6 @@ def workspace_checks_to_json(
 
 def workspace_check_result_to_json(
     result: WorkspaceProjectCheckResult,
-    doctor: bool,
     workspace_manifest: WorkspaceManifest | None,
 ) -> dict[str, Any]:
     item: dict[str, Any] = {
@@ -576,7 +573,7 @@ def workspace_check_result_to_json(
         "path": str(result.root),
         "manifest_path": str(result.manifest_path) if result.manifest_path is not None else None,
         "manifest": result.manifest,
-        "checks": [workspace_check_item_to_json(check, doctor) for check in result.checks],
+        "checks": [workspace_check_item_to_json(check) for check in result.checks],
     }
     if workspace_manifest is not None:
         item.update(workspace_manifest_item_metadata(result))
@@ -623,9 +620,7 @@ def add_workspace_manifest_json(
     payload["repository_count"] = len(items)
 
 
-def workspace_check_item_to_json(check: ArtifactCheck, doctor: bool) -> dict[str, Any]:
-    if doctor:
-        return check_to_doctor_json(check)
+def workspace_check_item_to_json(check: ArtifactCheck) -> dict[str, Any]:
     return check_to_json(check)
 
 

--- a/cli/python/base_setup/checks.py
+++ b/cli/python/base_setup/checks.py
@@ -34,10 +34,6 @@ def check_to_json(check: ArtifactCheck) -> dict[str, Any]:
     return payload
 
 
-def check_to_doctor_json(check: ArtifactCheck) -> dict[str, Any]:
-    return check_to_json(check)
-
-
 def checks_status(checks: Iterable[ArtifactCheck]) -> str:
     statuses = tuple(doctor_status(check) for check in checks)
     if "error" in statuses:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -14,7 +14,6 @@ from .artifacts import reconcile_artifacts
 from .artifacts import resolve_artifact_definitions
 from .build import check_build
 from .checks import ArtifactCheck
-from .checks import check_to_doctor_json
 from .checks import check_to_json
 from .checks import checks_payload_to_json
 from .checks import doctor_status
@@ -284,7 +283,7 @@ def doctor_manifest(
 ) -> int:
     checks = manifest_checks(default_manifest, manifest, remote_network=remote_network)
     if output_format == "json":
-        print(json.dumps([check_to_doctor_json(check) for check in checks], indent=2))
+        print(json.dumps([check_to_json(check) for check in checks], indent=2))
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
     if output_format != "text":
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
@@ -309,7 +308,7 @@ def doctor_pre_venv_manifest(
 ) -> int:
     checks = pre_venv_manifest_checks(manifest, remote_network=remote_network)
     if output_format == "json":
-        print(json.dumps([check_to_doctor_json(check) for check in checks], separators=(",", ":")))
+        print(json.dumps([check_to_json(check) for check in checks], separators=(",", ":")))
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
     if output_format != "text":
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -136,8 +136,8 @@ class ProjectCheckTests(unittest.TestCase):
         )
 
         self.assertEqual(engine.doctor_status(check), "warn")
-        self.assertEqual(setup_checks.check_to_doctor_json(check)["id"], "BASE-P033")
-        self.assertEqual(setup_checks.check_to_doctor_json(check)["status"], "warn")
+        self.assertEqual(setup_checks.check_to_json(check)["id"], "BASE-P033")
+        self.assertEqual(setup_checks.check_to_json(check)["status"], "warn")
 
         default_manifest = BaseManifest(
             path=Path("default_manifest.yaml"),


### PR DESCRIPTION
## Summary
- Remove `check_to_doctor_json` from the `base_setup` check serializer.
- Replace setup and workspace-reporting call sites with `check_to_json`.

## Validation
- rg -n "check_to_doctor_json" cli/python/base_setup cli/python/base_projects
- env -u BASE_HOME PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_diagnostics.py cli/python/base_projects/tests/test_workspace_checks.py cli/python/base_projects/tests/test_workspace_status_manifest.py
- git diff --check
- env -u BASE_HOME ./bin/base-test

Fixes #582