### PR TITLE
Redact compound secret assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Redacted compound secret-like command-output assignments such as
+  `GITHUB_TOKEN=...`, `DB_PASSWORD=...`, and
+  `AWS_SECRET_ACCESS_KEY=...` from setup failure summaries and debug logs.
 - Removed `eval` from Bash `.baserc` guard variable snapshots while preserving
   Bash 4.2 compatibility.
 - Replaced `install.sh` shell strict mode with explicit installer command

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -18,7 +18,9 @@ from .errors import ArtifactError
 
 
 COMMAND_OUTPUT_TAIL_CHARS = 4000
-SECRET_VALUE_RE = re.compile(r"(?i)\b(token|password|secret|api[-_]?key)=\S+")
+SECRET_VALUE_RE = re.compile(
+    r"(?i)(?P<name>[A-Za-z0-9_.:-]*(?:token|password|secret|api[-_]?key)[A-Za-z0-9_.:-]*)=\S+"
+)
 URL_CREDENTIALS_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s:@]+:[^@\s/]+@")
 HOMEBREW_LINK_FAILURE = "The `brew link` step did not complete successfully"
 HOMEBREW_LINK_DRY_RUN_RE = re.compile(r"(?m)^\s*(brew link --overwrite [^\r\n]+ --dry-run)\s*$")
@@ -128,7 +130,7 @@ def format_command(command: list[str]) -> str:
 
 def redact_command_output(text: str) -> str:
     text = URL_CREDENTIALS_RE.sub(r"\1[REDACTED]@", text)
-    return SECRET_VALUE_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+    return SECRET_VALUE_RE.sub(lambda match: f"{match.group('name')}=[REDACTED]", text)
 
 
 def command_failure_guidance(stdout_tail: str, stderr_tail: str) -> str:

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -596,6 +596,36 @@ class ProcessTests(unittest.TestCase):
         self.assertIn("[REDACTED]", message)
         self.assertIn("[REDACTED]", debug_text)
 
+    def test_redact_command_output_redacts_compound_secret_assignments(self) -> None:
+        output = "\n".join(
+            [
+                "token=ghp_short",
+                "--github-token=ghp_flag",
+                "GITHUB_TOKEN=ghp_compound",
+                "DB_PASSWORD=db-secret",
+                "SOME_SECRET=value-secret",
+                "API_KEY=api-secret",
+                "AWS_SECRET_ACCESS_KEY=aws-secret",
+            ]
+        )
+
+        redacted = process.redact_command_output(output)
+
+        self.assertNotIn("ghp_short", redacted)
+        self.assertNotIn("ghp_flag", redacted)
+        self.assertNotIn("ghp_compound", redacted)
+        self.assertNotIn("db-secret", redacted)
+        self.assertNotIn("value-secret", redacted)
+        self.assertNotIn("api-secret", redacted)
+        self.assertNotIn("aws-secret", redacted)
+        self.assertIn("token=[REDACTED]", redacted)
+        self.assertIn("--github-token=[REDACTED]", redacted)
+        self.assertIn("GITHUB_TOKEN=[REDACTED]", redacted)
+        self.assertIn("DB_PASSWORD=[REDACTED]", redacted)
+        self.assertIn("SOME_SECRET=[REDACTED]", redacted)
+        self.assertIn("API_KEY=[REDACTED]", redacted)
+        self.assertIn("AWS_SECRET_ACCESS_KEY=[REDACTED]", redacted)
+
     def test_run_command_failure_truncates_large_single_chunk_tail(self) -> None:
         ctx = fake_context()
         stdout = io.StringIO()


### PR DESCRIPTION
## Summary
- Expand setup command-output redaction to cover compound secret-like assignment names such as `GITHUB_TOKEN`, `DB_PASSWORD`, and `AWS_SECRET_ACCESS_KEY`.
- Add regression coverage for compound token/password/secret/API key assignments.
- Note the security hardening in the changelog.

## Validation
- RED: `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_artifacts.ProcessTests.test_redact_command_output_redacts_compound_secret_assignments` failed before the fix with `GITHUB_TOKEN=ghp_compound` still present.
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_artifacts`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/process.py cli/python/base_setup/tests/test_artifacts.py`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test` (Python: 419 passed, 1 skipped; BATS/integration: ok 1..460)

## Demo Impact
- None. Security hardening only.

## AI Context
- Not updated. This tightens the existing command-output redaction contract without changing Base product workflow, architecture, or command surface.

Fixes #715