### PR TITLE
Add maintained Base product assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   re-parsing `~/.base.d/config.yaml`.
 - Added `base_cli.App.subcommand()` so one Python CLI can expose multiple
   Base-managed entry points.
+- Added `docs/product-assessment.md` as a maintained review of Base's
+  originality, usefulness, adoption potential, and engineering-skill evidence.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Base exists to provide that missing common layer.
 For a concise evaluator view of where Base fits, what it gives a multi-repo
 workspace, and how it compares with adjacent tools, see
 [Why Base](docs/why-base.md).
+For a candid maintained assessment of Base's originality, usefulness, adoption
+potential, and engineering evidence, see
+[Product Assessment](docs/product-assessment.md).
 
 Common first-run and product questions are answered in [FAQ.md](FAQ.md).
 Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md). Release notes

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,9 @@ reference. The filename should answer "what is this about?"
 - [Why Base](why-base.md) is the concise evaluator page for why Base exists,
   what it gives a multi-repo workspace, and how it compares with adjacent
   developer-environment tools.
+- [Product Assessment](product-assessment.md) records the maintained assessment
+  of Base's originality, usefulness, adoption potential, and creator/engineering
+  skill evidence.
 - [Command Quick Reference](command-reference.md) is the one-page lookup table
   for the current `basectl` command surface and important flags.
 - [Technical Overview](technical-overview.md) is the scannable product and

