### PR TITLE
Add repo init Project config onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Added a one-page command quick reference for the current `basectl` command
   surface.
+- Added `.github/base-project.yml` to the standard `basectl repo init`
+  baseline so repo Project taxonomy and issue defaults can move through the
+  same review path as other repository files.
 
 ### Changed
 
+- Changed `basectl repo init --pr` to continue into GitHub-side configuration
+  when the generated baseline is already present, while still stopping after
+  opening a pull request when file changes are needed.
 - Updated the Homebrew release process to require bottle publishing for
   supported macOS installs before accepting the 1.0 upgrade rehearsal.
 - Removed the stale `CLAUDE.md` agent guide in favor of the canonical

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -10,6 +10,7 @@ BASE_REPO_BASELINE_FILES=(
     CHANGELOG.md
     CONTRIBUTING.md
     .github/pull_request_template.md
+    .github/base-project.yml
     LICENSE
     .gitignore
     base_manifest.yaml
@@ -716,6 +717,7 @@ required_files=(
   CHANGELOG.md
   CONTRIBUTING.md
   .github/pull_request_template.md
+  .github/base-project.yml
   LICENSE
   base_manifest.yaml
   .github/workflows/tests.yml
@@ -753,6 +755,21 @@ jobs:
 EOF
 }
 
+base_repo_write_project_config() {
+    local dry_run="$1"
+    local root="$2"
+
+    base_repo_write_stream "$dry_run" "$root/.github/base-project.yml" <<'EOF'
+project:
+  areas: []
+  initiatives: []
+  issue_defaults:
+    status: Backlog
+    priority: P2
+    size: S
+EOF
+}
+
 base_repo_write_baseline() {
     local copyright_holder="$4"
     local description="$3"
@@ -770,6 +787,7 @@ base_repo_write_baseline() {
     base_repo_write_changelog "$dry_run" "$name" "$root" || status=1
     base_repo_write_contributing "$dry_run" "$name" "$root" || status=1
     base_repo_write_pull_request_template "$dry_run" "$root" || status=1
+    base_repo_write_project_config "$dry_run" "$root" || status=1
     base_repo_write_license "$dry_run" "$copyright_holder" "$root" || status=1
     base_repo_write_gitignore "$dry_run" "$root" || status=1
     base_repo_write_manifest "$dry_run" "$name" "$root" || status=1
@@ -1285,6 +1303,18 @@ base_repo_finish_pr_baseline() {
     return "$status"
 }
 
+base_repo_pr_baseline_has_changes() {
+    local root="$1"
+
+    base_repo_stage_pr_baseline_files "$root" || return 2
+    if git -C "$root" diff --cached --quiet --; then
+        git -C "$root" reset --quiet || return 2
+        return 1
+    fi
+    git -C "$root" reset --quiet || return 2
+    return 0
+}
+
 base_repo_check_baseline() {
     local missing=0
     local path="$1"
@@ -1338,6 +1368,7 @@ base_repo_check_agent_guidance() {
 
 base_repo_init() {
     local configure=1
+    local baseline_change_status=0
     local copyright_holder=""
     local create_pr=0
     local default_branch=""
@@ -1551,8 +1582,28 @@ base_repo_init() {
     base_repo_write_baseline "$dry_run" "$name" "$description" "$copyright_holder" "$root" || return 1
 
     if ((create_pr)); then
-        base_repo_finish_pr_baseline "$dry_run" "$name" "$root" "$github_repo" "$pr_branch" "$default_branch"
-        return $?
+        if [[ "$dry_run" == "1" ]]; then
+            base_repo_finish_pr_baseline "$dry_run" "$name" "$root" "$github_repo" "$pr_branch" "$default_branch"
+            return $?
+        fi
+        if base_repo_pr_baseline_has_changes "$root"; then
+            base_repo_finish_pr_baseline "$dry_run" "$name" "$root" "$github_repo" "$pr_branch" "$default_branch"
+            return $?
+        else
+            baseline_change_status=$?
+            case "$baseline_change_status" in
+                1)
+                    if ((configure)); then
+                        log_info "No repository baseline changes to commit; continuing with GitHub repository configuration."
+                    else
+                        log_info "No repository baseline changes to commit; GitHub repository configuration skipped by --no-configure."
+                    fi
+                    ;;
+                *)
+                    return 1
+                    ;;
+            esac
+        fi
     fi
 
     if ((configure)); then

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -171,6 +171,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
     [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/.github/pull_request_template.md'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/.github/base-project.yml'."* ]]
     [[ "$output" == *"[DRY-RUN] Would create executable '$repo_dir/tests/validate.sh'."* ]]
     [[ "$output" == *"[DRY-RUN] Would create private GitHub repository 'codeforester/base-demo' if it does not already exist."* ]]
     [[ "$output" == *"gh repo edit codeforester/base-demo"* ]]
@@ -228,6 +229,7 @@ load ./basectl_helpers.bash
     [ -f "$repo_dir/CHANGELOG.md" ]
     [ -f "$repo_dir/CONTRIBUTING.md" ]
     [ -f "$repo_dir/.github/pull_request_template.md" ]
+    [ -f "$repo_dir/.github/base-project.yml" ]
     [ -f "$repo_dir/LICENSE" ]
     [ -f "$repo_dir/.gitignore" ]
     [ -f "$repo_dir/base_manifest.yaml" ]
@@ -236,6 +238,10 @@ load ./basectl_helpers.bash
     grep -Fqx "0.1.0" "$repo_dir/VERSION"
     grep -Fq "name: base-demo" "$repo_dir/base_manifest.yaml"
     grep -Fq "command: ./tests/validate.sh" "$repo_dir/base_manifest.yaml"
+    grep -Fq "issue_defaults:" "$repo_dir/.github/base-project.yml"
+    grep -Fq "status: Backlog" "$repo_dir/.github/base-project.yml"
+    grep -Fq "priority: P2" "$repo_dir/.github/base-project.yml"
+    grep -Fq "size: S" "$repo_dir/.github/base-project.yml"
     grep -Fq "<category>/<issue>-<YYYYMMDD>-<slug>" "$repo_dir/CONTRIBUTING.md"
     grep -Fq "git worktree add -b <branch> ../base-demo-worktrees/<slug> origin/<default-branch>" "$repo_dir/CONTRIBUTING.md"
     grep -Fq 'Update `CHANGELOG.md` only for notable user-visible or release-worthy' "$repo_dir/CONTRIBUTING.md"
@@ -780,7 +786,7 @@ EOF
     [ -f "$repo_dir/base_manifest.yaml" ]
     grep -Fq "repo create codeforester/base-demo --private --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap" ]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml" ]
     ! grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"
 }
 
@@ -832,12 +838,64 @@ EOF
     git --git-dir="$remote_dir" show-ref --verify --quiet refs/heads/base/repo-baseline-base-demo
     commit_files="$(git -C "$repo_dir" show --name-only --pretty=format: HEAD)"
     [[ "$commit_files" == *"VERSION"* ]]
+    [[ "$commit_files" == *".github/base-project.yml"* ]]
     [[ "$commit_files" == *"base_manifest.yaml"* ]]
     [[ "$commit_files" != *"src/app.txt"* ]]
     grep -Fq "pr create --repo codeforester/base-demo --base master --head base/repo-baseline-base-demo --title Add Base repository baseline --body-file" "$TEST_STATE_DIR/gh-args"
     ! grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     grep -Fq "Add Base-managed repository baseline files." "$TEST_STATE_DIR/pr-body"
     grep -Fq "basectl repo init base-demo --path" "$TEST_STATE_DIR/pr-body"
+}
+
+@test "basectl repo init --pr configures GitHub when baseline has no changes" {
+    local remote_dir="$TEST_TMPDIR/origin.git"
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    init_git_repo "$repo_dir"
+    run_basectl repo init base-demo --path "$repo_dir" --no-configure
+    [ "$status" -eq 0 ]
+    commit_all "$repo_dir" "Add Base baseline"
+    git init --bare "$remote_dir" >/dev/null 2>&1
+    git -C "$repo_dir" remote add origin "$remote_dir"
+    git -C "$repo_dir" push -u origin master >/dev/null 2>&1
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$*" == "repo view codeforester/base-demo --json defaultBranchRef --jq .defaultBranchRef.name" ]]; then
+    printf 'master\n'
+    exit 0
+fi
+if [[ "$1" == "api" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/project-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        "$BASE_REPO_ROOT/bin/basectl" repo init base-demo \
+            --path "$repo_dir" \
+            --repo codeforester/base-demo \
+            --pr \
+            --copy-project-fields-from "Base Roadmap"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No repository baseline changes to commit; continuing with GitHub repository configuration."* ]]
+    grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+    ! grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
 }
 
 @test "basectl repo init --pr requires a clean target worktree" {

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -56,7 +56,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl repo init <name>` | Create a Base-managed repository baseline and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--dry-run` |
+| `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--copy-project-fields-from <title>`, `--no-project`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
 | `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files. | `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--dry-run` |

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -46,9 +46,12 @@ basectl repo init base-demo \
 or uses the predictable branch `base/repo-baseline-<name>`, writes any missing
 baseline files, commits only the baseline file set, pushes the branch to
 `origin`, and opens a GitHub pull request against the repository default branch.
-This path is for reviewable file changes only; it does not create the GitHub
-repository or change repository settings and labels. Run `basectl repo
-configure` separately when GitHub-side configuration should be applied.
+When the generated baseline produces file changes, `repo init --pr` stops after
+opening the pull request. After that pull request is merged, rerun the same
+`repo init --pr` command; when there are no baseline file changes left, it
+continues with the same GitHub-side configuration that `repo init` normally
+performs. `repo configure` remains available when only GitHub-side settings need
+to be repaired or resynced.
 
 Check the local baseline:
 
@@ -120,6 +123,7 @@ existing issues during Project configuration.
 - `CHANGELOG.md`
 - `CONTRIBUTING.md`
 - `.github/pull_request_template.md`
+- `.github/base-project.yml`
 - `LICENSE`
 - `.gitignore`
 - `base_manifest.yaml`
@@ -145,6 +149,23 @@ test:
 The generated validation script checks for the required baseline files. It is
 not a replacement for project tests; it is the seed contract that lets
 `basectl test <project>` work immediately.
+
+The generated `.github/base-project.yml` starts with the shared issue defaults
+and empty repo-specific taxonomy lists:
+
+```yaml
+project:
+  areas: []
+  initiatives: []
+  issue_defaults:
+    status: Backlog
+    priority: P2
+    size: S
+```
+
+Edit `areas` and `initiatives` in the baseline pull request before merging when
+the repository already knows its taxonomy. Leaving them empty is valid; future
+`repo configure` runs still apply the shared Project fields and issue defaults.
 
 ## Optional Agent Guidance
 


### PR DESCRIPTION
## Summary
- Add `.github/base-project.yml` to the standard `basectl repo init` baseline and generated self-validation.
- Let `repo init --pr` continue into GitHub-side configuration when rerun after the baseline has no file changes.
- Document the two-phase `--pr` onboarding flow and update the changelog.

## Validation
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

Closes #668