### PR TITLE
Add AGPL application notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,19 @@
+Base - a workspace control plane for developers who keep multiple repositories checked out side by side.
+Copyright (C) 2026 Ramesh Padmanabhaiah
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 


### PR DESCRIPTION
## Summary
- Add a Base-specific AGPL application notice to the top of LICENSE.
- Keep the GNU AGPL v3 license text intact underneath.

## Issue
Fixes #731

## Validation
- `grep -Fq "Copyright (C) 2026 Ramesh Padmanabhaiah" LICENSE`
- `git diff --check`
- `git diff --cached --check`

## Demo Impact
None. Documentation/license text only.

## Notes
- The AGPL "How to Apply These Terms to Your New Programs" appendix remains unchanged, including its template placeholders, because it is part of the official license document.
- Project status could not be updated through `basectl gh` because the local `gh` token is invalid; issue and PR creation used the GitHub connector instead.