### PR TITLE
Define macOS support floor and add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,49 @@ jobs:
             tests/base_init.bats \
             tests/install.bats
 
+  macos:
+    name: macOS smoke tests
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Homebrew tools
+        run: |
+          brew install bash bats-core
+          echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
+
+      - name: Run Base setup and check smoke tests
+        run: |
+          ./bin/basectl ci setup base --format json
+          ./bin/basectl ci check base --format json
+
+      - name: Verify shell profile integration
+        run: |
+          test_home="$(mktemp -d)"
+          brew_bash="$(brew --prefix)/bin/bash"
+
+          HOME="$test_home" ./bin/basectl update-profile
+          test -f "$test_home/.bash_profile"
+          test -f "$test_home/.bashrc"
+
+          env -u BASE_HOME \
+            HOME="$test_home" \
+            PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+            "$brew_bash" --rcfile "$test_home/.bashrc" -i -c 'command -v basectl >/dev/null && basectl --version'
+
+      - name: Run focused macOS BATS tests
+        run: |
+          bats \
+            cli/bash/commands/basectl/tests/update-profile.bats \
+            tests/base_init.bats \
+            tests/install.bats
+
   integration:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -916,12 +916,21 @@ Python installed through Base setup.
 
 Intended supported platforms are:
 
-- macOS on Apple Silicon
-- macOS on Intel Macs
+- macOS 14 Sonoma or newer on Apple Silicon
+- macOS 14 Sonoma or newer on Intel Macs
 - at least one Linux variant in the future, with the first target still to be decided
 
-The supported macOS version floor is still TBD. Linux support is a design target,
-but not yet an implemented or tested support contract. Windows is out of scope.
+The supported macOS version floor is macOS 14 Sonoma. Support means Base is
+tested and expected to work on macOS 14 or newer with Homebrew's supported
+install contract, Xcode Command Line Tools, a Homebrew-managed Bash, Git, and
+Python installed through Base setup. Older macOS releases may work from source,
+but they are outside Base's tested support contract. Linux support is a design
+target, but not yet an implemented or tested support contract. Windows is out of
+scope.
+
+The macOS CI floor runs on GitHub's `macos-14` runner. Newer macOS runners may
+be added for coverage, but the floor job should stay until Base intentionally
+raises the support floor.
 
 OS-specific behavior should stay isolated behind small helpers instead of being
 scattered through command code. For example, the Base runtime prompt can prefer

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -20,6 +20,10 @@ The formula points at a versioned tag archive and records that archive's
 `sha256`, so the archive must be available before the formula can be updated and
 validated. Supported macOS installs should use Homebrew bottles; source builds
 remain a fallback for unsupported hosts or explicit source-build validation.
+Base's current supported macOS floor is macOS 14 Sonoma. Keep Homebrew bottle
+workflows, formula validation, and Base's macOS CI floor aligned with that
+support contract until the Compatibility section in the top-level README is
+changed intentionally.
 
 ## Version Policy
 


### PR DESCRIPTION
## Summary

- Define macOS 14 Sonoma as Base's supported macOS floor for Apple Silicon and Intel Macs.
- Record that Homebrew bottle validation and the Base macOS CI floor should stay aligned with the README compatibility contract.
- Add a `macos-14` smoke job that installs Homebrew Bash/BATS, runs `basectl ci setup` and `basectl ci check`, verifies generated shell profile integration in an isolated `HOME`, and runs focused macOS BATS coverage.

## Issue

Closes #630
Closes #632

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "yaml ok"'`
- Isolated profile smoke: generated temporary `.bash_profile` and `.bashrc`, then resolved `basectl 0.4.4` through the generated Bash startup path.
- `env -u BASE_HOME ./bin/base-test`
  - Python: 385 passed, 1 skipped
  - BATS: completed through `ok 431`

The new hosted `macos-14` job itself will first run in GitHub Actions on this PR.

## Demo Impact

None. CI and compatibility documentation only.

## Notes

The macOS floor is set to Sonoma because Homebrew's current install requirements are macOS 14 or newer, and GitHub Actions exposes a `macos-14` runner suitable for a support-floor smoke job.

`.ai-context/` is not changed because this PR updates support policy and CI coverage, not the current release/status context.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
