### PR TITLE
Validate manifest project names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Aligned bootstrap and installer candidate-list splitting with the scoped
   `IFS=: read -ra` Bash pattern.
+- Normalized Base's built-in default, developer, and SRE profile manifest
+  names to the same safe project-name syntax enforced for project manifests.
 - Made `base_cli` log source paths prefer the active project root before
   falling back to the process working directory.
 
@@ -42,6 +44,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Redacted compound secret-like command-output assignments such as
   `GITHUB_TOKEN=...`, `DB_PASSWORD=...`, and
   `AWS_SECRET_ACCESS_KEY=...` from setup failure summaries and debug logs.
+- Rejected path-unsafe `project.name` values in `base_manifest.yaml` before
+  they can be used in Base-managed state paths.
 - Removed `eval` from Bash `.baserc` guard variable snapshots while preserving
   Bash 4.2 compatibility.
 - Replaced `install.sh` shell strict mode with explicit installer command

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -50,7 +50,7 @@ def write_default_manifest(base_home: Path) -> None:
     default_manifest = base_home / "lib" / "base" / "default_manifest.yaml"
     default_manifest.parent.mkdir(parents=True)
     default_manifest.write_text(
-        "project:\n  name: __base_defaults__\nartifacts: []\n",
+        "project:\n  name: base-defaults\nartifacts: []\n",
         encoding="utf-8",
     )
 

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -227,6 +227,11 @@ def _read_project_name(path: Path, project_data: Any) -> str:
     project_name = project_data.get("name")
     if not isinstance(project_name, str) or not project_name:
         raise ManifestError(f"{path}: project.name is required.")
+    if not COMMAND_NAME_RE.fullmatch(project_name):
+        raise ManifestError(
+            f"{path}: project.name must be a valid name "
+            "(alphanumeric with optional dots, dashes, underscores, or colons)."
+        )
     return project_name
 
 

--- a/cli/python/base_setup/tests/test_bootstrap.py
+++ b/cli/python/base_setup/tests/test_bootstrap.py
@@ -16,7 +16,7 @@ class BootstrapManifestTests(unittest.TestCase):
         ctx = fake_context()
         default_manifest = BaseManifest(
             path=Path("default_manifest.yaml"),
-            project_name="__base_defaults__",
+            project_name="base-defaults",
             brewfile=None,
             artifacts=(
                 ArtifactRequest(artifact_type="python-package", name="click", version="8.4.1", bootstrap=True),

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -131,6 +131,49 @@ class ManifestParsingTests(unittest.TestCase):
                 read_manifest(manifest_path)
 
 
+    def test_rejects_path_unsafe_project_names(self) -> None:
+        for project_name in ("../../etc", "../base", "demo/name", "demo name", ".hidden", "demo?"):
+            with self.subTest(project_name=project_name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                f"  name: {project_name}",
+                                "",
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaisesRegex(ManifestError, "project.name must be a valid name"):
+                        read_manifest(manifest_path)
+
+
+    def test_accepts_valid_project_name_characters(self) -> None:
+        for project_name in ("demo", "demo.1", "demo-1", "demo_1", "demo:local", "2demo"):
+            with self.subTest(project_name=project_name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                f"  name: {project_name}",
+                                "",
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    manifest = read_manifest(manifest_path)
+
+                self.assertEqual(manifest.project_name, project_name)
+
+
 
     def test_reads_manifest_required_environment_variables(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/base/default_manifest.yaml
+++ b/lib/base/default_manifest.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 project:
-  name: __base_defaults__
+  name: base-defaults
 
 artifacts:
   - type: python-package

--- a/lib/base/dev_manifest.yaml
+++ b/lib/base/dev_manifest.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 project:
-  name: __base_dev__
+  name: base-dev
 
 artifacts:
   - type: tool

--- a/lib/base/sre_manifest.yaml
+++ b/lib/base/sre_manifest.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 project:
-  name: __base_sre__
+  name: base-sre
 
 artifacts:
   - type: tool


### PR DESCRIPTION
## Summary
- Validate `project.name` in `base_manifest.yaml` against Base safe project-name syntax before it can feed Base-managed state paths.
- Add regression coverage for path-unsafe names and allowed punctuation/digit-leading names.
- Normalize Base built-in default/dev/SRE manifest names to the same safe syntax.

## Validation
- RED: `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_manifest.ManifestParsingTests.test_rejects_path_unsafe_project_names` failed before the fix because unsafe names were accepted.
- First full gate exposed the internal manifest-name conflict (`__base_defaults__`, `__base_dev__`, `__base_sre__`), then the built-in names and matching fixtures were normalized.
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_dev/tests/test_engine.py cli/python/base_projects/tests/test_workspace_checks.py -q` (44 passed)
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_bootstrap.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_manifest.py -q` (82 passed, 1 skipped, 67 subtests passed)
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/manifest.py cli/python/base_setup/tests/test_manifest.py cli/python/base_projects/tests/test_workspace_checks.py cli/python/base_setup/tests/test_bootstrap.py`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test` (Python: 421 passed, 1 skipped; BATS/integration: ok 1..460)

## Demo Impact
- None. Manifest parser hardening only.

## AI Context
- Not updated. This tightens manifest validation and internal profile names without changing Base product workflow, architecture, or command surface.

Fixes #714