### PR TITLE
Read ask_yes_no answers from tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made `lib_std.sh` yes/no prompts read from the controlling terminal so
+  redirected stdin stays available to the caller.
 - Compared `lib_std.sh` Bash major and minor versions arithmetically so older
   major versions with two-digit minors cannot bypass the Bash 4.2 minimum.
 - Resolved `lib_std.sh` relative imports without changing directories so

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -1085,21 +1085,36 @@ ask_yes_no() {
         return 1
     fi
 
-    local message=$1 user_input
+    local message=$1 user_input tty_fd
+    if ! exec {tty_fd}</dev/tty 2>/dev/null; then
+        log_error "ask_yes_no: /dev/tty is not available"
+        return 1
+    fi
+
     while true; do
         # Prompt the user for input.
         # -n 1: Reads only one character.
         # -r: Prevents backslash from acting as an escape character.
         # -p: Displays the prompt string.
         # The text "[y/N]" suggests that 'N' is the default choice.
-        read -r -n 1 -p "$message [y/N]: " user_input
+        if ! read -r -n 1 -p "$message [y/N]: " user_input <&"$tty_fd"; then
+            exec {tty_fd}<&-
+            echo
+            return 1
+        fi
         
         # Add a newline since the user won't press Enter.
         echo
 
         case "$user_input" in
-            [yY]) return 0;;
-            [nN]) return 1;;
+            [yY])
+                exec {tty_fd}<&-
+                return 0
+                ;;
+            [nN])
+                exec {tty_fd}<&-
+                return 1
+                ;;
             *) echo "Invalid input. Please enter 'y' or 'n'.";;
         esac
     done

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -32,6 +32,83 @@ run_tty_script() {
     fi
 }
 
+run_pty_command() {
+    local input="$1"
+    local driver="$TEST_TMPDIR/pty-driver.py"
+    shift
+
+    cat > "$driver" <<'PY'
+import errno
+import os
+import pty
+import select
+import signal
+import sys
+import time
+
+input_bytes = sys.argv[1].encode()
+command = sys.argv[2:]
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.execvp(command[0], command)
+
+os.write(fd, input_bytes)
+output = bytearray()
+status = None
+deadline = time.monotonic() + 10
+
+while True:
+    if time.monotonic() > deadline:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        status = 124
+        break
+
+    readable, _, _ = select.select([fd], [], [], 0.05)
+    if readable:
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError as exc:
+            if exc.errno == errno.EIO:
+                chunk = b""
+            else:
+                raise
+        if chunk:
+            output.extend(chunk)
+
+    waited, child_status = os.waitpid(pid, os.WNOHANG)
+    if waited:
+        if os.WIFEXITED(child_status):
+            status = os.WEXITSTATUS(child_status)
+        elif os.WIFSIGNALED(child_status):
+            status = 128 + os.WTERMSIG(child_status)
+        else:
+            status = 1
+        while True:
+            readable, _, _ = select.select([fd], [], [], 0)
+            if not readable:
+                break
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError as exc:
+                if exc.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            output.extend(chunk)
+        break
+
+sys.stdout.buffer.write(output)
+sys.exit(status if status is not None else 1)
+PY
+
+    bats_run python3 "$driver" "$input" "$@"
+}
+
 setup() {
     setup_test_tmpdir
     PATH="$BASE_TEST_ORIG_PATH"
@@ -1026,14 +1103,14 @@ EOF
     create_script "$script" <<EOF
 #!/usr/bin/env bash
 source "$STDLIB_PATH"
-if ask_yes_no "Proceed" <<<"y"; then
+if ask_yes_no "Proceed"; then
     echo "answer=yes"
 else
     echo "answer=no"
 fi
 EOF
 
-    bats_run bash "$script"
+    run_pty_command $'y\n' "$script"
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"answer=yes"* ]]
@@ -1045,17 +1122,42 @@ EOF
     create_script "$script" <<EOF
 #!/usr/bin/env bash
 source "$STDLIB_PATH"
-if ask_yes_no "Proceed" <<<"n"; then
+if ask_yes_no "Proceed"; then
     echo "answer=yes"
 else
     echo "answer=no"
 fi
 EOF
 
-    bats_run bash "$script"
+    run_pty_command $'n\n' "$script"
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"answer=no"* ]]
+}
+
+@test "ask_yes_no reads from terminal when stdin is redirected" {
+    local script="$TEST_TMPDIR/ask-tty.sh"
+    local normalized
+
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+source "$STDLIB_PATH"
+if ask_yes_no "Proceed"; then
+    echo "answer=yes"
+else
+    echo "answer=no"
+fi
+printf 'stdin='
+cat
+EOF
+
+    run_pty_command $'y\n' bash -c "printf 'n\npayload\n' | \"$script\""
+    normalized="${output//$'\r'/}"
+
+    [ "$status" -eq 0 ]
+    [[ "$normalized" == *"answer=yes"* ]]
+    [[ "$normalized" == *"stdin=n"* ]]
+    [[ "$normalized" == *"payload"* ]]
 }
 
 @test "ask_yes_no validates argument count" {


### PR DESCRIPTION
## Summary

- Make `ask_yes_no` open `/dev/tty` read-only and read prompt answers from the controlling terminal.
- Keep invalid-argument behavior unchanged and return safely when no terminal is available.
- Add a Python stdlib PTY test helper and a regression proving redirected stdin remains available to the caller.

## RED

- `bats --print-output-on-failure --filter "ask_yes_no" lib/bash/std/tests/lib_std.bats`
- The redirected-stdin regression failed against the old implementation: terminal input `y` was ignored, stdin `n` was consumed, and the remaining pipeline lost the first byte.

## GREEN / Validation

- `bats --print-output-on-failure --filter "ask_yes_no" lib/bash/std/tests/lib_std.bats`
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `bats lib/bash/std/tests/lib_std.bats`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact

- None. Internal Bash stdlib prompt behavior fix.

Fixes #657
