### PR TITLE
Improve repo help and issue Project intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `.github/base-project.yml` to the standard `basectl repo init`
   baseline so repo Project taxonomy and issue defaults can move through the
   same review path as other repository files.
+- Added repo Project metadata handoff to `basectl gh issue create` so new
+  issues are added to the repo Project with defaults from
+  `.github/base-project.yml` when the repository is known.
 
 ### Changed
 
+- Changed `basectl repo` help to show command-specific options for each
+  subcommand instead of one shared option list.
 - Changed `basectl repo init --pr` to continue into GitHub-side configuration
   when the generated baseline is already present, while still stopping after
   opening a pull request when file changes are needed.

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -8,7 +8,7 @@ base_gh_usage() {
     cat <<'EOF'
 Usage:
   basectl gh issue list [gh options...]
-  basectl gh issue create --category <bug|enhancement|documentation|ci|security> --title <title> [--body <body>]
+  basectl gh issue create --category <bug|enhancement|documentation|ci|security> --title <title> [--body <body>] [--repo <owner/name>] [project options...]
   basectl gh issue start <number> [--category <bug|enhancement|documentation|ci|security>] [--title <title>]
   basectl gh pr create [gh options...]
   basectl gh pr status [gh options...]
@@ -30,9 +30,17 @@ Purpose:
 Branch naming:
   <category>/<issue>-<YYYYMMDD>-<slug>
 
+Issue create project options:
+  --repo <owner/name>           Repository to create the issue in. Defaults to the origin remote.
+  --project <title>             Project to update. Defaults to the repository name.
+  --project-owner <login>       Project owner. Defaults to the repository owner.
+  --no-project                  Skip Project metadata updates.
+
 Notes:
   - This command requires the GitHub CLI (`gh`) for GitHub operations.
   - Issues created through this command are assigned to codeforester.
+  - When the GitHub repo is known, issue create also adds the issue to the
+    repo-named Project and applies defaults from .github/base-project.yml.
   - Pull request implementation work should happen in a dedicated worktree.
   - Branch and worktree pruning are dry-run by default and apply only when --yes is passed.
   - TODO import is currently a dry-run planning command.
@@ -148,6 +156,74 @@ base_gh_issue_title() {
     gh issue view "$issue" --json title --jq '.title'
 }
 
+base_gh_infer_github_repo() {
+    local remote_url
+
+    remote_url="$(git remote get-url origin 2>/dev/null || true)"
+    [[ -n "$remote_url" ]] || return 1
+
+    case "$remote_url" in
+        git@github.com:*.git)
+            remote_url="${remote_url#git@github.com:}"
+            remote_url="${remote_url%.git}"
+            ;;
+        https://github.com/*.git)
+            remote_url="${remote_url#https://github.com/}"
+            remote_url="${remote_url%.git}"
+            ;;
+        https://github.com/*)
+            remote_url="${remote_url#https://github.com/}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    [[ "$remote_url" == */* ]] || return 1
+    printf '%s\n' "$remote_url"
+}
+
+base_gh_default_project_title() {
+    local repo="$1"
+
+    printf '%s\n' "${repo#*/}"
+}
+
+base_gh_project_owner_from_repo() {
+    local repo="$1"
+
+    printf '%s\n' "${repo%%/*}"
+}
+
+base_gh_project_config_path() {
+    local root path
+
+    root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    [[ -n "$root" ]] || return 1
+    path="$root/.github/base-project.yml"
+    [[ -f "$path" ]] || return 1
+    printf '%s\n' "$path"
+}
+
+base_gh_issue_number_from_output() {
+    local output="$1"
+    local issue_number
+
+    issue_number="$(printf '%s\n' "$output" | sed -nE 's#.*github.com/[^/]+/[^/]+/issues/([0-9]+).*#\1#p' | tail -n 1)"
+    [[ -n "$issue_number" ]] || return 1
+    printf '%s\n' "$issue_number"
+}
+
+base_gh_project_issue_set_fields() {
+    local wrapper="${BASE_GH_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
+
+    [[ -x "$wrapper" ]] || {
+        base_gh_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+    "$wrapper" --project base base_github_projects project issue set-fields "$@"
+}
+
 base_gh_current_issue_from_branch() {
     local branch
 
@@ -187,12 +263,25 @@ base_gh_do_issue() {
 }
 
 base_gh_issue_create() {
-    local category="" title="" body=""
+    local body=""
+    local category=""
+    local configure_project=1
+    local config_path=""
+    local github_repo=""
+    local issue_number=""
+    local issue_output=""
+    local project_owner=""
+    local project_title=""
+    local title=""
 
     while (($#)); do
         case "$1" in
             --category)
                 category="${2:-}"
+                shift
+                ;;
+            --repo)
+                github_repo="${2:-}"
                 shift
                 ;;
             --title)
@@ -202,6 +291,17 @@ base_gh_issue_create() {
             --body)
                 body="${2:-}"
                 shift
+                ;;
+            --project)
+                project_title="${2:-}"
+                shift
+                ;;
+            --project-owner)
+                project_owner="${2:-}"
+                shift
+                ;;
+            --no-project)
+                configure_project=0
                 ;;
             -h|--help)
                 base_gh_usage
