### PR TITLE
Normalize lib_std dry-run values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   during `basectl repo configure` migrations, preserving existing target values.
 - Made `assert_not_null` reject invalid variable-name arguments without logging
   the raw value, and clarified that callers must pass variable names.
+- Made `lib_std.sh` dry-run handling treat `DRY_RUN` and `dry_run` values of
+  `true`, `1`, `yes`, and `on` consistently, avoiding accidental live execution.
 - Fixed documentation drift for `basectl logs` syntax, project virtual
   environment location, and README coverage of the `basectl ci` command.
 - Made `basectl activate` prefer a uv project's repo-local `.venv` when

--- a/lib/bash/std/README.md
+++ b/lib/bash/std/README.md
@@ -165,6 +165,10 @@ DRY_RUN=true
 run brew install jq
 ```
 
+`DRY_RUN` and `dry_run` both accept `true`, `1`, `yes`, and `on`. Use
+`is_dry_run` when a script needs to branch on the same normalized dry-run state
+without executing a command through `run`.
+
 Handle a failing command yourself with `--no-exit`:
 
 ```bash

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -34,7 +34,7 @@
 #   assert_* utilities           # Validation helpers (assert_not_null / assert_integer / ...).
 #
 # Patterns:
-#   run some_cmd                 # exits on failure; DRY_RUN=true prints instead.
+#   run some_cmd                 # exits on failure; DRY_RUN=true/1/yes/on prints instead.
 #   some_cmd || fatal_error ...  # preserves failing exit code before terminating.
 #   add_to_path -p "/opt/tools"  # inject directories without duplicates.
 #
@@ -579,6 +579,25 @@ fatal_error() {
 #################################################### COMMAND EXECUTION #################################################
 
 #
+# is_dry_run - Returns true when dry-run mode is enabled.
+#
+# Dry-run mode may be enabled through either DRY_RUN or dry_run. Both names
+# accept common truthy values so callers do not need to duplicate normalization.
+#
+is_dry_run() {
+    local value
+
+    for value in "${DRY_RUN-}" "${dry_run-}"; do
+        case "${value,,}" in
+            true | 1 | yes | on)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+#
 # run - Safely executes a simple command with its arguments.
 #
 # This function is designed to be a secure and robust replacement for using
@@ -588,8 +607,8 @@ fatal_error() {
 # Features:
 #   - Secure: Does not use `eval`, preventing arbitrary code execution.
 #   - Argument Safe: Correctly handles spaces and special characters in arguments.
-#   - Dry-Run Mode: If the global variable DRY_RUN (or dry_run) is true, it prints the
-#     command instead of running it.
+#   - Dry-Run Mode: If the global variable DRY_RUN (or dry_run) is truthy, it
+#     prints the command instead of running it.
 #   - Exit on Failure: By default, it will exit the script if the command
 #     returns a non-zero exit code.
 #   - Optional No-Exit: If the first argument is `--no-exit`, the function
@@ -640,7 +659,7 @@ run() {
     printable_command="${printable_command% }"
 
     # --- Dry-Run Handling ---
-    if [[ "${DRY_RUN-}" == true || "${dry_run-}" == true ]]; then
+    if is_dry_run; then
         # Use printf with the %q format specifier. This is the safest way to
         # print a command and its arguments in a way that is unambiguous and
         # could be copied and pasted back into a shell.

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -522,6 +522,31 @@ EOF
     [ ! -e "$target" ]
 }
 
+@test "run treats common truthy dry-run values as dry-run mode" {
+    local case_name target value var_name
+
+    for case_name in \
+        "DRY_RUN=1" \
+        "DRY_RUN=yes" \
+        "DRY_RUN=on" \
+        "dry_run=true" \
+        "dry_run=1" \
+        "dry_run=yes" \
+        "dry_run=on"; do
+        unset DRY_RUN dry_run
+        var_name="${case_name%%=*}"
+        value="${case_name#*=}"
+        printf -v "$var_name" '%s' "$value"
+        export "$var_name"
+        target="$TEST_TMPDIR/dry-run-${var_name}-${value}.txt"
+
+        run touch "$target"
+
+        [ "$?" -eq 0 ]
+        [ ! -e "$target" ]
+    done
+}
+
 @test "run --no-exit returns the underlying failure status" {
     local stderr_file="$TEST_TMPDIR/run-no-exit.err"
     local rc


### PR DESCRIPTION
## Summary

- Added `is_dry_run` to normalize `DRY_RUN` and `dry_run` values in `lib_std.sh`.
- Updated `run` so `true`, `1`, `yes`, and `on` all trigger dry-run behavior instead of executing commands.
- Documented the accepted dry-run values and added regression coverage.

## Issue

Closes #655

## Validation

- `bats lib/bash/std/tests/lib_std.bats`
  - `64` cases completed, including the new truthy dry-run regression test and the existing macOS tty skip.
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`
  - Python: `397 passed, 1 skipped`.
  - BATS: `435` cases completed with exit code 0.

## Demo Impact

None.

## Notes

- AI context update is not applicable; this is a narrow stdlib behavior fix.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
