### PR TITLE
Add assert_executable helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `cwd` support to `base_cli.testing.invoke()` so tests can run commands
   from an explicit project context without leaking the process working
   directory.
+- Added `assert_executable` to `lib_std.sh` for explicit executable path checks.
 
 ### Fixed
 

--- a/lib/bash/std/README.md
+++ b/lib/bash/std/README.md
@@ -250,6 +250,7 @@ assert_integer retry_count
 assert_integer_range retry_count 0 5
 assert_command_exists git brew
 assert_file_exists "$manifest_path"
+assert_executable "$project_root/bin/build"
 assert_dir_exists "$project_root"
 ```
 
@@ -260,6 +261,9 @@ echoing the invalid value.
 
 The assertions favor clear failure messages over scattered one-off tests. Some
 helpers check all provided values and report all missing items together.
+Use `assert_executable` for explicit paths to project-local tools or scripts;
+use `assert_command_exists` for commands that should be discoverable through
+`PATH`.
 
 ## Interactive Helpers
 

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -987,6 +987,45 @@ assert_file_exists() {
 }
 
 #
+# assert_executable - Checks that one or more paths exist and are executable files.
+#
+# This function iterates through all provided paths. If any path does not
+# exist, is not a regular file, or is not executable, it collects the names
+# and reports them all in a single fatal error.
+#
+# Use this for explicit paths such as project-local scripts. Use
+# `assert_command_exists` when checking whether a command is discoverable
+# through PATH.
+#
+# Usage:
+#   assert_executable "./bin/tool" "/opt/vendor/bin/tool"
+#
+# Arguments:
+#   $@: One or more executable file paths to check.
+#
+assert_executable() {
+    local missing_executables=()
+    local executable
+
+    if (($# == 0)); then
+        log_warn "assert_executable: No executable paths provided to check."
+        return 0
+    fi
+
+    for executable; do
+        if [[ ! -f "$executable" || ! -x "$executable" ]]; then
+            missing_executables+=("$executable")
+        fi
+    done
+
+    if ((${#missing_executables[@]} > 0)); then
+        fatal_error "These required executable paths do not exist, are not regular files, or are not executable: ${missing_executables[*]}"
+    fi
+
+    return 0
+}
+
+#
 # assert_dir_exists - Checks that one or more paths exist and are directories.
 #
 # This function iterates through all provided paths. If any path does not

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -1020,6 +1020,42 @@ EOF
     [[ "$output" == *"do not exist or are not regular files"* ]]
 }
 
+@test "assert_executable validates executable paths and warns on empty input" {
+    local target="$TEST_TMPDIR/tool.sh"
+    local stderr_file="$TEST_TMPDIR/assert-executable.err"
+
+    create_script "$target" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+    assert_executable "$target"
+
+    assert_executable 2>"$stderr_file"
+    [ "$?" -eq 0 ]
+    [[ "$(cat "$stderr_file")" == *"assert_executable: No executable paths provided to check."* ]]
+}
+
+@test "assert_executable exits for missing or non-executable paths" {
+    local script="$TEST_TMPDIR/assert-executable-fail.sh"
+    local target="$TEST_TMPDIR/not-executable.sh"
+
+    printf '#!/usr/bin/env bash\n' > "$target"
+
+    create_script "$script" <<EOF
+#!/usr/bin/env bash
+source "$STDLIB_PATH"
+assert_executable "$TEST_TMPDIR/missing-tool" "$target"
+EOF
+
+    bats_run bash "$script"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"do not exist, are not regular files, or are not executable"* ]]
+    [[ "$output" == *"$TEST_TMPDIR/missing-tool"* ]]
+    [[ "$output" == *"$target"* ]]
+}
+
 @test "assert_dir_exists validates directories and warns on empty input" {
     local target="$TEST_TMPDIR/dir"
     local stderr_file="$TEST_TMPDIR/assert-dir.err"


### PR DESCRIPTION
## Summary

- Add `assert_executable` for explicit executable path validation in `lib_std.sh`.
- Document the difference between explicit executable path checks and `PATH` command checks.
- Add BATS coverage for success, empty-input warning, missing paths, and non-executable paths.

## RED

- `bats --print-output-on-failure --filter "assert_executable" lib/bash/std/tests/lib_std.bats`
- Failed because `assert_executable` did not exist yet.

## GREEN / Validation

- `bats --filter "assert_executable" lib/bash/std/tests/lib_std.bats`
- `shellcheck --severity=error lib/bash/std/lib_std.sh`
- `git diff --check`
- `bats lib/bash/std/tests/lib_std.bats`
- `env -u BASE_HOME ./bin/base-test`
- Rebased across #689 and #690 changelog updates; final post-rebase validation:
  - `bats --filter "assert_executable" lib/bash/std/tests/lib_std.bats`
  - `shellcheck --severity=error lib/bash/std/lib_std.sh`
  - `git diff --check origin/master..HEAD`
  - `env -u BASE_HOME ./bin/base-test`

## Demo Impact

- None. Bash stdlib API addition.

Fixes #659
