### PR TITLE
Fix repo Project intake defaults

### DIFF
--- a/.github/base-project.yml
+++ b/.github/base-project.yml
@@ -1,0 +1,27 @@
+project:
+  areas:
+    - CLI
+    - Setup
+    - Workspace
+    - Manifest
+    - Runtime
+    - Shell
+    - Python
+    - Docs
+    - CI
+    - Packaging
+    - Security
+    - Product
+  initiatives:
+    - BanyanLabs Dogfood
+    - BanyanLabs Dogfooding
+    - Workspace Handling
+    - pyproject/uv
+    - v1.0 Readiness
+    - Adoption Polish
+  issue_defaults:
+    status: Backlog
+    priority: P2
+    area: Product
+    initiative: Adoption Polish
+    size: S

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Added
 
+- Added Base's own `.github/base-project.yml` so Base issues get repo Project
+  defaults through the same reviewed config file as other Base-managed repos.
 - Added `base_cli.ExitCode` constants for Base's standard command return
   values.
 - Added `cwd` support to `base_cli.testing.invoke()` so tests can run commands
@@ -46,6 +48,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made `basectl repo configure` apply `.github/base-project.yml`
+  `issue_defaults` to existing repo Project issue items that are missing those
+  values.
 - Reported a clear error when `BASE_ACTIVATE_SHELL` points to a non-Bash shell.
 - Made setup BATS command helpers run with noninteractive stdin so PTY-backed
   test runs exercise recovery guidance consistently.

--- a/README.md
+++ b/README.md
@@ -460,7 +460,8 @@ Base-managed default branch protection ruleset, configures a repo-named GitHub
 Project copied from `base-project-template`, and creates the standard GitHub
 labels documented in [Repository Baseline](docs/repo-baseline.md).
 When `.github/base-project.yml` exists, `repo configure` also adds missing
-repo-specific `Area` and `Initiative` Project options from that file.
+repo-specific `Area` and `Initiative` Project options from that file and applies
+its `issue_defaults` to Project issue items that are missing those values.
 Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -88,11 +88,13 @@ such command directories exist. Optional utility CLIs such as `caff` and
   Project title matches the repository name; missing Projects are copied from
   `base-project-template`, linked to the repository, and backfilled with
   repository issues. When `.github/base-project.yml` exists, repo-specific
-  `Area` and `Initiative` options are added from that file. Use `--no-project`
-  to skip Project setup, `--project <title>` to override the Project title, or
+  `Area` and `Initiative` options are added from that file and `issue_defaults`
+  are applied to missing Project item field values. Use `--no-project` to skip
+  Project setup, `--project <title>` to override the Project title, or
   `--initiative-option <name>` to seed repository-specific Initiative values.
   Use `--copy-project-fields-from <title>` during migration to copy missing
-  issue item field values from an existing Project into the repo Project.
+  issue item field values from an existing Project before config defaults fill
+  remaining blanks in the repo Project.
   `basectl repo agent-guidance [path]` seeds optional repo-local agent guidance
   files and `basectl repo check [path] --agent-guidance` verifies that optional
   layer for repos that opt in.

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -864,6 +864,8 @@ project:
   issue_defaults:
     status: Backlog
     priority: P2
+    area: Product
+    initiative: Adoption Polish
     size: S
 EOF
 }
@@ -1119,6 +1121,7 @@ base_repo_configure_project_metadata() {
         printf "[DRY-RUN] Would backfill issues from '%s' into GitHub Project '%s'.\n" "$repo" "$project_title"
         if [[ -n "$config_path" ]]; then
             printf "[DRY-RUN] Would read GitHub Project config from '%s'.\n" "$config_path"
+            printf "[DRY-RUN] Would apply issue defaults from '%s' to missing Project item fields.\n" "$config_path"
         fi
         if [[ -n "$copy_fields_from_project" ]]; then
             printf "[DRY-RUN] Would copy missing Project item field values from '%s' into '%s'.\n" \

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -306,6 +306,8 @@ load ./basectl_helpers.bash
     grep -Fq "issue_defaults:" "$repo_dir/.github/base-project.yml"
     grep -Fq "status: Backlog" "$repo_dir/.github/base-project.yml"
     grep -Fq "priority: P2" "$repo_dir/.github/base-project.yml"
+    grep -Fq "area: Product" "$repo_dir/.github/base-project.yml"
+    grep -Fq "initiative: Adoption Polish" "$repo_dir/.github/base-project.yml"
     grep -Fq "size: S" "$repo_dir/.github/base-project.yml"
     grep -Fq "<category>/<issue>-<YYYYMMDD>-<slug>" "$repo_dir/CONTRIBUTING.md"
     grep -Fq "git worktree add -b <branch> ../base-demo-worktrees/<slug> origin/<default-branch>" "$repo_dir/CONTRIBUTING.md"
@@ -527,6 +529,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Would read GitHub Project config from '$repo_dir/.github/base-project.yml'."* ]]
+    [[ "$output" == *"Would apply issue defaults from '$repo_dir/.github/base-project.yml' to missing Project item fields."* ]]
     [[ "$output" == *"--config $repo_dir/.github/base-project.yml"* ]]
 }
 

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from . import graphql_queries as queries
 from .project_item_fields import FieldCopySummary
