### PR TITLE
Make basectl test base package-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Made `basectl test base` package-aware so Homebrew-installed Base runs the
+  packaged Python test layer and skips source-checkout-only BATS tests with
+  clear guidance.
+
 ## [0.4.3] - 2026-06-11
 
 ### Added

--- a/bin/base-test
+++ b/bin/base-test
@@ -38,9 +38,25 @@ if [[ ! -x "$base_test_python" ]]; then
     exit 1
 fi
 
-env "${base_test_unset_env[@]}" \
-    PYTHONPATH="$base_test_home/lib/python:$base_test_home/cli/python${PYTHONPATH:+:$PYTHONPATH}" \
-    "$base_test_python" -m pytest
+base_test_is_source_checkout() {
+    command -v git >/dev/null 2>&1 || return 1
+    git -C "$base_test_home" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+base_test_run_python_suite() {
+    env "${base_test_unset_env[@]}" \
+        PYTHONPATH="$base_test_home/lib/python:$base_test_home/cli/python${PYTHONPATH:+:$PYTHONPATH}" \
+        "$base_test_python" -m pytest
+}
+
+base_test_run_python_suite
+
+if ! base_test_is_source_checkout; then
+    printf "INFO: Base source checkout not detected at '%s'.\n" "$base_test_home" >&2
+    printf 'INFO: Skipping source-checkout-only Bats tests for packaged Base.\n' >&2
+    printf "INFO: Run 'env -u BASE_HOME ./bin/base-test' from a Base source checkout for the full developer suite.\n" >&2
+    exit 0
+fi
 
 env "${base_test_unset_env[@]}" \
     bats \
@@ -51,6 +67,7 @@ env "${base_test_unset_env[@]}" \
     lib/bash/std/tests/lib_std.bats \
     lib/bash/version/tests/lib_version.bats \
     lib/shell/completions/tests/completions.bats \
+    tests/base_test.bats \
     tests/base_init.bats \
     tests/bootstrap.bats \
     tests/install.bats \

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -132,6 +132,12 @@ Accept the health checks when:
 - `basectl logs --path` prints the log directory path
 - `basectl logs --command setup` can read recent setup logs without a traceback
 
+`basectl test base` is safe to run from a Homebrew-managed Base install, but it
+is not the full developer source suite. It runs the packaged Python test layer
+and skips source-checkout-only BATS and integration tests with guidance to run
+`env -u BASE_HOME ./bin/base-test` from a Base source checkout for full
+developer validation.
+
 ### Reference Project Smoke Test
 
 Use `base-demo` to prove project discovery and project commands from a Homebrew

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,11 +43,17 @@ BATS tests next to Bash commands and libraries cover shell parsing, dispatch,
 small command contracts, and failure messages. Keep these focused on one command
 or library at a time.
 
-Run the full command/library suite through:
+From a source checkout, run the full command/library suite through:
 
 ```bash
-basectl test base
+env -u BASE_HOME ./bin/base-test
 ```
+
+`basectl test base` delegates to the same runner when the `base` project
+resolves to a source checkout. In a packaged install such as Homebrew,
+`basectl test base` is package-aware: it runs the packaged Python test layer and
+skips source-checkout-only BATS and integration tests with a message pointing
+back to the source checkout command above.
 
 ## Integration Tests
 

--- a/tests/base_test.bats
+++ b/tests/base_test.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load ../lib/bash/tests/test_helper.sh
+bats_require_minimum_version 1.5.0
+
+setup() {
+    setup_test_tmpdir
+    TEST_HOME="$TEST_TMPDIR/home"
+    TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
+    TEST_PACKAGE_HOME="$TEST_TMPDIR/homebrew/opt/base/libexec"
+    TEST_STATE_DIR="$TEST_TMPDIR/state"
+    mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
+}
+
+create_packaged_base_home() {
+    mkdir -p \
+        "$TEST_PACKAGE_HOME/bin" \
+        "$TEST_PACKAGE_HOME/cli/python" \
+        "$TEST_PACKAGE_HOME/lib/python"
+    cp "$BASE_REPO_ROOT/bin/base-test" "$TEST_PACKAGE_HOME/bin/base-test"
+}
+
+create_python_stub() {
+    cat > "$TEST_MOCKBIN/python" <<'EOF'
+#!/usr/bin/env bash
+printf 'python %s\n' "$*" >> "${BASE_TEST_STATE_DIR:?}/python.log"
+if [[ "${1:-}" == "-m" && "${2:-}" == "pytest" ]]; then
+    exit 0
+fi
+printf 'unexpected python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/python"
+}
+
+create_bats_stub() {
+    cat > "$TEST_MOCKBIN/bats" <<'EOF'
+#!/usr/bin/env bash
+printf 'bats %s\n' "$*" >> "${BASE_TEST_STATE_DIR:?}/bats.log"
+exit 42
+EOF
+    chmod +x "$TEST_MOCKBIN/bats"
+}
+
+@test "base-test skips source-only Bats suite for packaged Base homes" {
+    create_packaged_base_home
+    create_python_stub
+    create_bats_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_HOME="$TEST_PACKAGE_HOME" \
+        BASE_TEST_PYTHON="$TEST_MOCKBIN/python" \
+        BASE_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        "$TEST_PACKAGE_HOME/bin/base-test"
+
+    [ "$status" -eq 0 ]
+    grep -Fqx 'python -m pytest' "$TEST_STATE_DIR/python.log"
+    [ ! -f "$TEST_STATE_DIR/bats.log" ]
+    [[ "$output" == *"Base source checkout not detected at '$TEST_PACKAGE_HOME'."* ]]
+    [[ "$output" == *"Skipping source-checkout-only Bats tests for packaged Base."* ]]
+    [[ "$output" == *"Run 'env -u BASE_HOME ./bin/base-test' from a Base source checkout for the full developer suite."* ]]
+}


### PR DESCRIPTION
## Summary
- Detect when `bin/base-test` is running outside a Base source checkout.
- Keep packaged/Homebrew installs on the Python test layer and skip source-only BATS/integration tests with explicit guidance.
- Add a packaged-home regression test plus testing/install validation docs and changelog notes.

## Validation
- `bats tests/base_test.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

Fixes #596