### PR TITLE
Avoid subshell timestamp formatting in Bash logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Avoided subshell timestamp formatting in Bash `LOG_UTC` logging.
 - Made `lib_std.sh` yes/no prompts read from the controlling terminal so
   redirected stdin stays available to the caller.
 - Compared `lib_std.sh` Bash major and minor versions arithmetically so older

--- a/lib/bash/std/lib_std.sh
+++ b/lib/bash/std/lib_std.sh
@@ -425,16 +425,15 @@ _print_log() {
         source_path="${source_path#"$__SCRIPT_DIR__"/}"
         source_path="${source_path#./}"
 
-        local message timestamp
+        local message
         message="$(__join_message__ "$@")"
-        if [[ "${LOG_UTC:-}" == 1 ]]; then
-            timestamp="$(TZ=UTC0 printf '%(%Y-%m-%d %H:%M:%S)T' -1)"
-        else
-            timestamp="$(printf '%(%Y-%m-%d %H:%M:%S)T' -1)"
-        fi
         {
             printf '%b' "$color"
-            printf '%s %-7s %s ' "$timestamp" "$in_level" "${source_path}:${source_line}"
+            if [[ "${LOG_UTC:-}" == 1 ]]; then
+                TZ=UTC0 printf '%(%Y-%m-%d %H:%M:%S)T %-7s %s ' -1 "$in_level" "${source_path}:${source_line}"
+            else
+                printf '%(%Y-%m-%d %H:%M:%S)T %-7s %s ' -1 "$in_level" "${source_path}:${source_line}"
+            fi
             printf '%s' "$message"
             printf '%b\n' "$COLOR_OFF"
         } >&2

--- a/lib/bash/std/tests/lib_std.bats
+++ b/lib/bash/std/tests/lib_std.bats
@@ -445,6 +445,13 @@ EOF
     ! _print_log
 }
 
+@test "_print_log formats timestamps without command substitution" {
+    bats_run grep -nE 'timestamp="\$\((TZ=UTC0 )?printf' "$STDLIB_PATH"
+
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+}
+
 @test "log wrappers respect the configured log level" {
     local stderr_file="$TEST_TMPDIR/log-wrappers.err"
 


### PR DESCRIPTION
## Summary
- Remove timestamp command substitution from `_print_log`.
- Format local and UTC timestamps with inline Bash builtin `printf`.
- Add a regression test that rejects the timestamp subshell pattern.

## Root Cause
- #683 added `LOG_UTC=1` support by assigning the formatted timestamp through `$()`.
- That made every emitted Bash log line fork a subshell even though Bash builtin `printf '%(%T)T'` can format the timestamp directly.

## Validation
- RED: `bats --print-output-on-failure --filter "_print_log formats timestamps without command substitution" lib/bash/std/tests/lib_std.bats`
- GREEN: `bats --print-output-on-failure --filter "_print_log" lib/bash/std/tests/lib_std.bats`
- GREEN: `shellcheck --severity=error lib/bash/std/lib_std.sh`
- GREEN: `grep -nE 'timestamp="\$\((TZ=UTC0 )?printf' lib/bash/std/lib_std.sh` exits 1
- GREEN: `git diff --check`
- GREEN: `git diff --cached --check`
- GREEN: `bats --print-output-on-failure lib/bash/std/tests/lib_std.bats`
- GREEN: `env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. Internal Bash logging implementation only.

Fixes #702
