### PR TITLE
Add base_cli subcommand support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   default log files during startup.
 - Added `ctx.user_config` so Python commands can read typed user config without
   re-parsing `~/.base.d/config.yaml`.
+- Added `base_cli.App.subcommand()` so one Python CLI can expose multiple
+  Base-managed entry points.
 
 ### Changed
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -63,6 +63,32 @@ lib/python/base_cli/
   testing.py
 ```
 
+## Command Shape
+
+`App.command()` remains the simple path for a CLI with one entry point. A CLI
+that needs multiple verbs should use `App.subcommand()`:
+
+```python
+app = base_cli.App(name="workspace-tools")
+
+
+@app.subcommand()
+def status(ctx: base_cli.Context) -> None:
+    ...
+
+
+@app.subcommand("sync")
+@base_cli.option("--dry-run", is_flag=True)
+def sync_project(ctx: base_cli.Context, dry_run: bool) -> None:
+    ...
+```
+
+Each subcommand receives its own fresh `Context`, run ID, log file, temp/cache
+paths, cleanup hooks, project discovery, standard options, and sensitive-option
+redaction. `App.command()` and `App.subcommand()` are mutually exclusive on one
+`App` so command authors do not accidentally mix single-command and group-style
+registration.
+
 ## Context
 
 `Context` is the center of the API:

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -99,6 +99,32 @@ def main(ctx: base_cli.Context) -> None:
 In Base itself, prefer an explicit `App` so command names and versions are
 obvious at the top of the module.
 
+Use `@app.subcommand()` when one CLI needs multiple verbs while keeping Base's
+standard context, logging, redaction, and cleanup lifecycle for each invocation:
+
+```python
+app = base_cli.App(name="workspace-tools", version="0.1.0")
+
+
+@app.subcommand()
+@base_cli.argument("project")
+def status(ctx: base_cli.Context, project: str) -> None:
+    ctx.log.info("checking %s", project)
+
+
+@app.subcommand("sync")
+@base_cli.option("--dry-run", is_flag=True)
+def sync_project(ctx: base_cli.Context, dry_run: bool) -> None:
+    if ctx.dry_run:
+        ctx.log.info("previewing sync")
+```
+
+Subcommands use the same `base_cli.option()` and `base_cli.argument()` metadata
+as single commands. Standard Base options belong to the subcommand invocation,
+for example `workspace-tools status --debug demo`. Use either `@app.command()`
+for a single-command CLI or `@app.subcommand()` for a command group; do not mix
+the two registration styles on one `App`.
+
 ## Options And Arguments
 
 `base_cli.option` and `base_cli.argument` mirror Click's decorators:

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -39,9 +39,15 @@ class App:
         self._command_func: Callable[..., Any] | None = None
         self._command_args: tuple[Any, ...] = ()
         self._command_kwargs: dict[str, Any] = {}
+        self._subcommands: list[tuple[Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = []
 
     def command(self, *command_args: Any, **command_kwargs: Any):
         def decorator(func: Callable[..., Any]):
+            if self._subcommands:
+                raise RuntimeError(
+                    f"App '{self.name}' already has registered subcommands. "
+                    "Use @app.subcommand() for additional entry points."
+                )
             if self._command_func is not None:
                 raise RuntimeError(
                     f"App '{self.name}' already has a registered command. "
@@ -50,6 +56,18 @@ class App:
             self._command_func = func
             self._command_args = command_args
             self._command_kwargs = command_kwargs
+            return func
+
+        return decorator
+
+    def subcommand(self, *command_args: Any, **command_kwargs: Any):
+        def decorator(func: Callable[..., Any]):
+            if self._command_func is not None:
+                raise RuntimeError(
+                    f"App '{self.name}' already has a registered command. "
+                    "Use either @app.command() or @app.subcommand(), not both."
+                )
+            self._subcommands.append((func, command_args, command_kwargs))
             return func
 
         return decorator
@@ -64,11 +82,24 @@ class App:
         return self._click_command
 
     def _build_click_command(self) -> Any:
-        if self._command_func is None:
+        if self._command_func is None and not self._subcommands:
             raise RuntimeError("No command has been registered on this base_cli.App.")
 
         click = _require_click()
-        func = self._command_func
+        if self._command_func is not None:
+            wrapper = self._build_command_wrapper(click, self._command_func, include_version=True)
+            return click.command(*self._command_args, **self._command_kwargs)(wrapper)
+
+        group_wrapper = _build_group_wrapper()
+        if self.version is not None:
+            group_wrapper = click.version_option(self.version)(group_wrapper)
+        group = click.group(name=self.name)(group_wrapper)
+        for func, command_args, command_kwargs in self._subcommands:
+            wrapper = self._build_command_wrapper(click, func, include_version=False)
+            group.add_command(click.command(*command_args, **command_kwargs)(wrapper))
+        return group
+
+    def _build_command_wrapper(self, click: Any, func: Callable[..., Any], include_version: bool) -> Callable[..., Any]:
         sensitive_options = set(getattr(func, "__base_cli_sensitive_options__", set()))
         dry_run_parameter = getattr(func, "__base_cli_dry_run_parameter__", "dry_run")
 
@@ -93,8 +124,8 @@ class App:
                 wrapper = click.option(*param_decls, **attrs)(wrapper)
             elif kind == "argument":
                 wrapper = click.argument(*param_decls, **attrs)(wrapper)
-        wrapper = _decorate_standard_options(click, wrapper, self.version)
-        return click.command(*self._command_args, **self._command_kwargs)(wrapper)
+        wrapper = _decorate_standard_options(click, wrapper, self.version if include_version else None)
+        return wrapper
 
     def _create_context(self, standard: dict[str, Any], sensitive_options: set[str], dry_run: bool = False) -> Context:
         del sensitive_options
@@ -197,6 +228,13 @@ def _pop_standard_options(kwargs: dict[str, Any]) -> dict[str, Any]:
     for key in ("debug", "environment", "config", "keep_temp", "log_file"):
         standard[key] = kwargs.pop(key, None)
     return standard
+
+
+def _build_group_wrapper() -> Callable[[], None]:
+    def group_wrapper() -> None:
+        return None
+
+    return group_wrapper
 
 
 def _prune_log_files(

--- a/lib/python/base_cli/tests/test_app_subcommands.py
+++ b/lib/python/base_cli/tests/test_app_subcommands.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import base_cli
+from base_cli.testing import invoke
+
+
+@unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+class AppSubcommandTests(unittest.TestCase):
+    def test_runs_multiple_subcommands_with_base_lifecycle(self) -> None:
+        app = base_cli.App(name="multi-tool", version="0.1.0")
+        seen = {}
+
+        @app.subcommand()
+        @base_cli.option("--name", required=True)
+        def hello(ctx: base_cli.Context, name: str) -> None:
+            seen["hello"] = {
+                "name": name,
+                "run_id": ctx.run_id,
+                "temp_dir": ctx.temp_dir,
+                "cache_dir": ctx.cache_dir,
+                "log_file": ctx.log_file,
+            }
+            ctx.log.info("hello %s", name)
+
+        @app.subcommand()
+        @base_cli.argument("target")
+        def clean(ctx: base_cli.Context, target: str) -> None:
+            seen["clean"] = {
+                "target": target,
+                "run_id": ctx.run_id,
+                "temp_dir": ctx.temp_dir,
+                "cache_dir": ctx.cache_dir,
+                "log_file": ctx.log_file,
+            }
+            ctx.log.info("clean %s", target)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            hello_result = invoke(app, ["hello", "--name", "Ada"], home=home)
+            clean_result = invoke(app, ["clean", "cache"], home=home)
+
+            self.assertEqual(hello_result.exit_code, 0, hello_result.output)
+            self.assertEqual(clean_result.exit_code, 0, clean_result.output)
+            self.assertEqual(seen["hello"]["name"], "Ada")
+            self.assertEqual(seen["clean"]["target"], "cache")
+            self.assertNotEqual(seen["hello"]["run_id"], seen["clean"]["run_id"])
+            self.assertFalse(seen["hello"]["temp_dir"].exists())
+            self.assertFalse(seen["clean"]["temp_dir"].exists())
+            self.assertTrue(seen["hello"]["cache_dir"].is_dir())
+            self.assertTrue(seen["clean"]["cache_dir"].is_dir())
+            self.assertTrue(seen["hello"]["log_file"].is_file())
+            self.assertTrue(seen["clean"]["log_file"].is_file())
+            self.assertIn("hello Ada", hello_result.stderr)
+            self.assertIn("clean cache", clean_result.stderr)
+
+    def test_subcommand_standard_options_and_cleanup_hooks(self) -> None:
+        app = base_cli.App(name="subcommand-cleanup")
+        seen = {}
+
+        @app.subcommand()
+        @base_cli.option("--dry-run", is_flag=True)
+        def preview(ctx: base_cli.Context, dry_run: bool) -> None:
+            seen["dry_run"] = dry_run
+            seen["ctx_dry_run"] = ctx.dry_run
+            seen["log_file"] = ctx.log_file
+            seen["temp_dir"] = ctx.temp_dir
+            seen["cleanup_called"] = False
+            ctx.on_cleanup(lambda: seen.update(cleanup_called=True))
+            ctx.log.info("preview")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            result = invoke(app, ["preview", "--dry-run"], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(seen["dry_run"])
+            self.assertTrue(seen["ctx_dry_run"])
+            self.assertIsNone(seen["log_file"])
+            self.assertFalse(seen["temp_dir"].exists())
+            self.assertTrue(seen["cleanup_called"])
+            self.assertFalse((home / ".cache" / "base").exists())
+            self.assertIn("preview", result.stderr)
+
+    def test_subcommand_redacts_sensitive_options_per_subcommand(self) -> None:
+        app = base_cli.App(name="secret-subcommands")
+        seen = {}
+
+        @app.subcommand()
+        @base_cli.option("--token", sensitive=True, required=True)
+        def sync(ctx: base_cli.Context, token: str) -> None:
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("token length %d", len(token))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            with mock.patch.object(os.sys, "argv", ["secret-subcommands", "sync", "--token", "super-secret"]):
+                result = invoke(app, ["sync", "--token", "super-secret"], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            log_text = seen["log_file"].read_text(encoding="utf-8")
+            self.assertIn("argv=", log_text)
+            self.assertIn("--token", log_text)
+            self.assertIn("[REDACTED]", log_text)
+            self.assertNotIn("super-secret", log_text)
+
+    def test_rejects_top_level_command_after_subcommands(self) -> None:
+        app = base_cli.App(name="mixed-tool")
+
+        @app.subcommand()
+        def status(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with self.assertRaisesRegex(RuntimeError, "already has registered subcommands"):
+            @app.command()
+            def main(ctx: base_cli.Context) -> None:
+                del ctx


### PR DESCRIPTION
## Summary
- Add `App.subcommand()` for Base-managed Click command groups while preserving the existing `App.command()` single-command path.
- Share the Base lifecycle wrapper across single commands and subcommands so context creation, logging, redaction, dry-run, cleanup hooks, and standard options behave per invocation.
- Document the subcommand pattern in the base_cli README and design doc.

## Validation
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_app_subcommands.py -q`
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/app.py lib/python/base_cli/tests/test_app_subcommands.py`
- `PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`\n- `git diff --check`\n- `git diff --check --cached`\n- `env -u BASE_HOME ./bin/base-test`\n\n## Demo Impact\n- None. This is a Python framework API enhancement for CLI authors.\n\nCloses #639