### PR TITLE
Make base_cli dry-run explicit on context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   when `home` is supplied, with explicit environment overrides still honored.
 - Added `run --quiet` to suppress expected `--no-exit` failure warnings in
   probe-style Bash checks.
+- Added `ctx.dry_run` and `base_cli.option(..., dry_run=True)` so commands can
+  explicitly connect nonstandard preview flags to Base's no-durable-write mode.
 
 ### Fixed
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -81,6 +81,7 @@ ctx.log_file       # log_dir/<run-id>.log, or None when persistent logging is di
 ctx.config         # dict
 ctx.environment    # str
 ctx.debug          # bool
+ctx.dry_run        # bool
 ctx.keep_temp      # bool
 ctx.log            # logging.Logger
 ```
@@ -129,6 +130,9 @@ Directory lifecycle:
 | `logs/` | before command execution | never by default |
 | `cache/` | before command execution | explicit CLI logic only |
 | `tmp/<run-id>/` | before command execution | after command execution unless kept |
+
+Commands running with `ctx.dry_run` skip default `logs/`, `cache/`, and
+`tmp/<run-id>/` creation unless an explicit log file is supplied.
 
 Commands that inspect runtime artifacts can opt out of default persistent log
 creation with `base_cli.App(log_to_file=False)`. That still provides a context
@@ -181,6 +185,13 @@ Options may be marked sensitive:
 
 ```python
 @base_cli.option("--api-key", sensitive=True)
