### PR TITLE
Add Base-managed GitHub Project metadata

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -25,13 +25,20 @@ the canonical current command list.
   status, checks, or diagnostics.
 - `basectl repo <init|check|configure|agent-guidance|installer-template>` -
   create repository baselines, configure GitHub repository settings and default
-  branch protection, seed agent guidance, and write installer templates.
+  branch protection, configure standard GitHub Project metadata, seed agent
+  guidance, and write installer templates.
 - `basectl ci <setup|check|doctor> <project>` - run Base setup/check/doctor in
   non-interactive CI.
 - `basectl release <check|plan|notes|publish>` - inspect release readiness,
   print plans/notes, and publish guarded GitHub-side release artifacts.
-- `basectl gh <area> <command>` - manage GitHub issues, PRs, branches, and repo
-  hygiene using Base conventions.
+- `basectl gh <area> <command>` - manage GitHub issues, PRs, branches, repo
+  hygiene, and Project metadata using Base conventions.
+  - `basectl gh project doctor --project <title>` - inspect Project metadata
+    fields against the Base roadmap schema.
+  - `basectl gh project configure --project <title>` - create or repair the
+    standard Project metadata schema.
+  - `basectl gh project issue set-fields <number>` - add an issue to the
+    Project if needed and update its metadata fields.
 - `basectl clean` - remove old Base runtime logs, temp files, and cache entries.
 - `basectl logs` - list, print, open, or tail recent Base CLI runtime logs.
 - `basectl config <path|show|doctor>` - inspect Base's machine-local user
@@ -81,3 +88,5 @@ Important Python packages include:
 - `base_export_context` - deterministic local Markdown and Zip exports from a
   project's `.ai-context/` directory. Provider uploads are intentionally out of
   scope.
+- `base_github_projects` - GitHub Project V2 schema inspection, configuration,
+  and issue field updates for Base roadmap metadata.

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -16,6 +16,8 @@ Do not create new `type:*` labels.
 Issues created by automation should be assigned to `codeforester` when GitHub
 allows it. When an issue is tracked in the Base Roadmap Project, move its
 status through `In Progress`, `In Review`, and `Done` as the work advances.
+Base roadmap Project metadata uses five fields: `Status`, `Priority`, `Area`,
+`Size`, and `Initiative`.
 
 ## Branch And Worktree Flow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Protected default branches by default during `basectl repo configure`, with
   `--no-protect-default-branch` for repositories that intentionally skip the
   Base-managed ruleset.
+- Added Base-managed GitHub Project metadata configuration through
+  `basectl repo init`, `basectl repo configure`, and the lower-level
+  `basectl gh project` surface.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Current implemented commands include:
 - `basectl repo check [path]`
 - `basectl repo configure [path]`
 - `basectl repo agent-guidance [path]`
+- `basectl gh <area> <command>`
 - `basectl release check --version <version>`
 - `basectl release plan --version <version>`
 - `basectl release notes --version <version>`
@@ -401,11 +402,14 @@ basectl repo check ~/work/example --agent-guidance
 
 `repo configure` is intentionally idempotent. It enables Issues and Projects,
 standardizes merge settings, deletes branches after merge, applies the
-Base-managed default branch protection ruleset, and creates the standard
-GitHub labels documented in
+Base-managed default branch protection ruleset, configures standard GitHub
+Project metadata fields, and creates the standard GitHub labels documented in
 [Repository Baseline](docs/repo-baseline.md).
 Pass `--no-protect-default-branch` when a repository intentionally skips that
-ruleset.
+ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
+Project metadata, or `--project`, `--project-owner`, and
+`--initiative-option` when the default roadmap title or Initiative values need
+to vary by repository.
 
 Run a discovered project's declared test command with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -68,11 +68,12 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.
-- `basectl gh` manages GitHub issues, pull requests, branch naming, and
-  repository hygiene using Base's opinionated workflow. It uses standard
-  GitHub-style issue categories such as `bug`, `enhancement`, `documentation`,
-  `ci`, and `security`, and derives branch names from those categories. Prefer
-  this command for Base repository GitHub workflows when it supports the task.
+- `basectl gh` manages GitHub issues, pull requests, branch naming, repository
+  hygiene, and GitHub Project metadata using Base's opinionated workflow. It
+  uses standard GitHub-style issue categories such as `bug`, `enhancement`,
+  `documentation`, `ci`, and `security`, and derives branch names from those
+  categories. Prefer this command for Base repository GitHub workflows when it
+  supports the task.
 - `basectl onboard` guides first-run setup around existing setup, check,
   doctor, profile, and project-discovery primitives. See
   `docs/basectl-onboard.md`.
@@ -82,7 +83,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   creates the repository under `workspace.root` from `~/.base.d/config.yaml`,
   then falls back to the parent directory of `BASE_HOME`.
   `basectl repo check [path]` verifies the local baseline, and
-  `basectl repo configure [path]` reapplies the GitHub settings and labels.
+  `basectl repo configure [path]` reapplies the GitHub settings, labels,
+  default branch protection, and standard GitHub Project metadata. Use
+  `--no-project` to skip Project metadata or `--initiative-option <name>` to
+  seed repository-specific Initiative values.
   `basectl repo agent-guidance [path]` seeds optional repo-local agent guidance
   files and `basectl repo check [path] --agent-guidance` verifies that optional
   layer for repos that opt in.

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -15,14 +15,17 @@ Usage:
   basectl gh pr checks [gh options...]
   basectl gh pr ready [gh options...]
   basectl gh pr merge [gh options...]
+  basectl gh project doctor --project <title> [--owner <login>] [--schema base-roadmap]
+  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-roadmap] [--initiative-option <name>] [--dry-run]
+  basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [field options...]
   basectl gh branch stale [--days <days>]
   basectl gh branch prune [--dry-run] [--yes] [--remote]
   basectl gh worktree prune [--dry-run] [--yes]
   basectl gh todo import [--dry-run] [--file <path>]
 
 Purpose:
-  Manage GitHub issues, pull requests, branch naming, and repository hygiene
-  using Base's opinionated workflow.
+  Manage GitHub issues, pull requests, Project metadata, branch naming, and
+  repository hygiene using Base's opinionated workflow.
 
 Branch naming:
   <category>/<issue>-<YYYYMMDD>-<slug>
@@ -953,6 +956,16 @@ base_gh_do_todo() {
     esac
 }
 
+base_gh_do_project() {
+    local wrapper="${BASE_GH_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
+
+    [[ -x "$wrapper" ]] || {
+        base_gh_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+    "$wrapper" --project base base_github_projects project "$@"
+}
+
 base_gh_subcommand_main() {
     local area="${1:-}"
     shift || true
@@ -960,6 +973,7 @@ base_gh_subcommand_main() {
     case "$area" in
         issue) base_gh_do_issue "$@" ;;
         pr) base_gh_do_pr "$@" ;;
+        project) base_gh_do_project "$@" ;;
         branch) base_gh_do_branch "$@" ;;
         worktree) base_gh_do_worktree "$@" ;;
         todo) base_gh_do_todo "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -46,6 +46,11 @@ Options:
   --public                      Create a public GitHub repository when needed.
   --no-configure                Skip GitHub configuration during repo init.
   --no-protect-default-branch   Skip Base-managed default branch protection during repo configure.
+  --project <title>             GitHub Project title to configure. Defaults to <repo-name> Roadmap.
+  --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
+  --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
+  --initiative-option <name>    Initiative option to seed. May be repeated.
+  --no-project                  Skip GitHub Project metadata configuration.
   --dry-run                     Print planned changes without applying them.
   -v                            Enable DEBUG logging for this subcommand.
   -h, --help                    Show this help text.
@@ -814,6 +819,16 @@ base_repo_pretty_quote() {
     printf '"%s"' "$value"
 }
 
+base_repo_pretty_arg() {
+    local value="$1"
+
+    if [[ "$value" =~ ^[A-Za-z0-9_./:=@+-]+$ ]]; then
+        printf '%s' "$value"
+    else
+        base_repo_pretty_quote "$value"
+    fi
+}
+
 base_repo_configure_label() {
     local color="$3"
     local description="$4"
@@ -911,6 +926,97 @@ base_repo_configure_default_branch_protection() {
             return 1
         }
     fi
+}
+
+base_repo_title_case_name() {
+    local name="$1"
+
+    printf '%s\n' "$name" |
+        tr '._-' '   ' |
+        awk '{ for (i = 1; i <= NF; i++) { $i = toupper(substr($i, 1, 1)) substr($i, 2) } print }'
+}
+
+base_repo_default_project_title() {
+    local name
+    local repo="$1"
+
+    name="${repo#*/}"
+    if [[ "$repo" == "codeforester/base" || "$name" == "base" ]]; then
+        printf '%s\n' "Base Roadmap"
+        return 0
+    fi
+
+    printf '%s Roadmap\n' "$(base_repo_title_case_name "$name")"
+}
+
+base_repo_project_owner_from_repo() {
+    local repo="$1"
+
+    printf '%s\n' "${repo%%/*}"
+}
+
+base_repo_configure_project_metadata() {
+    local dry_run="$1"
+    local option
+    local owner="$4"
+    local output=""
+    local project_title="$3"
+    local repo="$2"
+    local schema="$5"
+    local status=0
+    local wrapper="${BASE_REPO_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
+    shift 5
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would configure GitHub Project '%s' for '%s'.\n" "$project_title" "$repo"
+        printf "[DRY-RUN] Would run: %s --project base base_github_projects project configure --project %s --owner %s --repo %s --schema %s" \
+            "$wrapper" \
+            "$(base_repo_pretty_arg "$project_title")" \
+            "$owner" \
+            "$repo" \
+            "$schema"
+        for option in "$@"; do
+            printf " --initiative-option %s" "$(base_repo_pretty_arg "$option")"
+        done
+        printf "\n"
+        printf "[DRY-RUN] Project fields: Status, Priority, Area, Size, Initiative\n"
+        return 0
+    fi
+
+    [[ -x "$wrapper" ]] || {
+        log_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+
+    local command=(
+        "$wrapper"
+        --project base
+        base_github_projects
+        project
+        configure
+        --project "$project_title"
+        --owner "$owner"
+        --repo "$repo"
+        --schema "$schema"
+    )
+    for option in "$@"; do
+        command+=(--initiative-option "$option")
+    done
+
+    output="$("${command[@]}" 2>&1)" || status=$?
+    if [[ "$status" -eq 0 ]]; then
+        [[ -z "$output" ]] || printf '%s\n' "$output"
+        return 0
+    fi
+    if [[ "$status" -eq 3 ]]; then
+        log_warn "GitHub Project metadata skipped for '$repo'."
+        [[ -z "$output" ]] || log_warn "$output"
+        return 0
+    fi
+
+    [[ -z "$output" ]] || log_error "$output"
+    log_error "Unable to configure GitHub Project metadata for '$repo'."
+    return 1
 }
 
 base_repo_configure_github() {
@@ -1188,10 +1294,15 @@ base_repo_init() {
     local github_visibility_explicit=0
     local name=""
     local path=""
+    local project_owner=""
+    local project_schema="base-roadmap"
+    local project_title=""
     local protect_default_branch=1
     local pr_branch=""
     local requested_visibility=""
     local root
+    local configure_project=1
+    local initiative_options=()
 
     while (($#)); do
         case "$1" in
@@ -1259,6 +1370,58 @@ base_repo_init() {
                 ;;
             --no-protect-default-branch)
                 protect_default_branch=0
+                shift
+                ;;
+            --project)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--project' requires an argument."
+                    return $?
+                }
+                project_title="$2"
+                shift 2
+                ;;
+            --project=*)
+                project_title="${1#--project=}"
+                shift
+                ;;
+            --project-owner)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--project-owner' requires an argument."
+                    return $?
+                }
+                project_owner="$2"
+                shift 2
+                ;;
+            --project-owner=*)
+                project_owner="${1#--project-owner=}"
+                shift
+                ;;
+            --project-schema)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--project-schema' requires an argument."
+                    return $?
+                }
+                project_schema="$2"
+                shift 2
+                ;;
+            --project-schema=*)
+                project_schema="${1#--project-schema=}"
+                shift
+                ;;
+            --initiative-option)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--initiative-option' requires an argument."
+                    return $?
+                }
+                initiative_options+=("$2")
+                shift 2
+                ;;
+            --initiative-option=*)
+                initiative_options+=("${1#--initiative-option=}")
+                shift
+                ;;
+            --no-project)
+                configure_project=0
                 shift
                 ;;
             --dry-run)
