### PR TITLE
Compare lib_std Bash versions arithmetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Compared `lib_std.sh` Bash major and minor versions arithmetically so older
+  major versions with two-digit minors cannot bypass the Bash 4.2 minimum.
 - Resolved `lib_std.sh` relative imports without changing directories so
   failing imports cannot leave the caller on the script directory stack.
 - Bounded `lib_std.sh` log caller stack walking so unusual stdlib-only frame

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -94,10 +94,24 @@ is_interactive() {
 # Note: This function is called before logging is initialized, so it uses `echo` to stderr.
 #
 check_bash_version() {
-    local current_version
+    local bash_major bash_minor test_version
 
-    current_version="${BASE_TEST_BASH_VERSION:-${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}}"
-    if ((current_version < 42)); then
+    if [[ -n "${BASE_TEST_BASH_VERSION:-}" ]]; then
+        test_version="$BASE_TEST_BASH_VERSION"
+        if [[ "$test_version" == *.* ]]; then
+            bash_major="${test_version%%.*}"
+            bash_minor="${test_version#*.}"
+        else
+            bash_major="${test_version:0:1}"
+            bash_minor="${test_version:1}"
+        fi
+    else
+        bash_major="${BASH_VERSINFO[0]}"
+        bash_minor="${BASH_VERSINFO[1]}"
+    fi
+    bash_minor="${bash_minor:-0}"
+
+    if ((bash_major < 4 || (bash_major == 4 && bash_minor < 2))); then
         echo "Error: This script requires Bash 4.2 or higher." >&2
         echo "Your version ($BASH_VERSION) is not compatible." >&2
         return 1

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -148,6 +148,21 @@ EOF
     [[ "$output" == *"requires Bash 4.2 or higher"* ]]
 }
 
+@test "stdlib passive bash version check rejects Bash 3.10 arithmetically" {
+    local script="$TEST_TMPDIR/bash-version-3-10.sh"
+
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+source "$STDLIB_PATH"
+BASE_TEST_BASH_VERSION=310 check_bash_version
+EOF
+
+    bats_run "$script"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"requires Bash 4.2 or higher"* ]]
+}
+
 @test "color initialization honors tty mode when --color is passed" {
     local script="$TEST_TMPDIR/tty-colors.sh"
     local normalized


### PR DESCRIPTION
## Summary

- Compare `lib_std.sh` Bash major and minor versions arithmetically instead of comparing a concatenated version string.
- Keep the existing `BASE_TEST_BASH_VERSION` override, including support for simulated two-digit minor versions like `310`.
- Add a BATS regression proving simulated Bash 3.10 still fails the Bash 4.2 minimum.

## RED

- `bats --print-output-on-failure --filter "stdlib passive bash version check" lib/bash/std/tests/lib_std.bats`
- The new Bash 3.10 regression failed because the old concatenated comparison treated `310` as newer than `42`.

## GREEN / Validation

- `bats --filter "stdlib passive bash version check" lib/bash/std/tests/lib_std.bats`
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `bats lib/bash/std/tests/lib_std.bats`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact

- None. Internal Bash stdlib compatibility check.

Fixes #658
