### PR TITLE
Add quiet probe mode to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `assert_executable` to `lib_std.sh` for explicit executable path checks.
 - Added a test-local `BASE_CACHE_DIR` default to `base_cli.testing.invoke()`
   when `home` is supplied, with explicit environment overrides still honored.
+- Added `run --quiet` to suppress expected `--no-exit` failure warnings in
+  probe-style Bash checks.
 
 ### Fixed
 

--- a/lib/bash/std/README.md
+++ b/lib/bash/std/README.md
@@ -177,6 +177,15 @@ if ! run --no-exit grep "needle" "$file"; then
 fi
 ```
 
+For expected probe failures where the caller handles the status, add `--quiet`
+to suppress the warning:
+
+```bash
+if ! run --no-exit --quiet test -f "$optional_file"; then
+    log_debug "Optional file is absent."
+fi
+```
+
 Use `run` for commands plus arguments. Keep shell features such as pipelines,
 redirection, process substitution, and complex conditionals explicit in the
 calling script so the code remains clear.

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -24,7 +24,8 @@
 #   __SCRIPT_DIR__    Absolute path to the script that sourced the library.
 #
 # Core helpers:
-#   run [--no-exit] cmd ...      # Safe command runner with dry-run & failure handling.
+#   run [--no-exit] [--quiet] cmd ...
+#                                # Safe command runner with dry-run & failure handling.
 #   exit_if_error rc msg...      # Log + exit when rc != 0 (preserves original status).
 #   fatal_error msg...           # Convenience wrapper: exit with last status or 1.
 #   add_to_path [-n] [-p] dir    # Append/prepend unique PATH entries.
@@ -625,16 +626,21 @@ is_dry_run() {
 #     prints the command instead of running it.
 #   - Exit on Failure: By default, it will exit the script if the command
 #     returns a non-zero exit code.
-#   - Optional No-Exit: If the first argument is `--no-exit`, the function
+#   - Optional No-Exit: If an initial argument is `--no-exit`, the function
 #     will not exit on failure, allowing the calling script to handle the error.
+#   - Optional Quiet Probe: If an initial argument is `--quiet`, handled
+#     failures do not log warnings. This is intended for expected probe
+#     failures and is most useful with `--no-exit`.
 #
 # Usage:
 #   run [options] command [arg1] [arg2] ...
 #
 # Options:
-#   --no-exit   If provided as the very first argument, the script will not
+#   --no-exit   If provided as an initial argument, the script will not
 #               exit if the command fails. The function will return the
 #               command's original exit code.
+#   --quiet     If provided as an initial argument with `--no-exit`, suppress
+#               the warning normally logged when the command fails.
 #
 # Examples:
 #   # Run a simple command. Exits if `ls` fails.
@@ -654,13 +660,28 @@ is_dry_run() {
 #
 ################################################################################
 run() {
-    local exit_on_failure=1
+    local exit_on_failure=1 quiet=0
 
-    # Check for the optional --no-exit flag.
-    if [[ "${1-}" == "--no-exit" ]]; then
-        exit_on_failure=0
-        shift # Remove the --no-exit flag from the arguments list.
-    fi
+    # Parse optional run flags before the command.
+    while (($#)); do
+        case "${1-}" in
+            --no-exit)
+                exit_on_failure=0
+                shift
+                ;;
+            --quiet)
+                quiet=1
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
 
     # Check if the command is empty.
     if [[ $# -eq 0 ]]; then
@@ -691,7 +712,9 @@ run() {
         if ((exit_on_failure)); then
             exit_if_error "$exit_code" "Command failed (exit $exit_code): ${printable_command}"
         else
-            log_warn "Command failed (exit $exit_code): ${printable_command} (continuing)."
+            if ((! quiet)); then
+                log_warn "Command failed (exit $exit_code): ${printable_command} (continuing)."
+            fi
             return $exit_code
         fi
     fi

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -760,6 +760,20 @@ EOF
     [[ "$(cat "$stderr_file")" == *"continuing"* ]]
 }
 
+@test "run --no-exit --quiet suppresses failure warning" {
+    local stderr_file="$TEST_TMPDIR/run-no-exit-quiet.err"
+    local rc
+
+    if run --no-exit --quiet bash -c 'exit 7' 2>"$stderr_file"; then
+        rc=0
+    else
+        rc=$?
+    fi
+
+    [ "$rc" -eq 7 ]
+    [ ! -s "$stderr_file" ]
+}
+
 @test "run exits the script on failure by default" {
     local script="$TEST_TMPDIR/run-fail.sh"
 


### PR DESCRIPTION
## Summary
- Parse initial `run` flags so `--no-exit`, `--quiet`, and `--` are handled before the command.
- Suppress handled failure warnings for `run --no-exit --quiet` probe checks while preserving existing `run --no-exit` warning behavior.
- Document the quiet probe pattern and add BATS coverage plus a changelog entry.

## Validation
- RED: `bats --print-output-on-failure --filter "run " lib/bash/std/tests/lib_std.bats` failed because `--quiet` was parsed as the command.
- GREEN: `bats --print-output-on-failure --filter "run " lib/bash/std/tests/lib_std.bats`
- GREEN: `shellcheck --severity=error lib/bash/std/lib_std.sh`
- GREEN: `git diff --check HEAD~1..HEAD`
- GREEN: `env -u BASE_HOME ./bin/base-test` (`405 passed, 1 skipped`; `452` BATS cases)

## Demo Impact
- None. Bash stdlib behavior only.

Fixes #660
