### PR TITLE
Report repo helper file writes

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -288,6 +288,7 @@ base_repo_write_stream() {
         log_error "Failed to write '$target'."
         return 1
     fi
+    printf "Created '%s'.\n" "$target"
 }
 
 base_repo_write_executable_stream() {
@@ -315,6 +316,13 @@ base_repo_write_executable_stream() {
         log_error "Failed to make '$target' executable."
         return 1
     fi
+    printf "Created executable '%s'.\n" "$target"
+}
+
+base_repo_print_review_hint() {
+    local target_dir="$1"
+
+    printf "Run git -C '%s' status --short to review changes.\n" "$target_dir"
 }
 
 base_repo_installer_template_path() {
@@ -1645,7 +1653,10 @@ base_repo_agent_guidance() {
     }
     base_repo_validate_name "$repo_name" || return 2
 
-    base_repo_write_agent_guidance "$dry_run" "$repo_name" "$default_branch" "$validation_command" "$root"
+    base_repo_write_agent_guidance "$dry_run" "$repo_name" "$default_branch" "$validation_command" "$root" || return $?
+    if [[ "$dry_run" != "1" ]]; then
+        base_repo_print_review_hint "$root"
+    fi
 }
 
 base_repo_configure() {
@@ -1821,7 +1832,10 @@ base_repo_installer_template() {
     fi
 
     path="$(base_repo_target_path "$path")"
-    base_repo_write_installer_template "$dry_run" "$path"
+    base_repo_write_installer_template "$dry_run" "$path" || return $?
+    if [[ "$dry_run" != "1" ]]; then
+        base_repo_print_review_hint "$(dirname -- "$path")"
+    fi
 }
 
 base_repo_subcommand_main() {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -38,6 +38,16 @@ load ./basectl_helpers.bash
     grep -Fq 'PROJECT_NAME="${PROJECT_NAME:-example-project}"' "$repo_dir/install.sh"
 }
 
+@test "basectl repo installer-template reports non-dry-run creation" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo installer-template "$repo_dir/install.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Created executable '$repo_dir/install.sh'."* ]]
+    [[ "$output" == *"Run git -C '$repo_dir' status --short to review changes."* ]]
+}
+
 @test "basectl repo installer-template leaves existing files unchanged" {
     local repo_dir="$TEST_TMPDIR/custom"
 
@@ -70,6 +80,18 @@ load ./basectl_helpers.bash
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/skills.md'."* ]]
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/.github/pull_request_template.md'."* ]]
     [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo agent-guidance reports non-dry-run creation" {
+    local repo_dir="$TEST_TMPDIR/agent-demo"
+
+    run_basectl repo agent-guidance "$repo_dir" --repo-name base-demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Created '$repo_dir/AGENTS.md'."* ]]
+    [[ "$output" == *"Created '$repo_dir/skills.md'."* ]]
+    [[ "$output" == *"Created '$repo_dir/.github/pull_request_template.md'."* ]]
+    [[ "$output" == *"Run git -C '$repo_dir' status --short to review changes."* ]]
 }
 
 @test "basectl repo agent-guidance prints command-specific help" {


### PR DESCRIPTION
## Summary

- Print created-file confirmations for repo helper writes.
- Add review hints for `repo agent-guidance` and `repo installer-template` so users know where to run `git status`.
- Cover non-dry-run output for both commands in BATS.

## Validation

```bash
bats --filter 'reports non-dry-run creation' cli/bash/commands/basectl/tests/repo.bats
# 1..2
# ok 1 basectl repo installer-template reports non-dry-run creation
# ok 2 basectl repo agent-guidance reports non-dry-run creation

bats cli/bash/commands/basectl/tests/repo.bats
# 1..43
# ok 43 basectl repo configure can infer GitHub repo from origin remote

git diff --check
git diff --cached --check
```

Fixes #621