@@ -223,10 +323,45 @@ base_gh_issue_create() {
     base_gh_validate_category "$category" || return 1
     base_gh_require_auth || return 1
 
+    [[ -n "$github_repo" ]] || github_repo="$(base_gh_infer_github_repo || true)"
     if [[ -n "$body" ]]; then
-        gh issue create --title "$title" --body "$body" --label "$category" --assignee codeforester
+        if [[ -n "$github_repo" ]]; then
+            issue_output="$(gh issue create --title "$title" --body "$body" --label "$category" --assignee codeforester --repo "$github_repo")" || return $?
+        else
+            issue_output="$(gh issue create --title "$title" --body "$body" --label "$category" --assignee codeforester)" || return $?
+        fi
     else
-        gh issue create --title "$title" --label "$category" --assignee codeforester
+        if [[ -n "$github_repo" ]]; then
+            issue_output="$(gh issue create --title "$title" --label "$category" --assignee codeforester --repo "$github_repo")" || return $?
+        else
+            issue_output="$(gh issue create --title "$title" --label "$category" --assignee codeforester)" || return $?
+        fi
+    fi
+    printf '%s\n' "$issue_output"
+
+    if ((configure_project)) && [[ -n "$github_repo" ]]; then
+        issue_number="$(base_gh_issue_number_from_output "$issue_output")" || {
+            base_gh_error "Unable to determine created issue number from gh output."
+            return 1
+        }
+        [[ -n "$project_title" ]] || project_title="$(base_gh_default_project_title "$github_repo")"
+        [[ -n "$project_owner" ]] || project_owner="$(base_gh_project_owner_from_repo "$github_repo")"
+        config_path="$(base_gh_project_config_path || true)"
+        if [[ -n "$config_path" ]]; then
+            base_gh_project_issue_set_fields "$issue_number" \
+                --project "$project_title" \
+                --owner "$project_owner" \
+                --repo "$github_repo" \
+                --config "$config_path"
+        else
+            base_gh_project_issue_set_fields "$issue_number" \
+                --project "$project_title" \
+                --owner "$project_owner" \
+                --repo "$github_repo" \
+                --status Backlog \
+                --priority P2 \
+                --size S
+        fi
     fi
 }
 

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -33,16 +33,28 @@ Usage:
   basectl repo agent-guidance [path] [options]
   basectl repo installer-template [path] [options]
 
