### PR TITLE
Add base_cli log retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   probe-style Bash checks.
 - Added `ctx.dry_run` and `base_cli.option(..., dry_run=True)` so commands can
   explicitly connect nonstandard preview flags to Base's no-durable-write mode.
+- Added `base_cli.App(max_log_files=...)` to let high-frequency CLIs prune old
+  default log files during startup.
 
 ### Changed
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -225,6 +225,15 @@ Commands running with `ctx.dry_run` also skip default `logs/`, `cache/`, and
 `tmp/<run-id>/` creation. Passing `--log-file <path>` still writes to that
 explicit file so tests and diagnostics can inspect dry-run logs when needed.
 
+High-frequency tools can set `base_cli.App(max_log_files=<count>)` to keep at
+most that many default persistent log files for the CLI. Retention runs during
+startup after the current run's default log file is resolved, and the current
+run's log file is never pruned. The policy is skipped for `ctx.dry_run`,
+`log_to_file=False`, and explicit `--log-file` paths so no-durable-write modes
+and caller-selected log locations stay under caller control. Use this as a
+small guardrail for busy local tools; `basectl clean` remains the broader
+maintenance command for caches, logs, and retained temp files.
+
 Logs use the same general shape as Base Bash logs:
 
 ```text

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import logging
 import sys
 from pathlib import Path
 from typing import Any, Callable
@@ -21,10 +22,19 @@ def _require_click():
 
 
 class App:
-    def __init__(self, name: str | None = None, version: str | None = None, log_to_file: bool = True) -> None:
+    def __init__(
+        self,
+        name: str | None = None,
+        version: str | None = None,
+        log_to_file: bool = True,
+        max_log_files: int | None = None,
+    ) -> None:
+        if max_log_files is not None and max_log_files < 1:
+            raise ValueError("max_log_files must be greater than 0 when set.")
         self.name = normalize_cli_name(name or sys.argv[0])
         self.version = version
         self.log_to_file = log_to_file
+        self.max_log_files = max_log_files
         self._click_command = None
         self._command_func: Callable[..., Any] | None = None
         self._command_args: tuple[Any, ...] = ()
@@ -104,6 +114,7 @@ class App:
         temp_dir = state_dir / "tmp" / run_id
 
         log_file = Path(standard["log_file"]).expanduser() if standard.get("log_file") else None
+        uses_default_log_file = log_file is None
         if dry_run or not self.log_to_file:
             if log_file is not None:
                 log_file.parent.mkdir(parents=True, exist_ok=True)
@@ -115,6 +126,8 @@ class App:
             log_file.parent.mkdir(parents=True, exist_ok=True)
         logger = configure_logger(self.name, log_file, debug)
         logger.debug("cli=%s run_id=%s environment=%s", self.name, run_id, environment)
+        if self.max_log_files is not None and uses_default_log_file and log_file is not None:
+            _prune_log_files(log_dir, log_file, self.max_log_files, logger)
 
         return Context(
             cli_name=self.name,
@@ -182,3 +195,38 @@ def _pop_standard_options(kwargs: dict[str, Any]) -> dict[str, Any]:
     for key in ("debug", "environment", "config", "keep_temp", "log_file"):
         standard[key] = kwargs.pop(key, None)
     return standard
+
+
+def _prune_log_files(
+    log_dir: Path,
+    current_log_file: Path,
+    max_log_files: int,
+    logger: logging.Logger,
+) -> None:
+    candidates: list[tuple[float, str, Path]] = []
+    for path in log_dir.glob("*.log"):
+        if _same_path(path, current_log_file):
+            continue
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            logger.warning("Could not inspect log file '%s' for pruning: %s", path, exc)
+            continue
+        candidates.append((stat.st_mtime, path.name, path))
+
+    excess_count = len(candidates) + 1 - max_log_files
+    if excess_count <= 0:
+        return
+
+    for _, _, path in sorted(candidates)[:excess_count]:
+        try:
+            path.unlink()
+        except OSError as exc:
+            logger.warning("Could not prune log file '%s': %s", path, exc)
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:
+        return left.absolute() == right.absolute()

--- a/lib/python/base_cli/tests/test_app_log_retention.py
+++ b/lib/python/base_cli/tests/test_app_log_retention.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import base_cli
+from base_cli.testing import invoke
+
+
+def write_log_file(path: Path, mtime: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("old log\n", encoding="utf-8")
+    os.utime(path, (mtime, mtime))
+
+
+class AppLogRetentionTests(unittest.TestCase):
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_prunes_oldest_default_logs(self) -> None:
+        app = base_cli.App(name="retention-demo", max_log_files=2)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("retention run")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_dir = home / ".cache" / "base" / "cli" / "retention-demo" / "logs"
+            oldest = log_dir / "oldest.log"
+            newest = log_dir / "newest.log"
+            write_log_file(oldest, 1)
+            write_log_file(newest, 2)
+
+            result = invoke(app, home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertFalse(oldest.exists())
+            self.assertTrue(newest.exists())
+            self.assertIsNotNone(seen["log_file"])
+            self.assertTrue(seen["log_file"].exists())
+            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 2)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_preserves_current_log_file(self) -> None:
+        app = base_cli.App(name="retention-current", max_log_files=1)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("keep current")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_dir = home / ".cache" / "base" / "cli" / "retention-current" / "logs"
+            old_a = log_dir / "old-a.log"
+            old_b = log_dir / "old-b.log"
+            write_log_file(old_a, 1)
+            write_log_file(old_b, 2)
+
+            result = invoke(app, home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertFalse(old_a.exists())
+            self.assertFalse(old_b.exists())
+            self.assertIsNotNone(seen["log_file"])
+            self.assertTrue(seen["log_file"].exists())
+            self.assertEqual(tuple(log_dir.glob("*.log")), (seen["log_file"],))
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_is_disabled_by_default(self) -> None:
+        app = base_cli.App(name="retention-unset")
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("no retention")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_dir = home / ".cache" / "base" / "cli" / "retention-unset" / "logs"
+            old_a = log_dir / "old-a.log"
+            old_b = log_dir / "old-b.log"
+            write_log_file(old_a, 1)
+            write_log_file(old_b, 2)
+
+            result = invoke(app, home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(old_a.exists())
+            self.assertTrue(old_b.exists())
+            self.assertIsNotNone(seen["log_file"])
+            self.assertTrue(seen["log_file"].exists())
+            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 3)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_skips_no_durable_write_modes(self) -> None:
+        dry_run_app = base_cli.App(name="retention-dry-run", max_log_files=1)
+        dry_seen = {}
+
+        @dry_run_app.command()
+        @base_cli.option("--dry-run", is_flag=True)
+        def dry_run_main(ctx: base_cli.Context, dry_run: bool) -> None:
+            dry_seen["dry_run"] = dry_run
+            dry_seen["log_file"] = ctx.log_file
+            ctx.log.info("dry retention")
+
+        no_file_app = base_cli.App(
+            name="retention-no-file",
+            log_to_file=False,
+            max_log_files=1,
+        )
+        no_file_seen = {}
+
+        @no_file_app.command()
+        def no_file_main(ctx: base_cli.Context) -> None:
+            no_file_seen["log_file"] = ctx.log_file
+            ctx.log.info("no file retention")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            dry_log_dir = home / ".cache" / "base" / "cli" / "retention-dry-run" / "logs"
+            no_file_log_dir = home / ".cache" / "base" / "cli" / "retention-no-file" / "logs"
+            dry_old = dry_log_dir / "old.log"
+            no_file_old = no_file_log_dir / "old.log"
+            write_log_file(dry_old, 1)
+            write_log_file(no_file_old, 1)
+
+            dry_result = invoke(dry_run_app, ["--dry-run"], home=home)
+            no_file_result = invoke(no_file_app, home=home)
+
+            self.assertEqual(dry_result.exit_code, 0, dry_result.output)
+            self.assertEqual(no_file_result.exit_code, 0, no_file_result.output)
+            self.assertTrue(dry_seen["dry_run"])
+            self.assertIsNone(dry_seen["log_file"])
+            self.assertIsNone(no_file_seen["log_file"])
+            self.assertTrue(dry_old.exists())
+            self.assertTrue(no_file_old.exists())
+            self.assertEqual(tuple(dry_log_dir.glob("*.log")), (dry_old,))
+            self.assertEqual(tuple(no_file_log_dir.glob("*.log")), (no_file_old,))


### PR DESCRIPTION
## Summary
- Add optional `base_cli.App(max_log_files=...)` support for pruning old default persistent logs.
- Preserve the current run log, skip no-durable-write modes, and leave explicit `--log-file` paths under caller control.
- Document the retention guardrail and add changelog coverage.
- Split retention tests into a focused module so the existing base_cli test module stays below pylint limits.

## Validation
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q -k log_retention`
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q`
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`\n- `git diff --check`\n- `env -u BASE_HOME ./bin/base-test`\n\n## Demo Impact\n- None. This is a framework-level guardrail for high-frequency Python CLIs using `base_cli`.\n\nCloses #647