### PR TITLE
Make setup BATS helper noninteractive under TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 ### Fixed
 
 - Reported a clear error when `BASE_ACTIVATE_SHELL` points to a non-Bash shell.
+- Made setup BATS command helpers run with noninteractive stdin so PTY-backed
+  test runs exercise recovery guidance consistently.
 - Redacted compound secret-like command-output assignments such as
   `GITHUB_TOKEN=...`, `DB_PASSWORD=...`, and
   `AWS_SECRET_ACCESS_KEY=...` from setup failure summaries and debug logs.

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -431,7 +431,8 @@ run_base_command() {
         BASE_SETUP_XCODE_WAIT_TIMEOUT_SECONDS=5 \
         BASE_SETUP_XCODE_WAIT_INTERVAL_SECONDS=0 \
         "${env_args[@]}" \
-        "$BASE_REPO_ROOT/bin/basectl" "${command_args[@]}"
+        "$BASE_REPO_ROOT/bin/basectl" "${command_args[@]}" \
+        </dev/null
 }
 
 run_base_command_separate_stderr() {
@@ -462,7 +463,8 @@ run_base_command_separate_stderr() {
         BASE_SETUP_XCODE_WAIT_TIMEOUT_SECONDS=5 \
         BASE_SETUP_XCODE_WAIT_INTERVAL_SECONDS=0 \
         "${env_args[@]}" \
-        "$BASE_REPO_ROOT/bin/basectl" "${command_args[@]}"
+        "$BASE_REPO_ROOT/bin/basectl" "${command_args[@]}" \
+        </dev/null
 }
 
 create_base_venv_stub() {


### PR DESCRIPTION
## Summary
- Run setup BATS command helpers with stdin redirected from /dev/null.
- Document the PTY-backed test harness fix in the changelog.

## Root Cause
- When BATS was launched from an interactive terminal, run_base_command could pass a TTY-backed stdin through to basectl setup.
- setup then treated the test invocation as interactive and exercised the xcode-select --install path instead of the noninteractive recovery guidance path.

## Validation
- Red: env -u BASE_HOME bats --filter "basectl setup gives recovery guidance when Xcode install needs an interactive terminal" cli/bash/commands/basectl/tests/setup.bats under PTY failed before the fix.
- Green: same PTY-filtered BATS case passes.
- env -u BASE_HOME bats cli/bash/commands/basectl/tests/setup.bats under PTY
- ./bin/basectl test base under PTY: 422 Python tests passed; 460 BATS tests passed, 1 skipped.
- git diff --check

Closes #720