### PR TITLE
Sync repo Project taxonomy from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ standardizes merge settings, deletes branches after merge, applies the
 Base-managed default branch protection ruleset, configures a repo-named GitHub
 Project copied from `base-project-template`, and creates the standard GitHub
 labels documented in [Repository Baseline](docs/repo-baseline.md).
+When `.github/base-project.yml` exists, `repo configure` also adds missing
+repo-specific `Area` and `Initiative` Project options from that file.
 Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -87,8 +87,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   default branch protection, and standard repo Project setup. By default, the
   Project title matches the repository name; missing Projects are copied from
   `base-project-template`, linked to the repository, and backfilled with
-  repository issues. Use `--no-project` to skip Project setup,
-  `--project <title>` to override the Project title, or
+  repository issues. When `.github/base-project.yml` exists, repo-specific
+  `Area` and `Initiative` options are added from that file. Use `--no-project`
+  to skip Project setup, `--project <title>` to override the Project title, or
   `--initiative-option <name>` to seed repository-specific Initiative values.
   `basectl repo agent-guidance [path]` seeds optional repo-local agent guidance
   files and `basectl repo check [path] --agent-guidance` verifies that optional

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -56,7 +56,8 @@ Options:
   -h, --help                    Show this help text.
 
 Create, check, and configure a standard Base-managed repository baseline, or
-write a reusable project installer template.
+write a reusable project installer template. When .github/base-project.yml
+exists, repo configure uses it for repo-specific GitHub Project taxonomy.
 EOF
 }
 
@@ -956,8 +957,18 @@ base_repo_project_owner_from_repo() {
     printf '%s\n' "${repo%%/*}"
 }
 
