### PR TITLE
Copy repo Project item fields from source project

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,10 @@ Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and
 `--initiative-option` when the default Project title or Initiative values need
-to vary by repository.
+to vary by repository. During Project migration, pass
+`--copy-project-fields-from <title>` to copy missing issue item field values
+from an existing Project into the repo Project without overwriting values that
+are already set.
 
 Run a discovered project's declared test command with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -91,6 +91,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
   `Area` and `Initiative` options are added from that file. Use `--no-project`
   to skip Project setup, `--project <title>` to override the Project title, or
   `--initiative-option <name>` to seed repository-specific Initiative values.
+  Use `--copy-project-fields-from <title>` during migration to copy missing
+  issue item field values from an existing Project into the repo Project.
   `basectl repo agent-guidance [path]` seeds optional repo-local agent guidance
   files and `basectl repo check [path] --agent-guidance` verifies that optional
   layer for repos that opt in.

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -50,6 +50,8 @@ Options:
   --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
   --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
   --initiative-option <name>    Initiative option to seed. May be repeated.
+  --copy-project-fields-from <title>
+                                Copy missing Project item field values from another Project.
   --no-project                  Skip GitHub Project metadata configuration.
   --dry-run                     Print planned changes without applying them.
   -v                            Enable DEBUG logging for this subcommand.
