### PR TITLE
Make activate prefer uv project venvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Fixed documentation drift for `basectl logs` syntax, project virtual
   environment location, and README coverage of the `basectl ci` command.
+- Made `basectl activate` prefer a uv project's repo-local `.venv` when
+  `pyproject.toml` and `uv.lock` are present, avoiding a misleading
+  Base-managed virtual environment in activated shells.
 
 ## [0.4.4] - 2026-06-12
 

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -32,11 +32,23 @@ base_activate_resolve_project() {
     env -u BASE_PROJECT_VENV_DIR "$wrapper" --project base base_projects resolve "$project" "$@"
 }
 
+base_activate_project_uses_uv() {
+    local project_root="$1"
+
+    [[ -n "$project_root" && -f "$project_root/pyproject.toml" && -f "$project_root/uv.lock" ]]
+}
+
 base_activate_project_venv_dir() {
     local project="$1"
+    local project_root="${2:-}"
 
     if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
         printf '%s\n' "$BASE_PROJECT_VENV_DIR"
+        return 0
+    fi
+
+    if base_activate_project_uses_uv "$project_root"; then
+        printf '%s\n' "$project_root/.venv"
         return 0
     fi
 
@@ -44,7 +56,7 @@ base_activate_project_venv_dir() {
 }
 
 base_activate_subcommand_main() {
-    local project="" wrapper resolve_output activate_shell
+    local project="" wrapper resolve_output activate_shell venv_fix
     local resolved_name project_root manifest_path venv_dir shell_rc
     local preserve_cwd="${BASE_ACTIVATE_PRESERVE_CWD:-0}"
     local args=()
@@ -105,9 +117,13 @@ base_activate_subcommand_main() {
         fatal_error "Unable to resolve project '$project'."
     }
 
-    venv_dir="$(base_activate_project_venv_dir "$resolved_name")"
+    venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root")"
+    venv_fix="Run 'basectl setup $resolved_name' first."
+    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_activate_project_uses_uv "$project_root"; then
+        venv_fix="Run 'uv sync' in '$project_root' first."
+    fi
     [[ -x "$venv_dir/bin/python" ]] || {
-        fatal_error "Project virtual environment Python was not found at '$venv_dir/bin/python'. Run 'basectl setup $resolved_name' first."
+        fatal_error "Project virtual environment Python was not found at '$venv_dir/bin/python'. $venv_fix"
     }
 
     shell_rc="$BASE_HOME/lib/bash/runtime/bashrc"

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -91,6 +91,77 @@ EOF
     [[ "$output" == *"BASE_PROJECT_VENV_DIR=$TEST_TMPDIR/custom-venv"* ]]
 }
 
+@test "basectl activate prefers uv project .venv when uv lockfile is present" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    mkdir -p "$(dirname "$base_python")" "$workspace/demo/.venv/bin"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'BASE_PROJECT_VENV_DIR=%s\n' "$BASE_PROJECT_VENV_DIR"
+EOF
+    printf '#!/usr/bin/env bash\n' > "$workspace/demo/.venv/bin/python"
+    chmod +x "$base_python" "$workspace/demo/.venv/bin/python" "$fake_bash"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf '[project]\nname = "demo"\n' > "$workspace/demo/pyproject.toml"
+    printf 'version = 1\n' > "$workspace/demo/uv.lock"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_ACTIVATE_SHELL="$fake_bash" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"BASE_PROJECT_VENV_DIR=$workspace/demo/.venv"* ]]
+}
+
+@test "basectl activate guides uv projects to create the uv environment" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$base_python")" "$workspace/demo"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$base_python"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf '[project]\nname = "demo"\n' > "$workspace/demo/pyproject.toml"
+    printf 'version = 1\n' > "$workspace/demo/uv.lock"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Project virtual environment Python was not found at '$workspace/demo/.venv/bin/python'."* ]]
+    [[ "$output" == *"Run 'uv sync' in '$workspace/demo' first."* ]]
+    [[ "$output" != *"Run 'basectl setup demo' first."* ]]
+}
+
 @test "basectl default runtime shell preserves caller working directory" {
     local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local project_activate="$TEST_HOME/.base.d/base/.venv/bin/activate"

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -109,6 +109,25 @@ and does not treat `[tool.base]` as an alternate manifest.
 Future uv-managed Python support should use an explicit `python:` manifest
 contract, tracked separately from the first read-only diagnostics slice.
 
+## Interim `uv` Activation Behavior
+
+Until the full uv-managed Python contract is implemented, `basectl activate`
+uses a conservative project-shape detector to avoid a misleading dual-venv
+shell. When the project root contains both `pyproject.toml` and `uv.lock`, and
+the caller has not set `BASE_PROJECT_VENV_DIR`, activation uses the repo-local
+uv environment at:
+
+```text
+<project-root>/.venv
+```
+
+This only affects the activated shell's virtual environment path. It does not
+make Base install dependencies from `pyproject.toml`, run `uv sync`, enforce the
+lockfile, or delegate `basectl run` through `uv run`. Full uv-managed setup,
+diagnostics, and command delegation remain part of the later uv support work.
+If the repo-local uv environment does not exist yet, activation asks the user to
+run `uv sync` in the project root.
+
 ## Non-Goals
 
 The structured Python section should not turn Base into a Python packaging

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -108,7 +108,7 @@ are available to project commands, runtime shells, and activation scripts.
 | `BASE_PROJECT` | Base | Resolved project name. Used by Base wrappers, prompts, logs, and project command dispatch. | Do not change after project resolution. Readonly in interactive Base runtime Bash shells. |
 | `BASE_PROJECT_ROOT` | Base | Physical project root directory. Project commands run from this directory. | Do not change after project resolution. Readonly in interactive Base runtime Bash shells. |
 | `BASE_PROJECT_MANIFEST` | Base | Physical path to the project's `base_manifest.yaml`. | Do not change after project resolution. Readonly in interactive Base runtime Bash shells. |
-| `BASE_PROJECT_VENV_DIR` | Shared | Project virtual environment directory. Users may set it before `basectl activate`, `basectl run`, or `basectl demo` to override the default `~/.base.d/<project>/.venv`. | May be set before project resolution. Do not change after Base resolves the project. Readonly in interactive Base runtime Bash shells. |
+| `BASE_PROJECT_VENV_DIR` | Shared | Project virtual environment directory. Users may set it before `basectl activate`, `basectl run`, or `basectl demo` to override the default. Activation defaults to `~/.base.d/<project>/.venv`, except uv-shaped projects with both `pyproject.toml` and `uv.lock` default to `<project-root>/.venv`. | May be set before project resolution. Do not change after Base resolves the project. Readonly in interactive Base runtime Bash shells. |
 
 Readonly shell attributes do not cross arbitrary process boundaries. For
 example, `basectl run` exports project variables to the project command process,


### PR DESCRIPTION
## Summary
- Make `basectl activate` prefer `<project-root>/.venv` for uv-shaped projects with both `pyproject.toml` and `uv.lock`.
- Preserve explicit `BASE_PROJECT_VENV_DIR` overrides and existing Base-managed venv defaults for non-uv projects.
- Add uv activation docs and changelog coverage, including the `uv sync` hint when the uv environment is missing.

## Validation
- `env -u BASE_HOME bats cli/bash/commands/basectl/tests/activate.bats --filter "prefers uv project"`
- `env -u BASE_HOME bats cli/bash/commands/basectl/tests/activate.bats --filter "guides uv projects"`
- `env -u BASE_HOME bats cli/bash/commands/basectl/tests/activate.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact
- Improves BankBuddy dogfood activation by avoiding the mismatched Base-managed venv warning for uv projects.

Closes #625
Related: #359