+Commands:
+  init                 Create baseline files and optionally configure GitHub.
+  check                Verify the local repository baseline.
+  configure            Apply GitHub settings, labels, branch protection, and Project metadata.
+  agent-guidance       Seed optional repo-local agent guidance files.
+  installer-template   Print or write the maintained project installer template.
+
+Run 'basectl repo <command> --help' for command-specific options.
+EOF
+}
+
+base_repo_init_usage() {
+    cat <<'EOF'
+Usage:
+  basectl repo init <name> [options]
+
 Options:
   --path <path>                 Target path for repo init. Defaults to workspace root plus <name>.
   --repo <owner/name>           GitHub repository to configure.
   --pr                          Commit the generated baseline on a branch and open a pull request.
   --description <text>          Repository description for generated README.
   --copyright-holder <name>     Copyright holder for generated LICENSE. Defaults to git config user.name.
-  --repo-name <name>            Repository name for generated agent guidance. Defaults to the target path basename.
-  --default-branch <name>       Default branch for generated agent guidance. Defaults to main.
-  --validation-command <cmd>    Validation command for generated agent guidance. Defaults to ./tests/validate.sh.
-  --agent-guidance              Include optional agent guidance files in repo check.
   --private                     Create a private GitHub repository when needed. This is the default.
   --public                      Create a public GitHub repository when needed.
   --no-configure                Skip GitHub configuration during repo init.
@@ -58,14 +70,98 @@ Options:
   -v                            Enable DEBUG logging for this subcommand.
   -h, --help                    Show this help text.
 
-Create, check, and configure a standard Base-managed repository baseline, or
-write a reusable project installer template. When .github/base-project.yml
-exists, repo configure uses it for repo-specific GitHub Project taxonomy.
+Examples:
+  basectl repo init bankbuddy --path . --repo codeforester/bankbuddy --pr
+  basectl repo init base-demo --repo codeforester/base-demo --public
+
+Creates the standard Base-managed repository baseline, including
+.github/base-project.yml. With --pr, the first run opens a baseline PR when
+files change; rerun the same command after merge to continue GitHub-side
+configuration.
+EOF
+}
+
+base_repo_check_usage() {
+    cat <<'EOF'
+Usage:
+  basectl repo check [path] [options]
+
+Options:
+  --agent-guidance              Include optional agent guidance files in repo check.
+  -v                            Enable DEBUG logging for this subcommand.
+  -h, --help                    Show this help text.
+
+Verifies the standard Base-managed repository baseline at path, or the current
+directory when path is omitted.
+EOF
+}
+
+base_repo_configure_usage() {
+    cat <<'EOF'
+Usage:
+  basectl repo configure [path] [options]
+
+Options:
+  --repo <owner/name>           GitHub repository to configure.
+  --no-protect-default-branch   Skip Base-managed default branch protection.
+  --project <title>             GitHub Project title to configure. Defaults to the repository name.
+  --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
+  --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
+  --initiative-option <name>    Initiative option to seed. May be repeated.
+  --copy-project-fields-from <title>
+                                Copy missing Project item field values from another Project.
+  --no-project                  Skip GitHub Project metadata configuration.
+  --dry-run                     Print planned changes without applying them.
+  -v                            Enable DEBUG logging for this subcommand.
+  -h, --help                    Show this help text.
+
+Applies GitHub-side repository settings, labels, branch protection, and
+repo Project metadata. When .github/base-project.yml exists, repo configure
+uses it for repo-specific GitHub Project taxonomy and issue defaults.
+EOF
+}
+
+base_repo_installer_template_usage() {
+    cat <<'EOF'
+Usage:
+  basectl repo installer-template [path] [options]
+
+Options:
+  --dry-run                     Print planned changes without applying them.
+  -v                            Enable DEBUG logging for this subcommand.
+  -h, --help                    Show this help text.
+
+Prints the maintained project installer template, or writes it to path when a
+path is provided.
 EOF
 }
 
 base_repo_usage_error() {
     base_repo_subcommand_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_repo_init_usage_error() {
+    base_repo_init_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_repo_check_usage_error() {
+    base_repo_check_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_repo_configure_usage_error() {
+    base_repo_configure_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_repo_installer_template_usage_error() {
+    base_repo_installer_template_usage >&2
     printf 'ERROR: %s\n' "$*" >&2
     return 2
 }
@@ -1393,12 +1489,12 @@ base_repo_init() {
     while (($#)); do
         case "$1" in
             -h|--help|help)
-                base_repo_subcommand_usage
+                base_repo_init_usage
                 return 0
                 ;;
             --path)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--path' requires an argument."
+                    base_repo_init_usage_error "Option '--path' requires an argument."
                     return $?
                 }
                 path="$2"
@@ -1410,7 +1506,7 @@ base_repo_init() {
                 ;;
             --repo)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--repo' requires an argument."
+                    base_repo_init_usage_error "Option '--repo' requires an argument."
                     return $?
                 }
                 github_repo="$2"
@@ -1426,7 +1522,7 @@ base_repo_init() {
                 ;;
             --description)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--description' requires an argument."
+                    base_repo_init_usage_error "Option '--description' requires an argument."
                     return $?
                 }
                 description="$2"
@@ -1434,7 +1530,7 @@ base_repo_init() {
                 ;;
             --copyright-holder)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--copyright-holder' requires an argument."
+                    base_repo_init_usage_error "Option '--copyright-holder' requires an argument."
                     return $?
                 }
                 copyright_holder="$2"
@@ -1443,7 +1539,7 @@ base_repo_init() {
             --private|--public)
                 requested_visibility="${1#--}"
                 if ((github_visibility_explicit)) && [[ "$github_visibility" != "$requested_visibility" ]]; then
-                    base_repo_usage_error "Options '--private' and '--public' cannot be used together."
+                    base_repo_init_usage_error "Options '--private' and '--public' cannot be used together."
                     return $?
                 fi
                 github_visibility="$requested_visibility"
@@ -1460,7 +1556,7 @@ base_repo_init() {
                 ;;
             --project)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--project' requires an argument."
+                    base_repo_init_usage_error "Option '--project' requires an argument."
                     return $?
                 }
                 project_title="$2"
