### PR TITLE
Bound lib_std log stack walking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Bounded `lib_std.sh` log caller stack walking so unusual stdlib-only frame
+  chains cannot scan indefinitely while finding a source location.
 - Made Bash `lib_std.sh` logging honor `LOG_UTC=1` so wrapper-driven Bash and
   Python logs use the same timestamp zone.
 - Made `lib_std.sh` color initialization check stderr when deciding whether

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -392,11 +392,11 @@ _print_log() {
         esac
 
         local source_path="${BASH_SOURCE[2]:-}" source_line="${BASH_LINENO[1]:-0}"
-        local frame=1 caller_info caller_line _caller_func caller_file
+        local frame=1 max_caller_frames=20 caller_info caller_line _caller_func caller_file
         if [[ -z "$source_path" || "$source_path" == "$__LIB_STD_PATH__" ]]; then
             source_path=""
             source_line=""
-            while caller_info=$(caller "$frame"); do
+            while ((frame <= max_caller_frames)) && caller_info=$(caller "$frame"); do
                 read -r caller_line _caller_func caller_file <<<"$caller_info"
                 if [[ -n "$caller_file" && "$caller_file" != "$__LIB_STD_PATH__" ]]; then
                     source_path="$caller_file"

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -380,6 +380,33 @@ EOF
     [[ "$output" == *"utc timestamp"* ]]
 }
 
+@test "_print_log bounds stdlib caller stack walking" {
+    local script="$TEST_TMPDIR/log-bounded-caller.sh"
+    local caller_log="$TEST_TMPDIR/caller-count.log"
+
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+source "$STDLIB_PATH"
+caller_log="$caller_log"
+: > "\$caller_log"
+caller() {
+    printf 'call\n' >> "\$caller_log"
+    caller_count="\$(wc -l < "\$caller_log")"
+    if ((caller_count > 20)); then
+        return 1
+    fi
+    printf '%s stdlib_frame %s\n' "\$1" "\$__LIB_STD_PATH__"
+}
+_print_log INFO "bounded stack walk" >/dev/null
+printf 'caller_count=%s\n' "\$(( \$(wc -l < "\$caller_log") ))"
+EOF
+
+    bats_run bash "$script"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"caller_count=20"* ]]
+}
+
 @test "file logging helpers print contents and warn on unknown loggers" {
     local target="$TEST_TMPDIR/log-target.txt"
     local stderr_file="$TEST_TMPDIR/log-file.err"


### PR DESCRIPTION
## Summary

- Bound `lib_std.sh` caller stack walking to 20 frames when logging needs to skip stdlib frames.
- Add a BATS regression that simulates an all-stdlib caller stack and proves the loop stops at the cap.
- Note the fix in the changelog.

## RED

- Temporarily removed the caller-frame cap and ran `bats --print-output-on-failure --filter "_print_log bounds stdlib caller stack walking" lib/bash/std/tests/lib_std.bats`.
- The regression failed with `caller_count=21`, proving the unbounded path kept scanning past the intended limit.

## GREEN / Validation

- `bats --filter "_print_log bounds stdlib caller stack walking" lib/bash/std/tests/lib_std.bats`
- `bats lib/bash/std/tests/lib_std.bats`
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact

- None. Internal Bash logging safety fix.

Fixes #661