+from .project_item_fields import apply_missing_project_item_defaults as _apply_missing_project_item_defaults
 from .project_item_fields import copy_missing_project_item_fields as _copy_missing_project_item_fields
 from .project_model import BASE_ROADMAP_SCHEMA, DEFAULT_TEMPLATE_PROJECT, FIELD_OPTION_TO_PROJECT_FIELD
 from .project_model import STANDARD_TEMPLATE_VIEWS, ConfigureAction, FieldUpdate, Finding, OwnerInfo
@@ -264,6 +265,15 @@ def issue_field_values_for_args(args: ProjectArguments) -> dict[str, str]:
     return values
 
 
+def project_field_defaults_for_config(config: ProjectConfig) -> dict[str, str]:
+    defaults: dict[str, str] = {}
+    for value_key, field_name in FIELD_OPTION_TO_PROJECT_FIELD.items():
+        option_name = config.issue_defaults.get(value_key)
+        if option_name:
+            defaults[field_name] = option_name
+    return defaults
+
+
 def read_project_config(path: Path) -> ProjectConfig:
     try:
         return _read_project_config(path)
@@ -447,11 +457,13 @@ def configure_command(args: ProjectArguments) -> int:
             create_single_select_field(project.project_id, spec)
         elif missing_option_names(field, spec):
             update_single_select_field(field, spec)
+    fields = fetch_project_fields(project.project_id)
     if args.repo:
         link_project_to_repository(project.project_id, args.repo)
         count = backfill_repository_issues(project.project_id, args.repo)
         print(f"✓ Backfilled {count} issue(s) from {args.repo}")
     copy_project_fields_from_source(owner, project.project_id, args.copy_fields_from_project)
+    apply_project_config_defaults(project.project_id, fields, project_config)
     print(f"✓ Configured GitHub Project {args.project_title}")
     return 0
 
