### PR TITLE
Clarify assert_not_null variable arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made `assert_not_null` reject invalid variable-name arguments without logging
+  the raw value, and clarified that callers must pass variable names.
 - Fixed documentation drift for `basectl logs` syntax, project virtual
   environment location, and README coverage of the `basectl ci` command.
 - Made `basectl activate` prefer a uv project's repo-local `.venv` when

--- a/lib/bash/std/README.md
+++ b/lib/bash/std/README.md
@@ -249,6 +249,11 @@ assert_file_exists "$manifest_path"
 assert_dir_exists "$project_root"
 ```
 
+`assert_not_null` takes variable names, not expanded values. Use
+`assert_not_null TOKEN`, not `assert_not_null "$TOKEN"`. When an argument is not
+a valid Bash variable name, `assert_not_null` reports likely misuse without
+echoing the invalid value.
+
 The assertions favor clear failure messages over scattered one-off tests. Some
 helpers check all provided values and report all missing items together.
 

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -780,17 +780,21 @@ safe_truncate() {
 #   TOKEN=""
 #   assert_not_null USER       # This will succeed.
 #   assert_not_null USER TOKEN # This will fail, listing TOKEN as empty.
+#   assert_not_null "$TOKEN"   # Wrong: pass variable names, not values.
 #
 # Arguments:
 #   $@: One or more variable names to check.
 #
 assert_not_null() {
-    local unset_vars=() var_name
+    local unset_vars=() var_name var_name_re='^[A-Za-z_][A-Za-z0-9_]*$'
     if (($# == 0)); then
         fatal_error "assert_not_null: No variable names provided for validation."
     fi
 
     for var_name in "$@"; do
+        if ! [[ "$var_name" =~ $var_name_re ]]; then
+            fatal_error "assert_not_null expects variable names, not values; one or more arguments are not valid Bash variable names."
+        fi
         # Use indirection to get the value of the variable whose name is stored in var_name.
         # The -v check is for unset variables, -z is for empty strings.
         # We check for empty string as per the request.

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -669,6 +669,23 @@ EOF
     [[ "$output" == *"These required variables are not set or are empty"* ]]
 }
 
+@test "assert_not_null rejects value-like arguments without echoing them" {
+    local script="$TEST_TMPDIR/assert-not-null-value.sh"
+
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+source "$STDLIB_PATH"
+token="secret token with spaces"
+assert_not_null "\$token"
+EOF
+
+    bats_run bash "$script"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"assert_not_null expects variable names, not values"* ]]
+    [[ "$output" != *"secret token with spaces"* ]]
+}
+
 @test "assert_integer accepts integers and rejects invalid values" {
     local count=42
     local signed=-3


### PR DESCRIPTION
## Summary

- Added a low-risk `assert_not_null` guard for arguments that are not valid Bash variable names.
- Changed the misuse diagnostic so value-like arguments are not echoed back into logs.
- Clarified the correct `assert_not_null TOKEN` form in the stdlib docs and inline usage comments.

## Issue

Closes #662

## Validation

- `bats lib/bash/std/tests/lib_std.bats`
  - `63` tests passed, including the new value-like argument regression test.
- `env -u BASE_HOME ./bin/base-test`
  - Python: `393 passed, 1 skipped`.
  - BATS: `433` tests passed.
- `git diff --check`
- `git diff --cached --check`

## Demo Impact

None.

## Notes

- AI context update is not applicable; this is a narrow stdlib behavior and documentation fix.
- This branch is independent from #664. If #664 merges first, this PR may need a small rebase around `CHANGELOG.md` and nearby stdlib documentation/test hunks.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