@@ -1472,7 +1568,7 @@ base_repo_init() {
                 ;;
             --project-owner)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--project-owner' requires an argument."
+                    base_repo_init_usage_error "Option '--project-owner' requires an argument."
                     return $?
                 }
                 project_owner="$2"
@@ -1484,7 +1580,7 @@ base_repo_init() {
                 ;;
             --project-schema)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--project-schema' requires an argument."
+                    base_repo_init_usage_error "Option '--project-schema' requires an argument."
                     return $?
                 }
                 project_schema="$2"
@@ -1496,7 +1592,7 @@ base_repo_init() {
                 ;;
             --initiative-option)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--initiative-option' requires an argument."
+                    base_repo_init_usage_error "Option '--initiative-option' requires an argument."
                     return $?
                 }
                 initiative_options+=("$2")
@@ -1508,7 +1604,7 @@ base_repo_init() {
                 ;;
             --copy-project-fields-from)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--copy-project-fields-from' requires an argument."
+                    base_repo_init_usage_error "Option '--copy-project-fields-from' requires an argument."
                     return $?
                 }
                 copy_project_fields_from="$2"
@@ -1532,12 +1628,12 @@ base_repo_init() {
                 shift
                 ;;
             -*)
-                base_repo_usage_error "Unknown repo init option '$1'."
+                base_repo_init_usage_error "Unknown repo init option '$1'."
                 return $?
                 ;;
             *)
                 if [[ -n "$name" ]]; then
-                    base_repo_usage_error "The 'repo init' command accepts exactly one repository name."
+                    base_repo_init_usage_error "The 'repo init' command accepts exactly one repository name."
                     return $?
                 fi
                 name="$1"