--- a/docs/product-assessment.md
+++ b/docs/product-assessment.md
@@ -1,0 +1,226 @@
+# Base Product Assessment
+
+Status: maintained product review artifact
+Last reviewed: 2026-06-14
+Base era reviewed: 1.0.x
+
+This document records a candid assessment of Base as a product and engineering
+effort. It is not marketing copy, and it should not drift into aspiration. When
+Base evolves, this page should be revised against the current implementation,
+current docs, real usage, and known adoption evidence.
+
+For the concise product fit page, see [Why Base](why-base.md). For the
+ecosystem boundary model, see [Tool Boundaries](tool-boundaries.md).
+
+## Maintenance Policy
+
+Review this assessment:
+
+- during each minor release line, such as `1.1.0`, `1.2.0`, and later;
+- before any major repositioning of Base's product scope;
+- before public claims about Linux, Windows, WSL, or team-scale adoption;
+- after meaningful external usage, contributor growth, or support feedback;
+- when Base absorbs or rejects a major adjacent-tool integration.
+
+When revising the assessment, prefer evidence in this order:
+
+1. current command behavior, tests, and release artifacts;
+2. current canonical docs such as `README.md`, `docs/why-base.md`,
+   `docs/tool-boundaries.md`, and `docs/architecture.md`;
+3. real usage in Base-managed repositories;
+4. user and contributor feedback;
+5. product intuition.
+
+## Current Product Thesis
+
+Base is a macOS-first local workspace control plane for developers who keep
+multiple repositories checked out side by side. It gives that workspace a common
+command surface for setup, diagnostics, project discovery, shell activation,
+tests, demos, builds, repository workflow, and release support.
+
+Base is strongest when it stays at the workspace orchestration layer. It should
+discover participating repositories, read their `base_manifest.yaml` contracts,
+invoke mature tools openly, report failures in a Base-native way, and keep the
+multi-repo workspace understandable.
+
+Base becomes weaker if it turns into a general version manager, automatic
+directory environment loader, dotfile manager, package solver, or generic task
+runner.
+
+## 1. Originality
+
+Assessment: moderately high originality.
+Working rating: 7/10.
+
+The individual ingredients are not new. Developer tooling already has shell
+bootstrap scripts, environment managers, task runners, manifests, health checks,
+repo templates, release scripts, and dotfile managers.
+
+The original part is the composition and product boundary. Base treats the local
+developer workspace as the product surface: a set of sibling repositories that
+should behave like one coherent place to work without becoming a monorepo.
+
+Most adjacent tools optimize one project, one shell, one task runner, one
+version-management story, one container, or one dotfile system. Base sits one
+level higher. It asks:
+
+> What projects are in this workspace, what do they declare, what is ready,
+> what is missing, and how do I run the common workflow without relearning each
+> repository from scratch?
+
+That framing is distinctive. Base is not original because every primitive is
+new; it is original because the primitives are assembled into a clear local
+workspace control-plane model.
+
+The main originality risk is misclassification. A new user may initially read
+Base as another `mise`, `direnv`, `just`, `chezmoi`, Nix, Devbox, or Dev
+Containers competitor. The product must keep making clear that Base delegates
+to those tools where they are stronger.
+
+## 2. Usefulness
+
+Assessment: high usefulness for the target audience.
+Working rating: 8/10 for multi-repo platform-style developers; lower for the
+general developer population.
+
+Base is especially useful for:
+
+- engineers working across several sibling repositories;
+- platform, SRE, infrastructure, and internal-tooling engineers;
+- teams that need repeatable onboarding without forcing a monorepo;
+- projects that want consistent `setup`, `check`, `doctor`, `test`, `run`,
+  `demo`, `build`, and release entry points;
+- developers who want explicit activation instead of hidden `cd`-triggered
+  environment changes;
+- repositories that benefit from standard GitHub issue, branch, worktree, PR,
+  and release workflow helpers.
+
+Base is less useful when:
+
+- the developer works in one simple repository;
+- a monorepo is already the right product shape;
+- the main problem is only language version pinning;
+- the main problem is full reproducibility through Nix, Devbox, or Dev
+  Containers;
+- automatic directory-based environment loading is the desired behavior;
+- the team does not want a managed shell startup section.
+
+The practical value is that Base reduces repeated human judgment. It turns
+questions like "How do I set this up?", "Which repos are part of this
+workspace?", "Is my shell sane?", "How do I test this project?", and "How do I
+open a repo-standard PR?" into repeatable commands and documented contracts.
+
+## 3. Adoption Potential
+
+Assessment: medium overall adoption potential, high potential inside a narrow
+wedge.
+
+The strongest wedge is:
+
+> Mac-first local workspace orchestration for serious multi-repo developers.
+
+That is a real market of users, especially among platform engineering,
+infrastructure, SRE, internal developer platform, and product engineers who
+work across multiple peer repositories.
+
+The blockers to broader adoption are also real:
+
+- Base touches shell startup, so users must trust it.
+- The category is not instantly obvious.
+- macOS-first scope limits the addressable audience.
+- Teams already committed to monorepos, Nix, Devbox, or Dev Containers need a
+  sharp reason to add another layer.
+- Single-author products need extra proof of reliability, maintainability, and
+  contributor onboarding.
+- Base must avoid becoming a place where every useful CLI is added to the core
+  product.
+
+The best adoption path is evidence-driven:
+
+- keep install and upgrade boring;
+- keep the first-run demo short and convincing;
+- make `base_manifest.yaml` adoption small and obvious;
+- prove Base across a few real repositories;
+- show failures clearly through `check`, `doctor`, logs, and JSON output;
+- keep platform/SRE utilities outside core Base, such as in
+  `base-platform-tools`;
+- broaden Linux, WSL, or Windows support only when the support contract is
+  narrow enough to keep.
+
+Base can become much larger, but the larger possibility is not "put every tool
+inside Base." The larger possibility is to become the trusted local control
+plane that makes a developer's workstation, repo set, diagnostics, and common
+workflow coherent.
+
+## 4. Creator And Engineering Skill Assessment
+
+Assessment: at least Staff-level; plausibly upper Staff or early Senior
+Staff-level in architecture and product judgment.
+
+This is not a formal performance review. It is an inference from the product
+and repository evidence.
+
+The strongest evidence for Staff-level skill:
+
+- clear product framing around a workspace control plane;
+- explicit ecosystem boundaries and refusal to replace mature tools wholesale;
+- a small project manifest contract instead of ad hoc per-repo logic;
+- repeatable command surface across setup, diagnostics, activation, tests,
+  demos, builds, repo workflow, and release support;
+- observable failure handling through `check`, `doctor`, stable finding IDs,
+  JSON-capable output, and logs;
+- issue-backed GitHub workflow, branch conventions, worktrees, PR templates,
+  changelog discipline, and release ceremony;
+- public documentation that explains not just commands, but product intent and
+  tool boundaries;
+- ability to separate Base's workstation orchestration role from adjacent
+  utility tooling such as `base-platform-tools`.
+
+The case for Senior Staff-level judgment is strongest in the product and system
+boundary decisions. The creator has not just written scripts; they have shaped
+a coherent operating model for a multi-repo workspace and repeatedly chosen
+delegation over unnecessary ownership.
+
+The reason not to claim "higher than Senior Staff" yet is that higher levels
+usually require evidence beyond single-author execution:
+
+- adoption by users other than the creator;
+- other contributors becoming productive through the architecture;
+- sustained maintenance under real support pressure;
+- organizational or ecosystem influence;
+- economic or operational impact beyond the original workflow.
+
+Single-handed creation proves breadth, taste, persistence, and engineering
+maturity. Staff-plus evaluation should also ask whether the system makes other
+people faster, safer, and more consistent.
+
+## Evaluation Rubric
+
+| Dimension | What To Look For | Current Assessment |
+|---|---|---|
+| Product judgment | Clear target user, clear problem, crisp non-goals | Strong |
+| Architecture | Coherent boundaries, small contracts, delegation to mature tools | Strong |
+| Execution | Working CLI, install paths, tests, docs, releases | Strong |
+| Developer experience | Reduces onboarding and workflow friction | Strong for target users |
+| Operational maturity | Diagnostics, dry runs, logs, release process, validation | Strong and improving |
+| Maintainability | Can another engineer understand and extend it safely? | Promising; needs more contributor proof |
+| Adoption evidence | Real users, real repos, external contributors, support history | Early |
+| Scope control | Keeps core orchestration distinct from utility tooling | Strong, but must be defended |
+
+## Overall Verdict
+
+Base is already beyond a personal script collection. It is a serious
+platform-engineering product with a defensible niche.
+
+Its most durable product identity is:
+
+> a local workspace control plane for multi-repo engineering.
+
+Base should keep that identity narrow and sharp. The next level of proof is not
+feature count; it is reliability, install simplicity, documentation clarity,
+external repo adoption, and evidence that another engineer can use and extend
+the system without needing the creator in the loop.
+
+## Assessment History
+
+- 2026-06-14: Initial maintained assessment added during the Base 1.0.x era.


### PR DESCRIPTION
## Summary
- Add `docs/product-assessment.md` as a maintained assessment of Base's originality, usefulness, adoption potential, and creator/engineering-skill evidence.
- Link the assessment from the README and docs map.
- Record the documentation addition in the changelog.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test` (`418 passed, 1 skipped`; BATS `1..458`, exit 0)

## Demo Impact
- None. Documentation-only change.

Closes #711