### PR TITLE
Clarify activate Bash runtime shell

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -53,10 +53,12 @@ Base separates shell startup from runtime activation:
 
 ## Activation Model
 
-Project activation uses subshells. `basectl activate <project>` validates the
-project, sets project runtime variables, starts a new shell, and applies the
-project environment inside that shell. Exiting the subshell returns to the
-previous environment, so Base does not need fragile deactivate logic.
+Project activation uses a Bash runtime shell. `basectl activate <project>`
+validates the project, sets project runtime variables, starts Bash with Base's
+runtime rcfile, and applies the project environment inside that shell. Exiting
+the shell returns to the previous environment, so Base does not need fragile
+deactivate logic. `BASE_ACTIVATE_SHELL` may point to another Bash executable,
+but not Zsh or another non-Bash shell.
 
 ## Tool Boundary Model
 

--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -5,8 +5,8 @@ the canonical current command list.
 
 ## Current Public Commands
 
-- `basectl activate <project>` - start an interactive Base runtime subshell for
-  a project.
+- `basectl activate <project>` - start an interactive Base Bash runtime shell
+  for a project.
 - `basectl setup [project]` - install and bootstrap the local Base CLI
   environment and optional project artifacts.
 - `basectl check [project]` - verify local Base and optional project artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Aligned bootstrap and installer candidate-list splitting with the scoped
   `IFS=: read -ra` Bash pattern.
+- Clarified that `basectl activate` starts a Bash runtime shell and that
+  `BASE_ACTIVATE_SHELL` must point to Bash.
 - Normalized Base's built-in default, developer, and SRE profile manifest
   names to the same safe project-name syntax enforced for project manifests.
 - Made `base_cli` log source paths prefer the active project root before
@@ -41,6 +43,7 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Reported a clear error when `BASE_ACTIVATE_SHELL` points to a non-Bash shell.
 - Redacted compound secret-like command-output assignments such as
   `GITHUB_TOKEN=...`, `DB_PASSWORD=...`, and
   `AWS_SECRET_ACCESS_KEY=...` from setup failure summaries and debug logs.

