### PR TITLE
Create repo projects from base template

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,13 +409,13 @@ basectl repo check ~/work/example --agent-guidance
 
 `repo configure` is intentionally idempotent. It enables Issues and Projects,
 standardizes merge settings, deletes branches after merge, applies the
-Base-managed default branch protection ruleset, configures standard GitHub
-Project metadata fields, and creates the standard GitHub labels documented in
-[Repository Baseline](docs/repo-baseline.md).
+Base-managed default branch protection ruleset, configures a repo-named GitHub
+Project copied from `base-project-template`, and creates the standard GitHub
+labels documented in [Repository Baseline](docs/repo-baseline.md).
 Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and
-`--initiative-option` when the default roadmap title or Initiative values need
+`--initiative-option` when the default Project title or Initiative values need
 to vary by repository.
 
 Run a discovered project's declared test command with:

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -84,9 +84,12 @@ such command directories exist. Optional utility CLIs such as `caff` and
   then falls back to the parent directory of `BASE_HOME`.
   `basectl repo check [path]` verifies the local baseline, and
   `basectl repo configure [path]` reapplies the GitHub settings, labels,
-  default branch protection, and standard GitHub Project metadata. Use
-  `--no-project` to skip Project metadata or `--initiative-option <name>` to
-  seed repository-specific Initiative values.
+  default branch protection, and standard repo Project setup. By default, the
+  Project title matches the repository name; missing Projects are copied from
+  `base-project-template`, linked to the repository, and backfilled with
+  repository issues. Use `--no-project` to skip Project setup,
+  `--project <title>` to override the Project title, or
+  `--initiative-option <name>` to seed repository-specific Initiative values.
   `basectl repo agent-guidance [path]` seeds optional repo-local agent guidance
   files and `basectl repo check [path] --agent-guidance` verifies that optional
   layer for repos that opt in.

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -46,7 +46,7 @@ Options:
   --public                      Create a public GitHub repository when needed.
   --no-configure                Skip GitHub configuration during repo init.
   --no-protect-default-branch   Skip Base-managed default branch protection during repo configure.
-  --project <title>             GitHub Project title to configure. Defaults to <repo-name> Roadmap.
+  --project <title>             GitHub Project title to configure. Defaults to the repository name.
   --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
   --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
   --initiative-option <name>    Initiative option to seed. May be repeated.
@@ -945,16 +945,9 @@ base_repo_title_case_name() {
 }
 
 base_repo_default_project_title() {
-    local name
     local repo="$1"
 
-    name="${repo#*/}"
-    if [[ "$repo" == "codeforester/base" || "$name" == "base" ]]; then
-        printf '%s\n' "Base Roadmap"
-        return 0
-    fi
-
-    printf '%s Roadmap\n' "$(base_repo_title_case_name "$name")"
+    printf '%s\n' "${repo#*/}"
 }
 
 base_repo_project_owner_from_repo() {
@@ -977,6 +970,9 @@ base_repo_configure_project_metadata() {
 
     if [[ "$dry_run" == "1" ]]; then
         printf "[DRY-RUN] Would configure GitHub Project '%s' for '%s'.\n" "$project_title" "$repo"
+        printf "[DRY-RUN] Would copy GitHub Project 'base-project-template' to '%s' if missing.\n" "$project_title"
+        printf "[DRY-RUN] Would link GitHub Project '%s' to repository '%s'.\n" "$project_title" "$repo"
+        printf "[DRY-RUN] Would backfill issues from '%s' into GitHub Project '%s'.\n" "$repo" "$project_title"
         printf "[DRY-RUN] Would run: %s --project base base_github_projects project configure --project %s --owner %s --repo %s --schema %s" \
             "$wrapper" \
             "$(base_repo_pretty_arg "$project_title")" \

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -428,7 +428,10 @@ EOF
     run_basectl repo configure "$repo_dir" --repo codeforester/base-demo --dry-run
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Would configure GitHub Project 'Base Demo Roadmap' for 'codeforester/base-demo'."* ]]
+    [[ "$output" == *"Would configure GitHub Project 'base-demo' for 'codeforester/base-demo'."* ]]
+    [[ "$output" == *"Would copy GitHub Project 'base-project-template' to 'base-demo' if missing."* ]]
+    [[ "$output" == *"Would link GitHub Project 'base-demo' to repository 'codeforester/base-demo'."* ]]
+    [[ "$output" == *"Would backfill issues from 'codeforester/base-demo' into GitHub Project 'base-demo'."* ]]
     [[ "$output" == *"--schema base-roadmap"* ]]
     [[ "$output" == *"Status, Priority, Area, Size, Initiative"* ]]
 }
@@ -527,7 +530,7 @@ EOF
 
     [ "$status" -eq 0 ]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project Base Demo Roadmap --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
 }
 
 @test "basectl repo configure warns when project metadata needs GitHub project scope" {
@@ -733,7 +736,7 @@ EOF
     [ -f "$repo_dir/base_manifest.yaml" ]
     grep -Fq "repo create codeforester/base-demo --private --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project Base Demo Roadmap --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
     ! grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"
 }
 

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -80,6 +80,12 @@ class ProjectInfo:
 
 
 @dataclass(frozen=True)
