### PR TITLE
Check stderr for lib_std color detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Made `lib_std.sh` color initialization check stderr when deciding whether
+  log colors can be rendered, so redirected stdout does not disable colored
+  logs while stderr is still a terminal.
+
 ## [1.0.0] - 2026-06-14
 
 ### Added

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -300,8 +300,8 @@ __join_message__() {
 # This is called from __stdlib_init__
 #
 __init_colors__() {
-    # If --color was not passed, or if the output is not a terminal, disable colors.
-    if [[ "$__color__" != 1 || ! -t 1 ]]; then
+    # If --color was not passed, or if the log stream is not a terminal, disable colors.
+    if [[ "$__color__" != 1 || ! -t 2 ]]; then
         COLOR_BOLD=""
         COLOR_RED=""
         COLOR_GREEN=""

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -169,6 +169,30 @@ EOF
     [[ "$normalized" == *"colors=enabled"* ]]
 }
 
+@test "color initialization uses stderr terminal for log colors" {
+    local script="$TEST_TMPDIR/stderr-colors.sh"
+    local stdout_file="$TEST_TMPDIR/stdout.txt"
+    local normalized
+
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+exec >"\$1"
+source "$STDLIB_PATH"
+if [[ -n "\${COLOR_RED:-}" ]]; then
+    printf 'colors=enabled\n' >&2
+else
+    printf 'colors=disabled\n' >&2
+fi
+EOF
+
+    run_tty_script "$script" "$stdout_file" --color
+    normalized="$(normalize_tty_output "$output")"
+
+    [ "$status" -eq 0 ]
+    [[ "$normalized" == *"colors=enabled"* ]]
+    [ ! -s "$stdout_file" ]
+}
+
 @test "import loads relative and absolute libraries" {
     local relative_dir="$TEST_TMPDIR/helpers"
     local absolute_lib="$TEST_TMPDIR/absolute.sh"


### PR DESCRIPTION
## Summary

- Changed `lib_std.sh` color initialization to check stderr, which is where logging writes.
- Added a regression test for the case where stdout is redirected but stderr is still attached to a terminal.
- Added the Unreleased changelog entry for the logging color fix.

## Issue

Fixes #653

## Validation

- RED: `bats --filter "color initialization uses stderr terminal for log colors" lib/bash/std/tests/lib_std.bats`
  - Failed before the implementation because colors were disabled when stdout was redirected.
- GREEN: `bats --filter "color initialization uses stderr terminal for log colors" lib/bash/std/tests/lib_std.bats`
  - `1` test passed.
- `bats lib/bash/std/tests/lib_std.bats`
  - `65` cases completed, including the new stderr-terminal color regression test and the existing macOS tty skip.
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`
  - Python: `398 passed, 1 skipped`.
  - BATS: `443` cases completed with exit code 0.

## Demo Impact

None.

## Notes

- AI context update is not applicable; this is a narrow Bash stdlib logging behavior fix.