--- a/README.md
+++ b/README.md
@@ -572,12 +572,18 @@ Once a project is discoverable, activate it with:
 basectl activate example
 ```
 
-Activation spawns a project-specific subshell, changes to the project root, sets
-`BASE_PROJECT` and related project variables, adds project-owned commands from
-`$PROJECT_ROOT/bin` when that directory exists, and activates the project
-virtual environment at `~/.base.d/<project>/.venv`. If the manifest declares
-`activate.source`, Base then sources each declared script in order. Exit that
-shell to return to the original environment.
+Activation spawns a project-specific Bash runtime shell, changes to the project
+root, sets `BASE_PROJECT` and related project variables, adds project-owned
+commands from `$PROJECT_ROOT/bin` when that directory exists, and activates the
+project virtual environment at `~/.base.d/<project>/.venv`. If the manifest
+declares `activate.source`, Base then sources each declared script in order.
+Exit that shell to return to the original environment.
+
+The activated runtime shell is always Bash, even when the user's login shell is
+Zsh. `BASE_ACTIVATE_SHELL` may point to another Bash executable, but it must not
+point to Zsh or another non-Bash shell. Zsh-specific aliases, options,
+completions, and prompt customizations are not loaded inside the activated Base
+runtime shell.
 
 Use `basectl activate example --no-cd` to keep the caller's current directory
 while still loading the selected project's Base runtime environment.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -48,9 +48,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
 ## Notes
 
 - `basectl setup` is the default local bootstrap path.
-- `basectl activate <project>` starts a project-specific runtime subshell with
-  the project virtual environment active and `$PROJECT_ROOT/bin` on `PATH` when
-  that directory exists.
+- `basectl activate <project>` starts a project-specific Bash runtime shell
+  with the project virtual environment active and `$PROJECT_ROOT/bin` on `PATH`
+  when that directory exists.
 - `basectl setup [project]` runs the Bash bootstrap layer first, then invokes the
   Python project setup layer for `base_manifest.yaml` artifacts. The optional
   project argument validates `project.name`.

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -14,7 +14,7 @@ Options:
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
-Start an interactive Base runtime subshell for a project.
+Start an interactive Base Bash runtime shell for a project.
 EOF
 }
 
@@ -53,6 +53,13 @@ base_activate_project_venv_dir() {
     fi
 
     printf '%s\n' "$HOME/.base.d/$project/.venv"
+}
+
+base_activate_shell_is_bash() {
+    local shell_path="$1"
+    local shell_name="${shell_path##*/}"
+
+    [[ "$shell_name" == "bash" || "$shell_name" == bash-* || "$shell_name" == *-bash ]]
 }
 
 base_activate_subcommand_main() {
@@ -139,5 +146,8 @@ base_activate_subcommand_main() {
         cd "$project_root" || fatal_error "Unable to enter project root '$project_root'."
     fi
     activate_shell="${BASE_ACTIVATE_SHELL:-${BASH:-bash}}"
+    if ! base_activate_shell_is_bash "$activate_shell"; then
+        fatal_error "basectl activate requires Bash. BASE_ACTIVATE_SHELL='$activate_shell' is not supported. Unset BASE_ACTIVATE_SHELL to use the default Bash runtime shell."
+    fi
     exec "$activate_shell" --rcfile "$shell_rc"
 }

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -258,6 +258,48 @@ EOF
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl activate <project> [options]"* ]]
     [[ "$output" == *"--no-cd"* ]]
+    [[ "$output" == *"interactive Base Bash runtime shell"* ]]
+}
+
+@test "basectl activate rejects non-Bash BASE_ACTIVATE_SHELL before exec" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local project_python="$TEST_HOME/.base.d/demo/.venv/bin/python"
+    local project_activate="$TEST_HOME/.base.d/demo/.venv/bin/activate"
+    local workspace="$TEST_TMPDIR/workspace"
+    local fake_zsh="$TEST_TMPDIR/zsh"
+
+    mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_zsh" <<'EOF'
+#!/usr/bin/env bash
+printf 'non-bash shell invoked\n'
+exit 99
+EOF
+    printf '#!/usr/bin/env bash\n' > "$project_python"
+    printf 'VIRTUAL_ENV=%s\nexport VIRTUAL_ENV\n' "$TEST_HOME/.base.d/demo/.venv" > "$project_activate"
+    chmod +x "$base_python" "$project_python" "$fake_zsh"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_ACTIVATE_SHELL="$fake_zsh" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BASE_ACTIVATE_SHELL"* ]]
+    [[ "$output" == *"requires Bash"* ]]
+    [[ "$output" != *"non-bash shell invoked"* ]]
 }
 
 @test "basectl activate reports missing project as a usage error" {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,13 +133,13 @@ activating a Python virtual environment. The naive approach of activate/deactiva
 (like Python venv) does not scale to the full richness of a shell environment. Tracking
 and restoring arbitrary shell state on deactivation is complex and error-prone.
 
-The solution: **spawn a subshell** when activating a project. The project environment
-lives inside the subshell. The user works in that subshell. When done, they `exit` (or
-Ctrl-D) and return to their base shell. No deactivation logic required. No state
-restoration complexity.
+The solution: **spawn a Bash runtime shell** when activating a project. The
+project environment lives inside that shell. The user works in that shell. When
+done, they `exit` (or Ctrl-D) and return to their base shell. No deactivation
+logic required. No state restoration complexity.
 
 This does not require a distinct shell function. A normal `basectl activate <project>`
-command can validate the target and launch the configured subshell.
+command can validate the target and launch the Bash runtime shell.
 
 ### Activation Flow
 
@@ -149,12 +149,12 @@ basectl activate myproject
 1. Look up BASE_HOME, resolve the workspace root, and scan known projects
 2. Validate myproject exists and has a valid manifest
 3. Set BASE_PROJECT=myproject
-4. Spawn a new subshell
-5. In the subshell: load the Base runtime and user Bash startup with guardrails
-6. In the subshell: activate the project's Python virtual environment
-7. In the subshell: source manifest-declared activate.source scripts
+4. Spawn a new Bash runtime shell
+5. In that shell: load the Base runtime and user Bash startup with guardrails
+6. In that shell: activate the project's Python virtual environment
+7. In that shell: source manifest-declared activate.source scripts
 8. Update the prompt to reflect the active project
-9. User works in subshell
+9. User works in the Bash runtime shell
 10. User exits → returns to base shell, prompt resets
 ```
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -18,7 +18,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | Command | What it does | Important flags |
 |---|---|---|
 | `basectl projects list` | Discover Base-managed projects under the workspace root. | `--workspace <path>`, `--format <text\|json>` |
