### PR TITLE
Teach update to handle Homebrew installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,8 @@ exec "$SHELL" -l
 
 Homebrew installs the Base files. `basectl setup` still prepares the local Base
 runtime under `~/.base.d/base/.venv`, and `basectl update-profile` adds Base to
-your shell startup path. When installed through Homebrew, update Base with:
+your shell startup path. When installed through Homebrew, `basectl update`
+hands off to Homebrew and runs setup afterward. This is equivalent to:
 
 ```bash
 brew upgrade codeforester/base/base
@@ -945,17 +946,23 @@ run `basectl update-profile --no-defaults` to disable them again. Plain
 `BASE_PROFILE_VERSION` records the schema version of this Base-managed file. It
 is reserved for future migrations and is not intended to be edited by users.
 
-Update Base itself from the checked-out repository with:
+Update Base itself with:
 
 ```bash
 basectl update
 ```
 
-This command is intentionally conservative: it only runs from the Base
-repository's default branch, requires tracked Base files to be clean, pulls the
-latest changes through Git, and then runs `basectl setup`. Untracked files do
-not block the update; Git still stops the pull if an incoming tracked file would
-overwrite them.
+This command is intentionally conservative. In a source checkout, it only runs
+from the Base repository's default branch, requires tracked Base files to be
+clean, pulls the latest changes through Git, and then runs `basectl setup`.
+Untracked files do not block the update; Git still stops the pull if an
+incoming tracked file would overwrite them.
+
+In a Homebrew-managed install, `basectl update` runs only the Base package
+upgrade, `brew upgrade codeforester/base/base`, and then runs `basectl setup`
+with inherited Base environment variables cleared. `basectl update --dry-run`
+prints the Git or Homebrew handoff it would perform without changing files or
+packages.
 
 Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
 is user-managed and may be hand-edited. It is intended for simple,

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -106,7 +106,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   stable file headings and use `INDEX.md` ordering when available. Zip exports
   contain only files from `.ai-context`.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
-- `basectl update` updates the Base repository from Git and then runs `basectl setup`.
+- `basectl update` updates source checkouts through Git, updates Homebrew
+  installs with `brew upgrade codeforester/base/base`, and then runs
+  `basectl setup`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`
   when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
   project names and paths.

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -19,17 +19,159 @@ Options:
   -h, --help  Show this help text.
 
 Purpose:
-  Update the Base repository from Git, then run basectl setup.
+  Update Base from Git for source checkouts, or through Homebrew for Homebrew
+  installs, then run basectl setup.
 
 Notes:
   - The repository must be on its default branch.
   - Tracked Base files must be clean; untracked files are left to Git's normal
     pull-time overwrite protection.