@@ -1547,7 +1643,7 @@ base_repo_init() {
     done
 
     [[ -n "$name" ]] || {
-        base_repo_usage_error "Repository name is required."
+        base_repo_init_usage_error "Repository name is required."
         return $?
     }
     base_repo_validate_name "$name" || return 2
@@ -1561,11 +1657,11 @@ base_repo_init() {
             github_repo="$(base_repo_infer_github_repo "$root" || true)"
         fi
         [[ -n "$github_repo" ]] || {
-            base_repo_usage_error "Option '--pr' requires --repo <owner/name> or an inferable GitHub origin remote."
+            base_repo_init_usage_error "Option '--pr' requires --repo <owner/name> or an inferable GitHub origin remote."
             return $?
         }
         if ((github_visibility_explicit)); then
-            base_repo_usage_error "Options '--private' and '--public' cannot be used with '--pr'."
+            base_repo_init_usage_error "Options '--private' and '--public' cannot be used with '--pr'."
             return $?
         fi
 
@@ -1644,7 +1740,7 @@ base_repo_check() {
     while (($#)); do
         case "$1" in
             -h|--help|help)
-                base_repo_subcommand_usage
+                base_repo_check_usage
                 return 0
                 ;;
             --agent-guidance)
@@ -1657,12 +1753,12 @@ base_repo_check() {
                 shift
                 ;;
             -*)
-                base_repo_usage_error "Unknown repo check option '$1'."
+                base_repo_check_usage_error "Unknown repo check option '$1'."
                 return $?
                 ;;
             *)
                 if [[ "$path" != "." ]]; then
-                    base_repo_usage_error "The 'repo check' command accepts at most one path."
+                    base_repo_check_usage_error "The 'repo check' command accepts at most one path."
                     return $?
                 fi
                 path="$1"
@@ -1786,12 +1882,12 @@ base_repo_configure() {
     while (($#)); do
         case "$1" in
             -h|--help|help)
-                base_repo_subcommand_usage
+                base_repo_configure_usage
                 return 0
                 ;;
             --repo)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--repo' requires an argument."
+                    base_repo_configure_usage_error "Option '--repo' requires an argument."
                     return $?
                 }
                 github_repo="$2"
@@ -1811,7 +1907,7 @@ base_repo_configure() {
                 ;;
             --project)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--project' requires an argument."
+                    base_repo_configure_usage_error "Option '--project' requires an argument."
                     return $?
                 }
                 project_title="$2"
@@ -1823,7 +1919,7 @@ base_repo_configure() {
                 ;;
             --project-owner)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--project-owner' requires an argument."
+                    base_repo_configure_usage_error "Option '--project-owner' requires an argument."
                     return $?
                 }
                 project_owner="$2"
@@ -1835,7 +1931,7 @@ base_repo_configure() {
                 ;;
             --project-schema)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--project-schema' requires an argument."
+                    base_repo_configure_usage_error "Option '--project-schema' requires an argument."
                     return $?
                 }
                 project_schema="$2"
@@ -1847,7 +1943,7 @@ base_repo_configure() {
                 ;;
             --initiative-option)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--initiative-option' requires an argument."
+                    base_repo_configure_usage_error "Option '--initiative-option' requires an argument."
                     return $?
                 }
                 initiative_options+=("$2")
@@ -1859,7 +1955,7 @@ base_repo_configure() {
                 ;;
             --copy-project-fields-from)
                 [[ -n "${2:-}" ]] || {
-                    base_repo_usage_error "Option '--copy-project-fields-from' requires an argument."
+                    base_repo_configure_usage_error "Option '--copy-project-fields-from' requires an argument."
                     return $?
                 }
                 copy_project_fields_from="$2"
@@ -1879,12 +1975,12 @@ base_repo_configure() {
                 shift
                 ;;
             -*)
-                base_repo_usage_error "Unknown repo configure option '$1'."
+                base_repo_configure_usage_error "Unknown repo configure option '$1'."
                 return $?
                 ;;
             *)
                 if [[ "$path" != "." ]]; then
-                    base_repo_usage_error "The 'repo configure' command accepts at most one path."
+                    base_repo_configure_usage_error "The 'repo configure' command accepts at most one path."
                     return $?
                 fi
                 path="$1"
@@ -1926,7 +2022,7 @@ base_repo_installer_template() {
     while (($#)); do
         case "$1" in
             -h|--help|help)
-                base_repo_subcommand_usage
+                base_repo_installer_template_usage
                 return 0
                 ;;
             --dry-run)
@@ -1939,12 +2035,12 @@ base_repo_installer_template() {
                 shift
                 ;;
             -*)
-                base_repo_usage_error "Unknown repo installer-template option '$1'."
+                base_repo_installer_template_usage_error "Unknown repo installer-template option '$1'."
                 return $?
                 ;;
             *)
                 if [[ -n "$path" ]]; then