-| `basectl activate <project>` | Start an interactive Base runtime subshell for a project. | `--workspace <path>`, `--no-cd` |
+| `basectl activate <project>` | Start an interactive Base Bash runtime shell for a project. | `--workspace <path>`, `--no-cd` |
 | `basectl test [project]` | Run the project's declared test command from the project root. | `--workspace <path>`, `--dry-run`, `-- <args>` |
 | `basectl run <project> <command>` | Run a named manifest command from the project root. | `--workspace <path>`, `--dry-run`, `-- <args>` |
 | `basectl run [project] --list` | List runnable commands declared by a project manifest. | `--workspace <path>` |

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -174,3 +174,21 @@ readonly by Base.
 Additional setup and bootstrap `BASE_SETUP_*`, `BASE_BOOTSTRAP_*`, and
 `BASE_INSTALL_*` variables exist for tests, CI, and narrow command overrides.
 Those are command-specific inputs, not shell runtime contract variables.
+
+### Activated Shell Contract
+
+`basectl activate <project>` starts an interactive Base Bash runtime shell with
+Base's runtime rcfile. The caller's login shell can be Bash, Zsh, or another
+shell, but activation itself is Bash so Base can load the Bash standard library,
+project virtual environment, manifest-declared `activate.source` scripts, and
+runtime prompt consistently.
+
+`BASE_ACTIVATE_SHELL` may point to a different Bash executable, such as a
+Homebrew-managed Bash. It must not point to Zsh or another non-Bash shell. Base
+rejects non-Bash values before exec so users see a direct configuration error
+instead of a Bash-rcfile failure from the target shell.
+
+Zsh-specific aliases, options, completions, and prompt customizations are not
+loaded in the activated Base runtime shell. Put shell-neutral shared settings in
+`~/.baserc` or project activation scripts when they need to apply to Base
+runtime activation.

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -75,10 +75,10 @@ convention-based library imports.
 
 **Layer 3 — Project environment** (`basectl activate <project>`)
 
-Spawns a subshell, sets `BASE_PROJECT`, activates the project venv at
+Spawns a Bash runtime shell, sets `BASE_PROJECT`, activates the project venv at
 `~/.base.d/<project>/.venv`, runs `activate.source` scripts declared in the
-manifest, and updates the prompt to `[project: branch] ~/path $`. Exit the
-subshell to return to the original environment — no deactivation logic needed.
+manifest, and updates the prompt to `[project: branch] ~/path $`. Exit that
+shell to return to the original environment - no deactivation logic needed.
 
 **Design choice — no `cd`-triggered activation:** switching directories does not
 change environment. Users explicitly activate projects with `basectl activate`.


### PR DESCRIPTION
## Summary
- Reject non-Bash BASE_ACTIVATE_SHELL values before execing the activated runtime shell.
- Clarify activate help, docs, and AI context around the Bash runtime shell contract.
- Document that Zsh-specific startup content is not loaded inside activated Base runtime shells.

## Validation
- bats cli/bash/commands/basectl/tests/activate.bats
- shellcheck --severity=error cli/bash/commands/basectl/subcommands/activate.sh
- git diff --check
- git diff --cached --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. Shell validation and documentation update only.

Fixes #716
Closes #717