### PR TITLE
Isolate base_cli testing cache paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `cwd` support to `base_cli.testing.invoke()` so tests can run commands
   from an explicit project context without leaking the process working
   directory.
+- Added a test-local `BASE_CACHE_DIR` default to `base_cli.testing.invoke()`
+  when callers supply a test `home`.
 
 ### Fixed
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -280,9 +280,9 @@ The package should include a small test helper:
 result = base_cli.testing.invoke(app, ["--debug"], cwd=project_root)
 ```
 
-This wraps Click's test runner and gives tests access to isolated `HOME`,
-captured output, generated Base state, and an explicit invocation directory for
-project discovery or no-project test cases.
+This wraps Click's test runner and gives tests access to isolated `HOME`, a
+test-local `BASE_CACHE_DIR`, captured output, generated Base state, and an
+explicit invocation directory for project discovery or no-project test cases.
 
 ## Phases
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -327,10 +327,12 @@ def test_command(tmp_path: Path) -> None:
     assert "hello Ada" in result.stdout
 ```
 
-The helper wraps Click's `CliRunner`, sets `HOME` when requested, changes to
-`cwd` only for the invocation, and keeps stderr separate on Click versions that
-support it. Use `cwd` for commands whose behavior depends on project discovery,
-including tests that intentionally run outside a Base project.
+The helper wraps Click's `CliRunner`, sets `HOME` when requested, defaults
+`BASE_CACHE_DIR` under that test home, changes to `cwd` only for the invocation,
+and keeps stderr separate on Click versions that support it. Use `cwd` for
+commands whose behavior depends on project discovery, including tests that
+intentionally run outside a Base project. Pass `env={"BASE_CACHE_DIR": ...}` to
+test a specific cache root.
 
 ## When To Use `base_cli`
 

--- a/lib/python/base_cli/testing.py
+++ b/lib/python/base_cli/testing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -11,15 +12,18 @@ def invoke(
     args: list[str] | None = None,
     home: Path | None = None,
     cwd: Path | str | None = None,
+    env: dict[str, str] | None = None,
 ):
     try:
         from click.testing import CliRunner
     except ImportError as exc:
         raise RuntimeError("Click is required for base_cli.testing. Run 'basectl setup' to install it.") from exc
 
-    env = {}
+    runner_env = dict(env or {})
     if home is not None:
-        env["HOME"] = str(home)
+        home = Path(home)
+        runner_env.setdefault("HOME", str(home))
+        runner_env.setdefault("BASE_CACHE_DIR", str(_cache_dir_for_home(home)))
     runner_kwargs = {}
     if "mix_stderr" in inspect.signature(CliRunner).parameters:
         runner_kwargs["mix_stderr"] = False
@@ -28,7 +32,13 @@ def invoke(
     if cwd is not None:
         os.chdir(cwd)
     try:
-        return runner.invoke(app.click_command, args or [], env=env)
+        return runner.invoke(app.click_command, args or [], env=runner_env)
     finally:
         if cwd is not None:
             os.chdir(original_cwd)
+
+
+def _cache_dir_for_home(home: Path) -> Path:
+    if sys.platform == "darwin":
+        return home / "Library" / "Caches" / "base"
+    return home / ".cache" / "base"

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -535,15 +535,73 @@ class BaseCliTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            with mock.patch.dict(os.environ, {"HOME": str(home), "BASE_CACHE_DIR": ""}):
-                from base_cli.testing import invoke
+            from base_cli.testing import invoke
 
-                result = invoke(app, [], home=home)
+            result = invoke(app, [], home=home)
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("stdout text", result.stdout)
         self.assertNotIn("stderr text", result.stdout)
         self.assertIn("stderr text", result.stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_testing_invoke_defaults_cache_dir_under_home(self) -> None:
+        app = base_cli.App(name="cache-default", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["state_dir"] = ctx.state_dir
+            seen["cache_dir"] = ctx.cache_dir
+            ctx.log.info("cache default")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            inherited_cache = root / "inherited-cache"
+            home.mkdir()
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(inherited_cache)}):
+                from base_cli.testing import invoke
+
+                result = invoke(app, [], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(seen["state_dir"].is_relative_to(home))
+            self.assertTrue(seen["cache_dir"].is_dir())
+            self.assertFalse(inherited_cache.exists())
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_testing_invoke_preserves_explicit_cache_dir_env(self) -> None:
+        app = base_cli.App(name="cache-override", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["state_dir"] = ctx.state_dir
+            seen["cache_dir"] = ctx.cache_dir
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            override_cache = root / "override-cache"
+            inherited_cache = root / "inherited-cache"
+            home.mkdir()
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(inherited_cache)}):
+                from base_cli.testing import invoke
+
+                result = invoke(
+                    app,
+                    [],
+                    home=home,
+                    env={"BASE_CACHE_DIR": str(override_cache)},
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(seen["state_dir"], override_cache / "cli" / "cache-override")
+            self.assertTrue(seen["cache_dir"].is_dir())
+            self.assertFalse(inherited_cache.exists())
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_testing_invoke_uses_supplied_cwd_for_manifest_discovery(self) -> None:


### PR DESCRIPTION
## Summary
- Default `base_cli.testing.invoke(home=...)` to a test-local `BASE_CACHE_DIR` under the supplied home.
- Add an explicit `env` override path so tests can still target a custom cache root.
- Cover inherited-cache leakage, explicit override behavior, and update the testing docs.

## Validation
- RED: `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q -k "testing_invoke_defaults_cache_dir_under_home or testing_invoke_preserves_explicit_cache_dir_env"` -> 2 failed for inherited `BASE_CACHE_DIR` leakage and missing `env`.
- GREEN: same focused command -> 2 passed, 39 deselected.
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q` -> 41 passed.
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test` -> Python 405 passed, 1 skipped; BATS ok 1..449.

Closes #645