### PR TITLE
Remove eval from baserc guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Removed `eval` from Bash `.baserc` guard variable snapshots while preserving
+  Bash 4.2 compatibility.
 - Replaced `install.sh` shell strict mode with explicit installer command
   failure handling.
 - Corrected the `git_get_current_branch` usage message to name the current

--- a/lib/bash/runtime/tests/runtime_bashrc.bats
+++ b/lib/bash/runtime/tests/runtime_bashrc.bats
@@ -49,6 +49,13 @@ create_fake_runtime_platform_tools() {
     touch "$platform_tools_home/base_manifest.yaml"
 }
 
+@test "baserc guard avoids eval" {
+    run grep -nE '^[[:space:]]*eval[[:space:]]' "$BASE_REPO_ROOT/lib/shell/baserc_guard.sh"
+
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+}
+
 @test "non-interactive bash ignores runtime rcfile" {
     cat > "$TEST_HOME/.bashrc" <<'EOF'
 touch "$HOME/user-bashrc-ran"
@@ -140,6 +147,23 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_SHELL=1"* ]]
     [[ "$output" == *"BASE_DEBUG="* ]]
+    [[ "$output" != *"ERROR:"* ]]
+}
+
+@test "baserc guard allows non-owned user variables" {
+    printf '%s\n' 'export BASE_USER_SETTING=enabled' > "$TEST_HOME/.baserc"
+
+    run env -i \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            printf "BASE_USER_SETTING=%s\n" "${BASE_USER_SETTING:-}"; \
+            printf "BASE_SHELL=%s\n" "${BASE_SHELL:-}"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_USER_SETTING=enabled"* ]]
+    [[ "$output" == *"BASE_SHELL=1"* ]]
     [[ "$output" != *"ERROR:"* ]]
 }
 

--- a/lib/shell/baserc_guard.sh
+++ b/lib/shell/baserc_guard.sh
@@ -65,8 +65,8 @@ base_baserc_guard_reject_owned_var() {
     local after_set
     local after_value
 
-    eval "after_set=\"\${$var_name+x}\""
-    eval "after_value=\"\${$var_name-}\""
+    after_set="${!var_name+x}"
+    after_value="${!var_name-}"
 
     if [[ "$after_set" == "$before_set" && "$after_value" == "$before_value" ]]; then
         return 0
@@ -88,6 +88,8 @@ base_baserc_guard_source() {
     local base_owned_vars
     local var_name
     local snapshot_name
+    local snapshot_set_name
+    local snapshot_value_name
     local before_set
     local before_value
     local baserc_status=0
@@ -98,8 +100,11 @@ base_baserc_guard_source() {
     base_owned_vars="$(base_baserc_guard_owned_vars)"
     for var_name in $base_owned_vars; do
         snapshot_name="base_baserc_guard_before_$var_name"
-        eval "local ${snapshot_name}_set=\"\${$var_name+x}\""
-        eval "local ${snapshot_name}_value=\"\${$var_name-}\""
+        snapshot_set_name="${snapshot_name}_set"
+        snapshot_value_name="${snapshot_name}_value"
+        local "$snapshot_set_name" "$snapshot_value_name"
+        printf -v "$snapshot_set_name" '%s' "${!var_name+x}"
+        printf -v "$snapshot_value_name" '%s' "${!var_name-}"
     done
 
     __base_baserc_sourced__=1
@@ -112,8 +117,10 @@ base_baserc_guard_source() {
 
     for var_name in $base_owned_vars; do
         snapshot_name="base_baserc_guard_before_$var_name"
-        eval "before_set=\"\${${snapshot_name}_set}\""
-        eval "before_value=\"\${${snapshot_name}_value}\""
+        snapshot_set_name="${snapshot_name}_set"
+        snapshot_value_name="${snapshot_name}_value"
+        before_set="${!snapshot_set_name-}"
+        before_value="${!snapshot_value_name-}"
         base_baserc_guard_reject_owned_var "$var_name" "$before_set" "$before_value" || baserc_status=1
     done
 


### PR DESCRIPTION
## Summary
- Replace eval-based baserc guard snapshots with Bash 4.2-compatible indirect expansion.
- Add runtime tests proving eval stays out of the guard and non-owned user variables still pass through.
- Note the shell guard cleanup in the changelog.

## Validation
- bats --print-output-on-failure --filter "baserc guard" lib/bash/runtime/tests/runtime_bashrc.bats
- shellcheck --severity=error lib/shell/baserc_guard.sh
- grep -nE '^[[:space:]]*eval[[:space:]]' lib/shell/baserc_guard.sh (expected no matches, exit 1)
- git diff --check
- bats --print-output-on-failure lib/bash/runtime/tests/runtime_bashrc.bats
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. Shell guard behavior only.

Closes #699