-                    base_repo_usage_error "The 'repo installer-template' command accepts at most one path."
+                    base_repo_installer_template_usage_error "The 'repo installer-template' command accepts at most one path."
                     return $?
                 fi
                 path="$1"

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -35,11 +35,71 @@ EOF
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main issue create --category bug --title "Repair branch pruning"
+            base_gh_subcommand_main issue create --category bug --title "Repair branch pruning" --no-project
         '
 
     [ "$status" -eq 0 ]
-    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Repair branch pruning --label bug --assignee codeforester" ]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Repair branch pruning --label bug --assignee codeforester --repo codeforester/base" ]
+}
+
+@test "basectl gh issue create updates repo project metadata when repo is known" {
+    local repo
+    local repo_root
+
+    repo="$TEST_TMPDIR/bankbuddy"
+    init_git_repo "$repo"
+    repo_root="$(cd "$repo" && pwd -P)"
+    git -C "$repo" remote add origin git@github.com:codeforester/bankbuddy.git
+    mkdir -p "$repo/.github"
+    cat > "$repo/.github/base-project.yml" <<'EOF'
+project:
+  areas:
+    - CLI
+  initiatives:
+    - MVP
+  issue_defaults:
+    status: Backlog
+    priority: P1
+    size: M
+    area: CLI
+    initiative: MVP
+EOF
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+if [[ "$1" == "issue" && "$2" == "create" ]]; then
+    printf 'https://github.com/codeforester/bankbuddy/issues/51\n'
+fi
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
+printf 'project metadata updated\n'
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_GH_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue create --category enhancement --title "Add transaction filter"
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"https://github.com/codeforester/bankbuddy/issues/51"* ]]
+    [[ "$output" == *"project metadata updated"* ]]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Add transaction filter --label enhancement --assignee codeforester --repo codeforester/bankbuddy" ]
+    [ "$(cat "$TEST_STATE_DIR/wrapper-args")" = "--project base base_github_projects project issue set-fields 51 --project bankbuddy --owner codeforester --repo codeforester/bankbuddy --config $repo_root/.github/base-project.yml" ]
 }
 
 @test "basectl gh issue create help does not require authentication" {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -13,8 +13,73 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl repo configure [path]"* ]]
     [[ "$output" == *"basectl repo agent-guidance [path]"* ]]
     [[ "$output" == *"basectl repo installer-template [path]"* ]]
+    [[ "$output" == *"Run 'basectl repo <command> --help' for command-specific options."* ]]
+    [[ "$output" != *"--no-protect-default-branch"* ]]
+    [[ "$output" != *"--copy-project-fields-from"* ]]
+    [[ "$output" != *"--repo-name <name>"* ]]
+}
+
+@test "basectl repo init prints command-specific help" {
+    run_basectl repo init --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl repo init <name> [options]"* ]]
+    [[ "$output" == *"--path <path>"* ]]
+    [[ "$output" == *"--pr"* ]]
+    [[ "$output" == *"--copy-project-fields-from <title>"* ]]
+    [[ "$output" == *"basectl repo init bankbuddy --path . --repo codeforester/bankbuddy --pr"* ]]
+    [[ "$output" != *"basectl repo agent-guidance"* ]]
+    [[ "$output" != *"--repo-name <name>"* ]]
+    [[ "$output" != *"--agent-guidance"* ]]
+}
+
+@test "basectl repo configure prints command-specific help" {
+    run_basectl repo configure --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl repo configure [path] [options]"* ]]
+    [[ "$output" == *"--repo <owner/name>"* ]]
     [[ "$output" == *"--no-protect-default-branch"* ]]
-    [[ "$output" == *"--copy-project-fields-from"* ]]
+    [[ "$output" == *"--copy-project-fields-from <title>"* ]]
+    [[ "$output" != *"--pr                          "* ]]
+    [[ "$output" != *"--private"* ]]
+    [[ "$output" != *"--public"* ]]
+    [[ "$output" != *"--description <text>"* ]]
+}
+
+@test "basectl repo check prints command-specific help" {
+    run_basectl repo check --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl repo check [path] [options]"* ]]
+    [[ "$output" == *"--agent-guidance"* ]]
+    [[ "$output" != *"--repo <owner/name>"* ]]
+    [[ "$output" != *"--pr"* ]]
+}
+
+@test "basectl repo installer-template prints command-specific help" {
+    run_basectl repo installer-template --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl repo installer-template [path] [options]"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" != *"--repo <owner/name>"* ]]
+    [[ "$output" != *"--project <title>"* ]]
+}
+
+@test "basectl repo init missing name shows focused usage and example" {
+    run_basectl repo init --repo codeforester/bankbuddy --pr
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"basectl repo init <name> [options]"* ]]
+    [[ "$output" == *"basectl repo init bankbuddy --path . --repo codeforester/bankbuddy --pr"* ]]
+    [[ "$output" == *"ERROR: Repository name is required."* ]]
+    [[ "$output" != *"basectl repo agent-guidance"* ]]
+    [[ "$output" != *"--repo-name <name>"* ]]
 }
 
 @test "basectl repo installer-template prints the maintained template" {

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -72,7 +72,7 @@ def print_usage(file=sys.stdout) -> None:
                 "[--owner <login>] [--repo <owner/name>] [--schema base-roadmap] [--config <path>] "
                 "[--copy-fields-from <title>] [--initiative-option <name>] [--dry-run]",
                 "  base_github_projects project issue set-fields <number> "
-                "--repo <owner/name> --project <title> [field options...]",
+                "--repo <owner/name> --project <title> [--config <path>] [field options...]",
             )
         ),
         file=file,
