### PR TITLE
Expose typed user config on base_cli context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   explicitly connect nonstandard preview flags to Base's no-durable-write mode.
 - Added `base_cli.App(max_log_files=...)` to let high-frequency CLIs prune old
   default log files during startup.
+- Added `ctx.user_config` so Python commands can read typed user config without
+  re-parsing `~/.base.d/config.yaml`.
 
 ### Changed
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -79,6 +79,7 @@ ctx.cache_dir      # state_dir/cache
 ctx.temp_dir       # state_dir/tmp/<run-id>
 ctx.log_file       # log_dir/<run-id>.log, or None when persistent logging is disabled
 ctx.config         # dict
+ctx.user_config    # typed user config from ~/.base.d/config.yaml
 ctx.environment    # str
 ctx.debug          # bool
 ctx.dry_run        # bool
@@ -219,6 +220,11 @@ V1 implements the shape and context fields, but only needs a minimal config
 loader: YAML files are merged when present, environment is read from
 `BASE_CLI_ENVIRONMENT`, and CLI options can override `--environment`, `--debug`,
 `--keep-temp`, and `--log-file`.
+
+`ctx.config` remains the merged raw configuration dictionary. `ctx.user_config`
+is the typed machine-local user config, so command authors can read
+`ctx.user_config.workspace.root` and IDE preferences without re-parsing the user
+config file.
 
 Standard environment variables:
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -188,6 +188,7 @@ Important fields include:
 - `ctx.log_file`: persistent log file for this run, or `None` when persistent
   logging is disabled.
 - `ctx.config`: merged configuration dictionary.
+- `ctx.user_config`: typed user configuration from `~/.base.d/config.yaml`.
 - `ctx.environment`: active environment, defaulting to `dev`.
 - `ctx.debug`: whether debug logging is enabled for the stderr stream.
 - `ctx.dry_run`: whether the command is running in a no-durable-write mode.
@@ -277,6 +278,12 @@ Environment variables currently recognized by the config layer:
 
 Command-line standard options are applied after config is loaded. For example,
 `--environment prod` overrides `environment: dev` from config.
+
+`ctx.config` exposes the merged raw configuration after user, project,
+explicit, and environment layers are applied. `ctx.user_config` exposes only the
+typed machine-local user config, including `workspace.root` and IDE
+preferences, so command code does not need to re-read `~/.base.d/config.yaml`
+for those structured values.
 
 The user config file is machine-local by default. Base owns the semantics of
 `~/.base.d/config.yaml`, while users own backup and sync choices such as iCloud,

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
-from .config import load_config
+from .config import load_config, read_user_config
 from .context import Context, reset_current_context, set_current_context
 from .logging import configure_logger, log_invocation
 from .paths import base_cache_root, discover_manifest, make_run_id, normalize_cli_name, resolve_base_home
@@ -102,6 +102,7 @@ class App:
         manifest_path = discover_manifest(Path.cwd())
         project_root = manifest_path.parent if manifest_path is not None else None
         explicit_config = Path(standard["config"]).expanduser() if standard.get("config") else None
+        user_config = read_user_config()
         config = load_config(project_root, explicit_config)
 
         environment = standard.get("environment") or config.get("environment") or "dev"
@@ -145,6 +146,7 @@ class App:
             debug=debug,
             keep_temp=keep_temp,
             log=logger,
+            user_config=user_config,
             dry_run=dry_run,
         )
 

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -7,11 +7,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
+from .config import UserConfig, UserIdeConfig
+
 
 _current_context: contextvars.ContextVar[Context | None] = contextvars.ContextVar(
     "base_cli_current_context",
     default=None,
 )
+
+
+def _default_user_config() -> UserConfig:
+    return UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))
 
 
 @dataclass
@@ -32,6 +38,7 @@ class Context:
     base_home: Path | None = None
     project_root: Path | None = None
     manifest_path: Path | None = None
+    user_config: UserConfig = field(default_factory=_default_user_config)
     cleanup_hooks: list[Callable[[], None]] = field(default_factory=list)
 
     def on_cleanup(self, hook: Callable[[], None]) -> None:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -14,7 +14,7 @@ from unittest import mock
 
 import base_cli
 from base_cli import config as config_module
-from base_cli.config import load_config, load_user_config, read_user_config, user_config_path
+from base_cli.config import UserConfig, load_config, load_user_config, read_user_config, user_config_path
 from base_cli.context import reset_current_context, set_current_context
 from base_cli.logging import BaseCliFormatter
 from base_cli.paths import base_cache_root, base_state_root, discover_manifest, normalize_cli_name
@@ -429,6 +429,76 @@ class BaseCliTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "ide.vscode.settings must be a mapping"):
                 read_user_config(home)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_context_exposes_default_typed_user_config(self) -> None:
+        app = base_cli.App(name="typed-config-default", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["config"] = ctx.config
+            seen["user_config"] = ctx.user_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["config"], {})
+        self.assertIsInstance(seen["user_config"], UserConfig)
+        self.assertEqual(seen["user_config"].raw, {})
+        self.assertIsNone(seen["user_config"].workspace.root)
+        self.assertIsNone(seen["user_config"].ide.enabled)
+        self.assertEqual(seen["user_config"].ide.preferences, {})
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_context_exposes_populated_typed_user_config(self) -> None:
+        app = base_cli.App(name="typed-config-populated", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["config"] = ctx.config
+            seen["workspace_root"] = ctx.user_config.workspace.root
+            seen["ide_enabled"] = ctx.user_config.ide.enabled
+            seen["vscode"] = ctx.user_config.ide.preferences["vscode"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            workspace.mkdir()
+            path.write_text(
+                "\n".join(
+                    [
+                        "workspace:",
+                        f"  root: {workspace}",
+                        "ide:",
+                        "  enabled: true",
+                        "  vscode:",
+                        "    install: false",
+                        "    extra_extensions:",
+                        "      - github.copilot",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["workspace_root"], workspace.resolve())
+        self.assertTrue(seen["ide_enabled"])
+        self.assertFalse(seen["vscode"].install)
+        self.assertEqual(seen["vscode"].extra_extensions, ("github.copilot",))
+        self.assertEqual(seen["config"]["workspace"]["root"], str(workspace))
+        self.assertTrue(seen["config"]["ide"]["enabled"])
 
     def test_log_debug_enables_python_debug_logging(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Add `ctx.user_config` as the typed machine-local user config alongside the existing merged raw `ctx.config`.
- Populate the typed config through `read_user_config()` when `base_cli.App` creates a command context.
- Document the raw merged config vs typed user config distinction in the base_cli docs.

## Validation
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q -k typed_user_config`
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/context.py lib/python/base_cli/app.py lib/python/base_cli/tests/test_base_cli.py`
- `PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`\n- `git diff --check`\n- `env -u BASE_HOME ./bin/base-test`\n\n## Demo Impact\n- None. This is a Python framework ergonomics enhancement for Base command authors.\n\nCloses #641