@@ -1332,6 +1495,17 @@ base_repo_init() {
         if [[ -n "$github_repo" ]]; then
             base_repo_ensure_github_repo "$dry_run" "$github_repo" "$description" "$github_visibility" || return 1
             base_repo_configure_github "$dry_run" "$github_repo" "$protect_default_branch" || return 1
+            if ((configure_project)); then
+                [[ -n "$project_title" ]] || project_title="$(base_repo_default_project_title "$github_repo")"
+                [[ -n "$project_owner" ]] || project_owner="$(base_repo_project_owner_from_repo "$github_repo")"
+                base_repo_configure_project_metadata \
+                    "$dry_run" \
+                    "$github_repo" \
+                    "$project_title" \
+                    "$project_owner" \
+                    "$project_schema" \
+                    "${initiative_options[@]}" || return 1
+            fi
         else
             if [[ "$dry_run" == "1" ]]; then
                 printf "[DRY-RUN] Would not create or configure a GitHub repository because no GitHub repo was provided or inferred. Pass --repo <owner/name> to include GitHub repository creation and configuration.\n"
@@ -1475,9 +1649,14 @@ base_repo_agent_guidance() {
 }
 
 base_repo_configure() {
+    local configure_project=1
     local dry_run=0
     local github_repo=""
+    local initiative_options=()
     local path="."
+    local project_owner=""
+    local project_schema="base-roadmap"
+    local project_title=""
     local protect_default_branch=1
 
     while (($#)); do
@@ -1504,6 +1683,58 @@ base_repo_configure() {
                 ;;
             --no-protect-default-branch)
                 protect_default_branch=0
+                shift
+                ;;
+            --project)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--project' requires an argument."
+                    return $?
+                }
+                project_title="$2"
+                shift 2
+                ;;
+            --project=*)
+                project_title="${1#--project=}"
+                shift
+                ;;
+            --project-owner)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--project-owner' requires an argument."
+                    return $?
+                }
+                project_owner="$2"
+                shift 2
+                ;;
+            --project-owner=*)
+                project_owner="${1#--project-owner=}"
+                shift
+                ;;
+            --project-schema)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--project-schema' requires an argument."
+                    return $?
+                }
+                project_schema="$2"
+                shift 2
+                ;;
+            --project-schema=*)
+                project_schema="${1#--project-schema=}"
+                shift
+                ;;
+            --initiative-option)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--initiative-option' requires an argument."
+                    return $?
+                }
+                initiative_options+=("$2")
+                shift 2
+                ;;
+            --initiative-option=*)
+                initiative_options+=("${1#--initiative-option=}")
+                shift
+                ;;
+            --no-project)
+                configure_project=0
                 shift
                 ;;
             -v)
@@ -1536,7 +1767,18 @@ base_repo_configure() {
         return 1
     }
 
-    base_repo_configure_github "$dry_run" "$github_repo" "$protect_default_branch"
+    base_repo_configure_github "$dry_run" "$github_repo" "$protect_default_branch" || return 1
+    if ((configure_project)); then
+        [[ -n "$project_title" ]] || project_title="$(base_repo_default_project_title "$github_repo")"
+        [[ -n "$project_owner" ]] || project_owner="$(base_repo_project_owner_from_repo "$github_repo")"
+        base_repo_configure_project_metadata \
+            "$dry_run" \
+            "$github_repo" \
+            "$project_title" \
+            "$project_owner" \
+            "$project_schema" \
+            "${initiative_options[@]}"
+    fi
 }
 
 base_repo_installer_template() {

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -147,6 +147,18 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "gh_areas=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl gh project ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "gh_project_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl gh project configure --); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "gh_project_configure_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl gh project issue set-fields 604 --); \
+            COMP_CWORD=6; \
+            _base_basectl_completion; \
+            printf "gh_project_issue_set_fields_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl gh worktree ""); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -180,14 +192,17 @@ EOF
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"repo_commands=init check configure agent-guidance installer-template"* ]]
-    [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --no-protect-default-branch --dry-run"* ]]
+    [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run"* ]]
     [[ "$output" == *"repo_check_options=--agent-guidance"* ]]
-    [[ "$output" == *"repo_configure_options=--repo --no-protect-default-branch --dry-run"* ]]
+    [[ "$output" == *"repo_configure_options=--repo --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run"* ]]
     [[ "$output" == *"repo_agent_guidance_options=--repo-name --default-branch --validation-command --dry-run"* ]]
     [[ "$output" == *"repo_installer_template_options=--dry-run"* ]]
     [[ "$output" == *"ci_commands=setup check doctor"* ]]
     [[ "$output" == *"ci_check_options=--format --manifest --profile"* ]]
-    [[ "$output" == *"gh_areas=issue pr branch worktree todo"* ]]
+    [[ "$output" == *"gh_areas=issue pr branch worktree todo project"* ]]
+    [[ "$output" == *"gh_project_commands=doctor configure issue"* ]]
+    [[ "$output" == *"gh_project_configure_options=--project --owner --schema --initiative-option --repo --dry-run"* ]]
+    [[ "$output" == *"gh_project_issue_set_fields_options=--repo --project --owner --status --priority --area --initiative --size --dry-run"* ]]
     [[ "$output" == *"gh_worktree_commands=prune"* ]]
     [[ "$output" == *"gh_worktree_prune_options=--dry-run --yes"* ]]
 }

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -9,6 +9,9 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl gh issue start <number>"* ]]
+    [[ "$output" == *"basectl gh project doctor --project <title>"* ]]
+    [[ "$output" == *"basectl gh project configure --project <title>"* ]]
+    [[ "$output" == *"basectl gh project issue set-fields <number>"* ]]
     [[ "$output" == *"basectl gh worktree prune"* ]]
     [[ "$output" == *"<category>/<issue>-<YYYYMMDD>-<slug>"* ]]
     [[ "$output" == *"assigned to codeforester"* ]]
@@ -62,6 +65,29 @@ EOF
     [[ "$output" == *"basectl gh issue create"* ]]
     [[ "$output" != *"GitHub CLI authentication is not ready."* ]]
     [[ "$output" != *"unexpected gh args"* ]]
+}
+
+@test "basectl gh project dispatches to Python engine" {
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_GH_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main project doctor --project "Base Roadmap" --owner codeforester
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/wrapper-args")" = "--project base base_github_projects project doctor --project Base Roadmap --owner codeforester" ]
 }
 
 @test "basectl gh issue list reports missing gh authentication clearly" {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -398,6 +398,55 @@ EOF
     [[ "$output" != *"rulesets"* ]]
 }
 
+@test "basectl repo configure dry-run configures project metadata by default" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+
+    run_basectl repo configure "$repo_dir" --repo codeforester/base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Would configure GitHub Project 'Base Demo Roadmap' for 'codeforester/base-demo'."* ]]
+    [[ "$output" == *"--schema base-roadmap"* ]]
+    [[ "$output" == *"Status, Priority, Area, Size, Initiative"* ]]
+}
+
+@test "basectl repo configure can skip project metadata" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+
+    run_basectl repo configure "$repo_dir" \
+        --repo codeforester/base-demo \
+        --no-project \
+        --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
+    [[ "$output" != *"GitHub Project"* ]]
+    [[ "$output" != *"base_github_projects"* ]]
+}
+
+@test "basectl repo configure accepts project metadata overrides" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+
+    run_basectl repo configure "$repo_dir" \
+        --repo codeforester/bankbuddy \
+        --project "BankBuddy Roadmap" \
+        --project-owner codeforester \
+        --initiative-option MVP \
+        --initiative-option Imports \
+        --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Would configure GitHub Project 'BankBuddy Roadmap' for 'codeforester/bankbuddy'."* ]]
+    [[ "$output" == *"--owner codeforester"* ]]
+    [[ "$output" == *"--initiative-option MVP"* ]]
+    [[ "$output" == *"--initiative-option Imports"* ]]
+}
+
 @test "basectl repo configure applies GitHub settings through gh" {
     local repo_dir="$TEST_TMPDIR/repo"
 
@@ -418,12 +467,79 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     grep -Fq "label create bug --repo codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     grep -Fq "label create needs-demo --repo codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+}
+
+@test "basectl repo configure applies project metadata through Base project engine" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/project-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 0 ]
+    grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project Base Demo Roadmap --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
+}
+
+@test "basectl repo configure warns when project metadata needs GitHub project scope" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh auth refresh -h github.com -s project\n' >&2
+exit 3
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GitHub Project metadata skipped for 'codeforester/base-demo'."* ]]
+    [[ "$output" == *"gh auth refresh -h github.com -s project"* ]]
 }
 
 @test "basectl repo configure updates an existing Base ruleset" {
@@ -453,7 +569,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
     grep -Fq "api-list api repos/codeforester/base-demo/rulesets" "$TEST_STATE_DIR/gh-args"
@@ -491,7 +607,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
     grep -Fq "api-list api repos/codeforester/base-demo/rulesets" "$TEST_STATE_DIR/gh-args"
@@ -525,7 +641,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
     grep -Fq "api-list api repos/codeforester/base-demo/rulesets" "$TEST_STATE_DIR/gh-args"
@@ -556,7 +672,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 1 ]
     grep -Fq "api-list api repos/codeforester/base-demo/rulesets" "$TEST_STATE_DIR/gh-args"
@@ -578,10 +694,16 @@ fi
 printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
 EOF
     chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/project-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
 
     run env \
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo init base-demo --path "$repo_dir" --repo codeforester/base-demo
 
@@ -589,6 +711,7 @@ EOF
     [ -f "$repo_dir/base_manifest.yaml" ]
     grep -Fq "repo create codeforester/base-demo --private --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project Base Demo Roadmap --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
     ! grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"
 }
 
@@ -682,7 +805,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo init base-demo --path "$repo_dir" --repo codeforester/base-demo --public
+        "$BASE_REPO_ROOT/bin/basectl" repo init base-demo --path "$repo_dir" --repo codeforester/base-demo --public --no-project
 
     [ "$status" -eq 0 ]
     grep -Fq "repo create codeforester/base-demo --public --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"

