### PR TITLE
Use scoped colon splitting in bootstrap scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Aligned bootstrap and installer candidate-list splitting with the scoped
+  `IFS=: read -ra` Bash pattern.
 - Made `base_cli` log source paths prefer the active project root before
   falling back to the process working directory.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -83,7 +83,7 @@ BOOTSTRAP_BREW_BIN=""
 bootstrap_find_brew() {
     local candidate
     local candidates="${BASE_BOOTSTRAP_BREW_CANDIDATES:-/opt/homebrew/bin/brew:/usr/local/bin/brew}"
-    local old_ifs
+    local -a candidate_paths
 
     if [[ -n "${BASE_BOOTSTRAP_BREW_BIN:-}" && -x "${BASE_BOOTSTRAP_BREW_BIN:-}" ]]; then
         printf '%s\n' "$BASE_BOOTSTRAP_BREW_BIN"
@@ -95,15 +95,13 @@ bootstrap_find_brew() {
         return 0
     fi
 
-    old_ifs="$IFS"
-    IFS=:
-    for candidate in $candidates; do
-        IFS="$old_ifs"
+    IFS=: read -ra candidate_paths <<< "$candidates"
+    for candidate in "${candidate_paths[@]}"; do
+        [[ -n "$candidate" ]] || continue
         [[ -x "$candidate" ]] || continue
         printf '%s\n' "$candidate"
         return 0
     done
-    IFS="$old_ifs"
 
     return 1
 }
@@ -187,7 +185,7 @@ bootstrap_find_supported_bash() {
     local candidate
     local candidates="${BASE_BOOTSTRAP_BASH_CANDIDATES:-/opt/homebrew/bin/bash:/usr/local/bin/bash}"
     local current_version
-    local old_ifs
+    local -a candidate_paths
 
     current_version="$(bootstrap_bash_version_number)"
     if [[ "$current_version" -ge 42 ]]; then
@@ -195,15 +193,13 @@ bootstrap_find_supported_bash() {
         return 0
     fi
 
-    old_ifs="$IFS"
-    IFS=:
-    for candidate in $candidates; do
-        IFS="$old_ifs"
+    IFS=: read -ra candidate_paths <<< "$candidates"
+    for candidate in "${candidate_paths[@]}"; do
+        [[ -n "$candidate" ]] || continue
         [[ -x "$candidate" ]] || continue
         printf '%s\n' "$candidate"
         return 0
     done
-    IFS="$old_ifs"
 
     return 1
 }

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ install_find_supported_bash() {
     local candidate
     local candidates="${BASE_INSTALL_BASH_CANDIDATES:-/opt/homebrew/bin/bash:/usr/local/bin/bash}"
     local current_version
-    local old_ifs
+    local -a candidate_paths
 
     current_version="$(install_bash_version_number)"
     if [[ "$current_version" -ge 42 ]]; then
@@ -63,15 +63,13 @@ install_find_supported_bash() {
         return 0
     fi
 
-    old_ifs="$IFS"
-    IFS=:
-    for candidate in $candidates; do
-        IFS="$old_ifs"
+    IFS=: read -ra candidate_paths <<< "$candidates"
+    for candidate in "${candidate_paths[@]}"; do
+        [[ -n "$candidate" ]] || continue
         [[ -x "$candidate" ]] || continue
         printf '%s\n' "$candidate"
         return 0
     done
-    IFS="$old_ifs"
 
     return 1
 }
@@ -79,7 +77,7 @@ install_find_supported_bash() {
 install_find_brew() {
     local candidate
     local candidates="${BASE_INSTALL_BREW_CANDIDATES:-/opt/homebrew/bin/brew:/usr/local/bin/brew}"
-    local old_ifs
+    local -a candidate_paths
 
     if [[ -n "${BASE_INSTALL_BREW_BIN:-}" && -x "${BASE_INSTALL_BREW_BIN:-}" ]]; then
         printf '%s\n' "$BASE_INSTALL_BREW_BIN"
@@ -91,15 +89,13 @@ install_find_brew() {
         return 0
     fi
 
-    old_ifs="$IFS"
-    IFS=:
-    for candidate in $candidates; do
-        IFS="$old_ifs"
+    IFS=: read -ra candidate_paths <<< "$candidates"
+    for candidate in "${candidate_paths[@]}"; do
+        [[ -n "$candidate" ]] || continue
         [[ -x "$candidate" ]] || continue
         printf '%s\n' "$candidate"
         return 0
     done
-    IFS="$old_ifs"
 
     return 1
 }

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -110,6 +110,16 @@ EOF
     [ "$output" = "" ]
 }
 
+@test "bootstrap uses scoped colon splitting for candidate lists" {
+    run grep -n 'old_ifs' "$BASE_REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+
+    run grep -c 'IFS=: read -ra' "$BASE_REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 2 ]
+}
+
 @test "bootstrap source dry-run installs first-mile prerequisites and prints handoff commands" {
     local install_dir="$TEST_HOME/work/base"
 

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -105,6 +105,16 @@ assert_base_init_loads() {
     [[ "$output" == *"Restart your shell with: exec \"\$SHELL\" -l"* ]]
 }
 
+@test "installer uses scoped colon splitting for candidate lists" {
+    run grep -n 'old_ifs' "$BASE_REPO_ROOT/install.sh"
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+
+    run grep -c 'IFS=: read -ra' "$BASE_REPO_ROOT/install.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 2 ]
+}
+
 @test "installer bootstraps Homebrew Bash before setup when system Bash is too old" {
     run env \
         HOME="$TEST_HOME" \


### PR DESCRIPTION
## Summary
- Replace `old_ifs` save/restore loops in `bootstrap.sh` and `install.sh`.
- Use scoped `IFS=: read -ra` candidate-list splitting for Homebrew and Bash probes.
- Add regression tests to keep the standalone scripts aligned with the stdlib splitting pattern.

## Root Cause
- The standalone bootstrap and installer scripts predated the safer `lib_std.sh` path-splitting style.
- The old save/restore pattern was correct in normal flow, but easier to break with early returns or future edits.

## Validation
- Baseline: `bats --print-output-on-failure tests/bootstrap.bats tests/install.bats`
- RED: `bats --print-output-on-failure --filter "scoped colon splitting" tests/bootstrap.bats tests/install.bats`
- GREEN: `bats --print-output-on-failure --filter "scoped colon splitting" tests/bootstrap.bats tests/install.bats`
- GREEN: `shellcheck --severity=error bootstrap.sh install.sh`
- GREEN: `grep -n 'old_ifs' bootstrap.sh install.sh` exits 1
- GREEN: `git diff --check`
- GREEN: `git diff --cached --check`
- GREEN: `bats --print-output-on-failure tests/bootstrap.bats tests/install.bats`
- GREEN: `bash bootstrap.sh --dry-run`
- GREEN: `bash install.sh --dry-run`
- GREEN: `env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. First-mile installer/bootstrap implementation cleanup only.

Fixes #700
