### PR TITLE
Generate AGPL licenses for new repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Made `basectl repo init` generate AGPL-3.0-or-later licenses for new
+  repositories.
 - Relicensed Base prospectively from MIT to AGPL-3.0-or-later.
 - Aligned bootstrap and installer candidate-list splitting with the scoped
   `IFS=: read -ra` Bash pattern.

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ basectl repo init example --repo codeforester/example
 ```
 
 This creates the local repository baseline: README, version, changelog,
-contributing guide, MIT license, `.gitignore`, `base_manifest.yaml`, a
+contributing guide, AGPL-3.0-or-later license, `.gitignore`, `base_manifest.yaml`, a
 `tests/validate.sh` contract, and a GitHub Actions workflow that runs it.
 By default, `repo init` creates the repository under `workspace.root` from
 `~/.base.d/config.yaml`; if that is not configured, it falls back to the parent

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -54,7 +54,7 @@ Options:
   --repo <owner/name>           GitHub repository to configure.
   --pr                          Commit the generated baseline on a branch and open a pull request.
   --description <text>          Repository description for generated README.
-  --copyright-holder <name>     Copyright holder for generated LICENSE. Defaults to git config user.name.
+  --copyright-holder <name>     Copyright holder for generated AGPL license. Defaults to git config user.name.
   --private                     Create a private GitHub repository when needed. This is the default.
   --public                      Create a public GitHub repository when needed.
   --no-configure                Skip GitHub configuration during repo init.
@@ -740,32 +740,34 @@ base_repo_write_license() {
     local copyright_holder="$2"
     local dry_run="$1"
     local root="$3"
+    local source_license="${BASE_HOME:-}/LICENSE"
     local year
 
+    [[ -f "$source_license" ]] || {
+        log_error "Base AGPL license text '$source_license' was not found."
+        return 1
+    }
+
     year="$(base_repo_baseline_year)"
-    base_repo_write_stream "$dry_run" "$root/LICENSE" <<EOF
-MIT License
+    {
+        cat <<EOF
+Copyright (C) $year $copyright_holder
 
-Copyright (c) $year $copyright_holder
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
 EOF
+        printf '\n'
+        cat "$source_license"
+    } | base_repo_write_stream "$dry_run" "$root/LICENSE"
 }
 
 base_repo_write_gitignore() {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -313,6 +313,7 @@ load ./basectl_helpers.bash
     grep -Fq "## Checklist" "$repo_dir/.github/pull_request_template.md"
     grep -Fq "CHANGELOG is updated for notable user-visible or release-worthy changes." "$repo_dir/.github/pull_request_template.md"
     ! grep -Fq "Demo Impact" "$repo_dir/.github/pull_request_template.md"
+    grep -Fq "GNU Affero General Public License" "$repo_dir/LICENSE"
 
     run bash -c 'cd "$1" && ./tests/validate.sh' _ "$repo_dir"
     [ "$status" -eq 0 ]
@@ -338,7 +339,8 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" repo init git-owner --path "$repo_dir" --no-configure
 
     [ "$status" -eq 0 ]
-    grep -Fq "Copyright (c) $(date +%Y) Ada Lovelace" "$repo_dir/LICENSE"
+    grep -Fq "Copyright (C) $(date +%Y) Ada Lovelace" "$repo_dir/LICENSE"
+    grep -Fq "GNU Affero General Public License as published by" "$repo_dir/LICENSE"
 }
 
 @test "basectl repo init falls back to system username for copyright holder" {
@@ -358,7 +360,8 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" repo init system-owner --path "$repo_dir" --no-configure
 
     [ "$status" -eq 0 ]
-    grep -Fq "Copyright (c) $(date +%Y) $username" "$repo_dir/LICENSE"
+    grep -Fq "Copyright (C) $(date +%Y) $username" "$repo_dir/LICENSE"
+    grep -Fq "GNU Affero General Public License as published by" "$repo_dir/LICENSE"
 }
 
 @test "basectl repo init leaves existing files unchanged" {


### PR DESCRIPTION
## Summary
- Make `basectl repo init` generate AGPL-3.0-or-later license notices for new repos.
- Reuse Base's bundled root AGPL text so generated licenses stay aligned with Base.
- Update repo-init docs, changelog, and BATS expectations.

## Issue
Fixes #727

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats (red before implementation; failed on expected AGPL assertions)
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- git diff --cached --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
None. Repository scaffolding behavior only.

## Notes
This follows the Base relicensing in #729 / #726 and changes future repo scaffolding defaults only.