### PR TITLE
Handle plan-gated repo rulesets gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Changed `basectl repo configure` to warn instead of fail when GitHub reports
+  that default branch rulesets are unavailable for a private repository's plan.
 - Made `basectl test base` package-aware so Homebrew-installed Base runs the
   packaged Python test layer and skips source-checkout-only BATS tests with
   clear guidance.

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -859,10 +859,19 @@ base_repo_default_branch_ruleset_payload() {
 JSON
 }
 
+base_repo_rulesets_plan_gated_error() {
+    local message="$1"
+
+    [[ "$message" == *"Upgrade to GitHub Pro"* ]] &&
+        [[ "$message" == *"make this repository public"* ]] &&
+        [[ "$message" == *"(HTTP 403)"* ]]
+}
+
 base_repo_configure_default_branch_protection() {
     local dry_run="$1"
     local payload
     local repo="$2"
+    local ruleset_lookup_output=""
     local ruleset_id=""
 
     payload="$(base_repo_default_branch_ruleset_payload)"
@@ -878,11 +887,18 @@ base_repo_configure_default_branch_protection() {
     fi
 
     base_repo_require_gh || return 1
-    ruleset_id="$(gh api "repos/$repo/rulesets" \
-        --jq 'map(select(.name == "Base default branch protection" and .source_type == "Repository")) | .[0].id // ""')" || {
+    ruleset_lookup_output="$(gh api "repos/$repo/rulesets" \
+        --jq 'map(select(.name == "Base default branch protection" and .source_type == "Repository")) | .[0].id // ""' 2>&1)" || {
+        if base_repo_rulesets_plan_gated_error "$ruleset_lookup_output"; then
+            log_warn "Default branch protection skipped for '$repo'."
+            log_warn "$ruleset_lookup_output"
+            return 0
+        fi
+        [[ -z "$ruleset_lookup_output" ]] || log_error "$ruleset_lookup_output"
         log_error "Unable to inspect GitHub rulesets for '$repo'."
         return 1
     }
+    ruleset_id="$ruleset_lookup_output"
 
     if [[ -n "$ruleset_id" ]]; then
         printf '%s\n' "$payload" | gh api "repos/$repo/rulesets/$ruleset_id" --method PUT --input - || {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -503,6 +503,67 @@ EOF
     grep -Fq '"type":"non_fast_forward"' "$TEST_STATE_DIR/ruleset-payload"
 }
 
+@test "basectl repo configure warns when GitHub plan blocks rulesets" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
+    printf '%s\n' "api-list $*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+    printf '%s\n' "gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)" >&2
+    exit 1
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 0 ]
+    grep -Fq "api-list api repos/codeforester/base-demo/rulesets" "$TEST_STATE_DIR/gh-args"
+    [[ "$output" == *"Default branch protection skipped"* ]]
+    [[ "$output" == *"GitHub Pro"* ]]
+    [[ "$output" == *"make this repository public"* ]]
+}
+
+@test "basectl repo configure fails for unexpected ruleset lookup errors" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
+    printf '%s\n' "api-list $*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+    printf '%s\n' "gh: API rate limit exceeded. (HTTP 403)" >&2
+    exit 1
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 1 ]
+    grep -Fq "api-list api repos/codeforester/base-demo/rulesets" "$TEST_STATE_DIR/gh-args"
+    [[ "$output" == *"Unable to inspect GitHub rulesets for 'codeforester/base-demo'."* ]]
+    [[ "$output" != *"Default branch protection skipped"* ]]
+}
+
 @test "basectl repo init configures GitHub when repo is provided" {
     local repo_dir="$TEST_TMPDIR/base-demo"
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -192,6 +192,12 @@ require status checks, approval counts, CODEOWNERS, teams, or repository
 secrets. Pass `--no-protect-default-branch` when a repository intentionally
 skips this Base-managed ruleset.
 
+GitHub rulesets are available for public repositories on GitHub Free and for
+public and private repositories on GitHub Pro, Team, or Enterprise plans. When
+GitHub reports that rulesets are unavailable for a private repository's plan,
+`repo configure` leaves the supported settings and labels in place, logs a
+warning, and skips default branch protection.
+
 In apply mode, GitHub configuration requires the GitHub CLI and an authenticated
 session:
 


### PR DESCRIPTION
## Summary

- Treat GitHub's known plan-gated ruleset 403 as a non-fatal warning during `basectl repo configure`.
- Preserve fatal behavior for unexpected ruleset lookup failures.
- Document that private repositories without the required GitHub plan keep supported settings and labels but skip default branch protection.

## Issue

Fixes #600

## Validation

- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `git ls-files -z '*.sh' 'base_init.sh' 'install.sh' 'bin/*' | xargs -0 shellcheck --severity=error`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact

None. CLI error-handling fix only.

## Notes

- `.ai-context/` was not updated; the public command surface is unchanged.
