### PR TITLE
Document repo Project field copy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Copied missing GitHub Project item field values into repo-specific Projects
+  during `basectl repo configure` migrations, preserving existing target values.
 - Made `assert_not_null` reject invalid variable-name arguments without logging
   the raw value, and clarified that callers must pass variable names.
 - Fixed documentation drift for `basectl logs` syntax, project virtual


### PR DESCRIPTION
## Summary
- Add the missing Unreleased changelog entry for the repo Project item field-copy migration fix.
- Keep the actual tooling behavior from PR #665 documented in release notes.

## Notes
- PR #665 already implemented the #663 root-cause fix: `basectl repo configure --copy-project-fields-from <title>` copies missing single-select Project item values from a source Project without overwriting target values.
- This PR closes #663 again after documenting the fix.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests -q`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test` — Python: 397 passed, 1 skipped; BATS: 434 passed

Fixes #663