### PR TITLE
Reject duplicate base_cli command registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Made `lib_std.sh` color initialization check stderr when deciding whether
   log colors can be rendered, so redirected stdout does not disable colored
   logs while stderr is still a terminal.
+- Made `base_cli.App` reject duplicate command registrations instead of
+  silently overwriting the first command.
 
 ## [1.0.0] - 2026-06-14
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -32,6 +32,11 @@ class App:
 
     def command(self, *command_args: Any, **command_kwargs: Any):
         def decorator(func: Callable[..., Any]):
+            if self._command_func is not None:
+                raise RuntimeError(
+                    f"App '{self.name}' already has a registered command. "
+                    "Use subcommands for multiple entry points."
+                )
             self._command_func = func
             self._command_args = command_args
             self._command_kwargs = command_kwargs

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -373,6 +373,21 @@ class BaseCliTests(unittest.TestCase):
 
         self.assertEqual(config["log_level"], "debug")
 
+    def test_app_rejects_duplicate_command_registration(self) -> None:
+        app = base_cli.App(name="demo")
+
+        @app.command()
+        def first(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "App 'demo' already has a registered command.*subcommands",
+        ):
+            @app.command()
+            def second(ctx: base_cli.Context) -> None:
+                del ctx
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_runs_with_context_and_cleans_temp_dir(self) -> None:
         app = base_cli.App(name="demo", version="0.1.0")


### PR DESCRIPTION
## Summary

- Add a guard so a second `@app.command()` registration raises an actionable `RuntimeError` instead of silently overwriting the first command.
- Add regression coverage for duplicate registration and record the behavior in the changelog.

## Issue

Closes #643

## Validation

- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q` - 35 passed
- `git diff --check HEAD~1..HEAD` - passed
- `env -u BASE_HOME ./bin/base-test` - 399 passed, 1 skipped; BATS 445 passed

## Demo Impact

None.

## Notes

- AI Context unchanged: this is a small `base_cli` guardrail and the changelog captures the externally visible behavior.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`