### PR TITLE
Show Homebrew and source install choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `docs/why-base.md` as a concise evaluator page comparing Base with
   adjacent developer-environment tools.
 - Documented Base's `uv` ecosystem boundary in `docs/tool-boundaries.md`.
-- Clarified the direct Homebrew install path for users who already have
-  Homebrew and Bash.
+- Clarified the Homebrew and source checkout install choices for users who
+  already have Homebrew, Git, and Bash.
 - Added a one-page command quick reference for the current `basectl` command
   surface.
 - Added `.github/base-project.yml` to the standard `basectl repo init`

--- a/FAQ.md
+++ b/FAQ.md
@@ -47,13 +47,14 @@ exec "$SHELL" -l
 ```
 
 Use a source checkout when you are contributing to Base or want to inspect and
-run the repository directly. This is the preferred mode for a Base development
-machine:
+run the repository directly. This is also the preferred active install for a
+Base development machine:
 
 ```bash
 git clone https://github.com/codeforester/base.git ~/work/base
 ~/work/base/bin/basectl setup
 ~/work/base/bin/basectl update-profile
+exec "$SHELL" -l
 ```
 
 Use `install.sh` when you specifically want the source-install path to clone or

--- a/README.md
+++ b/README.md
@@ -36,20 +36,30 @@ are tracked in [CHANGELOG.md](CHANGELOG.md).
 
 ## Start Here
 
-### Already Have Homebrew And Bash?
+### Choose An Install Path
 
-If your Mac already has Homebrew and a supported Bash, install just Base through
-Homebrew:
+If your Mac already has Homebrew, Git, and a supported Bash, choose one of the
+normal Base install paths:
+
+- Use Homebrew when you want Base managed like an ordinary installed tool.
+- Use a source checkout when you want to inspect, contribute to, or dogfood Base
+  from the repository.
 
 ```bash
+# Homebrew-managed install
 brew install codeforester/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
 ```
 
-This is the shortest path when the first-mile macOS prerequisites are already
-in place.
+```bash
+# Source checkout install
+git clone https://github.com/codeforester/base.git ~/work/base
+~/work/base/bin/basectl setup
+~/work/base/bin/basectl update-profile
+exec "$SHELL" -l
+```
 
 ### New Or Uncertain macOS Machine?
 
@@ -76,8 +86,9 @@ For mode selection, dry-run behavior, and contributor setup details, see
 [First-Mile Bootstrap](docs/bootstrap.md).
 
 For Homebrew installs, Base itself lives under Homebrew's prefix rather than in
-your project workspace. On first setup, Base creates `~/.base.d/config.yaml`
-with the default workspace root:
+your project workspace. For source checkout installs, Base lives at the clone
+path you choose, usually `~/work/base`. In both modes, first setup creates
+`~/.base.d/config.yaml` with the default workspace root:
 
 ```yaml
 workspace:


### PR DESCRIPTION
## Summary
- Replace the Homebrew-first README install section with a chooser that shows Homebrew-managed and source-checkout installs together.
- Keep bootstrap guidance as the path for new or uncertain macOS machines.
- Align the FAQ source-checkout snippet with the login-shell restart step.
- Update the changelog entry to cover both install paths.

## Issue
Closes #678

## Validation
- `git diff --check`
- `git diff --check --cached`

## Demo Impact
None. Documentation-only change.

## Notes
AI Context: Not updated. This clarifies first-run documentation and does not change product behavior, command surface, architecture, workflows, manifest model, or release state.