--- a/cli/python/base_github_projects/__init__.py
+++ b/cli/python/base_github_projects/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub Projects V2 helpers for Base-managed repositories."""

--- a/cli/python/base_github_projects/__main__.py
+++ b/cli/python/base_github_projects/__main__.py
@@ -1,0 +1,5 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -1,0 +1,861 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+class ProjectUsageError(RuntimeError):
+    pass
+
+
+class ProjectError(RuntimeError):
+    pass
+
+
+class ProjectAuthError(ProjectError):
+    pass
+
+
+@dataclass(frozen=True)
+class SelectOption:
+    name: str
+    color: str
+    description: str
+    option_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SelectFieldSpec:
+    name: str
+    options: tuple[SelectOption, ...]
+
+
+@dataclass(frozen=True)
+class ProjectSchema:
+    fields: tuple[SelectFieldSpec, ...]
+
+    def field_by_name(self, name: str) -> SelectFieldSpec:
+        for field in self.fields:
+            if field.name == name:
+                return field
+        raise KeyError(name)
+
+
+@dataclass(frozen=True)
+class ProjectField:
+    field_id: str
+    name: str
+    data_type: str
+    options: tuple[SelectOption, ...] = ()
+
+
+@dataclass(frozen=True)
+class Finding:
+    status: str
+    name: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ConfigureAction:
+    action: str
+    name: str
+    message: str
+
+
+@dataclass(frozen=True)
+class FieldUpdate:
+    field_id: str
+    option_id: str
+    field_name: str
+    option_name: str
+
+
+@dataclass(frozen=True)
+class ProjectInfo:
+    project_id: str
+    title: str
+
+
+@dataclass(frozen=True)
+class OwnerInfo:
+    owner_id: str
+    login: str
+    project: ProjectInfo | None
+
+
+@dataclass(frozen=True)
+class ProjectArguments:
+    area: str
+    command: str
+    project_title: str | None = None
+    owner: str | None = None
+    repo: str | None = None
+    schema: str = "base-roadmap"
+    initiative_options: tuple[str, ...] = ()
+    dry_run: bool = False
+    issue_number: int | None = None
+    field_values: dict[str, str] | None = None
+
+
+BASE_ROADMAP_SCHEMA = ProjectSchema(
+    fields=(
+        SelectFieldSpec(
+            "Status",
+            (
+                SelectOption("Triage", "GRAY", "Needs clarification or initial classification."),
+                SelectOption("Backlog", "BLUE", "Accepted but not yet scheduled."),
+                SelectOption("Ready", "GREEN", "Scoped enough to pick up."),
+                SelectOption("In Progress", "YELLOW", "Actively being worked on."),
+                SelectOption("In Review", "ORANGE", "Pull request open, waiting on checks or review."),
+                SelectOption("Done", "PURPLE", "Completed or no further work remains."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Priority",
+            (
+                SelectOption("P0", "RED", "Urgent or blocking."),
+                SelectOption("P1", "ORANGE", "High priority."),
+                SelectOption("P2", "YELLOW", "Normal priority."),
+                SelectOption("P3", "BLUE", "Low priority or opportunistic."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Area",
+            (
+                SelectOption("CLI", "GRAY", "Command surface and user-facing CLI behavior."),
+                SelectOption("Setup", "GRAY", "Installation, setup, check, and doctor behavior."),
+                SelectOption("Workspace", "GRAY", "Workspace discovery and workspace-level commands."),
+                SelectOption("Manifest", "GRAY", "Manifest schema and project contract handling."),
+                SelectOption("Runtime", "GRAY", "Activation, shell runtime, and environment behavior."),
+                SelectOption("Shell", "GRAY", "Shell libraries, completions, and startup files."),
+                SelectOption("Python", "GRAY", "Python command packages and shared Python helpers."),
+                SelectOption("Docs", "GRAY", "Documentation and AI context."),
+                SelectOption("CI", "GRAY", "Continuous integration and validation automation."),
+                SelectOption("Packaging", "GRAY", "Release, Homebrew, installer, and distribution work."),
+                SelectOption("Security", "GRAY", "Permission, secret-handling, and hardening work."),
+                SelectOption("Product", "GRAY", "Product direction, roadmap, and adoption work."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Size",
+            (
+                SelectOption("S", "GREEN", "Small, focused change."),
+                SelectOption("M", "YELLOW", "Medium change with multiple files or interactions."),
+                SelectOption("L", "ORANGE", "Large change that should be split if possible."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Initiative",
+            (
+                SelectOption("BanyanLabs Dogfood", "GRAY", "Dogfood Base through BanyanLabs."),
+                SelectOption("Workspace Handling", "GRAY", "Workspace discovery and orchestration."),
+                SelectOption("pyproject/uv", "GRAY", "Python packaging and uv integration."),
+                SelectOption("v1.0 Readiness", "GRAY", "Stable public release readiness."),
+                SelectOption("Adoption Polish", "GRAY", "Install, docs, and adoption polish."),
+            ),
+        ),
+    )
+)
+
+
+FIELD_OPTION_TO_PROJECT_FIELD = {
+    "status": "Status",
+    "priority": "Priority",
+    "area": "Area",
+    "initiative": "Initiative",
+    "size": "Size",
+}
+HELP_OPTIONS = ("-h", "--help", "help")
+PROJECT_VALUE_OPTIONS = ("--project", "--owner", "--repo", "--schema", "--initiative-option")
+ISSUE_FIELD_OPTIONS = ("--status", "--priority", "--area", "--initiative", "--size")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parse_args(tuple(sys.argv[1:] if argv is None else argv))
+        return run_command(args)
+    except SystemExit as exc:
+        return int(exc.code or 0)
+    except ProjectUsageError as exc:
+        print_usage(file=sys.stderr)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    except ProjectAuthError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        print("Run `gh auth refresh -h github.com -s project` and retry.", file=sys.stderr)
+        return 3
+    except ProjectError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+def print_usage(file=sys.stdout) -> None:
+    print(
+        "\n".join(
+            (
+                "Usage:",
+                "  base_github_projects project doctor --project <title> "
+                "[--owner <login>] [--schema base-roadmap]",
+                "  base_github_projects project configure --project <title> "
+                "[--owner <login>] [--repo <owner/name>] [--schema base-roadmap] "
+                "[--initiative-option <name>] [--dry-run]",
+                "  base_github_projects project issue set-fields <number> "
+                "--repo <owner/name> --project <title> [field options...]",
+            )
+        ),
+        file=file,
+    )
+
+
+def parse_args(arguments: tuple[str, ...]) -> ProjectArguments:
+    if not arguments or arguments[0] in HELP_OPTIONS:
+        print_usage()
+        raise SystemExit(0)
+    if arguments[0] != "project":
+        raise ProjectUsageError(f"Unknown area '{arguments[0]}'.")
+    if len(arguments) < 2:
+        raise ProjectUsageError("The 'project' area requires a command.")
+
+    command = arguments[1]
+    remaining = list(arguments[2:])
+    if command == "doctor":
+        state = parse_project_options(remaining, allow_fields=False, allow_issue=False)
+        require_project_title(state)
+        return state_to_args("doctor", state)
+    if command == "configure":
+        state = parse_project_options(remaining, allow_fields=False, allow_issue=False)
+        require_project_title(state)
+        return state_to_args("configure", state)
+    if command == "issue":
+        if len(remaining) < 2 or remaining[0] != "set-fields":
+            raise ProjectUsageError("Expected 'project issue set-fields <number>'.")
+        try:
+            issue_number = int(remaining[1])
+        except ValueError as exc:
+            raise ProjectUsageError(f"Invalid issue number '{remaining[1]}'.") from exc
+        state = parse_project_options(remaining[2:], allow_fields=True, allow_issue=True)
+        require_project_title(state)
+        if not state.repo:
+            state.repo = infer_repo_from_git()
+        if not state.repo:
+            raise ProjectUsageError("The 'project issue set-fields' command requires --repo.")
+        return state_to_args("issue-set-fields", state, issue_number=issue_number)
+    raise ProjectUsageError(f"Unknown project command '{command}'.")
+
+
+@dataclass
+class OptionState:
+    project_title: str | None = None
+    owner: str | None = None
+    repo: str | None = None
+    schema: str = "base-roadmap"
+    initiative_options: list[str] | None = None
+    dry_run: bool = False
+    field_values: dict[str, str] | None = None
+
+
+def parse_project_options(remaining: list[str], *, allow_fields: bool, allow_issue: bool) -> OptionState:
+    state = OptionState(initiative_options=[], field_values={})
+    index = 0
+    while index < len(remaining):
+        arg = remaining[index]
+        if arg in HELP_OPTIONS:
+            print_usage()
+            raise SystemExit(0)
+        if apply_equals_option(state, arg, allow_fields=allow_fields):
+            index += 1
+            continue
+        if arg == "--dry-run":
+            state.dry_run = True
+            index += 1
+            continue
+        consumed = apply_spaced_option(state, remaining, index, allow_fields=allow_fields)
+        if consumed:
+            index += consumed
+            continue
+        if allow_issue:
+            raise ProjectUsageError(f"Unknown issue field option '{arg}'.")
+        raise ProjectUsageError(f"Unknown option '{arg}'.")
+    if state.schema != "base-roadmap":
+        raise ProjectUsageError("Only project schema 'base-roadmap' is supported.")
+    if not state.owner and state.repo:
+        state.owner = state.repo.split("/", 1)[0]
+    if not state.owner:
+        state.owner = infer_owner_from_git()
+    return state
+
+
+def apply_equals_option(state: OptionState, arg: str, *, allow_fields: bool) -> bool:
+    if not arg.startswith("--") or "=" not in arg:
+        return False
+    name, value = arg.split("=", 1)
+    if name in PROJECT_VALUE_OPTIONS:
+        apply_project_option(state, name, value)
+        return True
+    if allow_fields and name in ISSUE_FIELD_OPTIONS:
+        state.field_values[name[2:]] = value
+        return True
+    return False
+
+
+def apply_spaced_option(state: OptionState, remaining: list[str], index: int, *, allow_fields: bool) -> int:
+    option = remaining[index]
+    if option in PROJECT_VALUE_OPTIONS:
+        apply_project_option(state, option, option_value(remaining, index))
+        return 2
+    if allow_fields and option in ISSUE_FIELD_OPTIONS:
+        state.field_values[option[2:]] = option_value(remaining, index)
+        return 2
+    return 0
+
+
+def option_value(remaining: list[str], index: int) -> str:
+    option = remaining[index]
+    if index + 1 >= len(remaining):
+        raise ProjectUsageError(f"Option '{option}' requires an argument.")
+    return remaining[index + 1]
+
+
+def apply_project_option(state: OptionState, option: str, value: str) -> None:
+    if option == "--project":
+        state.project_title = value
+    elif option == "--owner":
+        state.owner = value
+    elif option == "--repo":
+        state.repo = value
+    elif option == "--schema":
+        state.schema = value
+    elif option == "--initiative-option":
+        state.initiative_options.append(value)
+
+
+def require_project_title(state: OptionState) -> None:
+    if not state.project_title:
+        raise ProjectUsageError("The project command requires --project.")
+
+
+def state_to_args(command: str, state: OptionState, issue_number: int | None = None) -> ProjectArguments:
+    return ProjectArguments(
+        area="project",
+        command=command,
+        project_title=state.project_title,
+        owner=state.owner,
+        repo=state.repo,
+        schema=state.schema,
+        initiative_options=tuple(state.initiative_options or ()),
+        dry_run=state.dry_run,
+        issue_number=issue_number,
+        field_values=dict(state.field_values or {}),
+    )
+
+
+def run_command(args: ProjectArguments) -> int:
+    if args.command == "doctor":
+        return doctor_command(args)
+    if args.command == "configure":
+        return configure_command(args)
+    if args.command == "issue-set-fields":
+        return issue_set_fields_command(args)
+    raise ProjectUsageError(f"Unknown project command '{args.command}'.")
+
+
+def schema_for_args(args: ProjectArguments) -> ProjectSchema:
+    if args.schema != "base-roadmap":
+        raise ProjectUsageError("Only project schema 'base-roadmap' is supported.")
+    if args.initiative_options:
+        return schema_with_initiatives(BASE_ROADMAP_SCHEMA, args.initiative_options)
+    return BASE_ROADMAP_SCHEMA
+
+
+def schema_with_initiatives(schema: ProjectSchema, initiative_options: tuple[str, ...]) -> ProjectSchema:
+    fields: list[SelectFieldSpec] = []
+    for field in schema.fields:
+        if field.name != "Initiative":
+            fields.append(field)
+            continue
+        existing = {option.name for option in field.options}
+        options = list(field.options)
+        for option_name in initiative_options:
+            if option_name not in existing:
+                options.append(SelectOption(option_name, "GRAY", "Project-specific initiative."))
+                existing.add(option_name)
+        fields.append(SelectFieldSpec(field.name, tuple(options)))
+    return ProjectSchema(tuple(fields))
+
+
+def compare_schema(fields: tuple[ProjectField, ...], schema: ProjectSchema) -> tuple[Finding, ...]:
+    by_name = {field.name: field for field in fields}
+    findings: list[Finding] = []
+    for spec in schema.fields:
+        field = by_name.get(spec.name)
+        if field is None:
+            findings.append(Finding("missing", spec.name, f"{spec.name} field is missing."))
+            continue
+        if field.data_type != "SINGLE_SELECT":
+            findings.append(
+                Finding("error", spec.name, f"{spec.name} exists with type {field.data_type}; expected SINGLE_SELECT.")
+            )
+            continue
+        existing_options = {option.name for option in field.options}
+        for option in spec.options:
+            if option.name not in existing_options:
+                findings.append(Finding("missing-option", spec.name, f"{spec.name} option {option.name} is missing."))
+    return tuple(findings)
+
+
+def configuration_plan(
+    *, project_exists: bool, fields: tuple[ProjectField, ...], schema: ProjectSchema
+) -> tuple[ConfigureAction, ...]:
+    actions: list[ConfigureAction] = []
+    if not project_exists:
+        actions.append(ConfigureAction("create-project", "Project", "Create GitHub Project."))
+    by_name = {field.name: field for field in fields}
+    for spec in schema.fields:
+        field = by_name.get(spec.name)
+        if field is None:
+            actions.append(ConfigureAction("create-field", spec.name, f"Create {spec.name} as SINGLE_SELECT."))
+            continue
+        if field.data_type != "SINGLE_SELECT":
+            message = f"{spec.name} exists with type {field.data_type}; expected SINGLE_SELECT."
+            actions.append(
+                ConfigureAction("error", spec.name, message)
+            )
+            continue
+        existing_options = {option.name for option in field.options}
+        missing_options = [option.name for option in spec.options if option.name not in existing_options]
+        if missing_options:
+            actions.append(
+                ConfigureAction("update-field", spec.name, f"Add missing options: {', '.join(missing_options)}.")
+            )
+    return tuple(actions)
+
+
+def merged_options(field: ProjectField, spec: SelectFieldSpec) -> tuple[SelectOption, ...]:
+    merged = list(field.options)
+    names = {option.name for option in merged}
+    for option in spec.options:
+        if option.name not in names:
+            merged.append(option)
+            names.add(option.name)
+    return tuple(merged)
+
+
+def resolve_issue_field_updates(
+    fields: tuple[ProjectField, ...], values: dict[str, str], *, project_title: str
+) -> tuple[FieldUpdate, ...]:
+    by_name = {field.name: field for field in fields}
+    updates: list[FieldUpdate] = []
+    for value_key, field_name in FIELD_OPTION_TO_PROJECT_FIELD.items():
+        option_name = values.get(value_key)
+        if not option_name:
+            continue
+        field = by_name.get(field_name)
+        if field is None:
+            raise ProjectUsageError(f"{field_name} field was not found in Project '{project_title}'.")
+        option = find_option(field, option_name)
+        if option is None or option.option_id is None:
+            if field_name == "Initiative":
+                raise ProjectUsageError(
+                    f"Initiative option '{option_name}' was not found in Project '{project_title}'. "
+                    f'Run `basectl gh project configure --project "{project_title}" '
+                    f'--initiative-option "{option_name}"` first.'
+                )
+            raise ProjectUsageError(f"{field_name} option '{option_name}' was not found in Project '{project_title}'.")
+        updates.append(FieldUpdate(field.field_id, option.option_id, field_name, option_name))
+    return tuple(updates)
+
+
+def find_option(field: ProjectField, name: str) -> SelectOption | None:
+    for option in field.options:
+        if option.name == name:
+            return option
+    return None
+
+
+def doctor_command(args: ProjectArguments) -> int:
+    owner = require_owner(args)
+    owner_info = find_owner_and_project(owner, args.project_title or "")
+    if owner_info.project is None:
+        print(f"MISSING Project {args.project_title}")
+        return 1
+    fields = fetch_project_fields(owner_info.project.project_id)
+    findings = compare_schema(fields, schema_for_args(args))
+    if not findings:
+        print(f"OK      Project {args.project_title}")
+        return 0
+    for finding in findings:
+        print(f"{finding.status.upper():<8}{finding.name}  {finding.message}")
+    return 1
+
+
+def configure_command(args: ProjectArguments) -> int:
+    owner = require_owner(args)
+    schema = schema_for_args(args)
+    owner_info = find_owner_and_project(owner, args.project_title or "")
+    project = owner_info.project
+    fields: tuple[ProjectField, ...] = ()
+    if project is not None:
+        fields = fetch_project_fields(project.project_id)
+    actions = configuration_plan(project_exists=project is not None, fields=fields, schema=schema)
+    errors = [action for action in actions if action.action == "error"]
+    if errors:
+        for action in errors:
+            print(f"ERROR   {action.name}  {action.message}", file=sys.stderr)
+        return 1
+    if args.dry_run:
+        render_dry_run_configure(args, actions)
+        return 0
+    if project is None:
+        project = create_project(owner_info.owner_id, args.project_title or "")
+        fields = ()
+    by_name = {field.name: field for field in fields}
+    for spec in schema.fields:
+        field = by_name.get(spec.name)
+        if field is None:
+            create_single_select_field(project.project_id, spec)
+        elif missing_option_names(field, spec):
+            update_single_select_field(field, spec)
+    print(f"✓ Configured GitHub Project {args.project_title}")
+    return 0
+
+
+def render_dry_run_configure(args: ProjectArguments, actions: tuple[ConfigureAction, ...]) -> None:
+    print(
+        f"[DRY-RUN] Would configure GitHub Project '{args.project_title}' "
+        f"for '{args.repo or args.owner or ''}' with --schema {args.schema}."
+    )
+    print("[DRY-RUN] Fields: Status, Priority, Area, Size, Initiative")
+    if args.initiative_options:
+        for option in args.initiative_options:
+            print(f"[DRY-RUN] Would ensure Initiative option {option}.")
+    for action in actions:
+        print(f"[DRY-RUN] Would {action.message}")
+
+
+def issue_set_fields_command(args: ProjectArguments) -> int:
+    owner = require_owner(args)
+    repo = require_repo(args)
+    owner_info = find_owner_and_project(owner, args.project_title or "")
+    if owner_info.project is None:
+        raise ProjectError(f"Project '{args.project_title}' was not found for owner '{owner}'.")
+    project = owner_info.project
+    fields = fetch_project_fields(project.project_id)
+    updates = resolve_issue_field_updates(fields, args.field_values or {}, project_title=args.project_title or "")
+    if not updates:
+        raise ProjectUsageError("At least one field option must be provided.")
+    repo_owner, repo_name = split_repo(repo)
+    issue_id = fetch_issue_id(repo_owner, repo_name, args.issue_number or 0)
+    item_id = find_project_item_id(project.project_id, issue_id)
+    if args.dry_run:
+        print(f"[DRY-RUN] Would add issue #{args.issue_number} to Project '{args.project_title}' if needed.")
+        for update in updates:
+            print(f"[DRY-RUN] Would set {update.field_name} to {update.option_name}.")
+        return 0
+    if item_id is None:
+        item_id = add_project_item(project.project_id, issue_id)
+    for update in updates:
+        update_item_field(project.project_id, item_id, update)
+    print(f"✓ Updated Project metadata for issue #{args.issue_number}")
+    return 0
+
+
+def require_owner(args: ProjectArguments) -> str:
+    owner = args.owner
+    if not owner and args.repo:
+        owner = args.repo.split("/", 1)[0]
+    if not owner:
+        owner = infer_owner_from_git()
+    if not owner:
+        raise ProjectUsageError("Project owner is required. Pass --owner <login>.")
+    return owner
+
+
+def require_repo(args: ProjectArguments) -> str:
+    repo = args.repo or infer_repo_from_git()
+    if not repo:
+        raise ProjectUsageError("Repository is required. Pass --repo <owner/name>.")
+    return repo
+
+
+def split_repo(repo: str) -> tuple[str, str]:
+    if "/" not in repo:
+        raise ProjectUsageError(f"Repository must be in owner/name form, got '{repo}'.")
+    owner, name = repo.split("/", 1)
+    if not owner or not name:
+        raise ProjectUsageError(f"Repository must be in owner/name form, got '{repo}'.")
+    return owner, name
+
+
+def infer_owner_from_git() -> str | None:
+    repo = infer_repo_from_git()
+    return repo.split("/", 1)[0] if repo else None
+
+
+def infer_repo_from_git() -> str | None:
+    result = subprocess.run(
+        ["git", "config", "--get", "remote.origin.url"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    remote = result.stdout.strip()
+    if remote.startswith("git@github.com:"):
+        remote = remote.removeprefix("git@github.com:")
+    elif remote.startswith("https://github.com/"):
+        remote = remote.removeprefix("https://github.com/")
+    else:
+        return None
+    remote = remote.removesuffix(".git")
+    return remote if "/" in remote else None
+
+
+def run_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
+    payload = json.dumps({"query": query, "variables": variables})
+    result = subprocess.run(
+        ["gh", "api", "graphql", "--input", "-"],
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout).strip()
+        if is_project_scope_error(message):
+            raise ProjectAuthError(message or "GitHub Project access requires the project scope.")
+        raise ProjectError(message or "GitHub GraphQL request failed.")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ProjectError("GitHub GraphQL returned invalid JSON.") from exc
+    if data.get("errors"):
+        message = "; ".join(str(error.get("message", error)) for error in data["errors"])
+        if is_project_scope_error(message):
+            raise ProjectAuthError(message)
+        raise ProjectError(message)
+    return data
+
+
+def is_project_scope_error(message: str) -> bool:
+    lowered = message.lower()
+    return (
+        "project" in lowered
+        and ("scope" in lowered or "resource not accessible" in lowered or "forbidden" in lowered)
+    ) or "projectv2" in lowered and "not accessible" in lowered
+
+
+def find_owner_and_project(owner: str, title: str) -> OwnerInfo:
+    owner_node = find_owner_node("user", owner)
+    if owner_node is None:
+        owner_node = find_owner_node("organization", owner)
+    if owner_node is None:
+        raise ProjectError(f"GitHub owner '{owner}' was not found.")
+    project = None
+    for node in owner_node.get("projectsV2", {}).get("nodes", []):
+        if node.get("title") == title:
+            project = ProjectInfo(project_id=node["id"], title=node["title"])
+            break
+    return OwnerInfo(owner_id=owner_node["id"], login=owner_node["login"], project=project)
+
+
+def find_owner_node(kind: str, owner: str) -> dict[str, object] | None:
+    query = f"""
+query($login: String!) {{
+  {kind}(login: $login) {{
+    id
+    login
+    projectsV2(first: 100) {{ nodes {{ id title }} }}
+  }}
+}}
+"""
+    try:
+        payload = run_graphql(query, {"login": owner})
+    except ProjectAuthError:
+        raise
+    except ProjectError as exc:
+        if is_missing_owner_lookup_error(str(exc), kind):
+            return None
+        raise
+    return payload["data"].get(kind)
+
+
+def is_missing_owner_lookup_error(message: str, kind: str) -> bool:
+    owner_type = "User" if kind == "user" else "Organization"
+    return f"Could not resolve to a {owner_type} with the login" in message
+
+
+def fetch_project_fields(project_id: str) -> tuple[ProjectField, ...]:
+    query = """
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      fields(first: 50) {
+        nodes {
+          __typename
+          ... on ProjectV2Field { id name dataType }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options { id name color description }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+    payload = run_graphql(query, {"id": project_id})
+    node = payload["data"].get("node")
+    if node is None:
+        raise ProjectError("GitHub Project was not found.")
+    fields: list[ProjectField] = []
+    for raw in node["fields"]["nodes"]:
+        if raw.get("__typename") not in ("ProjectV2Field", "ProjectV2SingleSelectField"):
+            continue
+        options = tuple(
+            SelectOption(
+                name=option["name"],
+                color=option["color"],
+                description=option.get("description", ""),
+                option_id=option.get("id"),
+            )
+            for option in raw.get("options", ())
+        )
+        fields.append(ProjectField(raw["id"], raw["name"], raw["dataType"], options))
+    return tuple(fields)
+
+
+def create_project(owner_id: str, title: str) -> ProjectInfo:
+    query = """
+mutation($ownerId: ID!, $title: String!) {
+  createProjectV2(input: {ownerId: $ownerId, title: $title}) {
+    projectV2 { id title }
+  }
+}
+"""
+    payload = run_graphql(query, {"ownerId": owner_id, "title": title})
+    project = payload["data"]["createProjectV2"]["projectV2"]
+    return ProjectInfo(project_id=project["id"], title=project["title"])
+
+
+def create_single_select_field(project_id: str, spec: SelectFieldSpec) -> None:
+    query = """
+mutation($projectId: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+  createProjectV2Field(input: {
+    projectId: $projectId,
+    dataType: SINGLE_SELECT,
+    name: $name,
+    singleSelectOptions: $options
+  }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name } }
+  }
+}
+"""
+    run_graphql(query, {"projectId": project_id, "name": spec.name, "options": options_payload(spec.options)})
+
+
+def update_single_select_field(field: ProjectField, spec: SelectFieldSpec) -> None:
+    query = """
+mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+  updateProjectV2Field(input: {
+    fieldId: $fieldId,
+    singleSelectOptions: $options
+  }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name } }
+  }
+}
+"""
+    run_graphql(query, {"fieldId": field.field_id, "options": options_payload(merged_options(field, spec))})
+
+
+def options_payload(options: tuple[SelectOption, ...]) -> list[dict[str, str]]:
+    payload: list[dict[str, str]] = []
+    for option in options:
+        item = {"name": option.name, "color": option.color, "description": option.description}
+        if option.option_id:
+            item["id"] = option.option_id
+        payload.append(item)
+    return payload
+
+
+def missing_option_names(field: ProjectField, spec: SelectFieldSpec) -> tuple[str, ...]:
+    existing = {option.name for option in field.options}
+    return tuple(option.name for option in spec.options if option.name not in existing)
+
+
+def fetch_issue_id(owner: str, name: str, number: int) -> str:
+    query = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) { id }
+  }
+}
+"""
+    payload = run_graphql(query, {"owner": owner, "name": name, "number": number})
+    issue = payload["data"]["repository"]["issue"]
+    if issue is None:
+        raise ProjectError(f"Issue #{number} was not found in {owner}/{name}.")
+    return issue["id"]
+
+
+def find_project_item_id(project_id: str, issue_id: str) -> str | None:
+    query = """
+query($projectId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          id
+          content { ... on Issue { id } }
+        }
+      }
+    }
+  }
+}
+"""
+    payload = run_graphql(query, {"projectId": project_id})
+    for item in payload["data"]["node"]["items"]["nodes"]:
+        if item.get("content", {}).get("id") == issue_id:
+            return item["id"]
+    return None
+
+
+def add_project_item(project_id: str, issue_id: str) -> str:
+    query = """
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+    item { id }
+  }
+}
+"""
+    payload = run_graphql(query, {"projectId": project_id, "contentId": issue_id})
+    return payload["data"]["addProjectV2ItemById"]["item"]["id"]
+
+
+def update_item_field(project_id: str, item_id: str, update: FieldUpdate) -> None:
+    query = """
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId,
+    itemId: $itemId,
+    fieldId: $fieldId,
+    value: {singleSelectOptionId: $optionId}
+  }) {
+    projectV2Item { id }
+  }
+}
+"""
+    run_graphql(
+        query,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": update.field_id,
+            "optionId": update.option_id,
+        },
+    )

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import pytest
+
+from base_github_projects import engine
+
+
+def test_parse_project_configure_arguments() -> None:
+    args = engine.parse_args(
+        (
+            "project",
+            "configure",
+            "--project",
+            "BankBuddy Roadmap",
+            "--owner",
+            "codeforester",
+            "--repo",
+            "codeforester/bankbuddy",
+            "--schema",
+            "base-roadmap",
+            "--initiative-option",
+            "MVP",
+            "--initiative-option",
+            "Imports",
+            "--dry-run",
+        )
+    )
+
+    assert args.area == "project"
+    assert args.command == "configure"
+    assert args.project_title == "BankBuddy Roadmap"
+    assert args.owner == "codeforester"
+    assert args.repo == "codeforester/bankbuddy"
+    assert args.schema == "base-roadmap"
+    assert args.initiative_options == ("MVP", "Imports")
+    assert args.dry_run is True
+
+
+def test_parse_project_arguments_accept_equals_options() -> None:
+    args = engine.parse_args(
+        (
+            "project",
+            "issue",
+            "set-fields",
+            "604",
+            "--project=Base Roadmap",
+            "--repo=codeforester/base",
+            "--status=Backlog",
+            "--priority=P2",
+            "--area=CLI",
+            "--initiative=v1.0 Readiness",
+            "--size=M",
+            "--dry-run",
+        )
+    )
+
+    assert args.command == "issue-set-fields"
+    assert args.project_title == "Base Roadmap"
+    assert args.repo == "codeforester/base"
+    assert args.issue_number == 604
+    assert args.field_values == {
+        "status": "Backlog",
+        "priority": "P2",
+        "area": "CLI",
+        "initiative": "v1.0 Readiness",
+        "size": "M",
+    }
+    assert args.dry_run is True
+
+
+def test_compare_schema_reports_missing_fields_wrong_types_and_missing_options() -> None:
+    fields = (
+        engine.ProjectField(field_id="status", name="Status", data_type="TEXT"),
+        engine.ProjectField(
+            field_id="priority",
+            name="Priority",
+            data_type="SINGLE_SELECT",
+            options=(
+                engine.SelectOption(name="P1", color="ORANGE", description="High priority", option_id="priority-p1"),
+            ),
+        ),
+    )
+
+    findings = engine.compare_schema(fields, engine.BASE_ROADMAP_SCHEMA)
+
+    assert engine.Finding("error", "Status", "Status exists with type TEXT; expected SINGLE_SELECT.") in findings
+    assert engine.Finding("missing", "Area", "Area field is missing.") in findings
+    assert engine.Finding("missing-option", "Priority", "Priority option P0 is missing.") in findings
+
+
+def test_configuration_plan_preserves_extra_options_and_adds_required_options() -> None:
+    field = engine.ProjectField(
+        field_id="priority",
+        name="Priority",
+        data_type="SINGLE_SELECT",
+        options=(
+            engine.SelectOption(name="P1", color="ORANGE", description="High priority", option_id="priority-p1"),
+            engine.SelectOption(name="Later", color="GRAY", description="Manual option", option_id="manual-later"),
+        ),
+    )
+
+    actions = engine.configuration_plan(
+        project_exists=True,
+        fields=(field,),
+        schema=engine.ProjectSchema(fields=(engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority"),)),
+    )
+
+    assert actions == (
+        engine.ConfigureAction("update-field", "Priority", "Add missing options: P0, P2, P3."),
+    )
+    updated = engine.merged_options(field, engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority"))
+    assert [option.name for option in updated] == ["P1", "Later", "P0", "P2", "P3"]
+    assert updated[0].option_id == "priority-p1"
+    assert updated[1].option_id == "manual-later"
+
+
+def test_resolve_issue_field_updates_returns_only_explicit_fields() -> None:
+    fields = (
+        engine.ProjectField(
+            field_id="status-field",
+            name="Status",
+            data_type="SINGLE_SELECT",
+            options=(
+                engine.SelectOption(name="Backlog", color="BLUE", description="Accepted", option_id="status-backlog"),
+            ),
+        ),
+        engine.ProjectField(
+            field_id="priority-field",
+            name="Priority",
+            data_type="SINGLE_SELECT",
+            options=(
+                engine.SelectOption(name="P2", color="YELLOW", description="Normal", option_id="priority-p2"),
+            ),
+        ),
+        engine.ProjectField(
+            field_id="area-field",
+            name="Area",
+            data_type="SINGLE_SELECT",
+            options=(
+                engine.SelectOption(name="CLI", color="GRAY", description="Command surface", option_id="area-cli"),
+            ),
+        ),
+    )
+
+    updates = engine.resolve_issue_field_updates(
+        fields,
+        {"status": "Backlog", "priority": "P2"},
+        project_title="Base Roadmap",
+    )
+
+    assert updates == (
+        engine.FieldUpdate("status-field", "status-backlog", "Status", "Backlog"),
+        engine.FieldUpdate("priority-field", "priority-p2", "Priority", "P2"),
+    )
+
+
+def test_resolve_issue_field_updates_reports_missing_initiative_option() -> None:
+    fields = (
+        engine.ProjectField(
+            field_id="initiative-field",
+            name="Initiative",
+            data_type="SINGLE_SELECT",
+            options=(),
+        ),
+    )
+
+    with pytest.raises(engine.ProjectUsageError) as excinfo:
+        engine.resolve_issue_field_updates(
+            fields,
+            {"initiative": "New Theme"},
+            project_title="Base Roadmap",
+        )
+
+    assert str(excinfo.value) == (
+        "Initiative option 'New Theme' was not found in Project 'Base Roadmap'. "
+        'Run `basectl gh project configure --project "Base Roadmap" '
+        '--initiative-option "New Theme"` first.'
+    )
+
+
+def test_doctor_command_fails_when_schema_is_incomplete(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        engine,
+        "find_owner_and_project",
+        lambda owner, title: engine.OwnerInfo(
+            owner_id="owner-id",
+            login=owner,
+            project=engine.ProjectInfo(project_id="project-id", title=title),
+        ),
+    )
+    monkeypatch.setattr(engine, "fetch_project_fields", lambda project_id: ())
+
+    status = engine.doctor_command(
+        engine.ProjectArguments(
+            area="project",
+            command="doctor",
+            project_title="Base Roadmap",
+            owner="codeforester",
+        )
+    )
+
+    assert status == 1
+    assert "MISSING Status" in capsys.readouterr().out
+
+
+def test_find_owner_and_project_uses_user_lookup_without_organization_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
+        assert "user(login:" in query
+        assert "organization(login:" not in query
+        assert variables == {"login": "codeforester"}
+        return {
+            "data": {
+                "user": {
+                    "id": "owner-id",
+                    "login": "codeforester",
+                    "projectsV2": {"nodes": [{"id": "project-id", "title": "Base Roadmap"}]},
+                }
+            }
+        }
+
+    monkeypatch.setattr(engine, "run_graphql", fake_run_graphql)
+
+    owner = engine.find_owner_and_project("codeforester", "Base Roadmap")
+
+    assert owner == engine.OwnerInfo(
+        owner_id="owner-id",
+        login="codeforester",
+        project=engine.ProjectInfo(project_id="project-id", title="Base Roadmap"),
+    )
+
+
+def test_find_owner_and_project_falls_back_to_organization_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_run_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
+        assert variables == {"login": "example-org"}
+        if "user(login:" in query:
+            calls.append("user")
+            raise engine.ProjectError("Could not resolve to a User with the login of 'example-org'.")
+        if "organization(login:" in query:
+            calls.append("organization")
+            return {
+                "data": {
+                    "organization": {
+                        "id": "owner-id",
+                        "login": "example-org",
+                        "projectsV2": {"nodes": []},
+                    }
+                }
+            }
+        raise AssertionError("unexpected GraphQL query")
+
+    monkeypatch.setattr(engine, "run_graphql", fake_run_graphql)
+
+    owner = engine.find_owner_and_project("example-org", "Roadmap")
+
+    assert calls == ["user", "organization"]
+    assert owner == engine.OwnerInfo(owner_id="owner-id", login="example-org", project=None)

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -37,10 +37,20 @@ assigned to `codeforester`.
 If assignment fails, the automation should mention that in its summary instead
 of silently leaving the issue unassigned.
 
-## Issue Project Status
+## Issue Project Metadata
 
-When an issue is tracked in the `Base Roadmap` Project, keep the issue's
-`Status` field aligned with the implementation train:
+When an issue is tracked in the `Base Roadmap` Project, use the standard
+Base roadmap fields:
+
+- `Status`: `Triage`, `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`
+- `Priority`: `P0`, `P1`, `P2`, `P3`
+- `Area`: `CLI`, `Setup`, `Workspace`, `Manifest`, `Runtime`, `Shell`,
+  `Python`, `Docs`, `CI`, `Packaging`, `Security`, `Product`
+- `Size`: `S`, `M`, `L`
+- `Initiative`: `BanyanLabs Dogfood`, `Workspace Handling`, `pyproject/uv`,
+  `v1.0 Readiness`, `Adoption Polish`
+
+Keep the issue's `Status` field aligned with the implementation train:
 
 - Set `Status` to `In Progress` before creating the implementation branch or
   starting work in a worktree.
@@ -53,6 +63,17 @@ When an issue is tracked in the `Base Roadmap` Project, keep the issue's
 
 Do not add pull requests as separate Project items by default. The issue owns
 milestone and Project tracking so roadmap views do not double count the work.
+
+`basectl repo init` and `basectl repo configure` configure the standard Project
+metadata by default when a GitHub repository is available. Use
+`basectl gh project` directly for lower-level Project inspection, schema
+repair, or issue field updates.
+
+```bash
+basectl gh project doctor --project "Base Roadmap" --owner codeforester
+basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap
+basectl gh project issue set-fields 604 --repo codeforester/base --project "Base Roadmap" --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
+```
 
 ## Preferred GitHub Interface
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -74,6 +74,15 @@ GitHub changes without applying them. In dry-run mode, `repo init` explicitly
 reports whether it would create a GitHub repository or why GitHub creation is
 being skipped.
 
+`repo init` and `repo configure` also configure the standard GitHub Project
+metadata schema by default when a GitHub repository is known. Pass
+`--no-project` to skip Project V2 metadata, `--project <title>` to override the
+Project title, `--project-owner <login>` to override the owner,
+`--project-schema base-roadmap` to select the schema, and repeat
+`--initiative-option <name>` to seed repository-specific Initiative values.
+`basectl gh project` is the lower-level direct surface for Project inspection,
+schema repair, and issue field updates.
+
 ## Local Baseline
 
 `repo init` creates these files when they do not already exist:
@@ -174,6 +183,7 @@ the current GitHub repository policy:
 - delete branch on merge enabled
 - squash commit message set to PR title and description
 - Base-managed default branch protection enabled
+- standard GitHub Project metadata enabled
 
 They also create or update these labels:
 
@@ -197,6 +207,23 @@ public and private repositories on GitHub Pro, Team, or Enterprise plans. When
 GitHub reports that rulesets are unavailable for a private repository's plan,
 `repo configure` leaves the supported settings and labels in place, logs a
 warning, and skips default branch protection.
+
+The Project metadata schema creates or updates single-select Project fields:
+
+- `Status`: `Triage`, `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`
+- `Priority`: `P0`, `P1`, `P2`, `P3`
+- `Area`: `CLI`, `Setup`, `Workspace`, `Manifest`, `Runtime`, `Shell`,
+  `Python`, `Docs`, `CI`, `Packaging`, `Security`, `Product`
+- `Size`: `S`, `M`, `L`
+- `Initiative`: `BanyanLabs Dogfood`, `Workspace Handling`, `pyproject/uv`,
+  `v1.0 Readiness`, `Adoption Polish`, plus values passed with
+  `--initiative-option`
+
+When Project V2 access is unavailable, `repo init` and `repo configure` log a
+warning that includes `gh auth refresh -h github.com -s project`, keep the
+supported repository settings in place, and skip Project metadata. Other
+Project errors remain failures because they can indicate a conflicting field
+schema or a broken GitHub request.
 
 In apply mode, GitHub configuration requires the GitHub CLI and an authenticated
 session:

--- a/docs/superpowers/plans/2026-06-11-github-project-roadmap-metadata.md
+++ b/docs/superpowers/plans/2026-06-11-github-project-roadmap-metadata.md
@@ -1,0 +1,684 @@
+# GitHub Project Roadmap Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `basectl repo init` and `basectl repo configure` land the
+standard Base GitHub repository and Project metadata configuration, and fix
+Base docs so `Status`, `Priority`, `Area`, `Size`, and `Initiative` are the
+standard issue Project fields.
+
+**Architecture:** Keep `basectl repo` as the user-facing onboarding entry
+point. Add a lower-level `basectl gh project` surface and focused Python module
+for GitHub Projects V2 GraphQL payloads, field matching, option matching, and
+dry-run reporting; `repo init` and `repo configure` delegate to that same
+Project engine after repository settings, labels, and branch protection. The
+feature is idempotent: schema configuration finds or creates the named Project,
+creates or updates the named fields and required options, preserves unrelated
+fields/options, and issue-field commands update only the explicit fields passed
+by the caller.
+
+**Tech Stack:** Bash command dispatch, Python `base_cli`, GitHub CLI
+`gh api graphql`, GitHub Projects V2 GraphQL API, BATS, pytest, ShellCheck,
+Zsh syntax checks, and Markdown docs.
+
+---
+
+## File Structure
+
+- Modify `docs/github-workflow.md`: document the canonical Project attributes
+  and synchronized option sets, including `Initiative`.
+- Modify `cli/bash/commands/basectl/subcommands/repo.sh`: add Project metadata
+  options to `repo init` and `repo configure`, default Project setup on, and
+  call the Project engine after repository GitHub settings.
+- Modify `cli/bash/commands/basectl/tests/repo.bats`: add default Project
+  configuration, opt-out, dry-run, and warning tests.
+- Modify `cli/bash/commands/basectl/subcommands/gh.sh`: add `project` to usage
+  and dispatch it to the Python engine through `base-wrapper`.
+- Create `cli/python/base_github_projects/__init__.py`: package marker.
+- Create `cli/python/base_github_projects/__main__.py`: module entry point.
+- Create `cli/python/base_github_projects/engine.py`: parse commands, run
+  GraphQL through `gh api graphql`, inspect/configure Project fields, add issue
+  items to Projects, and update single-select issue metadata.
+- Create `cli/python/base_github_projects/tests/test_engine.py`: unit tests for
+  argument parsing, schema comparison, dry-run output, GraphQL command building,
+  and item field update sequencing.
+- Modify `cli/bash/commands/basectl/tests/gh.bats`: add Bash dispatch and help
+  tests for `basectl gh project`.
+- Modify `cli/bash/commands/basectl/tests/completions.bats`: assert Bash
+  completion includes the new area and options.
+- Modify `lib/shell/completions/basectl_completion.sh`: complete
+  `gh project`, its subcommands, and supported options.
+- Modify `lib/shell/completions/basectl_completion.zsh`: add matching Zsh
+  completions.
+- Modify `cli/bash/commands/basectl/README.md`, `README.md`,
+  `.ai-context/COMMANDS.md`, and `.ai-context/WORKFLOWS.md`: document the
+  command surface and the repo/project boundary.
+- Modify `CHANGELOG.md`: add the user-visible command and documentation fix.
+
+## Canonical Schema
+
+Use this schema for `--schema base-roadmap`. Project-specific `Initiative`
+options are allowed, but the field itself is always required.
+
+```text
+Status:
+  Triage        GRAY    Needs clarification or initial classification.
+  Backlog       BLUE    Accepted but not yet scheduled.
+  Ready         GREEN   Scoped enough to pick up.
+  In Progress   YELLOW  Actively being worked on.
+  In Review     ORANGE  Pull request open, waiting on checks or review.
+  Done          PURPLE  Completed or no further work remains.
+
+Priority:
+  P0            RED     Urgent or blocking.
+  P1            ORANGE  High priority.
+  P2            YELLOW  Normal priority.
+  P3            BLUE    Low priority or opportunistic.
+
+Area:
+  CLI           GRAY    Command surface and user-facing CLI behavior.
+  Setup         GRAY    Installation, setup, check, and doctor behavior.
+  Workspace     GRAY    Workspace discovery and workspace-level commands.
+  Manifest      GRAY    Manifest schema and project contract handling.
+  Runtime       GRAY    Activation, shell runtime, and environment behavior.
+  Shell         GRAY    Shell libraries, completions, and startup files.
+  Python        GRAY    Python command packages and shared Python helpers.
+  Docs          GRAY    Documentation and AI context.
+  CI            GRAY    Continuous integration and validation automation.
+  Packaging     GRAY    Release, Homebrew, installer, and distribution work.
+  Security      GRAY    Permission, secret-handling, and hardening work.
+  Product       GRAY    Product direction, roadmap, and adoption work.
+
+Size:
+  S             GREEN   Small, focused change.
+  M             YELLOW  Medium change with multiple files or interactions.
+  L             ORANGE  Large change that should be split if possible.
+
+Initiative:
+  Field required. Options are project-owned. For Base Roadmap, seed:
+  BanyanLabs Dogfood, Workspace Handling, pyproject/uv, v1.0 Readiness,
+  Adoption Polish.
+```
+
+## Command Surface
+
+```bash
+basectl repo init bankbuddy --repo codeforester/bankbuddy
+basectl repo configure ~/work/bankbuddy --repo codeforester/bankbuddy
+basectl repo configure ~/work/bankbuddy --repo codeforester/bankbuddy --project "BankBuddy Roadmap" --initiative-option MVP --initiative-option Imports
+basectl repo configure ~/work/bankbuddy --repo codeforester/bankbuddy --no-project
+basectl gh project doctor --project "Base Roadmap" --owner codeforester
+basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap
+basectl gh project configure --project "BankBuddy Roadmap" --owner codeforester --schema base-roadmap --initiative-option MVP --initiative-option Imports
+basectl gh project issue set-fields 600 --repo codeforester/base --project "Base Roadmap" --owner codeforester --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
+```
+
+Rules:
+
+- `repo init` and `repo configure` enable standard Project metadata by default
+  when a GitHub repository is known.
+- `--no-project` skips Project V2 configuration.
+- `--project <title>` overrides the default Project title. The default is
+  `<RepositoryName> Roadmap`, except the Base repository uses `Base Roadmap`.
+- `--project-owner <login>` overrides the GitHub Project owner. The default is
+  the owner from `--repo <owner/name>` or the inferred `origin` repository.
+- `--project-schema base-roadmap` is the only schema in the first release.
+- `--initiative-option <name>` can be passed more than once and seeds
+  project-specific Initiative options.
+- If Project V2 access is missing during `repo init` or `repo configure`, log a
+  warning with `gh auth refresh -h github.com -s project` and keep the supported
+  repository settings in place.
+- `--project` is required for `doctor`, `configure`, and `issue set-fields`.
+- `--owner` defaults to the owner inferred from the current Git remote when
+  available; otherwise it is required.
+- `--repo <owner/name>` is required for `issue set-fields` unless the current
+  Git remote can infer it.
+- `configure` accepts `--dry-run` and prints the exact field/option changes it
+  would make.
+- `configure` creates missing `SINGLE_SELECT` fields. If a required field exists
+  with a different type, it fails and reports the mismatch.
+- `configure` updates required single-select options by name, preserving
+  unrelated options on the field.
+- `issue set-fields` adds the issue to the Project if needed, then updates only
+  the fields explicitly provided.
+- `issue set-fields` fails when a requested option is not present; it tells the
+  user to run `basectl gh project configure` with the needed
+  `--initiative-option` when the missing value is an Initiative.
+
+## Task 1: Fix The Documentation Contract
+
+**Files:**
+- Modify: `docs/github-workflow.md`
+- Modify: `.ai-context/WORKFLOWS.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] Update `docs/github-workflow.md` so the Projects section lists all five
+  canonical attributes: `Status`, `Priority`, `Area`, `Size`, and `Initiative`.
+- [ ] Replace the current partial `Area` option list with the schema above.
+- [ ] Add the Base Roadmap Initiative options from the schema above.
+- [ ] Update `.ai-context/WORKFLOWS.md` to say Project metadata uses those five
+  fields and that PRs should not be duplicate Project items.
+- [ ] Add a `CHANGELOG.md` Unreleased documentation entry:
+
+```markdown
+### Changed
+
+- Clarified that Base Roadmap Project metadata standardizes `Status`,
+  `Priority`, `Area`, `Size`, and `Initiative` fields.
+```
+
+- [ ] Run whitespace validation.
+
+```bash
+git diff --check
+```
+
+Expected: exit 0.
+
+## Task 2: Add RED Repo Entry-Point Tests
+
+**Files:**
+- Modify: `cli/bash/commands/basectl/tests/repo.bats`
+- Modify: `cli/bash/commands/basectl/tests/completions.bats`
+
+- [ ] Add a `repo configure --dry-run` test that expects Project metadata to be
+  configured by default:
+
+```bash
+[[ "$output" == *"Would configure GitHub Project 'Base Demo Roadmap' for 'codeforester/base-demo'."* ]]
+[[ "$output" == *"Status, Priority, Area, Size, Initiative"* ]]
+```
+
+- [ ] Add a `repo configure --no-project --dry-run` test that expects no
+  Project output.
+- [ ] Add a `repo configure --project "BankBuddy Roadmap" --project-owner
+  codeforester --initiative-option MVP --dry-run` test that expects those
+  values to be passed to the Project engine.
+- [ ] Add an apply-mode test that mocks `bin/base-wrapper` and expects:
+
+```text
+--project base base_github_projects project configure --project Base Demo Roadmap --owner codeforester --schema base-roadmap --repo codeforester/base-demo
+```
+
+- [ ] Add a Project-scope failure test where the Project engine returns exit 3
+  and stderr contains `gh auth refresh -h github.com -s project`; `repo
+  configure` should return success after warning because repository settings
+  still landed.
+- [ ] Add repo completion assertions for `--project`, `--project-owner`,
+  `--project-schema`, `--initiative-option`, and `--no-project`.
+- [ ] Run focused BATS and verify RED.
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats cli/bash/commands/basectl/tests/completions.bats
+```
+
+Expected: failure because repo Project options and Project engine delegation do
+not exist.
+
+## Task 3: Add RED Bash Dispatch And Completion Tests
+
+**Files:**
+- Modify: `cli/bash/commands/basectl/tests/gh.bats`
+- Modify: `cli/bash/commands/basectl/tests/completions.bats`
+
+- [ ] Add a help assertion to the existing `basectl gh prints help` test:
+
+```bash
+[[ "$output" == *"basectl gh project doctor --project <title>"* ]]
+[[ "$output" == *"basectl gh project configure --project <title>"* ]]
+[[ "$output" == *"basectl gh project issue set-fields <number>"* ]]
+```
+
+- [ ] Add a dispatch test that mocks `bin/base-wrapper` with a temporary wrapper
+  in `PATH` and expects `--project base base_github_projects project doctor`.
+
+```bash
+@test "basectl gh project dispatches to Python engine" {
+    cat > "$TEST_MOCKBIN/base-wrapper" <<'WRAPPER'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
+WRAPPER
+    chmod +x "$TEST_MOCKBIN/base-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main project doctor --project "Base Roadmap" --owner codeforester
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/wrapper-args")" = "--project base base_github_projects project doctor --project Base Roadmap --owner codeforester" ]
+}
+```
+
+- [ ] Add completion assertions for `project`, `doctor`, `configure`,
+  `issue`, `set-fields`, `--project`, `--owner`, `--schema`, `--dry-run`,
+  `--repo`, `--status`, `--priority`, `--area`, `--initiative`, and `--size`.
+- [ ] Run focused BATS and verify RED.
+
+```bash
+bats cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/completions.bats
+```
+
+Expected: failure because `gh project` dispatch and completions do not exist.
+
+## Task 4: Add Thin Bash Dispatch And Completions
+
+**Files:**
+- Modify: `cli/bash/commands/basectl/subcommands/gh.sh`
+- Modify: `lib/shell/completions/basectl_completion.sh`
+- Modify: `lib/shell/completions/basectl_completion.zsh`
+- Modify: `cli/bash/commands/basectl/README.md`
+
+- [ ] Update `base_gh_usage()` with:
+
+```text
+  basectl gh project doctor --project <title> [--owner <login>] [--schema base-roadmap]
+  basectl gh project configure --project <title> [--owner <login>] [--schema base-roadmap] [--initiative-option <name>] [--dry-run]
+  basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [field options...]
+```
+
+- [ ] Add a `base_gh_do_project()` helper:
+
+```bash
+base_gh_do_project() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+
+    [[ -x "$wrapper" ]] || {
+        base_gh_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+    "$wrapper" --project base base_github_projects project "$@"
+}
+```
+
+- [ ] Add `project) base_gh_do_project "$@" ;;` to
+  `base_gh_subcommand_main()`.
+- [ ] Update Bash and Zsh completions for the command surface in Task 2.
+- [ ] Update `cli/bash/commands/basectl/README.md` to mention Project metadata
+  support.
+- [ ] Run focused Bash/completion tests.
+
+```bash
+bats cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/completions.bats
+zsh -n lib/shell/completions/basectl_completion.zsh
+```
+
+Expected: Bash dispatch/completion tests pass; Python command tests still do not
+exist until Task 4.
+
+## Task 5: Add Python Project Schema Engine Tests
+
+**Files:**
+- Create: `cli/python/base_github_projects/__init__.py`
+- Create: `cli/python/base_github_projects/__main__.py`
+- Create: `cli/python/base_github_projects/engine.py`
+- Create: `cli/python/base_github_projects/tests/test_engine.py`
+
+- [ ] Create the package files with a minimal `main()` that returns 0 for help.
+- [ ] Add tests for `parse_args()`:
+  - `project doctor --project "Base Roadmap" --owner codeforester`
+  - `project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap --dry-run`
+  - `project issue set-fields 600 --repo codeforester/base --project "Base Roadmap" --owner codeforester --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M`
+- [ ] Add tests for `compare_schema(project, schema)`:
+  - missing fields produce missing-field findings
+  - wrong field type produces an error finding
+  - missing options produce missing-option findings
+  - extra options are preserved and do not fail doctor
+- [ ] Add tests for dry-run configure output:
+
+```text
+[DRY-RUN] Would create Project field Status as SINGLE_SELECT.
+[DRY-RUN] Would add Project option Area=CLI.
+[DRY-RUN] Would add Project option Initiative=v1.0 Readiness.
+```
+
+- [ ] Add tests for issue field update sequencing:
+  - resolve Project by owner/title
+  - resolve issue by repo/number
+  - add issue item to Project when missing
+  - update only provided fields
+  - fail when a provided option name is absent
+- [ ] Run pytest and verify RED.
+
+```bash
+PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_github_projects/tests -q
+```
+
+Expected: failure because the engine is only a stub.
+
+## Task 6: Implement Project Schema Discovery And Doctor
+
+**Files:**
+- Modify: `cli/python/base_github_projects/engine.py`
+- Modify: `cli/python/base_github_projects/tests/test_engine.py`
+
+- [ ] Define dataclasses:
+
+```python
+@dataclass(frozen=True)
+class SelectOption:
+    name: str
+    color: str
+    description: str
+    option_id: str | None = None
+
+@dataclass(frozen=True)
+class SelectFieldSpec:
+    name: str
+    options: tuple[SelectOption, ...]
+
+@dataclass(frozen=True)
+class ProjectField:
+    field_id: str
+    name: str
+    data_type: str
+    options: tuple[SelectOption, ...] = ()
+```
+
+- [ ] Encode the canonical schema from this plan as `BASE_ROADMAP_SCHEMA`.
+- [ ] Add `run_gh_graphql(query: str, variables: dict[str, str]) -> dict`.
+  It should run:
+
+```python
+subprocess.run(
+    ["gh", "api", "graphql"],
+    input=json.dumps({"query": query, "variables": variables}),
+    text=True,
+    capture_output=True,
+    check=False,
+)
+```
+
+- [ ] Add `find_project(owner: str, title: str)` that queries both
+  `user(login: $owner)` and `organization(login: $owner)` with
+  `projectsV2(first: 100)`, then matches `title` locally.
+- [ ] Add `fetch_project_fields(project_id: str)` using:
+
+```graphql
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      id
+      title
+      fields(first: 50) {
+        nodes {
+          __typename
+          ... on ProjectV2Field { id name dataType }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options { id name color description }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] Add `doctor` command rendering:
+
+```text
+OK      Status
+MISSING Initiative
+ERROR   Area exists with type TEXT; expected SINGLE_SELECT.
+```
+
+- [ ] Run tests.
+
+```bash
+PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_github_projects/tests -q
+```
+
+Expected: pass for parser, schema comparison, and doctor tests.
+
+## Task 7: Implement Idempotent Project Configure
+
+**Files:**
+- Modify: `cli/python/base_github_projects/engine.py`
+- Modify: `cli/python/base_github_projects/tests/test_engine.py`
+
+- [ ] Add `create_single_select_field(project_id, field_spec)` using:
+
+```graphql
+mutation($projectId: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+  createProjectV2Field(input: {
+    projectId: $projectId,
+    dataType: SINGLE_SELECT,
+    name: $name,
+    singleSelectOptions: $options
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField { id name }
+    }
+  }
+}
+```
+
+- [ ] Add `update_single_select_field(field, field_spec)` using
+  `updateProjectV2Field`. Build the option list as existing options by name
+  plus required missing options. Preserve existing option ids for existing
+  options.
+- [ ] For `Initiative`, combine existing options, Base defaults for
+  `"Base Roadmap"`, and any repeated `--initiative-option <name>` values.
+- [ ] In dry-run mode, print planned creates/updates and perform no mutations.
+- [ ] In apply mode, fail on wrong field types before making mutations.
+- [ ] Run tests.
+
+```bash
+PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_github_projects/tests -q
+```
+
+Expected: pass.
+
+## Task 8: Implement Issue Field Updates
+
+**Files:**
+- Modify: `cli/python/base_github_projects/engine.py`
+- Modify: `cli/python/base_github_projects/tests/test_engine.py`
+
+- [ ] Add issue lookup by repository and issue number:
+
+```graphql
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) { id number title }
+  }
+}
+```
+
+- [ ] Add project item lookup by content id:
+
+```graphql
+query($projectId: ID!, $contentId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          id
+          content { ... on Issue { id } }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] Add missing issue item through:
+
+```graphql
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+    item { id }
+  }
+}
+```
+
+- [ ] Add field updates through:
+
+```graphql
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId,
+    itemId: $itemId,
+    fieldId: $fieldId,
+    value: {singleSelectOptionId: $optionId}
+  }) {
+    projectV2Item { id }
+  }
+}
+```
+
+- [ ] Validate every provided option name before mutating. If `--initiative
+  "New Theme"` is not present, return:
+
+```text
+ERROR: Initiative option 'New Theme' was not found in Project 'Base Roadmap'. Run `basectl gh project configure --project "Base Roadmap" --initiative-option "New Theme"` first.
+```
+
+- [ ] Run tests.
+
+```bash
+PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_github_projects/tests -q
+```
+
+Expected: pass.
+
+## Task 9: Wire Repo Entry Point
+
+**Files:**
+- Modify: `cli/bash/commands/basectl/subcommands/repo.sh`
+- Modify: `cli/bash/commands/basectl/tests/repo.bats`
+- Modify: `lib/shell/completions/basectl_completion.sh`
+- Modify: `lib/shell/completions/basectl_completion.zsh`
+
+- [ ] Add usage text for:
+
+```text
+  --project <title>             GitHub Project title to configure. Defaults to <repo-name> Roadmap.
+  --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
+  --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
+  --initiative-option <name>    Initiative option to seed; may be repeated.
+  --no-project                  Skip GitHub Project metadata configuration.
+```
+
+- [ ] Parse these options in `base_repo_init()` and `base_repo_configure()`.
+- [ ] Add `base_repo_project_title "$repo"` that returns `Base Roadmap` for
+  `codeforester/base` and `<Title Case Repo Name> Roadmap` for other
+  repositories.
+- [ ] Add `base_repo_configure_project_metadata()` that calls:
+
+```bash
+"$BASE_HOME/bin/base-wrapper" --project base base_github_projects project configure \
+  --project "$project_title" \
+  --owner "$project_owner" \
+  --repo "$repo" \
+  --schema "$project_schema" \
+  "${initiative_options[@]/#/--initiative-option }"
+```
+
+- [ ] Build the repeated `--initiative-option <name>` arguments with an array
+  instead of string concatenation.
+- [ ] Treat Project engine exit code 3 as a warning in `repo init` and
+  `repo configure`, logging the engine output and continuing. Treat all other
+  nonzero exit codes as failures.
+- [ ] Include Project configuration in dry-run output after branch protection.
+- [ ] Run focused repo tests.
+
+```bash
+bats cli/bash/commands/basectl/tests/repo.bats
+```
+
+Expected: pass.
+
+## Task 10: Docs, Help, And Validation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/github-workflow.md`
+- Modify: `cli/bash/commands/basectl/README.md`
+- Modify: `.ai-context/COMMANDS.md`
+- Modify: `.ai-context/WORKFLOWS.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] Add examples for:
+
+```bash
+basectl gh project doctor --project "Base Roadmap" --owner codeforester
+basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap
+basectl gh project issue set-fields 600 --repo codeforester/base --project "Base Roadmap" --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
+```
+
+- [ ] State that `basectl repo init` and `basectl repo configure` are the
+  standard entry points for repository and Project V2 metadata setup, while
+  `basectl gh project` is the lower-level direct surface.
+- [ ] State that PRs are not added as duplicate Project items by default; the
+  issue owns Project metadata.
+- [ ] Add `CHANGELOG.md` Unreleased entries for the new command.
+- [ ] Run focused tests:
+
+```bash
+bats cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/completions.bats
+PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_github_projects/tests -q
+```
+
+Expected: pass.
+
+- [ ] Run shell checks and syntax checks:
+
+```bash
+shellcheck --severity=error cli/bash/commands/basectl/subcommands/gh.sh lib/shell/completions/basectl_completion.sh
+zsh -n lib/shell/completions/basectl_completion.zsh
+git diff --check
+```
+
+Expected: all exit 0.
+
+- [ ] Run full Base validation:
+
+```bash
+env -u BASE_HOME ./bin/base-test
+```
+
+Expected: full test suite passes.
+
+## Task 11: Publish Through The Base Train
+
+- [ ] Create a Base GitHub issue titled
+  `Add Base-managed GitHub Project roadmap metadata`.
+- [ ] Assign it to `codeforester`, label it `enhancement`, and add it to Base
+  Roadmap.
+- [ ] Set Project `Status` to `In Progress`.
+- [ ] Create branch
+  `enhancement/<issue>-20260611-github-project-roadmap-metadata` in a dedicated
+  worktree under `/Users/rameshhp/work/base-worktrees/`.
+- [ ] Implement the tasks above with focused commits.
+- [ ] Open a PR with `Fixes #<issue>`.
+- [ ] Set Project `Status` to `In Review`.
+- [ ] Watch CI and fix failures.
+- [ ] Squash merge when checks are green.
+- [ ] Verify issue closed and Project `Status` is `Done`.
+- [ ] Sync `/Users/rameshhp/work/base` with `git pull --ff-only`.
+- [ ] Run `git fetch --prune`.
+- [ ] Remove the task worktree and delete the local branch.
+
+## Self-Review
+
+- Spec coverage: the plan covers the documentation inconsistency, the explicit
+  `basectl gh project` command surface, reusable schema management, Base
+  Roadmap Initiative support, issue field updates, completions, docs, and full
+  validation.
+- Placeholder scan: no deferred implementation markers remain; each task has
+  concrete files, commands, or expected behavior.
+- Type consistency: command names, schema field names, and option names are
+  consistent across the command surface, tests, docs, and Python engine tasks.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -125,13 +125,13 @@ _base_basectl_completion() {
                     _base_basectl_completion_compgen "init check configure agent-guidance installer-template" "$cur"
                     ;;
                 init)
-                    _base_basectl_completion_compgen "--path --repo --description --copyright-holder --private --public --no-configure --no-protect-default-branch --dry-run -v -h --help" "$cur"
+                    _base_basectl_completion_compgen "--path --repo --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run -v -h --help" "$cur"
                     ;;
                 check)
                     _base_basectl_completion_compgen "--agent-guidance -v -h --help" "$cur"
                     ;;
                 configure)
-                    _base_basectl_completion_compgen "--repo --no-protect-default-branch --dry-run -v -h --help" "$cur"
+                    _base_basectl_completion_compgen "--repo --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run -v -h --help" "$cur"
                     ;;
                 agent-guidance)
                     _base_basectl_completion_compgen "--repo-name --default-branch --validation-command --dry-run -v -h --help" "$cur"
@@ -178,7 +178,7 @@ _base_basectl_completion() {
         gh)
             case "${COMP_WORDS[2]:-}" in
                 "")
-                    _base_basectl_completion_compgen "issue pr branch worktree todo" "$cur"
+                    _base_basectl_completion_compgen "issue pr branch worktree todo project" "$cur"
                     ;;
                 issue)
                     if ((COMP_CWORD == 3)); then
@@ -212,6 +212,26 @@ _base_basectl_completion() {
                     else
                         _base_basectl_completion_compgen "--dry-run --file -h --help" "$cur"
                     fi
+                    ;;
+                project)
+                    case "${COMP_WORDS[3]:-}" in
+                        "")
+                            _base_basectl_completion_compgen "doctor configure issue" "$cur"
+                            ;;
+                        doctor)
+                            _base_basectl_completion_compgen "--project --owner --schema -h --help" "$cur"
+                            ;;
+                        configure)
+                            _base_basectl_completion_compgen "--project --owner --schema --initiative-option --repo --dry-run -h --help" "$cur"
+                            ;;
+                        issue)
+                            if ((COMP_CWORD == 4)); then
+                                _base_basectl_completion_compgen "set-fields" "$cur"
+                            else
+                                _base_basectl_completion_compgen "--repo --project --owner --status --priority --area --initiative --size --dry-run -h --help" "$cur"
+                            fi
+                            ;;
+                    esac
                     ;;
             esac
             ;;

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -156,6 +156,11 @@ _base_basectl_completion() {
                         '--public[Create a public GitHub repository when needed]' \
                         '--no-configure[Skip GitHub configuration]' \
                         '--no-protect-default-branch[Skip Base-managed default branch protection]' \
+                        '--project[GitHub Project title]:title:' \
+                        '--project-owner[GitHub Project owner]:owner:' \
+                        '--project-schema[Project metadata schema]:schema:(base-roadmap)' \
+                        '--initiative-option[Initiative option to seed]:name:' \
+                        '--no-project[Skip GitHub Project metadata configuration]' \
                         '--dry-run[Print planned changes]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
@@ -172,6 +177,11 @@ _base_basectl_completion() {
                         '2:path:_files' \
                         '--repo[GitHub repository]:repo:' \
                         '--no-protect-default-branch[Skip Base-managed default branch protection]' \
+                        '--project[GitHub Project title]:title:' \
+                        '--project-owner[GitHub Project owner]:owner:' \
+                        '--project-schema[Project metadata schema]:schema:(base-roadmap)' \
+                        '--initiative-option[Initiative option to seed]:name:' \
+                        '--no-project[Skip GitHub Project metadata configuration]' \
                         '--dry-run[Print planned changes]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
@@ -268,7 +278,7 @@ _base_basectl_completion() {
         gh)
             case "${words[3]:-}" in
                 issue)
-                    _arguments '1:gh area:(issue pr branch worktree todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
                         '2:issue command:(list create start)' \
                         '--category[Issue category]:category:(bug enhancement documentation ci security)' \
                         '--title[Issue title]:title:' \
@@ -276,11 +286,11 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 pr)
-                    _arguments '1:gh area:(issue pr branch worktree todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
                         '2:pr command:(create status checks ready merge)'
                     ;;
                 branch)
-                    _arguments '1:gh area:(issue pr branch worktree todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
                         '2:branch command:(stale prune)' \
                         '--days[Stale threshold in days]:days:' \
                         '--dry-run[Show planned deletions]' \
@@ -289,21 +299,64 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 worktree)
-                    _arguments '1:gh area:(issue pr branch worktree todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
                         '2:worktree command:(prune)' \
                         '--dry-run[Show planned removals]' \
                         '--yes[Apply worktree pruning]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 todo)
-                    _arguments '1:gh area:(issue pr branch worktree todo)' \
+                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
                         '2:todo command:(import)' \
                         '--dry-run[Show planned issues]' \
                         '--file[TODO file]:path:_files' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
+                project)
+                    case "${words[4]:-}" in
+                        doctor)
+                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                                '2:project command:(doctor configure issue)' \
+                                '--project[GitHub Project title]:title:' \
+                                '--owner[GitHub Project owner]:owner:' \
+                                '--schema[Project metadata schema]:schema:(base-roadmap)' \
+                                '(-h --help)'{-h,--help}'[Show help text]'
+                            ;;
+                        configure)
+                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                                '2:project command:(doctor configure issue)' \
+                                '--project[GitHub Project title]:title:' \
+                                '--owner[GitHub Project owner]:owner:' \
+                                '--schema[Project metadata schema]:schema:(base-roadmap)' \
+                                '--initiative-option[Initiative option to seed]:name:' \
+                                '--repo[GitHub repository]:repo:' \
+                                '--dry-run[Print planned changes]' \
+                                '(-h --help)'{-h,--help}'[Show help text]'
+                            ;;
+                        issue)
+                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                                '2:project command:(doctor configure issue)' \
+                                '3:issue command:(set-fields)' \
+                                '4:issue number:' \
+                                '--repo[GitHub repository]:repo:' \
+                                '--project[GitHub Project title]:title:' \
+                                '--owner[GitHub Project owner]:owner:' \
+                                '--status[Status option]:status:' \
+                                '--priority[Priority option]:priority:' \
+                                '--area[Area option]:area:' \
+                                '--initiative[Initiative option]:initiative:' \
+                                '--size[Size option]:size:' \
+                                '--dry-run[Print planned changes]' \
+                                '(-h --help)'{-h,--help}'[Show help text]'
+                            ;;
+                        *)
+                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                                '2:project command:(doctor configure issue)'
+                            ;;
+                    esac
+                    ;;
                 *)
-                    _arguments '1:gh area:(issue pr branch worktree todo)'
+                    _arguments '1:gh area:(issue pr branch worktree todo project)'
                     ;;
             esac
             ;;


### PR DESCRIPTION
## Summary
- Add `basectl gh project` for Project V2 doctor, configure, and issue field updates.
- Make `basectl repo init` and `basectl repo configure` configure the standard roadmap Project metadata by default, with `--no-project` and schema override options.
- Document the canonical Status, Priority, Area, Size, and Initiative fields across README, repo baseline docs, GitHub workflow docs, and AI context.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests -q`
- `bats cli/bash/commands/basectl/tests/repo.bats cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/completions.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/gh.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`
- Live GitHub GraphQL schema introspection for Project V2 field and item update inputs

## Demo Impact
- None. Command and documentation behavior only.

## AI Context
- Updated `.ai-context/COMMANDS.md` and `.ai-context/WORKFLOWS.md`.

Fixes #604