### PR TITLE
Clarify just Base install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `docs/why-base.md` as a concise evaluator page comparing Base with
   adjacent developer-environment tools.
 - Documented Base's `uv` ecosystem boundary in `docs/tool-boundaries.md`.
+- Clarified the direct Homebrew install path for users who already have
+  Homebrew and Bash.
 - Added a one-page command quick reference for the current `basectl` command
   surface.
 - Added `.github/base-project.yml` to the standard `basectl repo init`

--- a/FAQ.md
+++ b/FAQ.md
@@ -36,12 +36,14 @@ bootstrap prints, typically:
 Use `bootstrap.sh` on a new or uncertain macOS machine. It handles missing
 first-mile prerequisites and then hands off to Base.
 
-Use Homebrew when you want Base managed like an ordinary installed tool:
+Use Homebrew when you already have Homebrew and Bash and want Base managed like
+an ordinary installed tool:
 
 ```bash
 brew install codeforester/base/base
 basectl setup
 basectl update-profile
+exec "$SHELL" -l
 ```
 
 Use a source checkout when you are contributing to Base or want to inspect and

--- a/README.md
+++ b/README.md
@@ -36,7 +36,25 @@ are tracked in [CHANGELOG.md](CHANGELOG.md).
 
 ## Start Here
 
-On a new macOS machine, start with the first-mile bootstrap script:
+### Already Have Homebrew And Bash?
+
+If your Mac already has Homebrew and a supported Bash, install just Base through
+Homebrew:
+
+```bash
+brew install codeforester/base/base
+basectl setup
+basectl update-profile
+exec "$SHELL" -l
+```
+
+This is the shortest path when the first-mile macOS prerequisites are already
+in place.
+
+### New Or Uncertain macOS Machine?
+
+On a new macOS machine, or any machine where Homebrew, Git, or a supported Bash
+may be missing, start with the first-mile bootstrap script:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash
@@ -67,15 +85,6 @@ workspace:
 ```
 
 Edit that value if your repositories live under a different shared directory.
-
-Or install directly through Homebrew when Homebrew is already available:
-
-```bash
-brew install codeforester/base/base
-basectl setup
-basectl update-profile
-exec "$SHELL" -l
-```
 
 After Base is installed, the common development loop is:
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -111,6 +111,7 @@ managed like a normal formula:
 brew install codeforester/base/base
 basectl setup
 basectl update-profile
+exec "$SHELL" -l
 ```
 
 Use `install.sh` when you specifically want the source-install script to clone


### PR DESCRIPTION
## Summary
- Move the direct Homebrew install path to the top of the README Start Here section for users who already have Homebrew and Bash.
- Keep the blank-machine bootstrap path visible immediately after the direct install route.
- Align the FAQ and bootstrap docs so the direct Homebrew flow includes `update-profile` and a login-shell restart.
- Note the docs polish in `CHANGELOG.md`.

## Issue
Closes #676

## Validation
- `git diff --check`
- `git diff --check --cached`

## Demo Impact
None. Documentation-only change.

## Notes
AI Context: Not updated. This clarifies first-run documentation and does not change product behavior, command surface, architecture, workflows, manifest model, or release state.