### PR TITLE
Make base_cli log source paths project-root aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `ctx.dry_run` and `base_cli.option(..., dry_run=True)` so commands can
   explicitly connect nonstandard preview flags to Base's no-durable-write mode.
 
+### Changed
+
+- Made `base_cli` log source paths prefer the active project root before
+  falling back to the process working directory.
+
 ### Fixed
 
 - Made `lib_std.sh` yes/no prompts read from the controlling terminal so

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -65,6 +65,9 @@ def _source_path(record: logging.LogRecord) -> str:
     base_home = os.environ.get("BASE_HOME")
     if base_home:
         candidates.append(Path(base_home))
+    project_root = _active_project_root()
+    if project_root is not None:
+        candidates.append(project_root)
     candidates.append(Path.cwd())
 
     for root in candidates:
@@ -73,6 +76,14 @@ def _source_path(record: logging.LogRecord) -> str:
         except ValueError:
             continue
     return str(path.resolve())
+
+
+def _active_project_root() -> Path | None:
+    try:
+        context = get_current_context()
+    except RuntimeError:
+        return None
+    return context.project_root
 
 
 def log_invocation(logger: logging.Logger, argv: list[str], sensitive_options: set[str]) -> None:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -15,6 +15,7 @@ from unittest import mock
 import base_cli
 from base_cli import config as config_module
 from base_cli.config import load_config, load_user_config, read_user_config, user_config_path
+from base_cli.context import reset_current_context, set_current_context
 from base_cli.logging import BaseCliFormatter
 from base_cli.paths import base_cache_root, base_state_root, discover_manifest, normalize_cli_name
 from base_cli.redaction import redact_argv
@@ -103,6 +104,69 @@ class BaseCliTests(unittest.TestCase):
             redact_argv(argv, {"api_key", "token"}),
             ["tool", "--api-key", "[REDACTED]", "--token=[REDACTED]", "--name", "visible"],
         )
+
+    def test_log_source_prefers_base_home(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            base_home = root / "base-home"
+            project = root / "project"
+            source = base_home / "lib" / "python" / "tool.py"
+            base_home.mkdir()
+            project.mkdir()
+            source.parent.mkdir(parents=True)
+            source.write_text("# test\n", encoding="utf-8")
+            context, _ = self.make_context(tmpdir)
+            context.project_root = project
+            record = logging.LogRecord(
+                name="base_cli.test",
+                level=logging.INFO,
+                pathname=str(source),
+                lineno=11,
+                msg="hello",
+                args=(),
+                exc_info=None,
+            )
+
+            token = set_current_context(context)
+            try:
+                with mock.patch.dict(os.environ, {"BASE_HOME": str(base_home)}):
+                    formatted = BaseCliFormatter().format(record)
+            finally:
+                reset_current_context(token)
+
+        self.assertIn("lib/python/tool.py:11 hello", formatted)
+
+    def test_log_source_uses_context_project_root_before_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            project = root / "project"
+            cwd = root / "runner"
+            source = project / "src" / "tool.py"
+            project.mkdir()
+            cwd.mkdir()
+            source.parent.mkdir(parents=True)
+            source.write_text("# test\n", encoding="utf-8")
+            context, _ = self.make_context(tmpdir)
+            context.project_root = project
+            record = logging.LogRecord(
+                name="base_cli.test",
+                level=logging.INFO,
+                pathname=str(source),
+                lineno=13,
+                msg="hello",
+                args=(),
+                exc_info=None,
+            )
+
+            token = set_current_context(context)
+            try:
+                with mock.patch.dict(os.environ, {"BASE_HOME": ""}), change_directory(cwd):
+                    formatted = BaseCliFormatter().format(record)
+            finally:
+                reset_current_context(token)
+
+        self.assertIn("src/tool.py:13 hello", formatted)
+        self.assertNotIn(str(source.resolve()), formatted)
 
     def test_log_source_fallback_uses_resolved_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Prefer `BASE_HOME`, then the active `base_cli.Context.project_root`, then process cwd when shortening log source paths.
- Cover Base-home precedence, project-root shortening, and no-context fallback behavior in formatter tests.
- Note the log path readability change in the changelog.

## Validation
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q -k log_source`
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. CLI logging output becomes shorter and more deterministic when commands run from outside the project root.

Closes #646