### PR TITLE
Correct git branch usage message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Corrected the `git_get_current_branch` usage message to name the current
+  helper.
 - Avoided subshell timestamp formatting in Bash `LOG_UTC` logging.
 - Made `lib_std.sh` yes/no prompts read from the controlling terminal so
   redirected stdin stays available to the caller.

--- a/lib/bash/git/lib_git.sh
+++ b/lib/bash/git/lib_git.sh
@@ -219,7 +219,7 @@ git_get_current_branch() {
 
     # --- Argument Validation ---
     if [[ -z "$target_dir" || -z "$result_var_name" ]]; then
-        log_error "Usage: get_git_branch <directory> <result_variable_name>"
+        log_error "Usage: git_get_current_branch <directory> <result_variable_name>"
         return 1
     fi
 

--- a/lib/bash/git/tests/lib_git.bats
+++ b/lib/bash/git/tests/lib_git.bats
@@ -32,6 +32,14 @@ setup() {
     [ "$branch" = "detached head" ]
 }
 
+@test "git_get_current_branch usage names the current function" {
+    bats_run git_get_current_branch
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: git_get_current_branch <directory> <result_variable_name>"* ]]
+    [[ "$output" != *"Usage: get_git_branch"* ]]
+}
+
 @test "git_update_repo skips dirty repositories when no dirty path is allowed" {
     local repo="$TEST_TMPDIR/repo"
 


### PR DESCRIPTION
## Summary
- Correct `git_get_current_branch` invalid-usage logging to name the current helper.
- Add BATS coverage for the usage message.
- Note the fix in the changelog.

## Root Cause
- The helper had been renamed, but the usage message still referenced the old `get_git_branch` name.

## Validation
- RED: `bats --print-output-on-failure --filter "git_get_current_branch usage names the current function" lib/bash/git/tests/lib_git.bats`
- GREEN: `bats --print-output-on-failure --filter "git_get_current_branch" lib/bash/git/tests/lib_git.bats`
- GREEN: `shellcheck --severity=error lib/bash/git/lib_git.sh`
- GREEN: `git diff --check`
- GREEN: `git diff --cached --check`
- GREEN: `bats --print-output-on-failure lib/bash/git/tests/lib_git.bats`
- GREEN: `env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. Usage message only.

Fixes #701