+class ProjectView:
+    name: str
+    layout: str
+
+
+@dataclass(frozen=True)
 class OwnerInfo:
     owner_id: str
     login: str
@@ -161,6 +167,13 @@ BASE_ROADMAP_SCHEMA = ProjectSchema(
 )
 
 
+DEFAULT_TEMPLATE_PROJECT = "base-project-template"
+STANDARD_TEMPLATE_VIEWS = (
+    ProjectView("Backlog", "TABLE_LAYOUT"),
+    ProjectView("Board", "BOARD_LAYOUT"),
+    ProjectView("By Status", "TABLE_LAYOUT"),
+    ProjectView("Roadmap", "ROADMAP_LAYOUT"),
+)
 FIELD_OPTION_TO_PROJECT_FIELD = {
     "status": "Status",
     "priority": "Priority",
@@ -496,20 +509,29 @@ def configure_command(args: ProjectArguments) -> int:
     schema = schema_for_args(args)
     owner_info = find_owner_and_project(owner, args.project_title or "")
     project = owner_info.project
+    should_copy_template = args.repo is not None and project is None
     fields: tuple[ProjectField, ...] = ()
     if project is not None:
         fields = fetch_project_fields(project.project_id)
-    actions = configuration_plan(project_exists=project is not None, fields=fields, schema=schema)
+    actions = (
+        ()
+        if should_copy_template
+        else configuration_plan(project_exists=project is not None, fields=fields, schema=schema)
+    )
     errors = [action for action in actions if action.action == "error"]
     if errors:
         for action in errors:
             print(f"ERROR   {action.name}  {action.message}", file=sys.stderr)
         return 1
     if args.dry_run:
-        render_dry_run_configure(args, actions)
+        render_dry_run_configure(args, actions, would_copy_template=should_copy_template)
         return 0
     if project is None:
-        project = create_project(owner_info.owner_id, args.project_title or "")
+        if args.repo:
+            project = copy_template_project(owner, owner_info.owner_id, args.project_title or "")
+            verify_standard_template_views(fetch_project_views(project.project_id))
+        else:
+            project = create_project(owner_info.owner_id, args.project_title or "")
         fields = fetch_project_fields(project.project_id)
     by_name = {field.name: field for field in fields}
     for spec in schema.fields:
@@ -518,15 +540,26 @@ def configure_command(args: ProjectArguments) -> int:
             create_single_select_field(project.project_id, spec)
         elif missing_option_names(field, spec):
             update_single_select_field(field, spec)
+    if args.repo:
+        link_project_to_repository(project.project_id, args.repo)
+        count = backfill_repository_issues(project.project_id, args.repo)
+        print(f"✓ Backfilled {count} issue(s) from {args.repo}")
     print(f"✓ Configured GitHub Project {args.project_title}")
     return 0
 
 
-def render_dry_run_configure(args: ProjectArguments, actions: tuple[ConfigureAction, ...]) -> None:
+def render_dry_run_configure(
+    args: ProjectArguments, actions: tuple[ConfigureAction, ...], *, would_copy_template: bool = False
+) -> None:
     print(
         f"[DRY-RUN] Would configure GitHub Project '{args.project_title}' "
         f"for '{args.repo or args.owner or ''}' with --schema {args.schema}."
     )
+    if would_copy_template:
+        print(f"[DRY-RUN] Would copy GitHub Project '{DEFAULT_TEMPLATE_PROJECT}' to '{args.project_title}'.")
+    if args.repo:
+        print(f"[DRY-RUN] Would link GitHub Project '{args.project_title}' to repository '{args.repo}'.")
+        print(f"[DRY-RUN] Would backfill issues from '{args.repo}' into GitHub Project '{args.project_title}'.")
     print("[DRY-RUN] Fields: Status, Priority, Area, Size, Initiative")
     if args.initiative_options:
         for option in args.initiative_options:
@@ -662,6 +695,13 @@ def find_owner_and_project(owner: str, title: str) -> OwnerInfo:
     return OwnerInfo(owner_id=owner_node["id"], login=owner_node["login"], project=project)
 
 
+def copy_template_project(owner: str, owner_id: str, title: str) -> ProjectInfo:
+    template = find_owner_and_project(owner, DEFAULT_TEMPLATE_PROJECT).project
+    if template is None:
+        raise ProjectError(f"Template Project '{DEFAULT_TEMPLATE_PROJECT}' was not found for owner '{owner}'.")
+    return copy_project(template.project_id, owner_id, title)
+
+
 def find_owner_node(kind: str, owner: str) -> dict[str, object] | None:
     query = f"""
 query($login: String!) {{
@@ -730,6 +770,38 @@ query($id: ID!) {
     return tuple(fields)
 
 
+def fetch_project_views(project_id: str) -> tuple[ProjectView, ...]:
+    query = """
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      views(first: 20) {
+        nodes { name layout }
+      }
+    }
+  }
+}
+"""
+    payload = run_graphql(query, {"id": project_id})
+    node = payload["data"].get("node")
+    if node is None:
+        raise ProjectError("GitHub Project was not found.")
+    return tuple(ProjectView(raw["name"], raw["layout"]) for raw in node["views"]["nodes"])
+
+
+def verify_standard_template_views(views: tuple[ProjectView, ...]) -> None:
+    by_name = {view.name: view for view in views}
+    errors: list[str] = []
+    for expected in STANDARD_TEMPLATE_VIEWS:
+        actual = by_name.get(expected.name)
+        if actual is None:
+            errors.append(f"{expected.name} view is missing")
+        elif actual.layout != expected.layout:
+            errors.append(f"{expected.name} view has layout {actual.layout}; expected {expected.layout}")
+    if errors:
+        raise ProjectError("Copied Project does not match template views: " + "; ".join(errors))
+
+
 def create_project(owner_id: str, title: str) -> ProjectInfo:
     query = """
 mutation($ownerId: ID!, $title: String!) {
@@ -741,6 +813,74 @@ mutation($ownerId: ID!, $title: String!) {
     payload = run_graphql(query, {"ownerId": owner_id, "title": title})
     project = payload["data"]["createProjectV2"]["projectV2"]
     return ProjectInfo(project_id=project["id"], title=project["title"])
+
+
+def copy_project(template_project_id: str, owner_id: str, title: str) -> ProjectInfo:
+    query = """
+mutation($projectId: ID!, $ownerId: ID!, $title: String!) {
+  copyProjectV2(input: {projectId: $projectId, ownerId: $ownerId, title: $title, includeDraftIssues: false}) {
+    projectV2 { id title }
+  }
+}
+"""
+    payload = run_graphql(query, {"projectId": template_project_id, "ownerId": owner_id, "title": title})
+    project = payload["data"]["copyProjectV2"]["projectV2"]
+    return ProjectInfo(project_id=project["id"], title=project["title"])
+
+
+def fetch_repository_id(repo: str) -> str:
+    owner, name = split_repo(repo)
+    query = """
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) { id }
+}
+"""
+    payload = run_graphql(query, {"owner": owner, "name": name})
+    repository = payload["data"].get("repository")
+    if repository is None:
+        raise ProjectError(f"Repository '{repo}' was not found.")
+    return repository["id"]
+
+
+def link_project_to_repository(project_id: str, repo: str) -> None:
+    if repo in fetch_project_repository_names(project_id):
+        return
+    repository_id = fetch_repository_id(repo)
+    query = """
+mutation($projectId: ID!, $repositoryId: ID!) {
+  linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) {
+    repository { id }
+  }
+}
+"""
+    run_graphql(query, {"projectId": project_id, "repositoryId": repository_id})
+
+
+def fetch_project_repository_names(project_id: str) -> set[str]:
+    repo_names: set[str] = set()
+    cursor: str | None = None
+    query = """
+query($projectId: ID!, $cursor: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      repositories(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { nameWithOwner }
+      }
+    }
+  }
+}
+"""
+    while True:
+        payload = run_graphql(query, {"projectId": project_id, "cursor": cursor})
+        node = payload["data"].get("node")
+        if node is None:
+            raise ProjectError("GitHub Project was not found.")
+        repositories = node["repositories"]
+        repo_names.update(raw["nameWithOwner"] for raw in repositories["nodes"])
+        if not repositories["pageInfo"]["hasNextPage"]:
+            return repo_names
+        cursor = repositories["pageInfo"]["endCursor"]
 
 
 def create_single_select_field(project_id: str, spec: SelectFieldSpec) -> None:
@@ -801,6 +941,76 @@ query($owner: String!, $name: String!, $number: Int!) {
     if issue is None:
         raise ProjectError(f"Issue #{number} was not found in {owner}/{name}.")
     return issue["id"]
+
+
+def fetch_repository_issue_ids(repo: str) -> tuple[str, ...]:
+    owner, name = split_repo(repo)
+    issue_ids: list[str] = []
+    cursor: str | None = None
+    query = """
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: CREATED_AT, direction: ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id }
+    }
+  }
+}
+"""
+    while True:
+        payload = run_graphql(query, {"owner": owner, "name": name, "cursor": cursor})
+        repository = payload["data"].get("repository")
+        if repository is None:
+            raise ProjectError(f"Repository '{repo}' was not found.")
+        issues = repository["issues"]
+        issue_ids.extend(node["id"] for node in issues["nodes"])
+        if not issues["pageInfo"]["hasNextPage"]:
+            return tuple(issue_ids)
+        cursor = issues["pageInfo"]["endCursor"]
+
+
+def fetch_project_issue_content_ids(project_id: str) -> set[str]:
+    issue_ids: set[str] = set()
+    cursor: str | None = None
+    query = """
+query($projectId: ID!, $cursor: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          content { ... on Issue { id } }
+        }
+      }
+    }
+  }
+}
+"""
+    while True:
+        payload = run_graphql(query, {"projectId": project_id, "cursor": cursor})
+        node = payload["data"].get("node")
+        if node is None:
+            raise ProjectError("GitHub Project was not found.")
+        items = node["items"]
+        for item in items["nodes"]:
+            issue_id = item.get("content", {}).get("id")
+            if issue_id:
+                issue_ids.add(issue_id)
+        if not items["pageInfo"]["hasNextPage"]:
+            return issue_ids
+        cursor = items["pageInfo"]["endCursor"]
+
+
+def backfill_repository_issues(project_id: str, repo: str) -> int:
+    existing = fetch_project_issue_content_ids(project_id)
+    added = 0
+    for issue_id in fetch_repository_issue_ids(repo):
+        if issue_id in existing:
+            continue
+        add_project_item(project_id, issue_id)
+        existing.add(issue_id)
+        added += 1
+    return added
 
 
 def find_project_item_id(project_id: str, issue_id: str) -> str | None:

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
+from . import graphql_queries as queries
+
 
 class ProjectUsageError(RuntimeError):
     pass
@@ -729,27 +731,7 @@ def is_missing_owner_lookup_error(message: str, kind: str) -> bool:
 
 
 def fetch_project_fields(project_id: str) -> tuple[ProjectField, ...]:
-    query = """
-query($id: ID!) {
-  node(id: $id) {
-    ... on ProjectV2 {
-      fields(first: 50) {
-        nodes {
-          __typename
-          ... on ProjectV2Field { id name dataType }
-          ... on ProjectV2SingleSelectField {
-            id
-            name
-            dataType
-            options { id name color description }
-          }
-        }
-      }
-    }
-  }
-}
-"""
-    payload = run_graphql(query, {"id": project_id})
+    payload = run_graphql(queries.FETCH_PROJECT_FIELDS, {"id": project_id})
     node = payload["data"].get("node")
     if node is None:
         raise ProjectError("GitHub Project was not found.")
@@ -771,18 +753,7 @@ query($id: ID!) {
 
 
 def fetch_project_views(project_id: str) -> tuple[ProjectView, ...]:
-    query = """
-query($id: ID!) {
-  node(id: $id) {
-    ... on ProjectV2 {
-      views(first: 20) {
-        nodes { name layout }
-      }
-    }
-  }
-}
-"""
-    payload = run_graphql(query, {"id": project_id})
+    payload = run_graphql(queries.FETCH_PROJECT_VIEWS, {"id": project_id})
     node = payload["data"].get("node")
     if node is None:
         raise ProjectError("GitHub Project was not found.")
@@ -803,39 +774,23 @@ def verify_standard_template_views(views: tuple[ProjectView, ...]) -> None:
 
 
 def create_project(owner_id: str, title: str) -> ProjectInfo:
-    query = """
-mutation($ownerId: ID!, $title: String!) {
-  createProjectV2(input: {ownerId: $ownerId, title: $title}) {
-    projectV2 { id title }
-  }
-}
-"""
-    payload = run_graphql(query, {"ownerId": owner_id, "title": title})
+    payload = run_graphql(queries.CREATE_PROJECT, {"ownerId": owner_id, "title": title})
     project = payload["data"]["createProjectV2"]["projectV2"]
     return ProjectInfo(project_id=project["id"], title=project["title"])
 
 
 def copy_project(template_project_id: str, owner_id: str, title: str) -> ProjectInfo:
-    query = """
-mutation($projectId: ID!, $ownerId: ID!, $title: String!) {
-  copyProjectV2(input: {projectId: $projectId, ownerId: $ownerId, title: $title, includeDraftIssues: false}) {
-    projectV2 { id title }
-  }
-}
-"""
-    payload = run_graphql(query, {"projectId": template_project_id, "ownerId": owner_id, "title": title})
+    payload = run_graphql(
+        queries.COPY_PROJECT,
+        {"projectId": template_project_id, "ownerId": owner_id, "title": title},
+    )
     project = payload["data"]["copyProjectV2"]["projectV2"]
     return ProjectInfo(project_id=project["id"], title=project["title"])
 
 
 def fetch_repository_id(repo: str) -> str:
     owner, name = split_repo(repo)
-    query = """
-query($owner: String!, $name: String!) {
-  repository(owner: $owner, name: $name) { id }
-}
-"""
-    payload = run_graphql(query, {"owner": owner, "name": name})
+    payload = run_graphql(queries.FETCH_REPOSITORY_ID, {"owner": owner, "name": name})
     repository = payload["data"].get("repository")
     if repository is None:
         raise ProjectError(f"Repository '{repo}' was not found.")
@@ -846,33 +801,14 @@ def link_project_to_repository(project_id: str, repo: str) -> None:
     if repo in fetch_project_repository_names(project_id):
         return
     repository_id = fetch_repository_id(repo)
-    query = """
-mutation($projectId: ID!, $repositoryId: ID!) {
-  linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) {
-    repository { id }
-  }
-}
-"""
-    run_graphql(query, {"projectId": project_id, "repositoryId": repository_id})
+    run_graphql(queries.LINK_PROJECT_TO_REPOSITORY, {"projectId": project_id, "repositoryId": repository_id})
 
 
 def fetch_project_repository_names(project_id: str) -> set[str]:
     repo_names: set[str] = set()
     cursor: str | None = None
-    query = """
-query($projectId: ID!, $cursor: String) {
-  node(id: $projectId) {
-    ... on ProjectV2 {
-      repositories(first: 100, after: $cursor) {
-        pageInfo { hasNextPage endCursor }
-        nodes { nameWithOwner }
-      }
-    }
-  }
-}
-"""
     while True:
-        payload = run_graphql(query, {"projectId": project_id, "cursor": cursor})
+        payload = run_graphql(queries.FETCH_PROJECT_REPOSITORY_NAMES, {"projectId": project_id, "cursor": cursor})
         node = payload["data"].get("node")
         if node is None:
             raise ProjectError("GitHub Project was not found.")
@@ -884,33 +820,17 @@ query($projectId: ID!, $cursor: String) {
 
 
 def create_single_select_field(project_id: str, spec: SelectFieldSpec) -> None:
-    query = """
-mutation($projectId: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
-  createProjectV2Field(input: {
-    projectId: $projectId,
-    dataType: SINGLE_SELECT,
-    name: $name,
-    singleSelectOptions: $options
-  }) {
-    projectV2Field { ... on ProjectV2SingleSelectField { id name } }
-  }
-}
-"""
-    run_graphql(query, {"projectId": project_id, "name": spec.name, "options": options_payload(spec.options)})
+    run_graphql(
+        queries.CREATE_SINGLE_SELECT_FIELD,
+        {"projectId": project_id, "name": spec.name, "options": options_payload(spec.options)},
+    )
 
 
 def update_single_select_field(field: ProjectField, spec: SelectFieldSpec) -> None:
-    query = """
-mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
-  updateProjectV2Field(input: {
-    fieldId: $fieldId,
-    singleSelectOptions: $options
-  }) {
-    projectV2Field { ... on ProjectV2SingleSelectField { id name } }
-  }
-}
-"""
-    run_graphql(query, {"fieldId": field.field_id, "options": options_payload(merged_options(field, spec))})
+    run_graphql(
+        queries.UPDATE_SINGLE_SELECT_FIELD,
+        {"fieldId": field.field_id, "options": options_payload(merged_options(field, spec))},
+    )
 
 
 def options_payload(options: tuple[SelectOption, ...]) -> list[dict[str, str]]:
@@ -929,14 +849,7 @@ def missing_option_names(field: ProjectField, spec: SelectFieldSpec) -> tuple[st
 
 
 def fetch_issue_id(owner: str, name: str, number: int) -> str:
-    query = """
-query($owner: String!, $name: String!, $number: Int!) {
-  repository(owner: $owner, name: $name) {
-    issue(number: $number) { id }
-  }
-}
-"""
-    payload = run_graphql(query, {"owner": owner, "name": name, "number": number})
+    payload = run_graphql(queries.FETCH_ISSUE_ID, {"owner": owner, "name": name, "number": number})
     issue = payload["data"]["repository"]["issue"]
     if issue is None:
         raise ProjectError(f"Issue #{number} was not found in {owner}/{name}.")
@@ -947,18 +860,8 @@ def fetch_repository_issue_ids(repo: str) -> tuple[str, ...]:
     owner, name = split_repo(repo)
     issue_ids: list[str] = []
     cursor: str | None = None
-    query = """
-query($owner: String!, $name: String!, $cursor: String) {
-  repository(owner: $owner, name: $name) {
-    issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: CREATED_AT, direction: ASC}) {
-      pageInfo { hasNextPage endCursor }
-      nodes { id }
-    }
-  }
-}
-"""
     while True:
-        payload = run_graphql(query, {"owner": owner, "name": name, "cursor": cursor})
+        payload = run_graphql(queries.FETCH_REPOSITORY_ISSUE_IDS, {"owner": owner, "name": name, "cursor": cursor})
         repository = payload["data"].get("repository")
         if repository is None:
             raise ProjectError(f"Repository '{repo}' was not found.")
@@ -972,22 +875,8 @@ query($owner: String!, $name: String!, $cursor: String) {
 def fetch_project_issue_content_ids(project_id: str) -> set[str]:
     issue_ids: set[str] = set()
     cursor: str | None = None
-    query = """
-query($projectId: ID!, $cursor: String) {
-  node(id: $projectId) {
-    ... on ProjectV2 {
-      items(first: 100, after: $cursor) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          content { ... on Issue { id } }
-        }
-      }
-    }
-  }
-}
-"""
     while True:
-        payload = run_graphql(query, {"projectId": project_id, "cursor": cursor})
+        payload = run_graphql(queries.FETCH_PROJECT_ISSUE_CONTENT_IDS, {"projectId": project_id, "cursor": cursor})
         node = payload["data"].get("node")
         if node is None:
             raise ProjectError("GitHub Project was not found.")
@@ -1014,21 +903,7 @@ def backfill_repository_issues(project_id: str, repo: str) -> int:
 
 
 def find_project_item_id(project_id: str, issue_id: str) -> str | None:
-    query = """
-query($projectId: ID!) {
-  node(id: $projectId) {
-    ... on ProjectV2 {
-      items(first: 100) {
-        nodes {
-          id
-          content { ... on Issue { id } }
-        }
-      }
-    }
-  }
-}
-"""
-    payload = run_graphql(query, {"projectId": project_id})
+    payload = run_graphql(queries.FIND_PROJECT_ITEM_ID, {"projectId": project_id})
     for item in payload["data"]["node"]["items"]["nodes"]:
         if item.get("content", {}).get("id") == issue_id:
             return item["id"]
@@ -1036,32 +911,13 @@ query($projectId: ID!) {
 
 
 def add_project_item(project_id: str, issue_id: str) -> str:
-    query = """
-mutation($projectId: ID!, $contentId: ID!) {
-  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-    item { id }
-  }
-}
-"""
-    payload = run_graphql(query, {"projectId": project_id, "contentId": issue_id})
+    payload = run_graphql(queries.ADD_PROJECT_ITEM, {"projectId": project_id, "contentId": issue_id})
     return payload["data"]["addProjectV2ItemById"]["item"]["id"]
 
 
 def update_item_field(project_id: str, item_id: str, update: FieldUpdate) -> None:
-    query = """
-mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: $projectId,
-    itemId: $itemId,
-    fieldId: $fieldId,
-    value: {singleSelectOptionId: $optionId}
-  }) {
-    projectV2Item { id }
-  }
-}
-"""
     run_graphql(
-        query,
+        queries.UPDATE_ITEM_FIELD,
         {
             "projectId": project_id,
             "itemId": item_id,

--- a/cli/python/base_github_projects/graphql_queries.py
+++ b/cli/python/base_github_projects/graphql_queries.py
@@ -1,0 +1,169 @@
+FETCH_PROJECT_FIELDS = """
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      fields(first: 50) {
+        nodes {
+          __typename
+          ... on ProjectV2Field { id name dataType }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options { id name color description }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+FETCH_PROJECT_VIEWS = """
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      views(first: 20) {
+        nodes { name layout }
+      }
+    }
+  }
+}
+"""
+
+CREATE_PROJECT = """
+mutation($ownerId: ID!, $title: String!) {
+  createProjectV2(input: {ownerId: $ownerId, title: $title}) {
+    projectV2 { id title }
+  }
+}
+"""
+
+COPY_PROJECT = """
+mutation($projectId: ID!, $ownerId: ID!, $title: String!) {
+  copyProjectV2(input: {projectId: $projectId, ownerId: $ownerId, title: $title, includeDraftIssues: false}) {
+    projectV2 { id title }
+  }
+}
+"""
+
+FETCH_REPOSITORY_ID = """
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) { id }
+}
+"""
+
+LINK_PROJECT_TO_REPOSITORY = """
+mutation($projectId: ID!, $repositoryId: ID!) {
+  linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) {
+    repository { id }
+  }
+}
+"""
+
+FETCH_PROJECT_REPOSITORY_NAMES = """
+query($projectId: ID!, $cursor: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      repositories(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { nameWithOwner }
+      }
+    }
+  }
+}
+"""
+
+CREATE_SINGLE_SELECT_FIELD = """
+mutation($projectId: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+  createProjectV2Field(input: {
+    projectId: $projectId,
+    dataType: SINGLE_SELECT,
+    name: $name,
+    singleSelectOptions: $options
+  }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name } }
+  }
+}
+"""
+
+UPDATE_SINGLE_SELECT_FIELD = """
+mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+  updateProjectV2Field(input: {
+    fieldId: $fieldId,
+    singleSelectOptions: $options
+  }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name } }
+  }
+}
+"""
+
+FETCH_ISSUE_ID = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) { id }
+  }
+}
+"""
+
+FETCH_REPOSITORY_ISSUE_IDS = """
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: CREATED_AT, direction: ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id }
+    }
+  }
+}
+"""
+
+FETCH_PROJECT_ISSUE_CONTENT_IDS = """
+query($projectId: ID!, $cursor: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          content { ... on Issue { id } }
+        }
+      }
+    }
+  }
+}
+"""
+
+FIND_PROJECT_ITEM_ID = """
+query($projectId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          id
+          content { ... on Issue { id } }
+        }
+      }
+    }
+  }
+}
+"""
+
+ADD_PROJECT_ITEM = """
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+    item { id }
+  }
+}
+"""
+
+UPDATE_ITEM_FIELD = """
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId,
+    itemId: $itemId,
+    fieldId: $fieldId,
+    value: {singleSelectOptionId: $optionId}
+  }) {
+    projectV2Item { id }
+  }
+}
+"""

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -263,6 +263,166 @@ def test_configure_command_refetches_default_fields_after_project_creation(
     assert created_fields == ["Priority", "Area", "Size", "Initiative"]
 
 
+def test_configure_command_copies_template_for_repo_project_and_backfills_issues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_field = engine.ProjectField(
+        field_id="status-field",
+        name="Status",
+        data_type="SINGLE_SELECT",
+        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Status").options,
+    )
+    priority_field = engine.ProjectField(
+        field_id="priority-field",
+        name="Priority",
+        data_type="SINGLE_SELECT",
+        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority").options,
+    )
+    area_field = engine.ProjectField(
+        field_id="area-field",
+        name="Area",
+        data_type="SINGLE_SELECT",
+        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Area").options,
+    )
+    size_field = engine.ProjectField(
+        field_id="size-field",
+        name="Size",
+        data_type="SINGLE_SELECT",
+        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Size").options,
+    )
+    initiative_field = engine.ProjectField(
+        field_id="initiative-field",
+        name="Initiative",
+        data_type="SINGLE_SELECT",
+        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Initiative").options,
+    )
+    calls: list[tuple[str, str]] = []
+    linked: list[tuple[str, str]] = []
+    backfilled: list[tuple[str, str]] = []
+
+    def fake_find_owner_and_project(owner: str, title: str) -> engine.OwnerInfo:
+        calls.append((owner, title))
+        if title == "base-demo":
+            return engine.OwnerInfo(owner_id="owner-id", login=owner, project=None)
+        if title == engine.DEFAULT_TEMPLATE_PROJECT:
+            return engine.OwnerInfo(
+                owner_id="owner-id",
+                login=owner,
+                project=engine.ProjectInfo(project_id="template-id", title=title),
+            )
+        raise AssertionError(f"unexpected project lookup: {title}")
+
+    monkeypatch.setattr(engine, "find_owner_and_project", fake_find_owner_and_project)
+    monkeypatch.setattr(
+        engine,
+        "copy_project",
+        lambda template_id, owner_id, title: engine.ProjectInfo(project_id="project-id", title=title),
+    )
+    monkeypatch.setattr(
+        engine,
+        "fetch_project_fields",
+        lambda project_id: (status_field, priority_field, area_field, size_field, initiative_field),
+    )
+    monkeypatch.setattr(engine, "create_single_select_field", lambda project_id, spec: None)
+    monkeypatch.setattr(engine, "update_single_select_field", lambda field, spec: None)
+    monkeypatch.setattr(engine, "fetch_project_views", lambda project_id: engine.STANDARD_TEMPLATE_VIEWS)
+    monkeypatch.setattr(
+        engine,
+        "link_project_to_repository",
+        lambda project_id, repo: linked.append((project_id, repo)),
+    )
+    monkeypatch.setattr(
+        engine,
+        "backfill_repository_issues",
+        lambda project_id, repo: backfilled.append((project_id, repo)),
+    )
+
+    status = engine.configure_command(
+        engine.ProjectArguments(
+            area="project",
+            command="configure",
+            project_title="base-demo",
+            owner="codeforester",
+            repo="codeforester/base-demo",
+        )
+    )
+
+    assert status == 0
+    assert calls == [
+        ("codeforester", "base-demo"),
+        ("codeforester", engine.DEFAULT_TEMPLATE_PROJECT),
+    ]
+    assert linked == [("project-id", "codeforester/base-demo")]
+    assert backfilled == [("project-id", "codeforester/base-demo")]
+
+
+def test_configure_command_dry_run_reports_template_copy_link_and_backfill(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        engine,
+        "find_owner_and_project",
+        lambda owner, title: engine.OwnerInfo(owner_id="owner-id", login=owner, project=None),
+    )
+
+    status = engine.configure_command(
+        engine.ProjectArguments(
+            area="project",
+            command="configure",
+            project_title="base-demo",
+            owner="codeforester",
+            repo="codeforester/base-demo",
+            dry_run=True,
+        )
+    )
+
+    assert status == 0
+    output = capsys.readouterr().out
+    assert "Would copy GitHub Project 'base-project-template' to 'base-demo'." in output
+    assert "Would link GitHub Project 'base-demo' to repository 'codeforester/base-demo'." in output
+    assert "Would backfill issues from 'codeforester/base-demo' into GitHub Project 'base-demo'." in output
+
+
+def test_backfill_repository_issues_adds_only_missing_project_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    added: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(engine, "fetch_repository_issue_ids", lambda repo: ("issue-1", "issue-2", "issue-3"))
+    monkeypatch.setattr(engine, "fetch_project_issue_content_ids", lambda project_id: {"issue-2"})
+    monkeypatch.setattr(
+        engine,
+        "add_project_item",
+        lambda project_id, issue_id: added.append((project_id, issue_id)) or f"item-{issue_id}",
+    )
+
+    engine.backfill_repository_issues("project-id", "codeforester/base-demo")
+
+    assert added == [("project-id", "issue-1"), ("project-id", "issue-3")]
+
+
+def test_link_project_to_repository_skips_existing_link(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(message: str) -> None:
+        raise AssertionError(message)
+
+    monkeypatch.setattr(
+        engine,
+        "fetch_project_repository_names",
+        lambda project_id: {"codeforester/base-demo"},
+    )
+    monkeypatch.setattr(
+        engine,
+        "fetch_repository_id",
+        lambda repo: fail("repository id should not be fetched"),
+    )
+    monkeypatch.setattr(
+        engine,
+        "run_graphql",
+        lambda query, variables: fail("mutation should not run"),
+    )
+
+    engine.link_project_to_repository("project-id", "codeforester/base-demo")
+
+
 def test_find_owner_and_project_uses_user_lookup_without_organization_error(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_run_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
         assert "user(login:" in query

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -58,7 +58,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 |---|---|---|
 | `basectl repo init <name>` | Create a Base-managed repository baseline and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
-| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and Project metadata. | `--repo <owner/name>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
+| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files. | `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--dry-run` |
 | `basectl repo installer-template [path]` | Print the maintained project installer starter script, or write it to a path. | `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -64,10 +64,12 @@ Keep the issue's `Status` field aligned with the implementation train:
 Do not add pull requests as separate Project items by default. The issue owns
 milestone and Project tracking so roadmap views do not double count the work.
 
-`basectl repo init` and `basectl repo configure` configure the standard Project
-metadata by default when a GitHub repository is available. Use
-`basectl gh project` directly for lower-level Project inspection, schema
-repair, or issue field updates.
+`basectl repo init` and `basectl repo configure` configure a repo-named Project
+by default when a GitHub repository is available. Base copies
+`base-project-template` when the repo Project is missing, links the Project to
+the repository, and backfills existing repository issues. Use `basectl gh
+project` directly for lower-level Project inspection, schema repair, or issue
+field updates.
 
 ```bash
 basectl gh project doctor --project "Base Roadmap" --owner codeforester
@@ -376,7 +378,9 @@ Releases, and the follow-up `codeforester/homebrew-base` tap update, see
 
 ## Projects
 
-Use one GitHub Project first: `Base Roadmap`.
+Use one operational GitHub Project per repository. The repo Project title should
+match the repository name, and new repo Projects should be copied from
+`base-project-template`.
 
 Recommended fields:
 
@@ -389,10 +393,11 @@ Recommended fields:
 
 Useful views:
 
+- Backlog table for open Backlog issues
 - Board by status
-- Priority view
-- Release view grouped by milestone
-- Bugs and CI
-- Ready for PR train
+- By Status table
+- Roadmap timeline
 
-Projects show workflow and prioritization. Milestones show release grouping.
+Repo Projects show workflow and prioritization. Milestones show release
+grouping. Cross-repo portfolio Projects should be curated roll-ups rather than
+the default destination for every repo issue.

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -74,12 +74,14 @@ GitHub changes without applying them. In dry-run mode, `repo init` explicitly
 reports whether it would create a GitHub repository or why GitHub creation is
 being skipped.
 
-`repo init` and `repo configure` also configure the standard GitHub Project
-metadata schema by default when a GitHub repository is known. Pass
-`--no-project` to skip Project V2 metadata, `--project <title>` to override the
-Project title, `--project-owner <login>` to override the owner,
-`--project-schema base-roadmap` to select the schema, and repeat
-`--initiative-option <name>` to seed repository-specific Initiative values.
+`repo init` and `repo configure` also configure a repo-named GitHub Project by
+default when a GitHub repository is known. If the Project is missing, Base copies
+`base-project-template`, links the new Project to the repository, and backfills
+the repository's existing issues into it. Pass `--no-project` to skip Project V2
+metadata, `--project <title>` to override the Project title, `--project-owner
+<login>` to override the owner, `--project-schema base-roadmap` to select the
+schema, and repeat `--initiative-option <name>` to seed repository-specific
+Initiative values.
 `basectl gh project` is the lower-level direct surface for Project inspection,
 schema repair, and issue field updates.
 
@@ -208,7 +210,8 @@ GitHub reports that rulesets are unavailable for a private repository's plan,
 `repo configure` leaves the supported settings and labels in place, logs a
 warning, and skips default branch protection.
 
-The Project metadata schema creates or updates single-select Project fields:
+The Project metadata schema creates or updates single-select Project fields on
+the repo Project:
 
 - `Status`: `Triage`, `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`
 - `Priority`: `P0`, `P1`, `P2`, `P3`


### PR DESCRIPTION
## Summary
- Make `basectl repo configure` default repo Project titles to the exact repository name and copy missing Projects from `base-project-template`.
- Link repo Projects to their target repositories and idempotently backfill existing repository issues.
- Update repo workflow docs and focused Python/BATS coverage for the new setup flow.
- Extract GraphQL query documents so the Project engine stays under the pylint module-size limit.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests -q`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`
- `./bin/basectl repo configure /Users/rameshhp/work/base-demo --repo codeforester/base-demo --dry-run`
- `git diff --check`
- `git diff --cached --check`
- `./tests/validate.sh` was not run because this checkout does not contain that script.

## Demo Impact
- No direct demo script impact. This improves the repo Project dashboard setup path.

Fixes #636