### PR TITLE
Add base_cli app subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   default log files during startup.
 - Added `ctx.user_config` so Python commands can read typed user config without
   re-parsing `~/.base.d/config.yaml`.
+- Added `base_cli.App.subcommand()` so one Python CLI can expose multiple verbs
+  while preserving Base context, logging, cleanup, and redaction.
 
 ### Changed
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -195,6 +195,27 @@ nonstandard parameter name:
 @base_cli.option("--preview", is_flag=True, dry_run=True)
 ```
 
+Apps that need multiple verbs can use subcommands:
+
+```python
+app = base_cli.App(name="workspace")
+
+
+@app.subcommand("status")
+def status(ctx: base_cli.Context) -> None:
+    ctx.log.info("checking workspace")
+
+
+@app.subcommand("sync")
+def sync(ctx: base_cli.Context) -> None:
+    ctx.log.info("syncing workspace")
+```
+
+Each subcommand gets the same Base lifecycle as a single-command app: a fresh
+context, standard options, logging, redaction, cleanup, and project discovery.
+An `App` should use either one `@app.command()` or one or more
+`@app.subcommand()` registrations, not both.
+
 For v1, sensitive values are redacted from automatic invocation logging. More
 advanced redaction of arbitrary log messages can follow after the basic CLI
 shape is stable.
@@ -321,13 +342,13 @@ override.
 - sensitive option redaction for invocation logging
 - manifest/project discovery
 - testing helper
+- subcommand groups
 
 ### V2
 
 - richer YAML config merging
 - project manifest loading helpers
 - version discovery conventions
-- subcommand groups
 - better error formatting and exit code conventions
 
 ### V3

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -99,6 +99,30 @@ def main(ctx: base_cli.Context) -> None:
 In Base itself, prefer an explicit `App` so command names and versions are
 obvious at the top of the module.
 
+Use `@app.subcommand()` when one executable needs multiple verbs:
+
+```python
+app = base_cli.App(name="workspace", version="0.1.0")
+
+
+@app.subcommand("status")
+def status(ctx: base_cli.Context) -> None:
+    ctx.log.info("checking workspace")
+
+
+@app.subcommand("sync")
+@base_cli.option("--preview", is_flag=True, dry_run=True)
+def sync(ctx: base_cli.Context, preview: bool) -> None:
+    del preview
+    if ctx.dry_run:
+        ctx.log.info("previewing sync")
+```
+
+Each subcommand receives a fresh `Context`, standard Base options, logging,
+redaction, cleanup, and project discovery. Do not mix `@app.command()` and
+`@app.subcommand()` on the same `App`; use `@app.command()` for one-command
+tools and `@app.subcommand()` for command groups.
+
 ## Options And Arguments
 
 `base_cli.option` and `base_cli.argument` mirror Click's decorators:

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -21,6 +21,10 @@ def _require_click():
     return click
 
 
+def _empty_group() -> None:
+    return None
+
+
 class App:
     def __init__(
         self,
@@ -39,9 +43,15 @@ class App:
         self._command_func: Callable[..., Any] | None = None
         self._command_args: tuple[Any, ...] = ()
         self._command_kwargs: dict[str, Any] = {}
+        self._subcommands: list[tuple[tuple[Any, ...], dict[str, Any], Callable[..., Any]]] = []
 
     def command(self, *command_args: Any, **command_kwargs: Any):
         def decorator(func: Callable[..., Any]):
+            if self._subcommands:
+                raise RuntimeError(
+                    f"App '{self.name}' already has registered subcommands. "
+                    "Use @app.subcommand() for additional entry points."
+                )
             if self._command_func is not None:
                 raise RuntimeError(
                     f"App '{self.name}' already has a registered command. "
@@ -50,6 +60,18 @@ class App:
             self._command_func = func
             self._command_args = command_args
             self._command_kwargs = command_kwargs
+            return func
+
+        return decorator
+
+    def subcommand(self, *command_args: Any, **command_kwargs: Any):
+        def decorator(func: Callable[..., Any]):
+            if self._command_func is not None:
+                raise RuntimeError(
+                    f"App '{self.name}' already has a registered command. "
+                    "Use @app.subcommand() only when building a command group."
+                )
+            self._subcommands.append((command_args, command_kwargs, func))
             return func
 
         return decorator
@@ -64,11 +86,44 @@ class App:
         return self._click_command
 
     def _build_click_command(self) -> Any:
-        if self._command_func is None:
+        if self._command_func is None and not self._subcommands:
             raise RuntimeError("No command has been registered on this base_cli.App.")
 
         click = _require_click()
-        func = self._command_func
+        if self._command_func is not None:
+            return self._build_lifecycle_command(
+                click,
+                self._command_func,
+                self._command_args,
+                self._command_kwargs,
+                include_version=True,
+            )
+
+        group_func = _empty_group
+        if self.version is not None:
+            group_func = click.version_option(self.version)(group_func)
+        group = click.group(name=self.name)(group_func)
+        for command_args, command_kwargs, func in self._subcommands:
+            command = self._build_lifecycle_command(
+                click,
+                func,
+                command_args,
+                command_kwargs,
+                include_version=False,
+            )
+            if command.name in group.commands:
+                raise RuntimeError(f"App '{self.name}' already has a subcommand named '{command.name}'.")
+            group.add_command(command)
+        return group
+
+    def _build_lifecycle_command(
+        self,
+        click: Any,
+        func: Callable[..., Any],
+        command_args: tuple[Any, ...],
+        command_kwargs: dict[str, Any],
+        include_version: bool,
+    ) -> Any:
         sensitive_options = set(getattr(func, "__base_cli_sensitive_options__", set()))
         dry_run_parameter = getattr(func, "__base_cli_dry_run_parameter__", "dry_run")
 
@@ -93,8 +148,8 @@ class App:
                 wrapper = click.option(*param_decls, **attrs)(wrapper)
             elif kind == "argument":
                 wrapper = click.argument(*param_decls, **attrs)(wrapper)
-        wrapper = _decorate_standard_options(click, wrapper, self.version)
-        return click.command(*self._command_args, **self._command_kwargs)(wrapper)
+        wrapper = _decorate_standard_options(click, wrapper, self.version if include_version else None)
+        return click.command(*command_args, **command_kwargs)(wrapper)
 
     def _create_context(self, standard: dict[str, Any], sensitive_options: set[str], dry_run: bool = False) -> Context:
         del sensitive_options

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -530,6 +530,101 @@ class BaseCliTests(unittest.TestCase):
             def second(ctx: base_cli.Context) -> None:
                 del ctx
 
+    def test_app_rejects_mixed_command_and_subcommand_registration(self) -> None:
+        subcommand_app = base_cli.App(name="subcommand-demo")
+
+        @subcommand_app.subcommand("status")
+        def status(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with self.assertRaisesRegex(RuntimeError, "already has registered subcommands"):
+            @subcommand_app.command()
+            def main(ctx: base_cli.Context) -> None:
+                del ctx
+
+        command_app = base_cli.App(name="command-demo")
+
+        @command_app.command()
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with self.assertRaisesRegex(RuntimeError, "already has a registered command"):
+            @command_app.subcommand("status")
+            def later_status(ctx: base_cli.Context) -> None:
+                del ctx
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_runs_subcommands_with_context_and_cleanup(self) -> None:
+        app = base_cli.App(name="multi-demo")
+        events = []
+
+        @app.subcommand("status")
+        @base_cli.option("--name", required=True)
+        def status(ctx: base_cli.Context, name: str) -> None:
+            events.append(("status", name, ctx.run_id, ctx.temp_dir, ctx.cache_dir, ctx.debug))
+            print(f"status {name}")
+
+        @app.subcommand("sync")
+        def sync(ctx: base_cli.Context) -> None:
+            events.append(("sync", None, ctx.run_id, ctx.temp_dir, ctx.cache_dir, ctx.debug))
+            print("sync")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            from base_cli.testing import invoke
+
+            status_result = invoke(app, ["status", "--name", "Ada"], home=home)
+            sync_result = invoke(app, ["sync", "--debug"], home=home)
+
+            self.assertFalse(events[0][3].exists())
+            self.assertFalse(events[1][3].exists())
+            self.assertTrue(events[0][4].is_dir())
+            self.assertTrue(events[1][4].is_dir())
+
+        self.assertEqual(status_result.exit_code, 0, status_result.output)
+        self.assertEqual(sync_result.exit_code, 0, sync_result.output)
+        self.assertIn("status Ada", status_result.stdout)
+        self.assertIn("sync", sync_result.stdout)
+        self.assertEqual(events[0][0:2], ("status", "Ada"))
+        self.assertEqual(events[1][0:2], ("sync", None))
+        self.assertNotEqual(events[0][2], events[1][2])
+        self.assertFalse(events[0][5])
+        self.assertTrue(events[1][5])
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_subcommand_redacts_sensitive_options(self) -> None:
+        app = base_cli.App(name="secret-subcommands")
+
+        @app.subcommand("login")
+        @base_cli.option("--token", sensitive=True, required=True)
+        def login(ctx: base_cli.Context, token: str) -> None:
+            del token
+            ctx.log.info("logged in")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_file = home / "login.log"
+
+            with mock.patch.object(
+                os.sys,
+                "argv",
+                ["secret-subcommands", "login", "--debug", "--token", "super-secret"],
+            ):
+                from base_cli.testing import invoke
+
+                result = invoke(
+                    app,
+                    ["login", "--debug", "--log-file", str(log_file), "--token", "super-secret"],
+                    home=home,
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            log_text = log_file.read_text(encoding="utf-8")
+            self.assertIn("login", log_text)
+            self.assertIn("--token", log_text)
+            self.assertIn("[REDACTED]", log_text)
+            self.assertNotIn("super-secret", log_text)
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_runs_with_context_and_cleans_temp_dir(self) -> None:
         app = base_cli.App(name="demo", version="0.1.0")


### PR DESCRIPTION
## Summary
- Add `base_cli.App.subcommand()` for Click-backed command groups.
- Preserve Base lifecycle behavior for every subcommand, including fresh context, standard options, logging, cleanup, dry-run handling, and redaction.
- Document the subcommand pattern and keep single-command apps unchanged.

## Validation
- RED: focused pytest `-k subcommand` failed before implementation because `App.subcommand()` was missing.
- GREEN: focused pytest `-k subcommand` -> 3 passed, 46 deselected.
- `BASE_HOME=$PWD PYTHONPATH=$PWD/lib/python:$PWD/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q` -> 49 passed.
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test` -> Python 417 passed, 1 skipped; BATS ok 1..452.

Closes #639