+base_repo_project_config_path() {
+    local root="$1"
+    local path="$root/.github/base-project.yml"
+
+    if [[ -f "$path" ]]; then
+        printf '%s\n' "$path"
+    fi
+}
+
 base_repo_configure_project_metadata() {
     local dry_run="$1"
+    local config_path="$6"
     local option
     local owner="$4"
     local output=""
@@ -966,19 +977,25 @@ base_repo_configure_project_metadata() {
     local schema="$5"
     local status=0
     local wrapper="${BASE_REPO_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
-    shift 5
+    shift 6
 
     if [[ "$dry_run" == "1" ]]; then
         printf "[DRY-RUN] Would configure GitHub Project '%s' for '%s'.\n" "$project_title" "$repo"
         printf "[DRY-RUN] Would copy GitHub Project 'base-project-template' to '%s' if missing.\n" "$project_title"
         printf "[DRY-RUN] Would link GitHub Project '%s' to repository '%s'.\n" "$project_title" "$repo"
         printf "[DRY-RUN] Would backfill issues from '%s' into GitHub Project '%s'.\n" "$repo" "$project_title"
+        if [[ -n "$config_path" ]]; then
+            printf "[DRY-RUN] Would read GitHub Project config from '%s'.\n" "$config_path"
+        fi
         printf "[DRY-RUN] Would run: %s --project base base_github_projects project configure --project %s --owner %s --repo %s --schema %s" \
             "$wrapper" \
             "$(base_repo_pretty_arg "$project_title")" \
             "$owner" \
             "$repo" \
             "$schema"
+        if [[ -n "$config_path" ]]; then
+            printf " --config %s" "$(base_repo_pretty_arg "$config_path")"
+        fi
         for option in "$@"; do
             printf " --initiative-option %s" "$(base_repo_pretty_arg "$option")"
         done
@@ -1003,6 +1020,9 @@ base_repo_configure_project_metadata() {
         --repo "$repo"
         --schema "$schema"
     )
+    if [[ -n "$config_path" ]]; then
+        command+=(--config "$config_path")
+    fi
     for option in "$@"; do
         command+=(--initiative-option "$option")
     done
@@ -1508,6 +1528,7 @@ base_repo_init() {
                     "$project_title" \
                     "$project_owner" \
                     "$project_schema" \
+                    "$(base_repo_project_config_path "$root")" \
                     "${initiative_options[@]}" || return 1
             fi
         else
@@ -1784,6 +1805,7 @@ base_repo_configure() {
             "$project_title" \
             "$project_owner" \
             "$project_schema" \
+            "$(base_repo_project_config_path "$path")" \
             "${initiative_options[@]}"
     fi
 }

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -436,6 +436,25 @@ EOF
     [[ "$output" == *"Status, Priority, Area, Size, Initiative"* ]]
 }
 
+@test "basectl repo configure dry-run passes repo project config when present" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir/.github"
+    cat > "$repo_dir/.github/base-project.yml" <<'EOF'
+project:
+  areas:
+    - Demo App
+  initiatives:
+    - Repo Dashboard
+EOF
+
+    run_basectl repo configure "$repo_dir" --repo codeforester/base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Would read GitHub Project config from '$repo_dir/.github/base-project.yml'."* ]]
+    [[ "$output" == *"--config $repo_dir/.github/base-project.yml"* ]]
+}
+
 @test "basectl repo configure can skip project metadata" {
     local repo_dir="$TEST_TMPDIR/repo"
 
@@ -503,7 +522,12 @@ EOF
 @test "basectl repo configure applies project metadata through Base project engine" {
     local repo_dir="$TEST_TMPDIR/repo"
 
-    mkdir -p "$repo_dir"
+    mkdir -p "$repo_dir/.github"
+    cat > "$repo_dir/.github/base-project.yml" <<'EOF'
+project:
+  areas:
+    - Demo App
+EOF
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$*" == "auth status -h github.com" ]]; then
@@ -530,7 +554,7 @@ EOF
 
     [ "$status" -eq 0 ]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml" ]
 }
 
 @test "basectl repo configure warns when project metadata needs GitHub project scope" {

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -4,8 +4,11 @@ import json
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from . import graphql_queries as queries
+from .project_config import ProjectConfig, ProjectConfigError
+from .project_config import read_project_config as _read_project_config
 
 
 class ProjectUsageError(RuntimeError):
@@ -102,6 +105,7 @@ class ProjectArguments:
     owner: str | None = None
     repo: str | None = None
     schema: str = "base-roadmap"
+    config_path: str | None = None
     initiative_options: tuple[str, ...] = ()
     dry_run: bool = False
     issue_number: int | None = None
@@ -184,7 +188,7 @@ FIELD_OPTION_TO_PROJECT_FIELD = {
     "size": "Size",
 }
 HELP_OPTIONS = ("-h", "--help", "help")
-PROJECT_VALUE_OPTIONS = ("--project", "--owner", "--repo", "--schema", "--initiative-option")
+PROJECT_VALUE_OPTIONS = ("--project", "--owner", "--repo", "--schema", "--config", "--initiative-option")
 ISSUE_FIELD_OPTIONS = ("--status", "--priority", "--area", "--initiative", "--size")
 
 
@@ -215,7 +219,7 @@ def print_usage(file=sys.stdout) -> None:
                 "  base_github_projects project doctor --project <title> "
                 "[--owner <login>] [--schema base-roadmap]",
                 "  base_github_projects project configure --project <title> "
-                "[--owner <login>] [--repo <owner/name>] [--schema base-roadmap] "
+                "[--owner <login>] [--repo <owner/name>] [--schema base-roadmap] [--config <path>] "
                 "[--initiative-option <name>] [--dry-run]",
                 "  base_github_projects project issue set-fields <number> "
                 "--repo <owner/name> --project <title> [field options...]",
@@ -267,6 +271,7 @@ class OptionState:
     owner: str | None = None
     repo: str | None = None
     schema: str = "base-roadmap"
+    config_path: str | None = None
     initiative_options: list[str] | None = None
     dry_run: bool = False
     field_values: dict[str, str] | None = None
@@ -343,6 +348,8 @@ def apply_project_option(state: OptionState, option: str, value: str) -> None:
         state.repo = value
     elif option == "--schema":
         state.schema = value
+    elif option == "--config":
+        state.config_path = value
     elif option == "--initiative-option":
         state.initiative_options.append(value)
 
@@ -360,6 +367,7 @@ def state_to_args(command: str, state: OptionState, issue_number: int | None = N
         owner=state.owner,
         repo=state.repo,
         schema=state.schema,
+        config_path=state.config_path,
         initiative_options=tuple(state.initiative_options or ()),
         dry_run=state.dry_run,
         issue_number=issue_number,
@@ -380,22 +388,52 @@ def run_command(args: ProjectArguments) -> int:
 def schema_for_args(args: ProjectArguments) -> ProjectSchema:
     if args.schema != "base-roadmap":
         raise ProjectUsageError("Only project schema 'base-roadmap' is supported.")
+    config = project_config_for_args(args)
     if args.initiative_options:
-        return schema_with_initiatives(BASE_ROADMAP_SCHEMA, args.initiative_options)
-    return BASE_ROADMAP_SCHEMA
+        return schema_with_project_config(
+            schema_with_initiatives(BASE_ROADMAP_SCHEMA, args.initiative_options),
+            config,
+        )
+    return schema_with_project_config(BASE_ROADMAP_SCHEMA, config)
+
+
+def project_config_for_args(args: ProjectArguments) -> ProjectConfig:
+    if not args.config_path:
+        return ProjectConfig()
+    return read_project_config(Path(args.config_path))
+
+
+def read_project_config(path: Path) -> ProjectConfig:
+    try:
+        return _read_project_config(path)
+    except ProjectConfigError as exc:
+        raise ProjectUsageError(str(exc)) from exc
 
 
 def schema_with_initiatives(schema: ProjectSchema, initiative_options: tuple[str, ...]) -> ProjectSchema:
+    return schema_with_extra_options(schema, "Initiative", initiative_options, "Project-specific initiative.")
+
+
+def schema_with_project_config(schema: ProjectSchema, config: ProjectConfig) -> ProjectSchema:
+    schema = schema_with_extra_options(schema, "Area", config.areas, "Repository-specific area.")
+    return schema_with_extra_options(schema, "Initiative", config.initiatives, "Repository-specific initiative.")
+
+
+def schema_with_extra_options(
+    schema: ProjectSchema, field_name: str, option_names: tuple[str, ...], description: str
+) -> ProjectSchema:
+    if not option_names:
+        return schema
     fields: list[SelectFieldSpec] = []
     for field in schema.fields:
-        if field.name != "Initiative":
+        if field.name != field_name:
             fields.append(field)
             continue
         existing = {option.name for option in field.options}
         options = list(field.options)
-        for option_name in initiative_options:
+        for option_name in option_names:
             if option_name not in existing:
-                options.append(SelectOption(option_name, "GRAY", "Project-specific initiative."))
+                options.append(SelectOption(option_name, "GRAY", description))
                 existing.add(option_name)
         fields.append(SelectFieldSpec(field.name, tuple(options)))
     return ProjectSchema(tuple(fields))
@@ -508,6 +546,7 @@ def doctor_command(args: ProjectArguments) -> int:
 
 def configure_command(args: ProjectArguments) -> int:
     owner = require_owner(args)
+    project_config = project_config_for_args(args)
     schema = schema_for_args(args)
     owner_info = find_owner_and_project(owner, args.project_title or "")
     project = owner_info.project
@@ -526,7 +565,12 @@ def configure_command(args: ProjectArguments) -> int:
             print(f"ERROR   {action.name}  {action.message}", file=sys.stderr)
         return 1
     if args.dry_run:
-        render_dry_run_configure(args, actions, would_copy_template=should_copy_template)
+        render_dry_run_configure(
+            args,
+            actions,
+            would_copy_template=should_copy_template,
+            project_config=project_config,
+        )
         return 0
     if project is None:
         if args.repo:
@@ -551,7 +595,11 @@ def configure_command(args: ProjectArguments) -> int:
 
 
 def render_dry_run_configure(
-    args: ProjectArguments, actions: tuple[ConfigureAction, ...], *, would_copy_template: bool = False
+    args: ProjectArguments,
+    actions: tuple[ConfigureAction, ...],
+    *,
+    would_copy_template: bool = False,
+    project_config: ProjectConfig | None = None,
 ) -> None:
     print(
         f"[DRY-RUN] Would configure GitHub Project '{args.project_title}' "
@@ -562,6 +610,13 @@ def render_dry_run_configure(
     if args.repo:
         print(f"[DRY-RUN] Would link GitHub Project '{args.project_title}' to repository '{args.repo}'.")
         print(f"[DRY-RUN] Would backfill issues from '{args.repo}' into GitHub Project '{args.project_title}'.")
+    if args.config_path:
+        print(f"[DRY-RUN] Would read GitHub Project config from '{args.config_path}'.")
+    config = project_config or ProjectConfig()
+    for option in config.areas:
+        print(f"[DRY-RUN] Would ensure Area option {option}.")
+    for option in config.initiatives:
+        print(f"[DRY-RUN] Would ensure Initiative option {option}.")
     print("[DRY-RUN] Fields: Status, Priority, Area, Size, Initiative")
     if args.initiative_options:
         for option in args.initiative_options:

--- a/cli/python/base_github_projects/project_config.py
+++ b/cli/python/base_github_projects/project_config.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+class ProjectConfigError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProjectConfig:
+    areas: tuple[str, ...] = ()
+    initiatives: tuple[str, ...] = ()
+    issue_defaults: dict[str, str] = field(default_factory=dict)
+
+
+ALLOWED_PROJECT_KEYS = {"areas", "initiatives", "issue_defaults"}
+ALLOWED_DEFAULT_KEYS = {"status", "priority", "size", "area", "initiative"}
+
+
+def read_project_config(path: Path) -> ProjectConfig:
+    data = read_yaml_mapping(path)
+    if not data:
+        return ProjectConfig(issue_defaults={})
+    project = data.get("project", {})
+    if not isinstance(project, dict):
+        raise ProjectConfigError(f"{path}: project must be a mapping.")
+    unexpected = set(project) - ALLOWED_PROJECT_KEYS
+    if unexpected:
+        names = ", ".join(sorted(unexpected))
+        raise ProjectConfigError(f"{path}: project contains unsupported keys: {names}.")
+    return ProjectConfig(
+        areas=read_string_list(path, project, "areas"),
+        initiatives=read_string_list(path, project, "initiatives"),
+        issue_defaults=read_issue_defaults(path, project),
+    )
+
+
+def read_yaml_mapping(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - depends on runtime packaging
+        raise ProjectConfigError("PyYAML is required to read GitHub Project config.") from exc
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ProjectConfigError(f"{path}: unable to read GitHub Project config: {exc.strerror}.") from exc
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ProjectConfigError(f"{path}: invalid YAML: {exc}") from exc
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ProjectConfigError(f"{path}: expected mapping at document root.")
+    unexpected = set(data) - {"project"}
+    if unexpected:
+        names = ", ".join(sorted(unexpected))
+        raise ProjectConfigError(f"{path}: unsupported top-level keys: {names}.")
+    return data
+
+
+def read_string_list(path: Path, project: dict[str, Any], key: str) -> tuple[str, ...]:
+    raw = project.get(key, ())
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ProjectConfigError(f"{path}: project.{key} must be a list of strings.")
+    values: list[str] = []
+    seen: set[str] = set()
+    for index, value in enumerate(raw):
+        if not isinstance(value, str) or not value.strip():
+            raise ProjectConfigError(f"{path}: project.{key}[{index}] must be a non-empty string.")
+        cleaned = value.strip()
+        if cleaned not in seen:
+            values.append(cleaned)
+            seen.add(cleaned)
+    return tuple(values)
+
+
+def read_issue_defaults(path: Path, project: dict[str, Any]) -> dict[str, str]:
+    raw = project.get("issue_defaults", {})
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ProjectConfigError(f"{path}: project.issue_defaults must be a mapping.")
+    unexpected = set(raw) - ALLOWED_DEFAULT_KEYS
+    if unexpected:
+        names = ", ".join(sorted(unexpected))
+        raise ProjectConfigError(f"{path}: project.issue_defaults contains unsupported keys: {names}.")
+    defaults: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(value, str) or not value.strip():
+            raise ProjectConfigError(f"{path}: project.issue_defaults.{key} must be a non-empty string.")
+        defaults[key] = value.strip()
+    return defaults

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from base_github_projects import engine
@@ -36,6 +38,25 @@ def test_parse_project_configure_arguments() -> None:
     assert args.dry_run is True
 
 
+def test_parse_project_configure_accepts_config_path() -> None:
+    args = engine.parse_args(
+        (
+            "project",
+            "configure",
+            "--project",
+            "base-demo",
+            "--owner",
+            "codeforester",
+            "--repo",
+            "codeforester/base-demo",
+            "--config",
+            ".github/base-project.yml",
+        )
+    )
+
+    assert args.config_path == ".github/base-project.yml"
+
+
 def test_parse_project_arguments_accept_equals_options() -> None:
     args = engine.parse_args(
         (
@@ -66,6 +87,70 @@ def test_parse_project_arguments_accept_equals_options() -> None:
         "size": "M",
     }
     assert args.dry_run is True
+
+
+def test_read_project_config_loads_repo_taxonomy(tmp_path: Path) -> None:
+    config_path = tmp_path / "base-project.yml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "project:",
+                "  areas:",
+                "    - Demo App",
+                "    - Documentation",
+                "  initiatives:",
+                "    - Demo Polish",
+                "    - Portfolio Dashboard",
+                "  issue_defaults:",
+                "    status: Backlog",
+                "    priority: P2",
+                "    size: S",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    config = engine.read_project_config(config_path)
+
+    assert config.areas == ("Demo App", "Documentation")
+    assert config.initiatives == ("Demo Polish", "Portfolio Dashboard")
+    assert config.issue_defaults == {"status": "Backlog", "priority": "P2", "size": "S"}
+
+
+def test_read_project_config_rejects_non_string_options(tmp_path: Path) -> None:
+    config_path = tmp_path / "base-project.yml"
+    config_path.write_text("project:\n  areas:\n    - Demo App\n    - 42\n", encoding="utf-8")
+
+    with pytest.raises(engine.ProjectUsageError) as excinfo:
+        engine.read_project_config(config_path)
+
+    assert str(excinfo.value) == f"{config_path}: project.areas[1] must be a non-empty string."
+
+
+def test_schema_for_args_adds_repo_project_config_options(tmp_path: Path) -> None:
+    config_path = tmp_path / "base-project.yml"
+    config_path.write_text(
+        "project:\n"
+        "  areas:\n"
+        "    - Demo App\n"
+        "  initiatives:\n"
+        "    - Demo Polish\n",
+        encoding="utf-8",
+    )
+
+    schema = engine.schema_for_args(
+        engine.ProjectArguments(
+            area="project",
+            command="configure",
+            project_title="base-demo",
+            owner="codeforester",
+            repo="codeforester/base-demo",
+            config_path=str(config_path),
+        )
+    )
+
+    assert "Demo App" in {option.name for option in schema.field_by_name("Area").options}
+    assert "Demo Polish" in {option.name for option in schema.field_by_name("Initiative").options}
 
 
 def test_compare_schema_reports_missing_fields_wrong_types_and_missing_options() -> None:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -58,7 +58,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 |---|---|---|
 | `basectl repo init <name>` | Create a Base-managed repository baseline and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
-| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
+| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files. | `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--dry-run` |
 | `basectl repo installer-template [path]` | Print the maintained project installer starter script, or write it to a path. | `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |
@@ -69,7 +69,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | `basectl gh branch prune` | Prune safe merged branches. | `--dry-run`, `--yes`, `--remote` |
 | `basectl gh worktree prune` | Prune stale merged worktrees. | `--dry-run`, `--yes` |
 | `basectl gh project doctor` | Inspect GitHub Project metadata against the Base roadmap schema. | `--project <title>`, `--owner <login>`, `--schema base-roadmap` |
-| `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--dry-run` |
+| `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--config <path>`, `--dry-run` |
 | `basectl gh project issue set-fields <number>` | Add an issue to the Project if needed and update metadata fields. | `--project <title>`, `--repo <owner/name>`, field options |
 | `basectl gh todo import` | Preview migration of `TODO.md` items into GitHub Issues. | `--dry-run`, `--file <path>` |
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -67,9 +67,10 @@ milestone and Project tracking so roadmap views do not double count the work.
 `basectl repo init` and `basectl repo configure` configure a repo-named Project
 by default when a GitHub repository is available. Base copies
 `base-project-template` when the repo Project is missing, links the Project to
-the repository, and backfills existing repository issues. Use `basectl gh
-project` directly for lower-level Project inspection, schema repair, or issue
-field updates.
+the repository, and backfills existing repository issues. When
+`.github/base-project.yml` exists, Base also adds missing repo-specific `Area`
+and `Initiative` options from that file. Use `basectl gh project` directly for
+lower-level Project inspection, schema repair, or issue field updates.
 
 ```bash
 basectl gh project doctor --project "Base Roadmap" --owner codeforester
@@ -386,10 +387,13 @@ Recommended fields:
 
 - `Status`: Triage, Backlog, Ready, In Progress, In Review, Done
 - `Priority`: P0, P1, P2, P3
-- `Area`: CLI, Setup, Workspace, Manifest, Runtime, Shell, Python, Docs, CI,
-  Packaging, Security, Product
+- `Area`: repo-specific options declared in `.github/base-project.yml`
 - `Size`: S, M, L
-- `PR Train`: optional text field for batch work
+- `Initiative`: repo-specific options declared in `.github/base-project.yml`
+
+Keep `Status`, `Priority`, and `Size` standardized across repos. Keep `Area`
+and `Initiative` repo-specific, and let `basectl repo configure` add missing
+options additively from the repo config file.
 
 Useful views:
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -81,9 +81,31 @@ the repository's existing issues into it. Pass `--no-project` to skip Project V2
 metadata, `--project <title>` to override the Project title, `--project-owner
 <login>` to override the owner, `--project-schema base-roadmap` to select the
 schema, and repeat `--initiative-option <name>` to seed repository-specific
-Initiative values.
+Initiative values. If `.github/base-project.yml` exists, Base reads repo-owned
+`Area` and `Initiative` options from that file and adds missing Project options
+without deleting or renaming existing options.
 `basectl gh project` is the lower-level direct surface for Project inspection,
 schema repair, and issue field updates.
+
+Repo Project taxonomy config uses this shape:
+
+```yaml
+project:
+  areas:
+    - Demo App
+    - Documentation
+  initiatives:
+    - Demo Polish
+    - Portfolio Dashboard
+  issue_defaults:
+    status: Backlog
+    priority: P2
+    size: S
+```
+
+`areas` and `initiatives` are applied by `repo configure`. `issue_defaults` is
+validated and reserved for issue intake automation; it does not set fields on
+existing issues during Project configuration.
 
 ## Local Baseline
 


### PR DESCRIPTION
## Summary
- Add `.github/base-project.yml` parsing for repo-specific Project taxonomy.
- Teach `basectl repo configure` to pass repo Project config into the Project engine when present.
- Add Area/Initiative options additively while leaving existing Project options untouched.
- Document the config shape and the non-destructive sync boundary.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests -q`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`
- `git diff --cached --check`
- `./tests/validate.sh` was not run because this checkout does not contain that script.

## Demo Impact
- No direct demo script impact. This enables `base-demo` to own its Project Area and Initiative options in `.github/base-project.yml`.

Fixes #637