### PR TITLE
Warn on outdated Xcode Command Line Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   logs while stderr is still a terminal.
 - Made `base_cli.App` reject duplicate command registrations instead of
   silently overwriting the first command.
+- Made `basectl doctor` warn when Homebrew reports installed Xcode Command Line
+  Tools are outdated or incomplete.
 
 ## [1.0.0] - 2026-06-14
 

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -139,6 +139,15 @@ base_doctor_check_homebrew() {
 
 base_doctor_check_xcode() {
     if setup_xcode_tools_installed; then
+        if setup_homebrew_reports_xcode_tools_issue; then
+            base_doctor_print_finding \
+                "warn" \
+                "BASE-D002" \
+                "Xcode Command Line Tools" \
+                "Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete." \
+                "$(setup_recovery_xcode_tools_update)"
+            return 0
+        fi
         base_doctor_print_finding \
             "ok" \
             "BASE-D002" \
@@ -211,7 +220,7 @@ base_doctor_run_json() {
     local remote_network="${2:-${BASE_SETUP_REMOTE_NETWORK:-}}"
     local status="ok"
 
-    setup_collect_base_check_results warn || true
+    BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true setup_collect_base_check_results warn || true
     errors="$(base_doctor_count_check_errors)"
     status="$(setup_check_results_status)"
 

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -21,6 +21,7 @@ _BASE_SETUP_VENV_DIR_CACHE=""
 _BASE_SETUP_PYTHONPATH_CACHE=""
 _BASE_SETUP_CHECK_NAMES=()
 _BASE_SETUP_CHECK_OK=()
+_BASE_SETUP_CHECK_STATUSES=()
 _BASE_SETUP_CHECK_MESSAGES=()
 _BASE_SETUP_CHECK_RECOVERIES=()
 _BASE_SETUP_CHECK_DEBUG_MESSAGES=()
@@ -358,6 +359,10 @@ setup_recovery_xcode_tools() {
     printf "%s\n" "Run 'xcode-select --install' in an interactive terminal, complete the installer, then rerun 'basectl setup'."
 }
 
+setup_recovery_xcode_tools_update() {
+    printf "%s\n" "Update Xcode Command Line Tools from Software Update, or reinstall them with 'xcode-select --install'."
+}
+
 setup_recovery_python() {
     printf "Run 'basectl setup' to install Homebrew Python, or run 'brew install %s'.\n" "$(setup_python_formula)"
 }
@@ -449,6 +454,25 @@ setup_refresh_brew_path() {
     brew_bin="$(setup_find_brew_bin)" || return 1
     add_to_path -p "$(dirname "$brew_bin")"
     return 0
+}
+
+setup_homebrew_doctor_output() {
+    local brew_bin
+
+    brew_bin="$(setup_find_brew_bin)" || return 1
+    "$brew_bin" doctor 2>&1 || true
+}
+
+setup_homebrew_reports_xcode_tools_issue() {
+    local doctor_output
+
+    doctor_output="$(setup_homebrew_doctor_output)" || return 1
+    [[ "$doctor_output" == *"Command Line Tools are too outdated"* ||
+        "$doctor_output" == *"Command Line Tools installation may be broken or incomplete"* ]]
+}
+
+setup_xcode_homebrew_diagnostics_enabled() {
+    [[ "${BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS:-false}" == true ]]
 }
 
 setup_install_homebrew() {
@@ -1135,9 +1159,38 @@ setup_run_base_dev_layer() {
 setup_clear_check_results() {
     _BASE_SETUP_CHECK_NAMES=()
     _BASE_SETUP_CHECK_OK=()
+    _BASE_SETUP_CHECK_STATUSES=()
     _BASE_SETUP_CHECK_MESSAGES=()
     _BASE_SETUP_CHECK_RECOVERIES=()
     _BASE_SETUP_CHECK_DEBUG_MESSAGES=()
+}
+
+setup_add_check_result_with_status() {
+    local name="$1"
+    local status="$2"
+    local message="$3"
+    local recovery="${4:-}"
+    local debug_message="${5:-}"
+    local ok=true
+
+    case "$status" in
+        ok|warn)
+            ok=true
+            ;;
+        error)
+            ok=false
+            ;;
+        *)
+            fatal_error "Invalid Base check status '$status'."
+            ;;
+    esac
+
+    _BASE_SETUP_CHECK_NAMES+=("$name")
+    _BASE_SETUP_CHECK_OK+=("$ok")
+    _BASE_SETUP_CHECK_STATUSES+=("$status")
+    _BASE_SETUP_CHECK_MESSAGES+=("$message")
+    _BASE_SETUP_CHECK_RECOVERIES+=("$recovery")
+    _BASE_SETUP_CHECK_DEBUG_MESSAGES+=("$debug_message")
 }
 
 setup_add_check_result() {
@@ -1146,12 +1199,10 @@ setup_add_check_result() {
     local message="$3"
     local recovery="${4:-}"
     local debug_message="${5:-}"
+    local status
 
-    _BASE_SETUP_CHECK_NAMES+=("$name")
-    _BASE_SETUP_CHECK_OK+=("$ok")
-    _BASE_SETUP_CHECK_MESSAGES+=("$message")
-    _BASE_SETUP_CHECK_RECOVERIES+=("$recovery")
-    _BASE_SETUP_CHECK_DEBUG_MESSAGES+=("$debug_message")
+    status="$(setup_diagnostic_status_from_ok "$ok")"
+    setup_add_check_result_with_status "$name" "$status" "$message" "$recovery" "$debug_message"
 }
 
 setup_write_check_result_file() {
@@ -1161,10 +1212,16 @@ setup_write_check_result_file() {
     local ok="$3"
     local path="$1"
     local recovery="${5:-}"
+    local status="${7:-}"
+
+    if [[ -z "$status" ]]; then
+        status="$(setup_diagnostic_status_from_ok "$ok")"
+    fi
 
     {
         printf 'name=%s\n' "$name"
         printf 'ok=%s\n' "$ok"
+        printf 'status=%s\n' "$status"
         printf 'message=%s\n' "$message"
         printf 'recovery=%s\n' "$recovery"
         printf 'debug=%s\n' "$debug_message"
@@ -1178,6 +1235,7 @@ setup_parse_check_result_file() {
 
     _BASE_SETUP_PARSED_CHECK_NAME=""
     _BASE_SETUP_PARSED_CHECK_OK=""
+    _BASE_SETUP_PARSED_CHECK_STATUS=""
     _BASE_SETUP_PARSED_CHECK_MESSAGE=""
     _BASE_SETUP_PARSED_CHECK_RECOVERY=""
     _BASE_SETUP_PARSED_CHECK_DEBUG_MESSAGE=""
@@ -1189,6 +1247,9 @@ setup_parse_check_result_file() {
                 ;;
             ok=*)
                 _BASE_SETUP_PARSED_CHECK_OK="${line#ok=}"
+                ;;
+            status=*)
+                _BASE_SETUP_PARSED_CHECK_STATUS="${line#status=}"
                 ;;
             message=*)
                 _BASE_SETUP_PARSED_CHECK_MESSAGE="${line#message=}"
@@ -1210,13 +1271,23 @@ setup_parse_check_result_file() {
             fatal_error "Base check probe result '$path' has invalid ok value '$_BASE_SETUP_PARSED_CHECK_OK'."
             ;;
     esac
+    if [[ -z "$_BASE_SETUP_PARSED_CHECK_STATUS" ]]; then
+        _BASE_SETUP_PARSED_CHECK_STATUS="$(setup_diagnostic_status_from_ok "$_BASE_SETUP_PARSED_CHECK_OK")"
+    fi
+    case "$_BASE_SETUP_PARSED_CHECK_STATUS" in
+        ok|warn|error)
+            ;;
+        *)
+            fatal_error "Base check probe result '$path' has invalid status value '$_BASE_SETUP_PARSED_CHECK_STATUS'."
+            ;;
+    esac
     [[ -n "$_BASE_SETUP_PARSED_CHECK_MESSAGE" ]] || fatal_error "Base check probe result '$path' is missing a message."
 }
 
 setup_add_parsed_check_result() {
-    setup_add_check_result \
+    setup_add_check_result_with_status \
         "$_BASE_SETUP_PARSED_CHECK_NAME" \
-        "$_BASE_SETUP_PARSED_CHECK_OK" \
+        "$_BASE_SETUP_PARSED_CHECK_STATUS" \
         "$_BASE_SETUP_PARSED_CHECK_MESSAGE" \
         "$_BASE_SETUP_PARSED_CHECK_RECOVERY" \
         "$_BASE_SETUP_PARSED_CHECK_DEBUG_MESSAGE"
@@ -1225,7 +1296,7 @@ setup_add_parsed_check_result() {
 setup_read_check_result_file() {
     setup_parse_check_result_file "$1"
     setup_add_parsed_check_result
-    [[ "$_BASE_SETUP_PARSED_CHECK_OK" == true ]]
+    [[ "$_BASE_SETUP_PARSED_CHECK_STATUS" != error ]]
 }
 
 setup_read_homebrew_check_result_file() {
@@ -1282,6 +1353,17 @@ setup_write_xcode_check_probe() {
     local result_file="$1"
 
     if setup_xcode_tools_installed; then
+        if setup_xcode_homebrew_diagnostics_enabled && setup_homebrew_reports_xcode_tools_issue; then
+            setup_write_check_result_file \
+                "$result_file" \
+                "xcode_command_line_tools" \
+                true \
+                "Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete." \
+                "$(setup_recovery_xcode_tools_update)" \
+                "" \
+                "warn"
+            return 0
+        fi
         setup_write_check_result_file \
             "$result_file" \
             "xcode_command_line_tools" \
@@ -1482,22 +1564,53 @@ setup_collect_base_check_results() {
 }
 
 setup_print_check_text_results() {
-    local count i
+    local count i status
 
     count="${#_BASE_SETUP_CHECK_NAMES[@]}"
     for ((i = 0; i < count; i++)); do
-        if [[ "${_BASE_SETUP_CHECK_OK[$i]}" == true ]]; then
-            log_info "${_BASE_SETUP_CHECK_MESSAGES[$i]}"
-            if [[ -n "${_BASE_SETUP_CHECK_DEBUG_MESSAGES[$i]}" ]]; then
-                log_debug "${_BASE_SETUP_CHECK_DEBUG_MESSAGES[$i]}"
-            fi
-        else
-            log_warn "${_BASE_SETUP_CHECK_MESSAGES[$i]}"
-            if [[ -n "${_BASE_SETUP_CHECK_RECOVERIES[$i]}" ]]; then
-                log_warn "${_BASE_SETUP_CHECK_RECOVERIES[$i]}"
-            fi
-        fi
+        status="${_BASE_SETUP_CHECK_STATUSES[$i]:-$(setup_diagnostic_status_from_ok "${_BASE_SETUP_CHECK_OK[$i]}")}"
+        case "$status" in
+            ok)
+                log_info "${_BASE_SETUP_CHECK_MESSAGES[$i]}"
+                if [[ -n "${_BASE_SETUP_CHECK_DEBUG_MESSAGES[$i]}" ]]; then
+                    log_debug "${_BASE_SETUP_CHECK_DEBUG_MESSAGES[$i]}"
+                fi
+                ;;
+            warn|error)
+                log_warn "${_BASE_SETUP_CHECK_MESSAGES[$i]}"
+                if [[ -n "${_BASE_SETUP_CHECK_RECOVERIES[$i]}" ]]; then
+                    log_warn "${_BASE_SETUP_CHECK_RECOVERIES[$i]}"
+                fi
+                ;;
+            *)
+                fatal_error "Invalid Base check status '$status'."
+                ;;
+        esac
     done
+}
+
+setup_check_result_status() {
+    local index="$1"
+    local status
+
+    status="${_BASE_SETUP_CHECK_STATUSES[$index]:-}"
+    if [[ -z "$status" ]]; then
+        status="$(setup_diagnostic_status_from_ok "${_BASE_SETUP_CHECK_OK[$index]}")"
+    fi
+    printf '%s\n' "$status"
+}
+
+setup_check_result_recovery() {
+    local index="$1"
+    local status
+
+    status="$(setup_check_result_status "$index")"
+    if [[ "$status" == ok ]]; then
+        printf '\n'
+        return 0
+    fi
+
+    printf '%s\n' "${_BASE_SETUP_CHECK_RECOVERIES[$index]}"
 }
 
 setup_run_check() {
@@ -1619,7 +1732,7 @@ setup_check_results_status() {
 
     count="${#_BASE_SETUP_CHECK_NAMES[@]}"
     for ((i = 0; i < count; i++)); do
-        status="$(setup_merge_diagnostic_status "$status" "$(setup_diagnostic_status_from_ok "${_BASE_SETUP_CHECK_OK[$i]}")")"
+        status="$(setup_merge_diagnostic_status "$status" "$(setup_check_result_status "$i")")"
     done
 
     printf '%s\n' "$status"
@@ -1677,11 +1790,8 @@ setup_print_check_json_results() {
         if ((i == count - 1)); then
             trailing_comma=""
         fi
-        status="$(setup_diagnostic_status_from_ok "${_BASE_SETUP_CHECK_OK[$i]}")"
-        fix="${_BASE_SETUP_CHECK_RECOVERIES[$i]}"
-        if [[ "$status" == ok ]]; then
-            fix=""
-        fi
+        status="$(setup_check_result_status "$i")"
+        fix="$(setup_check_result_recovery "$i")"
         setup_print_check_json_item \
             "$trailing_comma" \
             "$(setup_base_check_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -93,6 +93,69 @@ EOF
     [[ "$output" == *"Base doctor found no blocking issues."* ]]
 }
 
+@test "basectl doctor warns when Homebrew reports outdated Xcode Command Line Tools" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+if [[ "${1:-}" == "doctor" ]]; then
+    printf 'Warning: Your Command Line Tools are too outdated.\n'
+    printf 'Update them from Software Update in System Settings.\n'
+    exit 1
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+exit 1
+EOF
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$venv_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"warn"*"BASE-D002"*"Xcode Command Line Tools"*"Homebrew reports they are outdated or incomplete."* ]]
+    [[ "$output" == *"Fix: Update Xcode Command Line Tools from Software Update, or reinstall them with 'xcode-select --install'."* ]]
+    [[ "$output" == *"Base doctor found no blocking issues."* ]]
+}
+
 @test "basectl doctor --profile dev reports missing GitHub CLI" {
     local fake_bin="$TEST_TMPDIR/bin"
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
@@ -266,6 +329,69 @@ EOF
     [[ "$output" == *'"id":"BASE-D005","status":"error","name":"pyyaml"'* ]]
     [[ "$output" == *'"id":"BASE-D006","status":"error","name":"click"'* ]]
     [[ "$output" != *"Base doctor"* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl doctor --format json reports outdated Xcode Command Line Tools warning" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    cat > "$fake_bin/brew" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+    case "${2:-}" in
+        python@3.13) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "--prefix" ]]; then
+    printf '/tmp/fake-prefix\n'
+    exit 0
+fi
+if [[ "${1:-}" == "doctor" ]]; then
+    printf 'Warning: Your Command Line Tools are too outdated.\n'
+    printf 'Update them from Software Update in System Settings.\n'
+    exit 1
+fi
+exit 1
+EOF
+    cat > "$fake_bin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-p" ]]; then
+    printf '%s\n' "${BASE_TEST_XCODE_TOOLS_DIR:?}"
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+exit 1
+EOF
+    chmod +x "$fake_bin/brew" "$fake_bin/xcode-select" "$venv_python"
+    mkdir -p "$TEST_TMPDIR/xcode-tools/usr/bin"
+    touch "$TEST_TMPDIR/xcode-tools/usr/bin/clang"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status": "warn"'* ]]
+    [[ "$output" == *'"id":"BASE-D002","status":"warn","name":"xcode_command_line_tools","message":"Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete.","fix":"Update Xcode Command Line Tools from Software Update, or reinstall them with '\''xcode-select --install'\''."'* ]]
     [ "${stderr:-}" = "" ]
 }
 

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -75,7 +75,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | ID | Finding |
 | --- | --- |
 | `BASE-D001` | Homebrew availability and PATH refresh |
-| `BASE-D002` | Xcode Command Line Tools availability |
+| `BASE-D002` | Xcode Command Line Tools availability and Homebrew freshness |
 | `BASE-D003` | Homebrew Python formula availability |
 | `BASE-D004` | Base virtual environment integrity |
 | `BASE-D005` | Base `PyYAML` package availability |


### PR DESCRIPTION
## Summary
- Detect Homebrew doctor warnings for outdated or incomplete Xcode Command Line Tools.
- Surface the CLT freshness problem as a non-blocking BASE-D002 warning in text and JSON doctor output.
- Add warning-status plumbing for Base check result collection and document the finding.

## Validation
- bats cli/bash/commands/basectl/tests/doctor.bats
- bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats
- shellcheck --severity=error cli/bash/commands/basectl/subcommands/doctor.sh cli/bash/commands/basectl/subcommands/setup_common.sh
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. Diagnostics-only change.

Closes #721