### PR TITLE
Fix review documentation gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,9 @@ for issue-backed work, validation, and design-only sessions.
    enhancement/179-20260528-projects-list-json
    ```
 
+   `basectl gh issue start <number>` can generate the branch name and matching
+   `git worktree add` command from the issue label and title.
+
 5. Use an isolated Git worktree for each pull request:
 
    ```bash
@@ -66,14 +69,14 @@ available for local edits:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --source
-~/work/base/bin/basectl setup --dev
+~/work/base/bin/basectl setup --profile dev
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l
 ```
 
 `bootstrap.sh` installs missing first-mile prerequisites such as Homebrew, Git,
-and Bash 4.2+ before handing off to `basectl`. `basectl setup --dev` installs
-developer prerequisites such as BATS, the GitHub CLI, and ShellCheck. See
+and Bash 4.2+ before handing off to `basectl`. `basectl setup --profile dev`
+installs developer prerequisites such as BATS, the GitHub CLI, and ShellCheck. See
 [First-Mile Bootstrap](docs/bootstrap.md) for install modes and boundaries.
 
 ## Running Tests
@@ -93,9 +96,9 @@ workspace discovery, setup/check/doctor behavior, shell profile wiring, or
 installation layout assumptions. See [Testing](docs/testing.md) for the testing
 layers and integration-test boundaries.
 
-Use `basectl setup --dev` to install developer prerequisites such as BATS, the
-GitHub CLI, and ShellCheck. Use `basectl check --dev` or `basectl doctor --dev`
-to diagnose missing developer tools.
+Use `basectl setup --profile dev` to install developer prerequisites such as
+BATS, the GitHub CLI, and ShellCheck. Use `basectl check --profile dev` or
+`basectl doctor --profile dev` to diagnose missing developer tools.
 
 Shell files should pass ShellCheck. Python changes should pass the existing
 Python tests and lint workflows.

--- a/FAQ.md
+++ b/FAQ.md
@@ -178,14 +178,14 @@ Base reports Homebrew's suggested dry-run command when it sees this failure.
 Run the dry-run first and inspect the files Homebrew would overwrite:
 
 ```bash
-brew link --overwrite python@3.14 --dry-run
+brew link --overwrite python@3.13 --dry-run
 ```
 
 If the dry-run only lists stale files you are comfortable replacing, run the
 same command without `--dry-run`, then rerun the Base setup command:
 
 ```bash
-brew link --overwrite python@3.14
+brew link --overwrite python@3.13
 basectl setup --profile sre
 ```
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -382,8 +382,8 @@ Recommended fields:
 
 - `Status`: Triage, Backlog, Ready, In Progress, In Review, Done
 - `Priority`: P0, P1, P2, P3
-- `Area`: CLI, Setup, Manifest, Shell, Python, Docs, CI, Packaging, Security,
-  Product
+- `Area`: CLI, Setup, Workspace, Manifest, Runtime, Shell, Python, Docs, CI,
+  Packaging, Security, Product
 - `Size`: S, M, L
 - `PR Train`: optional text field for batch work
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,7 +74,9 @@ Complete these steps in `codeforester/base`:
 2. Create a release-prep branch and worktree from `origin/master`.
 3. Update release metadata:
    - `VERSION`
-   - README version badge and current-release text
+   - README version badge
+   - README `Current Status` section current-release prose
+   - `.ai-context/STATUS.md` `Current Release` section
    - `CHANGELOG.md`, moving relevant `Unreleased` entries into the new release
      section
 4. Validate the release-prep PR:


### PR DESCRIPTION
## Summary

- Correct the FAQ Homebrew Python recovery commands to use the current `python@3.13` default.
- Replace stale `--dev` contributor commands with `--profile dev` and point branch setup to `basectl gh issue start`.
- Reconcile release checklist and Project Area documentation with the maintained Base workflow fields.

## Issue

Closes #627
Closes #628
Closes #629
Closes #631
Closes #633

Multi-issue exception: these are tightly scoped documentation corrections from the same review batch.

## Validation

- `git diff --check`
- `rg -n -- 'python@3\\.14|basectl (setup|check|doctor) --dev|`Area`: CLI, Setup, Manifest' FAQ.md CONTRIBUTING.md docs/github-workflow.md` returned no matches.\n- `env -u BASE_HOME ./bin/base-test`\n  - Python: 385 passed, 1 skipped\n  - BATS: completed through `ok 431`\n\n## Demo Impact\n\nNone. Documentation-only change.\n\n## Notes\n\n`.ai-context/` is not changed because this PR updates the release checklist for future release metadata edits; it does not change the current published release context.\n\n## Checklist\n\n- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.\n- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.\n- [x] PR body explains what changed and how it was validated.\n- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.\n- [x] Relevant BATS and Python tests pass.\n- [x] Bug fixes include regression proof or a documented reproduction when practical.\n- [x] Documentation is updated when behavior or user-facing commands change.\n- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.\n- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.\n- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`