### PR TITLE
Resolve lib_std imports without pushd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Resolved `lib_std.sh` relative imports without changing directories so
+  failing imports cannot leave the caller on the script directory stack.
 - Bounded `lib_std.sh` log caller stack walking so unusual stdlib-only frame
   chains cannot scan indefinitely while finding a source location.
 - Made Bash `lib_std.sh` logging honor `LOG_UTC=1` so wrapper-driven Bash and

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -170,21 +170,16 @@ __stdlib_init__() {
 # to the function and be unavailable to other functions.
 #
 import() {
-    local lib
+    local lib import_path
     for lib; do
-        local pushed=0
-        # Unless an absolute library path is given, make it relative to the script's location
+        import_path="$lib"
         if [[ "$lib" != /* ]]; then
            [[ $__SCRIPT_DIR__ ]] || { printf '%s\n' "ERROR: __SCRIPT_DIR__ not set; import functionality needs it" >&2; exit 1; }
-           pushd "$__SCRIPT_DIR__" >/dev/null || exit_if_error 1 "Failed to enter script directory '$__SCRIPT_DIR__'."
-           pushed=1
+           import_path="$__SCRIPT_DIR__/$lib"
         fi
-        if [[ -f "$lib" ]]; then
-            source "$lib"
+        if [[ -f "$import_path" ]]; then
+            source "$import_path"
             exit_if_error $? "Import of library '$lib' not successful."
-            if ((pushed)); then
-                popd >/dev/null || exit_if_error 1 "Failed to leave script directory '$__SCRIPT_DIR__'."
-            fi
         else
             exit_if_error 1 "Library '$lib' does not exist"
         fi

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -236,6 +236,33 @@ EOF
     [[ "$output" != *"after"* ]]
 }
 
+@test "import failure does not leave relative import directory on the stack" {
+    local script_dir="$TEST_TMPDIR/driver"
+    local helper_dir="$script_dir/helpers"
+    local run_dir="$TEST_TMPDIR/run"
+    local script="$script_dir/import-failing-helper.sh"
+    local cwd_file="$TEST_TMPDIR/import-exit-pwd.txt"
+    local dirs_file="$TEST_TMPDIR/import-exit-dirs.txt"
+
+    mkdir -p "$helper_dir" "$run_dir"
+    cat > "$helper_dir/failing.sh" <<EOF
+trap 'pwd > "$cwd_file"; dirs -p > "$dirs_file"' EXIT
+exit_if_error 7 "helper failed during import"
+EOF
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+source "$STDLIB_PATH"
+import helpers/failing.sh
+EOF
+
+    bats_run bash -c "cd \"$run_dir\" && \"$script\""
+
+    [ "$status" -eq 7 ]
+    [ "$(cat "$cwd_file")" = "$run_dir" ]
+    [ "$(head -n 1 "$dirs_file")" = "$run_dir" ]
+    [[ "$(cat "$dirs_file")" != *"$script_dir"* ]]
+}
+
 @test "add_to_path appends an existing directory only once" {
     mkdir -p "$TEST_TMPDIR/bin"
     PATH="/usr/bin:/bin"


### PR DESCRIPTION
## Summary

- Resolve `lib_std.sh` relative imports by constructing an import path instead of using `pushd` / `popd`.
- Preserve absolute import behavior and existing missing-library messages.
- Add a regression that proves an aborting relative import does not leave the caller on the script directory stack.

## RED

- `bats --print-output-on-failure --filter "import failure does not leave relative import directory on the stack" lib/bash/std/tests/lib_std.bats`
- Failed against the old implementation because the imported helper's `EXIT` trap observed the script directory after `pushd`.

## GREEN / Validation

- `bats --filter "import (loads relative and absolute libraries|exits when a library is missing|failure does not leave relative import directory on the stack)" lib/bash/std/tests/lib_std.bats`
- `bats lib/bash/std/tests/lib_std.bats`
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`
- Rebased onto current `origin/master` after #684 merged, then reran:
  - `bats --filter "import (loads relative and absolute libraries|exits when a library is missing|failure does not leave relative import directory on the stack)" lib/bash/std/tests/lib_std.bats`
  - `shellcheck --severity=error lib/bash/std/lib_std.sh`
  - `git diff --check origin/master..HEAD`
  - `env -u BASE_HOME ./bin/base-test`

## Demo Impact

- None. Internal Bash stdlib import safety fix.

Fixes #656