+  - Homebrew installs update only the Base formula:
+    brew upgrade codeforester/base/base
 EOF
 }
 
 base_update_source_git_library() {
     import_base_lib git/lib_git.sh
+}
+
+base_update_homebrew_package() {
+    printf '%s\n' "codeforester/base/base"
+}
+
+base_update_is_homebrew_install() {
+    local base_home="$1"
+
+    case "$base_home" in
+        */opt/base/libexec|*/Cellar/base/*/libexec)
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    [[ -d "$base_home" ]] || return 1
+    [[ -f "$base_home/base_init.sh" || -x "$base_home/bin/basectl" ]]
+}
+
+base_update_homebrew_prefix() {
+    local package="$1"
+    local prefix
+
+    if prefix="$(brew --prefix base 2>/dev/null)" && [[ -n "$prefix" ]]; then
+        printf '%s\n' "$prefix"
+        return 0
+    fi
+
+    if prefix="$(brew --prefix "$package" 2>/dev/null)" && [[ -n "$prefix" ]]; then
+        printf '%s\n' "$prefix"
+        return 0
+    fi
+
+    return 1
+}
+
+base_update_homebrew_basectl() {
+    local base_home="$1"
+    local package="$2"
+    local basectl
+    local prefix
+
+    case "$base_home" in
+        */opt/base/libexec)
+            basectl="$base_home/bin/basectl"
+            if [[ -x "$basectl" ]]; then
+                printf '%s\n' "$basectl"
+                return 0
+            fi
+            ;;
+    esac
+
+    if prefix="$(base_update_homebrew_prefix "$package")"; then
+        basectl="$prefix/libexec/bin/basectl"
+        if [[ -x "$basectl" ]]; then
+            printf '%s\n' "$basectl"
+            return 0
+        fi
+
+        basectl="$prefix/bin/basectl"
+        if [[ -x "$basectl" ]]; then
+            printf '%s\n' "$basectl"
+            return 0
+        fi
+    fi
+
+    basectl="$base_home/bin/basectl"
+    if [[ -x "$basectl" ]]; then
+        printf '%s\n' "$basectl"
+        return 0
+    fi
+
+    return 1
+}
+
+base_update_run_homebrew_upgrade() {
+    local package="$1"
+
+    brew upgrade "$package"
+}
+
+base_update_run_homebrew_setup() {
+    local base_home="$1"
+    local package="$2"
+    local basectl
+
+    basectl="$(base_update_homebrew_basectl "$base_home" "$package")" || {
+        log_error "Unable to locate Homebrew-managed basectl after upgrade."
+        return 1
+    }
+
+    env \
+        -u BASE_HOME \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        -u BASE_PLATFORM_TOOLS_HOME \
+        -u BASE_PLATFORM_TOOLS_BIN_DIR \
+        -u BASE_PROJECT \
+        -u BASE_PROJECT_ROOT \
+        -u BASE_PROJECT_MANIFEST \
+        -u BASE_PROJECT_VENV_DIR \
+        "$basectl" setup
+}
+
+base_update_homebrew_install() {
+    local dry_run="$1"
+    local package
+
+    package="$(base_update_homebrew_package)"
+    log_info "Detected Homebrew-managed Base install at '$BASE_HOME'."
+
+    if ((dry_run)); then
+        log_info "[DRY-RUN] Would run: brew upgrade $package"
+        log_info "[DRY-RUN] Would run 'basectl setup' after the Homebrew upgrade with inherited Base environment cleared."
+        return 0
+    fi
+
+    if ! command -v brew >/dev/null 2>&1; then
+        log_error "Homebrew-managed Base install detected, but 'brew' is not available in PATH."
+        return 1
+    fi
+
+    log_info "Running Homebrew upgrade for $package."
+    base_update_run_homebrew_upgrade "$package" || return $?
+
+    log_info "Running basectl setup after Homebrew upgrade."
+    base_update_run_homebrew_setup "$BASE_HOME" "$package" || return $?
+
+    log_info "Base update is complete."
 }
 
 base_update_current_branch() {
@@ -112,6 +254,10 @@ base_update_subcommand_main() {
     log_debug "Running 'basectl update'."
 
     branch="$(base_update_current_branch "$BASE_HOME")" || {
+        if base_update_is_homebrew_install "$BASE_HOME"; then
+            base_update_homebrew_install "$dry_run"
+            return $?
+        fi
         log_error "Base home '$BASE_HOME' is not a Git repository."
         return 1
     }

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -9,8 +9,9 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl update [options]"* ]]
-    [[ "$output" == *"Update the Base repository from Git"* ]]
+    [[ "$output" == *"Update Base from Git for source checkouts, or through Homebrew"* ]]
     [[ "$output" == *"Tracked Base files must be clean"* ]]
+    [[ "$output" == *"brew upgrade codeforester/base/base"* ]]
 }
 
 @test "basectl update dry-run reports planned update and setup" {
@@ -30,6 +31,132 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would update Base repository at '$BASE_REPO_ROOT'."* ]]
     [[ "$output" == *"[DRY-RUN] Would run 'basectl setup' after updating."* ]]
+}
+
+@test "basectl update dry-run reports Homebrew handoff without running brew" {
+    local fake_base="$TEST_TMPDIR/homebrew/opt/base/libexec"
+
+    mkdir -p "$fake_base/bin"
+    touch "$fake_base/bin/basectl"
+    chmod +x "$fake_base/bin/basectl"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$fake_base" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        bash -c '
+            log_debug() { :; }
+            log_error() { printf "ERROR: %s\n" "$*"; }
+            log_info() { printf "INFO: %s\n" "$*"; }
+            log_warn() { printf "WARN: %s\n" "$*"; }
+            print_error() { printf "ERROR: %s\n" "$*"; }
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_run_homebrew_upgrade() { printf "brew should not run\n"; return 99; }
+            base_update_run_homebrew_setup() { printf "setup should not run\n"; return 99; }
+            base_update_subcommand_main --dry-run
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Detected Homebrew-managed Base install at '$fake_base'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: brew upgrade codeforester/base/base"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup' after the Homebrew upgrade with inherited Base environment cleared."* ]]
+    [[ "$output" != *"brew should not run"* ]]
+    [[ "$output" != *"setup should not run"* ]]
+}
+
+@test "basectl update runs exact Homebrew package upgrade and clears Base env for setup" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local fake_base="$TEST_TMPDIR/homebrew/opt/base/libexec"
+    local brew_log="$TEST_TMPDIR/brew.log"
+    local setup_log="$TEST_TMPDIR/setup.log"
+
+    mkdir -p "$fake_bin" "$fake_base/bin"
+    cat > "$fake_bin/brew" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$brew_log"
+exit 0
+EOF
+    chmod +x "$fake_bin/brew"
+    cat > "$fake_base/bin/basectl" <<EOF
+#!/usr/bin/env bash
+printf 'args=%s\n' "\$*" >> "$setup_log"
+printf 'BASE_HOME=%s\n' "\${BASE_HOME-unset}" >> "$setup_log"
+printf 'BASE_PROJECT=%s\n' "\${BASE_PROJECT-unset}" >> "$setup_log"
+EOF
+    chmod +x "$fake_base/bin/basectl"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$fake_base" \
+        BASE_PROJECT=stale-project \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -c '
+            log_debug() { :; }
+            log_error() { printf "ERROR: %s\n" "$*"; }
+            log_info() { printf "INFO: %s\n" "$*"; }
+            log_warn() { printf "WARN: %s\n" "$*"; }
+            print_error() { printf "ERROR: %s\n" "$*"; }
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$brew_log")" = "upgrade codeforester/base/base" ]
+    [[ "$(cat "$setup_log")" == *"args=setup"* ]]
+    [[ "$(cat "$setup_log")" == *"BASE_HOME=unset"* ]]
+    [[ "$(cat "$setup_log")" == *"BASE_PROJECT=unset"* ]]
+    [[ "$output" == *"Detected Homebrew-managed Base install at '$fake_base'."* ]]
+    [[ "$output" == *"Running Homebrew upgrade for codeforester/base/base."* ]]
+    [[ "$output" == *"Running basectl setup after Homebrew upgrade."* ]]
+    [[ "$output" == *"Base update is complete."* ]]
+}
+
+@test "basectl update uses current Homebrew opt basectl after Cellar-launched upgrades" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local homebrew="$TEST_TMPDIR/homebrew"
+    local cellar_base="$homebrew/Cellar/base/0.4.0/libexec"
+    local opt_prefix="$homebrew/opt/base"
+    local opt_base="$opt_prefix/libexec"
+    local setup_log="$TEST_TMPDIR/setup.log"
+
+    mkdir -p "$fake_bin" "$cellar_base/bin" "$opt_base/bin"
+    touch "$cellar_base/bin/basectl"
+    chmod +x "$cellar_base/bin/basectl"
+    cat > "$fake_bin/brew" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "--prefix" ]]; then
+    printf '%s\n' "$opt_prefix"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$fake_bin/brew"
+    cat > "$opt_base/bin/basectl" <<EOF
+#!/usr/bin/env bash
+printf 'opt-basectl args=%s\n' "\$*" >> "$setup_log"
+printf 'BASE_HOME=%s\n' "\${BASE_HOME-unset}" >> "$setup_log"
+EOF
+    chmod +x "$opt_base/bin/basectl"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$cellar_base" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -c '
+            log_debug() { :; }
+            log_error() { printf "ERROR: %s\n" "$*"; }
+            log_info() { printf "INFO: %s\n" "$*"; }
+            log_warn() { printf "WARN: %s\n" "$*"; }
+            print_error() { printf "ERROR: %s\n" "$*"; }
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$setup_log")" == *"opt-basectl args=setup"* ]]
+    [[ "$(cat "$setup_log")" == *"BASE_HOME=unset"* ]]
 }
 
 @test "basectl update refuses dirty worktrees before pulling" {


### PR DESCRIPTION
## Summary
- Teach `basectl update` to detect Homebrew-managed Base installs.
- For Homebrew installs, run only `brew upgrade codeforester/base/base`, then run `basectl setup` with inherited Base environment variables cleared.
- Preserve true `--dry-run` behavior by printing the Homebrew handoff without mutating Homebrew state.
- Update README and basectl command docs for the new install-route behavior.

## Validation
- `bats cli/bash/commands/basectl/tests/update.bats`
- `bats cli/bash/commands/basectl/tests/update.bats cli/bash/commands/basectl/tests/help.bats`
- `bats tests/bootstrap.bats tests/install.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

Closes #592