@@ -255,6 +255,13 @@ def project_config_for_args(args: ProjectArguments) -> ProjectConfig:
     if not args.config_path:
         return ProjectConfig()
     return read_project_config(Path(args.config_path))
+
+
+def issue_field_values_for_args(args: ProjectArguments) -> dict[str, str]:
+    config = project_config_for_args(args)
+    values = dict(config.issue_defaults)
+    values.update(args.field_values or {})
+    return values
 
 
 def read_project_config(path: Path) -> ProjectConfig:
@@ -505,7 +512,11 @@ def issue_set_fields_command(args: ProjectArguments) -> int:
         raise ProjectError(f"Project '{args.project_title}' was not found for owner '{owner}'.")
     project = owner_info.project
     fields = fetch_project_fields(project.project_id)
-    updates = resolve_issue_field_updates(fields, args.field_values or {}, project_title=args.project_title or "")
+    updates = resolve_issue_field_updates(
+        fields,
+        issue_field_values_for_args(args),
+        project_title=args.project_title or "",
+    )
     if not updates:
         raise ProjectUsageError("At least one field option must be provided.")
     repo_owner, repo_name = split_repo(repo)

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -146,6 +146,41 @@ def test_read_project_config_rejects_non_string_options(tmp_path: Path) -> None:
     assert str(excinfo.value) == f"{config_path}: project.areas[1] must be a non-empty string."
 
 
