### PR TITLE
Honor LOG_UTC in Bash logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made Bash `lib_std.sh` logging honor `LOG_UTC=1` so wrapper-driven Bash and
+  Python logs use the same timestamp zone.
 - Made `lib_std.sh` color initialization check stderr when deciding whether
   log colors can be rendered, so redirected stdout does not disable colored
   logs while stderr is still a terminal.

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -415,11 +415,16 @@ _print_log() {
         source_path="${source_path#"$__SCRIPT_DIR__"/}"
         source_path="${source_path#./}"
 
-        local message
+        local message timestamp
         message="$(__join_message__ "$@")"
+        if [[ "${LOG_UTC:-}" == 1 ]]; then
+            timestamp="$(TZ=UTC0 printf '%(%Y-%m-%d %H:%M:%S)T' -1)"
+        else
+            timestamp="$(printf '%(%Y-%m-%d %H:%M:%S)T' -1)"
+        fi
         {
             printf '%b' "$color"
-            printf '%(%Y-%m-%d %H:%M:%S)T %-7s %s ' -1 "$in_level" "${source_path}:${source_line}"
+            printf '%s %-7s %s ' "$timestamp" "$in_level" "${source_path}:${source_line}"
             printf '%s' "$message"
             printf '%b\n' "$COLOR_OFF"
         } >&2

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -351,6 +351,35 @@ EOF
     [[ "$(cat "$stderr_file")" == *"VERBOSE"* ]]
 }
 
+@test "_print_log uses local timestamps by default" {
+    local stderr_file="$TEST_TMPDIR/log-local-time.err"
+    local expected_before expected_after output
+
+    expected_before="$(TZ=Pacific/Honolulu printf '%(%Y-%m-%d %H)T' -1)"
+    TZ=Pacific/Honolulu log_info "local timestamp" 2>"$stderr_file"
+    expected_after="$(TZ=Pacific/Honolulu printf '%(%Y-%m-%d %H)T' -1)"
+    output="$(cat "$stderr_file")"
+
+    [[ "$output" == "$expected_before"* || "$output" == "$expected_after"* ]]
+    [[ "$output" == *"local timestamp"* ]]
+}
+
+@test "_print_log honors LOG_UTC for Bash timestamps" {
+    local stderr_file="$TEST_TMPDIR/log-utc-time.err"
+    local expected_before expected_after output local_before local_after
+
+    expected_before="$(TZ=UTC printf '%(%Y-%m-%d %H)T' -1)"
+    local_before="$(TZ=Pacific/Honolulu printf '%(%Y-%m-%d %H)T' -1)"
+    TZ=Pacific/Honolulu LOG_UTC=1 log_info "utc timestamp" 2>"$stderr_file"
+    expected_after="$(TZ=UTC printf '%(%Y-%m-%d %H)T' -1)"
+    local_after="$(TZ=Pacific/Honolulu printf '%(%Y-%m-%d %H)T' -1)"
+    output="$(cat "$stderr_file")"
+
+    [[ "$expected_before" != "$local_before" || "$expected_after" != "$local_after" ]]
+    [[ "$output" == "$expected_before"* || "$output" == "$expected_after"* ]]
+    [[ "$output" == *"utc timestamp"* ]]
+}
+
 @test "file logging helpers print contents and warn on unknown loggers" {
     local target="$TEST_TMPDIR/log-target.txt"
     local stderr_file="$TEST_TMPDIR/log-file.err"


### PR DESCRIPTION
## Summary

- Made Bash `lib_std.sh` logging honor `LOG_UTC=1` when formatting `_print_log` timestamps.
- Preserved local-time logging when `LOG_UTC` is unset.
- Added BATS coverage for both local-time and UTC Bash log timestamp behavior.

## Issue

Fixes #654

## Validation

- RED: `bats --filter "_print_log .*timestamps" lib/bash/std/tests/lib_std.bats`
  - Local-time control passed; `LOG_UTC=1` failed before the implementation because `_print_log` still used local time.
- GREEN: `bats --filter "_print_log .*timestamps" lib/bash/std/tests/lib_std.bats`
  - `2` tests passed.
- `bats lib/bash/std/tests/lib_std.bats`
  - `67` cases completed, including the new UTC/local timestamp coverage and the existing macOS tty skip.
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`
  - Python: `398 passed, 1 skipped`.
  - BATS: `445` cases completed with exit code 0.

## Demo Impact

None.

## Notes

- AI context update is not applicable; this is a narrow Bash stdlib logging behavior fix.