@@ -464,6 +476,23 @@ def copy_project_fields_from_source(owner: str, target_project_id: str, source_p
         raise ProjectError(f"Source Project '{source_project_title}' was not found for owner '{owner}'.")
     summary = copy_missing_project_item_fields(source.project_id, target_project_id)
     print(f"✓ Copied {summary.applied_count} Project item field value(s) from {source_project_title}")
+    for skipped in summary.skipped:
+        print(
+            f"WARN    Issue #{skipped.issue_number} {skipped.field_name}={skipped.option_name}: {skipped.reason}",
+            file=sys.stderr,
+        )
+
+
+def apply_project_config_defaults(
+    target_project_id: str,
+    target_fields: tuple[ProjectField, ...],
+    project_config: ProjectConfig,
+) -> None:
+    defaults = project_field_defaults_for_config(project_config)
+    if not defaults:
+        return
+    summary = apply_missing_project_item_defaults(target_project_id, target_fields, defaults)
+    print(f"✓ Applied {summary.applied_count} default Project item field value(s)")
     for skipped in summary.skipped:
         print(
             f"WARN    Issue #{skipped.issue_number} {skipped.field_name}={skipped.option_name}: {skipped.reason}",
@@ -496,6 +525,13 @@ def render_dry_run_configure(
         print(f"[DRY-RUN] Would ensure Area option {option}.")
     for option in config.initiatives:
         print(f"[DRY-RUN] Would ensure Initiative option {option}.")
+    if config.issue_defaults:
+        rendered = ", ".join(
+            f"{FIELD_OPTION_TO_PROJECT_FIELD[key]}={value}"
+            for key, value in config.issue_defaults.items()
+            if key in FIELD_OPTION_TO_PROJECT_FIELD
+        )
+        print(f"[DRY-RUN] Would apply issue defaults to missing Project item fields: {rendered}.")
     print("[DRY-RUN] Fields: Status, Priority, Area, Size, Initiative")
     if args.initiative_options:
         for option in args.initiative_options:
@@ -871,4 +907,17 @@ def copy_missing_project_item_fields(source_project_id: str, target_project_id: 
         source_project_id=source_project_id,
         target_project_id=target_project_id,
         target_fields=fetch_project_fields(target_project_id),
+    )
+
+
+def apply_missing_project_item_defaults(
+    target_project_id: str,
+    target_fields: tuple[ProjectField, ...],
+    field_defaults: dict[str, str],
+) -> FieldCopySummary:
+    return _apply_missing_project_item_defaults(
+        run_graphql=run_graphql,
+        target_project_id=target_project_id,
+        target_fields=target_fields,
+        field_defaults=field_defaults,
     )

--- a/cli/python/base_github_projects/project_item_fields.py
+++ b/cli/python/base_github_projects/project_item_fields.py
@@ -102,6 +102,47 @@ def plan_missing_field_copies(
     return ProjectFieldCopyPlan(tuple(updates), tuple(skipped))
 
 
+def plan_missing_field_defaults(
+    *,
+    target_items: dict[str, ProjectIssueItem],
+    target_fields: dict[str, ProjectSelectField],
+    field_defaults: dict[str, str],
+) -> ProjectFieldCopyPlan:
+    updates: list[ProjectFieldCopy] = []
+    skipped: list[ProjectFieldCopySkip] = []
+    for target in sorted(target_items.values(), key=lambda item: item.issue_number):
+        for field_name, option_name in field_defaults.items():
+            if target.values.get(field_name):
+                continue
+            target_field = target_fields.get(field_name)
+            if target_field is None:
+                skipped.append(
+                    ProjectFieldCopySkip(
+                        target.issue_number, field_name, option_name, "target field is missing"
+                    )
+                )
+                continue
+            option_id = target_field.options.get(option_name)
+            if option_id is None:
+                skipped.append(
+                    ProjectFieldCopySkip(
+                        target.issue_number, field_name, option_name, "target option is missing"
+                    )
+                )
+                continue
+            updates.append(
+                ProjectFieldCopy(
+                    item_id=target.item_id,
+                    issue_number=target.issue_number,
+                    field_name=field_name,
+                    option_name=option_name,
+                    field_id=target_field.field_id,
+                    option_id=option_id,
+                )
+            )
+    return ProjectFieldCopyPlan(tuple(updates), tuple(skipped))
+
+
 def copy_missing_project_item_fields(
     *,
     run_graphql: Callable[[str, dict[str, object]], dict[str, object]],
@@ -113,6 +154,31 @@ def copy_missing_project_item_fields(
         source_items=fetch_project_issue_items(run_graphql, source_project_id),
         target_items=fetch_project_issue_items(run_graphql, target_project_id),
         target_fields=select_fields_by_name(target_fields),
+    )
+    for update in plan.updates:
+        run_graphql(
+            queries.UPDATE_ITEM_FIELD,
+            {
+                "projectId": target_project_id,
+                "itemId": update.item_id,
+                "fieldId": update.field_id,
+                "optionId": update.option_id,
+            },
+        )
+    return FieldCopySummary(len(plan.updates), plan.skipped)
+
+
+def apply_missing_project_item_defaults(
+    *,
+    run_graphql: Callable[[str, dict[str, object]], dict[str, object]],
+    target_project_id: str,
+    target_fields: Iterable[object],
+    field_defaults: dict[str, str],
+) -> FieldCopySummary:
+    plan = plan_missing_field_defaults(
+        target_items=fetch_project_issue_items(run_graphql, target_project_id),
+        target_fields=select_fields_by_name(target_fields),
+        field_defaults=field_defaults,
     )
     for update in plan.updates:
         run_graphql(

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -543,6 +543,105 @@ def test_configure_command_copies_missing_project_fields_when_requested(
     assert copied == [("source-project", "target-project")]
 
 
+def test_configure_command_applies_issue_defaults_from_project_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "base-project.yml"
+    config_path.write_text(
+        "project:\n"
+        "  areas:\n"
+        "    - Product\n"
+        "  initiatives:\n"
+        "    - Adoption Polish\n"
+        "  issue_defaults:\n"
+        "    status: Backlog\n"
+        "    priority: P2\n"
+        "    area: Product\n"
+        "    initiative: Adoption Polish\n"
+        "    size: S\n",
+        encoding="utf-8",
+    )
+    fields = (
+        engine.ProjectField(
+            field_id="status-field",
+            name="Status",
+            data_type="SINGLE_SELECT",
+            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Status").options,
+        ),
+        engine.ProjectField(
+            field_id="priority-field",
+            name="Priority",
+            data_type="SINGLE_SELECT",
+            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority").options,
+        ),
+        engine.ProjectField(
+            field_id="area-field",
+            name="Area",
+            data_type="SINGLE_SELECT",
+            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Area").options,
+        ),
+        engine.ProjectField(
+            field_id="initiative-field",
+            name="Initiative",
+            data_type="SINGLE_SELECT",
+            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Initiative").options,
+        ),
+        engine.ProjectField(
+            field_id="size-field",
+            name="Size",
+            data_type="SINGLE_SELECT",
+            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Size").options,
+        ),
+    )
+    applied: list[tuple[str, dict[str, str]]] = []
+
+    def fake_find_owner_and_project(owner: str, title: str) -> engine.OwnerInfo:
+        return engine.OwnerInfo(
+            owner_id="owner-id",
+            login=owner,
+            project=engine.ProjectInfo(project_id="target-project", title=title),
+        )
+
+    monkeypatch.setattr(engine, "find_owner_and_project", fake_find_owner_and_project)
+    monkeypatch.setattr(engine, "fetch_project_fields", lambda project_id: fields)
+    monkeypatch.setattr(engine, "create_single_select_field", lambda project_id, spec: None)
+    monkeypatch.setattr(engine, "update_single_select_field", lambda field, spec: None)
+    monkeypatch.setattr(engine, "link_project_to_repository", lambda project_id, repo: None)
+    monkeypatch.setattr(engine, "backfill_repository_issues", lambda project_id, repo: 0)
+    monkeypatch.setattr(
+        engine,
+        "apply_missing_project_item_defaults",
+        lambda project_id, target_fields, defaults: applied.append((project_id, defaults))
+        or engine.FieldCopySummary(5, ()),
+    )
+
+    status = engine.configure_command(
+        engine.ProjectArguments(
+            area="project",
+            command="configure",
+            project_title="base",
+            owner="codeforester",
+            repo="codeforester/base",
+            config_path=str(config_path),
+        )
+    )
+
+    assert status == 0
+    assert applied == [
+        (
+            "target-project",
+            {
+                "Status": "Backlog",
+                "Priority": "P2",
+                "Area": "Product",
+                "Initiative": "Adoption Polish",
+                "Size": "S",
+            },
+        )
+    ]
+
+
 def test_configure_command_dry_run_reports_template_copy_link_and_backfill(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -661,6 +760,57 @@ def test_plan_project_item_field_copies_skips_existing_values_and_missing_option
     assert plan.skipped == (
         project_item_fields.ProjectFieldCopySkip(1, "Size", "M", "target option is missing"),
         project_item_fields.ProjectFieldCopySkip(1, "Area", "CLI", "target field is missing"),
+    )
+
+
+def test_plan_project_item_field_defaults_skips_existing_values_and_missing_options() -> None:
+    from base_github_projects import project_item_fields
+
+    target_items = {
+        "issue-1": project_item_fields.ProjectIssueItem(
+            item_id="target-item-1",
+            issue_id="issue-1",
+            issue_number=1,
+            title="one",
+            values={"Priority": "P1"},
+        ),
+        "issue-2": project_item_fields.ProjectIssueItem(
+            item_id="target-item-2",
+            issue_id="issue-2",
+            issue_number=2,
+            title="two",
+            values={},
+        ),
+    }
+    target_fields = {
+        "Priority": project_item_fields.ProjectSelectField(
+            field_id="priority-field",
+            options={"P2": "priority-p2"},
+        ),
+        "Size": project_item_fields.ProjectSelectField(field_id="size-field", options={}),
+    }
+
+    plan = project_item_fields.plan_missing_field_defaults(
+        target_items=target_items,
+        target_fields=target_fields,
+        field_defaults={"Priority": "P2", "Size": "S", "Area": "CLI"},
+    )
+
+    assert plan.updates == (
+        project_item_fields.ProjectFieldCopy(
+            item_id="target-item-2",
+            issue_number=2,
+            field_name="Priority",
+            option_name="P2",
+            field_id="priority-field",
+            option_id="priority-p2",
+        ),
+    )
+    assert plan.skipped == (
+        project_item_fields.ProjectFieldCopySkip(1, "Size", "S", "target option is missing"),
+        project_item_fields.ProjectFieldCopySkip(1, "Area", "CLI", "target field is missing"),
+        project_item_fields.ProjectFieldCopySkip(2, "Size", "S", "target option is missing"),
+        project_item_fields.ProjectFieldCopySkip(2, "Area", "CLI", "target field is missing"),
     )
 
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -58,7 +58,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 |---|---|---|
 | `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--copy-project-fields-from <title>`, `--no-project`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
-| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
+| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` to seed options and fill missing issue defaults when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files. | `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--dry-run` |
 | `basectl repo installer-template [path]` | Print the maintained project installer starter script, or write it to a path. | `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -69,10 +69,11 @@ by default when a GitHub repository is available. Base copies
 `base-project-template` when the repo Project is missing, links the Project to
 the repository, and backfills existing repository issues. When
 `.github/base-project.yml` exists, Base also adds missing repo-specific `Area`
-and `Initiative` options from that file. `basectl gh issue create` uses the
-same file's `issue_defaults` when it adds newly created issues to the repo
-Project. Use `basectl gh project` directly for lower-level Project inspection,
-schema repair, or issue field updates.
+and `Initiative` options from that file and applies the same file's
+`issue_defaults` to Project issue items that are missing those values.
+`basectl gh issue create` uses the defaults immediately when it adds newly
+created issues to the repo Project. Use `basectl gh project` directly for
+lower-level Project inspection, schema repair, or issue field updates.
 When migrating from an existing shared Project, pass
 `--copy-project-fields-from <title>` to copy missing `Status`, `Priority`,
 `Area`, `Initiative`, and `Size` issue item values into the repo Project without

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -86,7 +86,9 @@ metadata, `--project <title>` to override the Project title, `--project-owner
 schema, and repeat `--initiative-option <name>` to seed repository-specific
 Initiative values. If `.github/base-project.yml` exists, Base reads repo-owned
 `Area` and `Initiative` options from that file and adds missing Project options
-without deleting or renaming existing options.
+without deleting or renaming existing options. Base also applies the file's
+`issue_defaults` to repo Project issue items when those field values are still
+blank.
 During migration from an older shared Project, pass
 `--copy-project-fields-from <title>` to copy missing Project item field values
 by issue, field name, and option name into the repo Project. Existing target
@@ -107,13 +109,15 @@ project:
   issue_defaults:
     status: Backlog
     priority: P2
+    area: Product
+    initiative: Adoption Polish
     size: S
 ```
 
 `areas` and `initiatives` are applied by `repo configure`. `issue_defaults` is
-validated by Project tooling and used by `basectl gh issue create` when it adds
-new issues to the repo Project. It does not set fields on existing issues during
-Project configuration.
+validated by Project tooling, used by `basectl gh issue create` when it adds new
+issues to the repo Project, and applied by `repo configure` to existing Project
+issue items that are missing those field values.
 
 ## Local Baseline
 
@@ -161,12 +165,15 @@ project:
   issue_defaults:
     status: Backlog
     priority: P2
+    area: Product
+    initiative: Adoption Polish
     size: S
 ```
 
-Edit `areas` and `initiatives` in the baseline pull request before merging when
-the repository already knows its taxonomy. Leaving them empty is valid; future
-`repo configure` runs still apply the shared Project fields and issue defaults.
+Edit `areas`, `initiatives`, or the default `area`/`initiative` in the baseline
+pull request before merging when the repository already knows its taxonomy.
+Leaving the option lists empty is valid; future `repo configure` runs still
+apply the shared Project fields and issue defaults.
 
 ## Optional Agent Guidance
 


### PR DESCRIPTION
## Summary
- Add Base's own `.github/base-project.yml` with repo Project defaults for all custom fields.
- Make `basectl repo configure` apply config `issue_defaults` to existing repo Project issue items that are missing those values after backfill/copy.
- Update `repo init` generated defaults, docs, and focused tests so new Base-managed repos start with `Status`, `Priority`, `Area`, `Initiative`, and `Size` defaults.

## Root Cause
- Issue #731 was created through the ChatGPT Codex Connector path and did not receive the repo-named `base` Project metadata path.
- Base itself was missing `.github/base-project.yml`, so even Base-managed issue creation had no repo-local default `Area`/`Initiative` values to apply.
- `repo configure` backfilled Project membership and could copy fields from another Project, but it did not fill remaining blanks from repo config defaults.

## Issue
Fixes #733

## Validation
- `env PYTHONPATH=cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests/test_engine.py`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `bats cli/bash/commands/basectl/tests/gh.bats`
- `./bin/basectl repo configure . --repo codeforester/base --dry-run`
- `git diff --check`
- `git diff --cached --check`

## Demo Impact
None. GitHub Project metadata repair only.

## Notes
- I also repaired the live `base` Project membership for #731 and set its missing custom fields before this PR.
- A fresh plain `gh issue create` reproduction (#733) now auto-added to both Projects; the PR ensures missing custom fields can be repaired deterministically by Base config.