+def test_issue_field_values_use_config_defaults_and_explicit_overrides(tmp_path: Path) -> None:
+    config_path = tmp_path / "base-project.yml"
+    config_path.write_text(
+        "project:\n"
+        "  areas: []\n"
+        "  initiatives: []\n"
+        "  issue_defaults:\n"
+        "    status: Backlog\n"
+        "    priority: P2\n"
+        "    size: S\n"
+        "    area: CLI\n",
+        encoding="utf-8",
+    )
+
+    values = engine.issue_field_values_for_args(
+        engine.ProjectArguments(
+            area="project",
+            command="issue-set-fields",
+            project_title="base-demo",
+            owner="codeforester",
+            repo="codeforester/base-demo",
+            config_path=str(config_path),
+            issue_number=604,
+            field_values={"priority": "P1"},
+        )
+    )
+
+    assert values == {
+        "status": "Backlog",
+        "priority": "P1",
+        "size": "S",
+        "area": "CLI",
+    }
+
+
 def test_schema_for_args_adds_repo_project_config_options(tmp_path: Path) -> None:
     config_path = tmp_path / "base-project.yml"
     config_path.write_text(

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -62,7 +62,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files. | `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--dry-run` |
 | `basectl repo installer-template [path]` | Print the maintained project installer starter script, or write it to a path. | `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |
-| `basectl gh issue create` | Create an issue with Base category conventions. | `--category <bug\|enhancement\|documentation\|ci\|security>`, `--title <title>`, `--body <body>` |
+| `basectl gh issue create` | Create an issue with Base category conventions, assign it, and add repo Project metadata when the repo is known. | `--category <bug\|enhancement\|documentation\|ci\|security>`, `--title <title>`, `--body <body>`, `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--no-project` |
 | `basectl gh issue start <number>` | Start issue-backed branch naming workflow. | `--category <category>`, `--title <title>` |
 | `basectl gh pr create/status/checks/ready/merge` | Create and manage pull requests through Base's workflow wrapper. | passes through `gh` options |
 | `basectl gh branch stale` | Report stale local branches. | `--days <days>` |
@@ -70,7 +70,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | `basectl gh worktree prune` | Prune stale merged worktrees. | `--dry-run`, `--yes` |
 | `basectl gh project doctor` | Inspect GitHub Project metadata against the Base roadmap schema. | `--project <title>`, `--owner <login>`, `--schema base-roadmap` |
 | `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--config <path>`, `--copy-fields-from <title>`, `--dry-run` |
-| `basectl gh project issue set-fields <number>` | Add an issue to the Project if needed and update metadata fields. | `--project <title>`, `--repo <owner/name>`, field options |
+| `basectl gh project issue set-fields <number>` | Add an issue to the Project if needed and update metadata fields. | `--project <title>`, `--repo <owner/name>`, `--config <path>`, field options |
 | `basectl gh todo import` | Preview migration of `TODO.md` items into GitHub Issues. | `--dry-run`, `--file <path>` |
 
 ## Release And Context

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -69,8 +69,10 @@ by default when a GitHub repository is available. Base copies
 `base-project-template` when the repo Project is missing, links the Project to
 the repository, and backfills existing repository issues. When
 `.github/base-project.yml` exists, Base also adds missing repo-specific `Area`
-and `Initiative` options from that file. Use `basectl gh project` directly for
-lower-level Project inspection, schema repair, or issue field updates.
+and `Initiative` options from that file. `basectl gh issue create` uses the
+same file's `issue_defaults` when it adds newly created issues to the repo
+Project. Use `basectl gh project` directly for lower-level Project inspection,
+schema repair, or issue field updates.
 When migrating from an existing shared Project, pass
 `--copy-project-fields-from <title>` to copy missing `Status`, `Priority`,
 `Area`, `Initiative`, and `Size` issue item values into the repo Project without

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -111,8 +111,9 @@ project:
 ```
 
 `areas` and `initiatives` are applied by `repo configure`. `issue_defaults` is
-validated and reserved for issue intake automation; it does not set fields on
-existing issues during Project configuration.
+validated by Project tooling and used by `basectl gh issue create` when it adds
+new issues to the repo Project. It does not set fields on existing issues during
+Project configuration.
 
 ## Local Baseline
 


### PR DESCRIPTION
## Summary
- Split `basectl repo` help into command-specific usage for `init`, `check`, `configure`, and `installer-template`.
- Make `basectl gh issue create` infer the GitHub repo, create the issue there, and update the repo-named Project with defaults from `.github/base-project.yml`.
- Teach Project issue field updates to merge config `issue_defaults` with explicit field overrides.

## Validation
- `bash -n cli/bash/commands/basectl/subcommands/gh.sh cli/bash/commands/basectl/subcommands/repo.sh`
- `bats cli/bash/commands/basectl/tests/gh.bats`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `PYTHONPATH=cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests/test_engine.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_github_projects/engine.py`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

Closes #670
Closes #638