### PR TITLE
Add cwd support to base_cli testing invoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Added `base_cli.ExitCode` constants for Base's standard command return
   values.
+- Added `cwd` support to `base_cli.testing.invoke()` so tests can run commands
+  from an explicit project context without leaking the process working
+  directory.
 
 ### Fixed
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -277,11 +277,12 @@ ctx.on_cleanup(close_connection)
 The package should include a small test helper:
 
 ```python
-result = base_cli.testing.invoke(app, ["--debug"])
+result = base_cli.testing.invoke(app, ["--debug"], cwd=project_root)
 ```
 
 This wraps Click's test runner and gives tests access to isolated `HOME`,
-captured output, and generated Base state.
+captured output, generated Base state, and an explicit invocation directory for
+project discovery or no-project test cases.
 
 ## Phases
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -317,15 +317,20 @@ from base_cli.testing import invoke
 
 
 def test_command(tmp_path: Path) -> None:
-    result = invoke(app, ["--name", "Ada"], home=tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "base_manifest.yaml").write_text("project:\n  name: demo\n")
+
+    result = invoke(app, ["--name", "Ada"], home=tmp_path, cwd=project)
 
     assert result.exit_code == 0
     assert "hello Ada" in result.stdout
 ```
 
-The helper wraps Click's `CliRunner`, sets `HOME` when requested, and keeps
-stderr separate on Click versions that support it. This makes it straightforward
-to assert that program output and logs do not get mixed.
+The helper wraps Click's `CliRunner`, sets `HOME` when requested, changes to
+`cwd` only for the invocation, and keeps stderr separate on Click versions that
+support it. Use `cwd` for commands whose behavior depends on project discovery,
+including tests that intentionally run outside a Base project.
 
 ## When To Use `base_cli`
 

--- a/lib/python/base_cli/testing.py
+++ b/lib/python/base_cli/testing.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import inspect
+import os
 from pathlib import Path
 from typing import Any
 
 
-def invoke(app: Any, args: list[str] | None = None, home: Path | None = None):
+def invoke(
+    app: Any,
+    args: list[str] | None = None,
+    home: Path | None = None,
+    cwd: Path | str | None = None,
+):
     try:
         from click.testing import CliRunner
     except ImportError as exc:
@@ -18,4 +24,11 @@ def invoke(app: Any, args: list[str] | None = None, home: Path | None = None):
     if "mix_stderr" in inspect.signature(CliRunner).parameters:
         runner_kwargs["mix_stderr"] = False
     runner = CliRunner(**runner_kwargs)
-    return runner.invoke(app.click_command, args or [], env=env)
+    original_cwd = Path.cwd()
+    if cwd is not None:
+        os.chdir(cwd)
+    try:
+        return runner.invoke(app.click_command, args or [], env=env)
+    finally:
+        if cwd is not None:
+            os.chdir(original_cwd)

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -546,6 +546,91 @@ class BaseCliTests(unittest.TestCase):
         self.assertIn("stderr text", result.stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_testing_invoke_uses_supplied_cwd_for_manifest_discovery(self) -> None:
+        app = base_cli.App(name="project-aware", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["cwd"] = Path.cwd()
+            seen["manifest_path"] = ctx.manifest_path
+            seen["project_root"] = ctx.project_root
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project = root / "project"
+            nested = project / "nested"
+            home.mkdir()
+            nested.mkdir(parents=True)
+            manifest_path = project / "base_manifest.yaml"
+            manifest_path.write_text("project:\n  name: demo\n", encoding="utf-8")
+            original_cwd = Path.cwd()
+
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home, cwd=nested)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["cwd"], nested.resolve())
+        self.assertEqual(seen["manifest_path"], manifest_path.resolve())
+        self.assertEqual(seen["project_root"], project.resolve())
+        self.assertEqual(Path.cwd(), original_cwd)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_testing_invoke_uses_supplied_cwd_without_manifest(self) -> None:
+        app = base_cli.App(name="no-project", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["cwd"] = Path.cwd()
+            seen["manifest_path"] = ctx.manifest_path
+            seen["project_root"] = ctx.project_root
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            isolated = root / "isolated"
+            home.mkdir()
+            isolated.mkdir()
+            original_cwd = Path.cwd()
+
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home, cwd=isolated)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["cwd"], isolated.resolve())
+        self.assertIsNone(seen["manifest_path"])
+        self.assertIsNone(seen["project_root"])
+        self.assertEqual(Path.cwd(), original_cwd)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_testing_invoke_restores_cwd_after_failure_result(self) -> None:
+        app = base_cli.App(name="failing", log_to_file=False)
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+            raise RuntimeError("boom")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            cwd = root / "cwd"
+            home.mkdir()
+            cwd.mkdir()
+            original_cwd = Path.cwd()
+
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home, cwd=cwd)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertEqual(Path.cwd(), original_cwd)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_standard_options_manifest_context_and_sensitive_redaction(self) -> None:
         app = base_cli.App(name="secret-tool", version="0.1.0")
         seen = {}


### PR DESCRIPTION
## Summary
- Add a `cwd` parameter to `base_cli.testing.invoke()` and restore the original process directory after invocation.
- Cover manifest discovery from `cwd`, no-manifest cwd behavior, and restoration after a failing invocation result.
- Update the package README and docs mirror to show `cwd` for project-context-sensitive tests.

## Validation
- RED: `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q -k "testing_invoke_uses_supplied_cwd or testing_invoke_restores_cwd"` failed with unexpected `cwd` keyword.
- GREEN: same focused command -> 3 passed, 36 deselected.
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q` -> 39 passed.
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test` -> Python 403 passed, 1 skipped; BATS ok 1..449.

Closes #642