+```
+
+Options may also be marked as the command's dry-run control when they use a
+nonstandard parameter name:
+
+```python
+@base_cli.option("--preview", is_flag=True, dry_run=True)
 ```
 
 For v1, sensitive values are redacted from automatic invocation logging. More

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -122,6 +122,19 @@ def main(ctx: base_cli.Context, token: str) -> None:
 
 Both `--token secret` and `--token=secret` are redacted in debug logs.
 
+Use `dry_run=True` when a nonstandard option should drive `ctx.dry_run` and
+Base's default durable-write suppression:
+
+```python
+@base_cli.option("--preview", is_flag=True, dry_run=True)
+def main(ctx: base_cli.Context, preview: bool) -> None:
+    if ctx.dry_run:
+        ctx.log.info("previewing changes")
+```
+
+The conventional `dry_run` parameter is recognized automatically, so commands
+using `@base_cli.option("--dry-run", is_flag=True)` do not need the marker.
+
 ## Standard Options
 
 Every `base_cli.App` command gets these options:
@@ -177,6 +190,7 @@ Important fields include:
 - `ctx.config`: merged configuration dictionary.
 - `ctx.environment`: active environment, defaulting to `dev`.
 - `ctx.debug`: whether debug logging is enabled for the stderr stream.
+- `ctx.dry_run`: whether the command is running in a no-durable-write mode.
 - `ctx.keep_temp`: whether `ctx.temp_dir` should survive cleanup.
 - `ctx.log`: standard Python logger configured by Base.
 
@@ -206,6 +220,10 @@ to keep the standard context and `--debug` behavior without creating default
 `logs/`, `cache/`, or `tmp/<run-id>/` directories. `base_logs` uses this mode so
 `basectl logs` does not appear in its own output. An explicit `--log-file <path>`
 still enables file logging for that invocation.
+
+Commands running with `ctx.dry_run` also skip default `logs/`, `cache/`, and
+`tmp/<run-id>/` creation. Passing `--log-file <path>` still writes to that
+explicit file so tests and diagnostics can inspect dry-run logs when needed.
 
 Logs use the same general shape as Base Bash logs:
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -60,11 +60,12 @@ class App:
         click = _require_click()
         func = self._command_func
         sensitive_options = set(getattr(func, "__base_cli_sensitive_options__", set()))
+        dry_run_parameter = getattr(func, "__base_cli_dry_run_parameter__", "dry_run")
 
         @functools.wraps(func)
         def wrapper(**kwargs: Any):
             standard = _pop_standard_options(kwargs)
-            context = self._create_context(standard, sensitive_options, dry_run=bool(kwargs.get("dry_run")))
+            context = self._create_context(standard, sensitive_options, dry_run=bool(kwargs.get(dry_run_parameter)))
             token = set_current_context(context)
             try:
                 log_invocation(context.log, sys.argv, sensitive_options)
@@ -131,6 +132,7 @@ class App:
             debug=debug,
             keep_temp=keep_temp,
             log=logger,
+            dry_run=dry_run,
         )
 
 
@@ -138,7 +140,7 @@ def command(*args: Any, **kwargs: Any):
     return App().command(*args, **kwargs)
 
 
-def option(*param_decls: str, sensitive: bool = False, **attrs: Any):
+def option(*param_decls: str, sensitive: bool = False, dry_run: bool = False, **attrs: Any):
     def decorator(func: Callable[..., Any]):
         specs = list(getattr(func, "__base_cli_param_specs__", []))
         specs.append(("option", param_decls, attrs))
@@ -147,6 +149,8 @@ def option(*param_decls: str, sensitive: bool = False, **attrs: Any):
             options = set(getattr(func, "__base_cli_sensitive_options__", set()))
             options.add(parameter_name_from_decls(param_decls))
             func.__base_cli_sensitive_options__ = options
+        if dry_run:
+            func.__base_cli_dry_run_parameter__ = parameter_name_from_decls(param_decls)
         return func
 
     return decorator

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -28,6 +28,7 @@ class Context:
     debug: bool
     keep_temp: bool
     log: logging.Logger
+    dry_run: bool = False
     base_home: Path | None = None
     project_root: Path | None = None
     manifest_path: Path | None = None

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -439,6 +439,7 @@ class BaseCliTests(unittest.TestCase):
         @base_cli.option("--dry-run", is_flag=True)
         def main(ctx: base_cli.Context, dry_run: bool) -> None:
             seen["dry_run"] = dry_run
+            seen["ctx_dry_run"] = ctx.dry_run
             seen["temp_dir"] = ctx.temp_dir
             seen["cache_dir"] = ctx.cache_dir
             seen["log_dir"] = ctx.log_dir
@@ -453,12 +454,45 @@ class BaseCliTests(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertTrue(seen["dry_run"])
+            self.assertTrue(seen["ctx_dry_run"])
             self.assertIsNone(seen["log_file"])
             self.assertFalse(seen["temp_dir"].exists())
             self.assertFalse(seen["cache_dir"].exists())
             self.assertFalse(seen["log_dir"].exists())
             self.assertFalse((home / ".cache" / "base").exists())
             self.assertIn("dry run", result.stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_custom_dry_run_option_sets_context_and_avoids_cache_writes(self) -> None:
+        app = base_cli.App(name="preview-demo", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        @base_cli.option("--preview", is_flag=True, dry_run=True)
+        def main(ctx: base_cli.Context, preview: bool) -> None:
+            seen["preview"] = preview
+            seen["ctx_dry_run"] = ctx.dry_run
+            seen["temp_dir"] = ctx.temp_dir
+            seen["cache_dir"] = ctx.cache_dir
+            seen["log_dir"] = ctx.log_dir
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("preview")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            from base_cli.testing import invoke
+
+            result = invoke(app, ["--preview"], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(seen["preview"])
+            self.assertTrue(seen["ctx_dry_run"])
+            self.assertIsNone(seen["log_file"])
+            self.assertFalse(seen["temp_dir"].exists())
+            self.assertFalse(seen["cache_dir"].exists())
+            self.assertFalse(seen["log_dir"].exists())
+            self.assertFalse((home / ".cache" / "base").exists())
+            self.assertIn("preview", result.stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_can_disable_default_persistent_logging(self) -> None:
@@ -498,6 +532,7 @@ class BaseCliTests(unittest.TestCase):
         @base_cli.option("--dry-run", is_flag=True)
         def main(ctx: base_cli.Context, dry_run: bool) -> None:
             seen["dry_run"] = dry_run
+            seen["ctx_dry_run"] = ctx.dry_run
             seen["temp_dir"] = ctx.temp_dir
             seen["cache_dir"] = ctx.cache_dir
             seen["log_file"] = ctx.log_file
@@ -512,6 +547,7 @@ class BaseCliTests(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertTrue(seen["dry_run"])
+            self.assertTrue(seen["ctx_dry_run"])
             self.assertEqual(seen["log_file"], log_file)
             self.assertTrue(log_file.is_file())
             self.assertEqual(log_file.stat().st_mode & 0o777, 0o600)


### PR DESCRIPTION
## Summary
- Add `ctx.dry_run` to `base_cli.Context` and populate it before runtime directories are created.
- Preserve automatic support for conventional `dry_run` parameters.
- Add `base_cli.option(..., dry_run=True)` for nonstandard preview/no-write flags and document the API.

## Validation
- RED: `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q -k dry_run` failed because `ctx.dry_run` was missing and `dry_run=True` passed through to Click.
- GREEN: same focused command -> 3 passed, 39 deselected.
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q` -> 42 passed.
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test` -> Python 406 passed, 1 skipped; BATS ok 1..451.

Closes #640