@@ -983,6 +985,7 @@ base_repo_project_config_path() {
 base_repo_configure_project_metadata() {
     local dry_run="$1"
     local config_path="$6"
+    local copy_fields_from_project="$7"
     local option
     local owner="$4"
     local output=""
@@ -991,7 +994,7 @@ base_repo_configure_project_metadata() {
     local schema="$5"
     local status=0
     local wrapper="${BASE_REPO_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
-    shift 6
+    shift 7
 
     if [[ "$dry_run" == "1" ]]; then
         printf "[DRY-RUN] Would configure GitHub Project '%s' for '%s'.\n" "$project_title" "$repo"
@@ -1001,6 +1004,11 @@ base_repo_configure_project_metadata() {
         if [[ -n "$config_path" ]]; then
             printf "[DRY-RUN] Would read GitHub Project config from '%s'.\n" "$config_path"
         fi
+        if [[ -n "$copy_fields_from_project" ]]; then
+            printf "[DRY-RUN] Would copy missing Project item field values from '%s' into '%s'.\n" \
+                "$copy_fields_from_project" \
+                "$project_title"
+        fi
         printf "[DRY-RUN] Would run: %s --project base base_github_projects project configure --project %s --owner %s --repo %s --schema %s" \
             "$wrapper" \
             "$(base_repo_pretty_arg "$project_title")" \
@@ -1009,6 +1017,9 @@ base_repo_configure_project_metadata() {
             "$schema"
         if [[ -n "$config_path" ]]; then
             printf " --config %s" "$(base_repo_pretty_arg "$config_path")"
+        fi
+        if [[ -n "$copy_fields_from_project" ]]; then
+            printf " --copy-fields-from %s" "$(base_repo_pretty_arg "$copy_fields_from_project")"
         fi
         for option in "$@"; do
             printf " --initiative-option %s" "$(base_repo_pretty_arg "$option")"
@@ -1036,6 +1047,9 @@ base_repo_configure_project_metadata() {
     )
     if [[ -n "$config_path" ]]; then
         command+=(--config "$config_path")
+    fi
+    if [[ -n "$copy_fields_from_project" ]]; then
+        command+=(--copy-fields-from "$copy_fields_from_project")
     fi
     for option in "$@"; do
         command+=(--initiative-option "$option")
@@ -1337,6 +1351,7 @@ base_repo_init() {
     local project_owner=""
     local project_schema="base-roadmap"
     local project_title=""
+    local copy_project_fields_from=""
     local protect_default_branch=1
     local pr_branch=""
     local requested_visibility=""
@@ -1460,6 +1475,18 @@ base_repo_init() {
                 initiative_options+=("${1#--initiative-option=}")
                 shift
                 ;;
+            --copy-project-fields-from)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--copy-project-fields-from' requires an argument."
+                    return $?
+                }
+                copy_project_fields_from="$2"
+                shift 2
+                ;;
+            --copy-project-fields-from=*)
+                copy_project_fields_from="${1#--copy-project-fields-from=}"
+                shift
+                ;;
             --no-project)
                 configure_project=0
                 shift
@@ -1545,6 +1572,7 @@ base_repo_init() {
                     "$project_owner" \
                     "$project_schema" \
                     "$(base_repo_project_config_path "$root")" \
+                    "$copy_project_fields_from" \
                     "${initiative_options[@]}" || return 1
             fi
         else
@@ -1694,6 +1722,7 @@ base_repo_agent_guidance() {
 
 base_repo_configure() {
     local configure_project=1
+    local copy_project_fields_from=""
     local dry_run=0
     local github_repo=""
     local initiative_options=()
@@ -1777,6 +1806,18 @@ base_repo_configure() {
                 initiative_options+=("${1#--initiative-option=}")
                 shift
                 ;;
+            --copy-project-fields-from)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_usage_error "Option '--copy-project-fields-from' requires an argument."
+                    return $?
+                }
+                copy_project_fields_from="$2"
+                shift 2
+                ;;
+            --copy-project-fields-from=*)
+                copy_project_fields_from="${1#--copy-project-fields-from=}"
+                shift
+                ;;
             --no-project)
                 configure_project=0
                 shift
@@ -1822,6 +1863,7 @@ base_repo_configure() {
             "$project_owner" \
             "$project_schema" \
             "$(base_repo_project_config_path "$path")" \
+            "$copy_project_fields_from" \
             "${initiative_options[@]}"
     fi
 }

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -14,6 +14,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl repo agent-guidance [path]"* ]]
     [[ "$output" == *"basectl repo installer-template [path]"* ]]
     [[ "$output" == *"--no-protect-default-branch"* ]]
+    [[ "$output" == *"--copy-project-fields-from"* ]]
 }
 
 @test "basectl repo installer-template prints the maintained template" {
@@ -491,6 +492,21 @@ EOF
     [[ "$output" == *"--initiative-option Imports"* ]]
 }
 
+@test "basectl repo configure can copy project fields from a source project" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+
+    run_basectl repo configure "$repo_dir" \
+        --repo codeforester/base \
+        --copy-project-fields-from "Base Roadmap" \
+        --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Would copy missing Project item field values from 'Base Roadmap' into 'base'."* ]]
+    [[ "$output" == *'--copy-fields-from "Base Roadmap"'* ]]
+}
+
 @test "basectl repo configure applies GitHub settings through gh" {
     local repo_dir="$TEST_TMPDIR/repo"
 
@@ -550,13 +566,15 @@ EOF
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" \
+            --repo codeforester/base-demo \
+            --copy-project-fields-from "Base Roadmap"
 
     [ "$status" -eq 0 ]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     [[ "$output" == *"Configuring GitHub Project 'base-demo' for 'codeforester/base-demo'."* ]]
-    [[ "$output" == *"Running: $TEST_MOCKBIN/project-wrapper --project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml"* ]]
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml" ]
+    [[ "$output" == *"Running: $TEST_MOCKBIN/project-wrapper --project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from \"Base Roadmap\""* ]]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
 }
 
 @test "basectl repo configure warns when project metadata needs GitHub project scope" {

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -7,6 +7,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import graphql_queries as queries
+from .project_item_fields import FieldCopySummary
+from .project_item_fields import copy_missing_project_item_fields as _copy_missing_project_item_fields
+from .project_model import BASE_ROADMAP_SCHEMA, DEFAULT_TEMPLATE_PROJECT, FIELD_OPTION_TO_PROJECT_FIELD
+from .project_model import STANDARD_TEMPLATE_VIEWS, ConfigureAction, FieldUpdate, Finding, OwnerInfo
+from .project_model import ProjectArguments, ProjectField, ProjectInfo, ProjectSchema, ProjectView
+from .project_model import SelectFieldSpec, SelectOption
 from .project_config import ProjectConfig, ProjectConfigError
 from .project_config import read_project_config as _read_project_config
 
@@ -23,172 +29,16 @@ class ProjectAuthError(ProjectError):
     pass
 
 
-@dataclass(frozen=True)
-class SelectOption:
-    name: str
-    color: str
-    description: str
-    option_id: str | None = None
-
-
-@dataclass(frozen=True)
-class SelectFieldSpec:
-    name: str
-    options: tuple[SelectOption, ...]
-
-
-@dataclass(frozen=True)
-class ProjectSchema:
-    fields: tuple[SelectFieldSpec, ...]
-
-    def field_by_name(self, name: str) -> SelectFieldSpec:
-        for field in self.fields:
-            if field.name == name:
-                return field
-        raise KeyError(name)
-
-
-@dataclass(frozen=True)
-class ProjectField:
-    field_id: str
-    name: str
-    data_type: str
-    options: tuple[SelectOption, ...] = ()
-
-
-@dataclass(frozen=True)
-class Finding:
-    status: str
-    name: str
-    message: str
-
-
-@dataclass(frozen=True)
-class ConfigureAction:
-    action: str
-    name: str
-    message: str
-
-
-@dataclass(frozen=True)
-class FieldUpdate:
-    field_id: str
-    option_id: str
-    field_name: str
-    option_name: str
-
-
-@dataclass(frozen=True)
-class ProjectInfo:
-    project_id: str
-    title: str
-
-
-@dataclass(frozen=True)
-class ProjectView:
-    name: str
-    layout: str
-
-
-@dataclass(frozen=True)
-class OwnerInfo:
-    owner_id: str
-    login: str
-    project: ProjectInfo | None
-
-
-@dataclass(frozen=True)
-class ProjectArguments:
-    area: str
-    command: str
-    project_title: str | None = None
-    owner: str | None = None
-    repo: str | None = None
-    schema: str = "base-roadmap"
-    config_path: str | None = None
-    initiative_options: tuple[str, ...] = ()
-    dry_run: bool = False
-    issue_number: int | None = None
-    field_values: dict[str, str] | None = None
-
-
-BASE_ROADMAP_SCHEMA = ProjectSchema(
-    fields=(
-        SelectFieldSpec(
-            "Status",
-            (
-                SelectOption("Triage", "GRAY", "Needs clarification or initial classification."),
-                SelectOption("Backlog", "BLUE", "Accepted but not yet scheduled."),
-                SelectOption("Ready", "GREEN", "Scoped enough to pick up."),
-                SelectOption("In Progress", "YELLOW", "Actively being worked on."),
-                SelectOption("In Review", "ORANGE", "Pull request open, waiting on checks or review."),
-                SelectOption("Done", "PURPLE", "Completed or no further work remains."),
-            ),
-        ),
-        SelectFieldSpec(
-            "Priority",
-            (
-                SelectOption("P0", "RED", "Urgent or blocking."),
-                SelectOption("P1", "ORANGE", "High priority."),
-                SelectOption("P2", "YELLOW", "Normal priority."),
-                SelectOption("P3", "BLUE", "Low priority or opportunistic."),
-            ),
-        ),
-        SelectFieldSpec(
-            "Area",
-            (
-                SelectOption("CLI", "GRAY", "Command surface and user-facing CLI behavior."),
-                SelectOption("Setup", "GRAY", "Installation, setup, check, and doctor behavior."),
-                SelectOption("Workspace", "GRAY", "Workspace discovery and workspace-level commands."),
-                SelectOption("Manifest", "GRAY", "Manifest schema and project contract handling."),
-                SelectOption("Runtime", "GRAY", "Activation, shell runtime, and environment behavior."),
-                SelectOption("Shell", "GRAY", "Shell libraries, completions, and startup files."),
-                SelectOption("Python", "GRAY", "Python command packages and shared Python helpers."),
-                SelectOption("Docs", "GRAY", "Documentation and AI context."),
-                SelectOption("CI", "GRAY", "Continuous integration and validation automation."),
-                SelectOption("Packaging", "GRAY", "Release, Homebrew, installer, and distribution work."),
-                SelectOption("Security", "GRAY", "Permission, secret-handling, and hardening work."),
-                SelectOption("Product", "GRAY", "Product direction, roadmap, and adoption work."),
-            ),
-        ),
-        SelectFieldSpec(
-            "Size",
-            (
-                SelectOption("S", "GREEN", "Small, focused change."),
-                SelectOption("M", "YELLOW", "Medium change with multiple files or interactions."),
-                SelectOption("L", "ORANGE", "Large change that should be split if possible."),
-            ),
-        ),
-        SelectFieldSpec(
-            "Initiative",
-            (
-                SelectOption("BanyanLabs Dogfood", "GRAY", "Dogfood Base through BanyanLabs."),
-                SelectOption("Workspace Handling", "GRAY", "Workspace discovery and orchestration."),
-                SelectOption("pyproject/uv", "GRAY", "Python packaging and uv integration."),
-                SelectOption("v1.0 Readiness", "GRAY", "Stable public release readiness."),
-                SelectOption("Adoption Polish", "GRAY", "Install, docs, and adoption polish."),
-            ),
-        ),
-    )
-)
-
-
-DEFAULT_TEMPLATE_PROJECT = "base-project-template"
-STANDARD_TEMPLATE_VIEWS = (
-    ProjectView("Backlog", "TABLE_LAYOUT"),
-    ProjectView("Board", "BOARD_LAYOUT"),
-    ProjectView("By Status", "TABLE_LAYOUT"),
-    ProjectView("Roadmap", "ROADMAP_LAYOUT"),
-)
-FIELD_OPTION_TO_PROJECT_FIELD = {
-    "status": "Status",
-    "priority": "Priority",
-    "area": "Area",
-    "initiative": "Initiative",
-    "size": "Size",
-}
 HELP_OPTIONS = ("-h", "--help", "help")
-PROJECT_VALUE_OPTIONS = ("--project", "--owner", "--repo", "--schema", "--config", "--initiative-option")
+PROJECT_VALUE_OPTIONS = (
+    "--project",
+    "--owner",
+    "--repo",
+    "--schema",
+    "--config",
+    "--copy-fields-from",
+    "--initiative-option",
+)
 ISSUE_FIELD_OPTIONS = ("--status", "--priority", "--area", "--initiative", "--size")
 
 
@@ -220,7 +70,7 @@ def print_usage(file=sys.stdout) -> None:
                 "[--owner <login>] [--schema base-roadmap]",
                 "  base_github_projects project configure --project <title> "
                 "[--owner <login>] [--repo <owner/name>] [--schema base-roadmap] [--config <path>] "
-                "[--initiative-option <name>] [--dry-run]",
+                "[--copy-fields-from <title>] [--initiative-option <name>] [--dry-run]",
                 "  base_github_projects project issue set-fields <number> "
                 "--repo <owner/name> --project <title> [field options...]",
             )
@@ -272,6 +122,7 @@ class OptionState:
     repo: str | None = None
     schema: str = "base-roadmap"
     config_path: str | None = None
+    copy_fields_from_project: str | None = None
     initiative_options: list[str] | None = None
     dry_run: bool = False
     field_values: dict[str, str] | None = None
@@ -350,6 +201,8 @@ def apply_project_option(state: OptionState, option: str, value: str) -> None:
         state.schema = value
     elif option == "--config":
         state.config_path = value
+    elif option == "--copy-fields-from":
+        state.copy_fields_from_project = value
     elif option == "--initiative-option":
         state.initiative_options.append(value)
 
@@ -368,6 +221,7 @@ def state_to_args(command: str, state: OptionState, issue_number: int | None = N
         repo=state.repo,
         schema=state.schema,
         config_path=state.config_path,
+        copy_fields_from_project=state.copy_fields_from_project,
         initiative_options=tuple(state.initiative_options or ()),
         dry_run=state.dry_run,
         issue_number=issue_number,
@@ -590,8 +444,24 @@ def configure_command(args: ProjectArguments) -> int:
         link_project_to_repository(project.project_id, args.repo)
         count = backfill_repository_issues(project.project_id, args.repo)
         print(f"✓ Backfilled {count} issue(s) from {args.repo}")
+    copy_project_fields_from_source(owner, project.project_id, args.copy_fields_from_project)
     print(f"✓ Configured GitHub Project {args.project_title}")
     return 0
+
+
+def copy_project_fields_from_source(owner: str, target_project_id: str, source_project_title: str | None) -> None:
+    if not source_project_title:
+        return
+    source = find_owner_and_project(owner, source_project_title).project
+    if source is None:
+        raise ProjectError(f"Source Project '{source_project_title}' was not found for owner '{owner}'.")
+    summary = copy_missing_project_item_fields(source.project_id, target_project_id)
+    print(f"✓ Copied {summary.applied_count} Project item field value(s) from {source_project_title}")
+    for skipped in summary.skipped:
+        print(
+            f"WARN    Issue #{skipped.issue_number} {skipped.field_name}={skipped.option_name}: {skipped.reason}",
+            file=sys.stderr,
+        )
 
 
 def render_dry_run_configure(
@@ -610,6 +480,8 @@ def render_dry_run_configure(
     if args.repo:
         print(f"[DRY-RUN] Would link GitHub Project '{args.project_title}' to repository '{args.repo}'.")
         print(f"[DRY-RUN] Would backfill issues from '{args.repo}' into GitHub Project '{args.project_title}'.")
+    if args.copy_fields_from_project:
+        print(f"[DRY-RUN] Would copy missing item field values from GitHub Project '{args.copy_fields_from_project}'.")
     if args.config_path:
         print(f"[DRY-RUN] Would read GitHub Project config from '{args.config_path}'.")
     config = project_config or ProjectConfig()
@@ -979,4 +851,13 @@ def update_item_field(project_id: str, item_id: str, update: FieldUpdate) -> Non
             "fieldId": update.field_id,
             "optionId": update.option_id,
         },
+    )
+
+
+def copy_missing_project_item_fields(source_project_id: str, target_project_id: str) -> FieldCopySummary:
+    return _copy_missing_project_item_fields(
+        run_graphql=run_graphql,
+        source_project_id=source_project_id,
+        target_project_id=target_project_id,
+        target_fields=fetch_project_fields(target_project_id),
     )

--- a/cli/python/base_github_projects/graphql_queries.py
+++ b/cli/python/base_github_projects/graphql_queries.py
@@ -132,6 +132,37 @@ query($projectId: ID!, $cursor: String) {
 }
 """
 
+FETCH_PROJECT_ISSUE_ITEMS_WITH_FIELDS = """
+query($projectId: ID!, $cursor: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          content {
+            ... on Issue {
+              id
+              number
+              title
+            }
+          }
+          fieldValues(first: 50) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
 FIND_PROJECT_ITEM_ID = """
 query($projectId: ID!) {
   node(id: $projectId) {

--- a/cli/python/base_github_projects/project_item_fields.py
+++ b/cli/python/base_github_projects/project_item_fields.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from . import graphql_queries as queries
+
+
+FIELD_COPY_NAMES = ("Status", "Priority", "Area", "Initiative", "Size")
+
+
+@dataclass(frozen=True)
+class ProjectIssueItem:
+    item_id: str
+    issue_id: str
+    issue_number: int
+    title: str
+    values: dict[str, str]
+
+
+@dataclass(frozen=True)
+class ProjectSelectField:
+    field_id: str
+    options: dict[str, str]
+
+
+@dataclass(frozen=True)
+class ProjectFieldCopy:
+    item_id: str
+    issue_number: int
+    field_name: str
+    option_name: str
+    field_id: str
+    option_id: str
+
+
+@dataclass(frozen=True)
+class ProjectFieldCopySkip:
+    issue_number: int
+    field_name: str
+    option_name: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ProjectFieldCopyPlan:
+    updates: tuple[ProjectFieldCopy, ...]
+    skipped: tuple[ProjectFieldCopySkip, ...]
+
+
+@dataclass(frozen=True)
+class FieldCopySummary:
+    applied_count: int
+    skipped: tuple[ProjectFieldCopySkip, ...]
+
+
+def plan_missing_field_copies(
+    *,
+    source_items: dict[str, ProjectIssueItem],
+    target_items: dict[str, ProjectIssueItem],
+    target_fields: dict[str, ProjectSelectField],
+    field_names: tuple[str, ...] = FIELD_COPY_NAMES,
+) -> ProjectFieldCopyPlan:
+    updates: list[ProjectFieldCopy] = []
+    skipped: list[ProjectFieldCopySkip] = []
+    for issue_id, target in sorted(target_items.items(), key=lambda item: item[1].issue_number):
+        source = source_items.get(issue_id)
+        if source is None:
+            continue
+        for field_name in field_names:
+            if target.values.get(field_name):
+                continue
+            option_name = source.values.get(field_name)
+            if not option_name:
+                continue
+            target_field = target_fields.get(field_name)
+            if target_field is None:
+                skipped.append(
+                    ProjectFieldCopySkip(
+                        target.issue_number, field_name, option_name, "target field is missing"
+                    )
+                )
+                continue
+            option_id = target_field.options.get(option_name)
+            if option_id is None:
+                skipped.append(
+                    ProjectFieldCopySkip(
+                        target.issue_number, field_name, option_name, "target option is missing"
+                    )
+                )
+                continue
+            updates.append(
+                ProjectFieldCopy(
+                    item_id=target.item_id,
+                    issue_number=target.issue_number,
+                    field_name=field_name,
+                    option_name=option_name,
+                    field_id=target_field.field_id,
+                    option_id=option_id,
+                )
+            )
+    return ProjectFieldCopyPlan(tuple(updates), tuple(skipped))
+
+
+def copy_missing_project_item_fields(
+    *,
+    run_graphql: Callable[[str, dict[str, object]], dict[str, object]],
+    source_project_id: str,
+    target_project_id: str,
+    target_fields: Iterable[object],
+) -> FieldCopySummary:
+    plan = plan_missing_field_copies(
+        source_items=fetch_project_issue_items(run_graphql, source_project_id),
+        target_items=fetch_project_issue_items(run_graphql, target_project_id),
+        target_fields=select_fields_by_name(target_fields),
+    )
+    for update in plan.updates:
+        run_graphql(
+            queries.UPDATE_ITEM_FIELD,
+            {
+                "projectId": target_project_id,
+                "itemId": update.item_id,
+                "fieldId": update.field_id,
+                "optionId": update.option_id,
+            },
+        )
+    return FieldCopySummary(len(plan.updates), plan.skipped)
+
+
+def select_fields_by_name(fields: Iterable[object]) -> dict[str, ProjectSelectField]:
+    selected: dict[str, ProjectSelectField] = {}
+    for field in fields:
+        if getattr(field, "data_type", "") != "SINGLE_SELECT":
+            continue
+        options = {
+            option.name: option.option_id
+            for option in getattr(field, "options", ())
+            if option.option_id is not None
+        }
+        selected[field.name] = ProjectSelectField(field.field_id, options)
+    return selected
+
+
+def fetch_project_issue_items(
+    run_graphql: Callable[[str, dict[str, object]], dict[str, object]],
+    project_id: str,
+) -> dict[str, ProjectIssueItem]:
+    items: dict[str, ProjectIssueItem] = {}
+    cursor: str | None = None
+    while True:
+        payload = run_graphql(
+            queries.FETCH_PROJECT_ISSUE_ITEMS_WITH_FIELDS,
+            {"projectId": project_id, "cursor": cursor},
+        )
+        node = payload["data"].get("node")
+        project_items = node["items"]
+        for raw in project_items["nodes"]:
+            content = raw.get("content") or {}
+            issue_id = content.get("id")
+            if not issue_id:
+                continue
+            items[issue_id] = ProjectIssueItem(
+                item_id=raw["id"],
+                issue_id=issue_id,
+                issue_number=content["number"],
+                title=content["title"],
+                values=single_select_values(raw),
+            )
+        if not project_items["pageInfo"]["hasNextPage"]:
+            return items
+        cursor = project_items["pageInfo"]["endCursor"]
+
+
+def single_select_values(raw_item: dict[str, object]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_value in raw_item["fieldValues"]["nodes"]:
+        if raw_value.get("__typename") != "ProjectV2ItemFieldSingleSelectValue":
+            continue
+        field = raw_value.get("field") or {}
+        field_name = field.get("name")
+        if field_name:
+            values[field_name] = raw_value["name"]
+    return values

--- a/cli/python/base_github_projects/project_model.py
+++ b/cli/python/base_github_projects/project_model.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SelectOption:
+    name: str
+    color: str
+    description: str
+    option_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SelectFieldSpec:
+    name: str
+    options: tuple[SelectOption, ...]
+
+
+@dataclass(frozen=True)
+class ProjectSchema:
+    fields: tuple[SelectFieldSpec, ...]
+
+    def field_by_name(self, name: str) -> SelectFieldSpec:
+        for field in self.fields:
+            if field.name == name:
+                return field
+        raise KeyError(name)
+
+
+@dataclass(frozen=True)
+class ProjectField:
+    field_id: str
+    name: str
+    data_type: str
+    options: tuple[SelectOption, ...] = ()
+
+
+@dataclass(frozen=True)
+class Finding:
+    status: str
+    name: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ConfigureAction:
+    action: str
+    name: str
+    message: str
+
+
+@dataclass(frozen=True)
+class FieldUpdate:
+    field_id: str
+    option_id: str
+    field_name: str
+    option_name: str
+
+
+@dataclass(frozen=True)
+class ProjectInfo:
+    project_id: str
+    title: str
+
+
+@dataclass(frozen=True)
+class ProjectView:
+    name: str
+    layout: str
+
+
+@dataclass(frozen=True)
+class OwnerInfo:
+    owner_id: str
+    login: str
+    project: ProjectInfo | None
+
+
+@dataclass(frozen=True)
+class ProjectArguments:
+    area: str
+    command: str
+    project_title: str | None = None
+    owner: str | None = None
+    repo: str | None = None
+    schema: str = "base-roadmap"
+    config_path: str | None = None
+    copy_fields_from_project: str | None = None
+    initiative_options: tuple[str, ...] = ()
+    dry_run: bool = False
+    issue_number: int | None = None
+    field_values: dict[str, str] | None = None
+
+
+BASE_ROADMAP_SCHEMA = ProjectSchema(
+    fields=(
+        SelectFieldSpec(
+            "Status",
+            (
+                SelectOption("Triage", "GRAY", "Needs clarification or initial classification."),
+                SelectOption("Backlog", "BLUE", "Accepted but not yet scheduled."),
+                SelectOption("Ready", "GREEN", "Scoped enough to pick up."),
+                SelectOption("In Progress", "YELLOW", "Actively being worked on."),
+                SelectOption("In Review", "ORANGE", "Pull request open, waiting on checks or review."),
+                SelectOption("Done", "PURPLE", "Completed or no further work remains."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Priority",
+            (
+                SelectOption("P0", "RED", "Urgent or blocking."),
+                SelectOption("P1", "ORANGE", "High priority."),
+                SelectOption("P2", "YELLOW", "Normal priority."),
+                SelectOption("P3", "BLUE", "Low priority or opportunistic."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Area",
+            (
+                SelectOption("CLI", "GRAY", "Command surface and user-facing CLI behavior."),
+                SelectOption("Setup", "GRAY", "Installation, setup, check, and doctor behavior."),
+                SelectOption("Workspace", "GRAY", "Workspace discovery and workspace-level commands."),
+                SelectOption("Manifest", "GRAY", "Manifest schema and project contract handling."),
+                SelectOption("Runtime", "GRAY", "Activation, shell runtime, and environment behavior."),
+                SelectOption("Shell", "GRAY", "Shell libraries, completions, and startup files."),
+                SelectOption("Python", "GRAY", "Python command packages and shared Python helpers."),
+                SelectOption("Docs", "GRAY", "Documentation and AI context."),
+                SelectOption("CI", "GRAY", "Continuous integration and validation automation."),
+                SelectOption("Packaging", "GRAY", "Release, Homebrew, installer, and distribution work."),
+                SelectOption("Security", "GRAY", "Permission, secret-handling, and hardening work."),
+                SelectOption("Product", "GRAY", "Product direction, roadmap, and adoption work."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Size",
+            (
+                SelectOption("S", "GREEN", "Small, focused change."),
+                SelectOption("M", "YELLOW", "Medium change with multiple files or interactions."),
+                SelectOption("L", "ORANGE", "Large change that should be split if possible."),
+            ),
+        ),
+        SelectFieldSpec(
+            "Initiative",
+            (
+                SelectOption("BanyanLabs Dogfood", "GRAY", "Dogfood Base through BanyanLabs."),
+                SelectOption("Workspace Handling", "GRAY", "Workspace discovery and orchestration."),
+                SelectOption("pyproject/uv", "GRAY", "Python packaging and uv integration."),
+                SelectOption("v1.0 Readiness", "GRAY", "Stable public release readiness."),
+                SelectOption("Adoption Polish", "GRAY", "Install, docs, and adoption polish."),
+            ),
+        ),
+    )
+)
+
+DEFAULT_TEMPLATE_PROJECT = "base-project-template"
+STANDARD_TEMPLATE_VIEWS = (
+    ProjectView("Backlog", "TABLE_LAYOUT"),
+    ProjectView("Board", "BOARD_LAYOUT"),
+    ProjectView("By Status", "TABLE_LAYOUT"),
+    ProjectView("Roadmap", "ROADMAP_LAYOUT"),
+)
+FIELD_OPTION_TO_PROJECT_FIELD = {
+    "status": "Status",
+    "priority": "Priority",
+    "area": "Area",
+    "initiative": "Initiative",
+    "size": "Size",
+}

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -57,6 +57,25 @@ def test_parse_project_configure_accepts_config_path() -> None:
     assert args.config_path == ".github/base-project.yml"
 
 
+def test_parse_project_configure_accepts_copy_fields_from_project() -> None:
+    args = engine.parse_args(
+        (
+            "project",
+            "configure",
+            "--project",
+            "base",
+            "--owner",
+            "codeforester",
+            "--repo",
+            "codeforester/base",
+            "--copy-fields-from",
+            "Base Roadmap",
+        )
+    )
+
+    assert args.copy_fields_from_project == "Base Roadmap"
+
+
 def test_parse_project_arguments_accept_equals_options() -> None:
     args = engine.parse_args(
         (
@@ -441,6 +460,54 @@ def test_configure_command_copies_template_for_repo_project_and_backfills_issues
     assert backfilled == [("project-id", "codeforester/base-demo")]
 
 
+def test_configure_command_copies_missing_project_fields_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    copied: list[tuple[str, str]] = []
+
+    def fake_find_owner_and_project(owner: str, title: str) -> engine.OwnerInfo:
+        if title == "base":
+            return engine.OwnerInfo(
+                owner_id="owner-id",
+                login=owner,
+                project=engine.ProjectInfo(project_id="target-project", title=title),
+            )
+        if title == "Base Roadmap":
+            return engine.OwnerInfo(
+                owner_id="owner-id",
+                login=owner,
+                project=engine.ProjectInfo(project_id="source-project", title=title),
+            )
+        raise AssertionError(f"unexpected project lookup: {title}")
+
+    monkeypatch.setattr(engine, "find_owner_and_project", fake_find_owner_and_project)
+    monkeypatch.setattr(engine, "fetch_project_fields", lambda project_id: ())
+    monkeypatch.setattr(engine, "create_single_select_field", lambda project_id, spec: None)
+    monkeypatch.setattr(engine, "update_single_select_field", lambda field, spec: None)
+    monkeypatch.setattr(engine, "fetch_project_views", lambda project_id: engine.STANDARD_TEMPLATE_VIEWS)
+    monkeypatch.setattr(engine, "link_project_to_repository", lambda project_id, repo: None)
+    monkeypatch.setattr(engine, "backfill_repository_issues", lambda project_id, repo: 0)
+    monkeypatch.setattr(
+        engine,
+        "copy_missing_project_item_fields",
+        lambda source_id, target_id: copied.append((source_id, target_id)) or engine.FieldCopySummary(3, ()),
+    )
+
+    status = engine.configure_command(
+        engine.ProjectArguments(
+            area="project",
+            command="configure",
+            project_title="base",
+            owner="codeforester",
+            repo="codeforester/base",
+            copy_fields_from_project="Base Roadmap",
+        )
+    )
+
+    assert status == 0
+    assert copied == [("source-project", "target-project")]
+
+
 def test_configure_command_dry_run_reports_template_copy_link_and_backfill(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -467,6 +534,99 @@ def test_configure_command_dry_run_reports_template_copy_link_and_backfill(
     assert "Would copy GitHub Project 'base-project-template' to 'base-demo'." in output
     assert "Would link GitHub Project 'base-demo' to repository 'codeforester/base-demo'." in output
     assert "Would backfill issues from 'codeforester/base-demo' into GitHub Project 'base-demo'." in output
+
+
+def test_configure_command_dry_run_reports_field_copy_source(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        engine,
+        "find_owner_and_project",
+        lambda owner, title: engine.OwnerInfo(owner_id="owner-id", login=owner, project=None),
+    )
+
+    status = engine.configure_command(
+        engine.ProjectArguments(
+            area="project",
+            command="configure",
+            project_title="base",
+            owner="codeforester",
+            repo="codeforester/base",
+            copy_fields_from_project="Base Roadmap",
+            dry_run=True,
+        )
+    )
+
+    assert status == 0
+    output = capsys.readouterr().out
+    assert "Would copy missing item field values from GitHub Project 'Base Roadmap'." in output
+
+
+def test_plan_project_item_field_copies_skips_existing_values_and_missing_options() -> None:
+    from base_github_projects import project_item_fields
+
+    source_items = {
+        "issue-1": project_item_fields.ProjectIssueItem(
+            item_id="source-item-1",
+            issue_id="issue-1",
+            issue_number=1,
+            title="one",
+            values={"Priority": "P1", "Size": "M", "Area": "CLI"},
+        ),
+        "issue-2": project_item_fields.ProjectIssueItem(
+            item_id="source-item-2",
+            issue_id="issue-2",
+            issue_number=2,
+            title="two",
+            values={"Priority": "P2"},
+        ),
+    }
+    target_items = {
+        "issue-1": project_item_fields.ProjectIssueItem(
+            item_id="target-item-1",
+            issue_id="issue-1",
+            issue_number=1,
+            title="one",
+            values={"Priority": "P0"},
+        ),
+        "issue-2": project_item_fields.ProjectIssueItem(
+            item_id="target-item-2",
+            issue_id="issue-2",
+            issue_number=2,
+            title="two",
+            values={},
+        ),
+    }
+    target_fields = {
+        "Priority": project_item_fields.ProjectSelectField(
+            field_id="priority-field",
+            options={"P1": "priority-p1", "P2": "priority-p2"},
+        ),
+        "Size": project_item_fields.ProjectSelectField(field_id="size-field", options={"S": "size-s"}),
+    }
+
+    plan = project_item_fields.plan_missing_field_copies(
+        source_items=source_items,
+        target_items=target_items,
+        target_fields=target_fields,
+        field_names=("Priority", "Size", "Area"),
+    )
+
+    assert plan.updates == (
+        project_item_fields.ProjectFieldCopy(
+            item_id="target-item-2",
+            issue_number=2,
+            field_name="Priority",
+            option_name="P2",
+            field_id="priority-field",
+            option_id="priority-p2",
+        ),
+    )
+    assert plan.skipped == (
+        project_item_fields.ProjectFieldCopySkip(1, "Size", "M", "target option is missing"),
+        project_item_fields.ProjectFieldCopySkip(1, "Area", "CLI", "target field is missing"),
+    )
 
 
 def test_backfill_repository_issues_adds_only_missing_project_items(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -58,7 +58,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 |---|---|---|
 | `basectl repo init <name>` | Create a Base-managed repository baseline and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
-| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
+| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files. | `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--dry-run` |
 | `basectl repo installer-template [path]` | Print the maintained project installer starter script, or write it to a path. | `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |
@@ -69,7 +69,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | `basectl gh branch prune` | Prune safe merged branches. | `--dry-run`, `--yes`, `--remote` |
 | `basectl gh worktree prune` | Prune stale merged worktrees. | `--dry-run`, `--yes` |
 | `basectl gh project doctor` | Inspect GitHub Project metadata against the Base roadmap schema. | `--project <title>`, `--owner <login>`, `--schema base-roadmap` |
-| `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--config <path>`, `--dry-run` |
+| `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--config <path>`, `--copy-fields-from <title>`, `--dry-run` |
 | `basectl gh project issue set-fields <number>` | Add an issue to the Project if needed and update metadata fields. | `--project <title>`, `--repo <owner/name>`, field options |
 | `basectl gh todo import` | Preview migration of `TODO.md` items into GitHub Issues. | `--dry-run`, `--file <path>` |
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -71,10 +71,15 @@ the repository, and backfills existing repository issues. When
 `.github/base-project.yml` exists, Base also adds missing repo-specific `Area`
 and `Initiative` options from that file. Use `basectl gh project` directly for
 lower-level Project inspection, schema repair, or issue field updates.
+When migrating from an existing shared Project, pass
+`--copy-project-fields-from <title>` to copy missing `Status`, `Priority`,
+`Area`, `Initiative`, and `Size` issue item values into the repo Project without
+overwriting values already set there.
 
 ```bash
 basectl gh project doctor --project "Base Roadmap" --owner codeforester
 basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap
+basectl repo configure ~/work/base --repo codeforester/base --copy-project-fields-from "Base Roadmap"
 basectl gh project issue set-fields 604 --repo codeforester/base --project "Base Roadmap" --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
 ```
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -84,6 +84,10 @@ schema, and repeat `--initiative-option <name>` to seed repository-specific
 Initiative values. If `.github/base-project.yml` exists, Base reads repo-owned
 `Area` and `Initiative` options from that file and adds missing Project options
 without deleting or renaming existing options.
+During migration from an older shared Project, pass
+`--copy-project-fields-from <title>` to copy missing Project item field values
+by issue, field name, and option name into the repo Project. Existing target
+values are preserved.
 `basectl gh project` is the lower-level direct surface for Project inspection,
 schema repair, and issue field updates.
 
@@ -243,6 +247,11 @@ the repo Project:
 - `Initiative`: `BanyanLabs Dogfood`, `Workspace Handling`, `pyproject/uv`,
   `v1.0 Readiness`, `Adoption Polish`, plus values passed with
   `--initiative-option`
+
+`--copy-project-fields-from <title>` copies these single-select fields when the
+source Project item has a value and the target repo Project item does not:
+`Status`, `Priority`, `Area`, `Initiative`, and `Size`. Values are skipped and
+reported when the repo Project does not have a matching option.
 
 When Project V2 access is unavailable, `repo init` and `repo configure` log a
 warning that includes `gh auth refresh -h github.com -s project`, keep the


### PR DESCRIPTION
## Summary
- Add explicit `--copy-project-fields-from <title>` support to `basectl repo configure` and the lower-level Project configure engine.
- Copy missing repo Project item values from a source Project by issue id, field name, and option name without overwriting existing target values.
- Split Project model and item-field copy planning into dedicated modules, and document the migration path.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests -q`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test` — Python: 397 passed, 1 skipped; BATS: 433 passed

Fixes #663