### PR TITLE
Add base_cli ExitCode constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `base_cli.ExitCode` constants for Base's standard command return
+  values.
+
 ### Fixed
 
 - Compared `lib_std.sh` Bash major and minor versions arithmetically so older

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -136,6 +136,26 @@ Every `base_cli.App` command gets these options:
 The command receives only its own application-specific options. Standard options
 are consumed before the command function is called.
 
+## Exit Codes
+
+Use `base_cli.ExitCode` when command code or tests need to name Base's standard
+command result meanings:
+
+- `ExitCode.SUCCESS` (`0`): the command completed successfully.
+- `ExitCode.FAILURE` (`1`): the command was valid, but an operational problem
+  prevented successful completion.
+- `ExitCode.USAGE_ERROR` (`2`): the command could not proceed because user
+  input, configuration, or environment setup was invalid or incomplete.
+
+Existing commands can keep returning integers. New code should prefer the named
+constants when it makes intent clearer:
+
+```python
+if ctx.project_root is None:
+    ctx.log.error("run this command from a Base project")
+    return base_cli.ExitCode.USAGE_ERROR
+```
+
 ## Context
 
 `Context` is the object command code should pass around instead of rediscovering

--- a/lib/python/base_cli/__init__.py
+++ b/lib/python/base_cli/__init__.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from .app import App, argument, command, option
 from .context import Context, get_current_context
+from .exit_codes import ExitCode
 from .logging import log_critical, log_debug, log_error, log_info, log_warning
 
 __all__ = [
     "App",
     "Context",
+    "ExitCode",
     "argument",
     "command",
     "get_current_context",

--- a/lib/python/base_cli/exit_codes.py
+++ b/lib/python/base_cli/exit_codes.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class ExitCode:
+    """Base-standard command exit code constants."""
+
+    SUCCESS = 0
+    FAILURE = 1
+    USAGE_ERROR = 2

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -373,6 +373,14 @@ class BaseCliTests(unittest.TestCase):
 
         self.assertEqual(config["log_level"], "debug")
 
+    def test_exit_code_constants_match_base_conventions(self) -> None:
+        from base_cli import ExitCode
+
+        self.assertEqual(ExitCode.SUCCESS, 0)
+        self.assertEqual(ExitCode.FAILURE, 1)
+        self.assertEqual(ExitCode.USAGE_ERROR, 2)
+        self.assertIs(ExitCode, base_cli.ExitCode)
+
     def test_app_rejects_duplicate_command_registration(self) -> None:
         app = base_cli.App(name="demo")
 


### PR DESCRIPTION
## Summary
- Add a public `base_cli.ExitCode` namespace for Base standard command return values.
- Export the API from `base_cli` and document when to use each value.
- Cover the public constants with a unit test that imports through the package API.

## Validation
- RED: `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py::BaseCliTests::test_exit_code_constants_match_base_conventions -q` failed with missing `ExitCode`.
- GREEN: `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q` -> 36 passed.
- `git diff --check origin/master..HEAD`
- `env -u BASE_HOME ./bin/base-test` -> Python 400 passed, 1 skipped; BATS ok 1..448.

Closes #644