### PR TITLE
Log repo project configuration progress

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -838,6 +838,20 @@ base_repo_pretty_arg() {
     fi
 }
 
+base_repo_pretty_command() {
+    local arg
+    local first=1
+
+    for arg in "$@"; do
+        if ((first)); then
+            first=0
+        else
+            printf ' '
+        fi
+        base_repo_pretty_arg "$arg"
+    done
+}
+
 base_repo_configure_label() {
     local color="$3"
     local description="$4"
@@ -1027,6 +1041,8 @@ base_repo_configure_project_metadata() {
         command+=(--initiative-option "$option")
     done
 
+    log_info "Configuring GitHub Project '$project_title' for '$repo'."
+    log_info "Running: $(base_repo_pretty_command "${command[@]}")"
     output="$("${command[@]}" 2>&1)" || status=$?
     if [[ "$status" -eq 0 ]]; then
         [[ -z "$output" ]] || printf '%s\n' "$output"

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -554,6 +554,8 @@ EOF
 
     [ "$status" -eq 0 ]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+    [[ "$output" == *"Configuring GitHub Project 'base-demo' for 'codeforester/base-demo'."* ]]
+    [[ "$output" == *"Running: $TEST_MOCKBIN/project-wrapper --project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml"* ]]
     [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml" ]
 }
 


### PR DESCRIPTION
## Summary
- Add non-dry-run progress logging before `basectl repo configure` invokes the GitHub Project metadata engine.
- Render the exact project wrapper command so long sync/backfill phases are visible instead of looking stuck.

## Validation
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test` — Python: 393 passed, 1 skipped; BATS: 432 passed

Fixes #651