### PR TITLE
Fix AGPL license cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Moved the README license notice out of the opening product summary and made
+  the MIT-to-AGPL version boundary explicit.
 - Made `basectl repo init` generate AGPL-3.0-or-later licenses for new
   repositories.
 - Relicensed Base prospectively from MIT to AGPL-3.0-or-later.
@@ -48,6 +50,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made `basectl repo init` generate repo-specific AGPL license files without
+  copying Base's own application notice into new repositories.
 - Made `basectl repo configure` apply `.github/base-project.yml`
   `issue_defaults` to existing repo Project issue items that are missing those
   values.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Base - a workspace control plane for developers who keep multiple repositories checked out side by side.
-Copyright (C) 2026 Ramesh Padmanabhaiah
+Copyright (C) 2019-2026 Ramesh Padmanabhaiah
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free

--- a/README.md
+++ b/README.md
@@ -5,26 +5,6 @@
 ![Platform: macOS](https://img.shields.io/badge/platform-macOS-lightgrey)
 ![Version](https://img.shields.io/badge/version-1.0.0-blue)
 
-## License
-
-Copyright (C) 2019-2026 Ramesh Padmanabhaiah
-
-Base is free software: you can redistribute it and/or modify it under the
-terms of the GNU Affero General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option) any
-later version.
-
-Base is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE. See the GNU Affero General Public License for more
-details.
-
-You should have received a copy of the GNU Affero General Public License along
-with Base. If not, see <https://www.gnu.org/licenses/>.
-
-Versions before this relicensing change remain available under the MIT License
-as originally published. New versions are licensed under AGPL-3.0-or-later.
-
 Base is a workspace control plane for developers who keep multiple repositories
 checked out side by side.
 
@@ -1306,3 +1286,10 @@ tracked in GitHub Issues using the workflow in
 Base is the repo you check out once per workspace so that all the other repos
 in that workspace become easier to set up, easier to test, and easier to run in
 a controlled shell environment.
+
+## License
+
+Base is licensed under AGPL-3.0-or-later starting with v1.0.1.
+
+Versions through v1.0.0 remain available under the MIT License as originally
+published. See [LICENSE](LICENSE) for the current license terms.

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -736,7 +736,18 @@ base_repo_write_agent_guidance() {
     return "$status"
 }
 
+base_repo_agpl_license_text() {
+    local source_license="$1"
+
+    awk '
+        /^[[:space:]]*GNU AFFERO GENERAL PUBLIC LICENSE$/ { found = 1 }
+        found { print }
+        END { if (!found) exit 1 }
+    ' "$source_license"
+}
+
 base_repo_write_license() {
+    local canonical_license
     local copyright_holder="$2"
     local dry_run="$1"
     local root="$3"
@@ -745,6 +756,11 @@ base_repo_write_license() {
 
     [[ -f "$source_license" ]] || {
         log_error "Base AGPL license text '$source_license' was not found."
+        return 1
+    }
+
+    canonical_license="$(base_repo_agpl_license_text "$source_license")" || {
+        log_error "Base AGPL license text '$source_license' did not contain the canonical AGPL terms."
         return 1
     }
 
@@ -766,7 +782,7 @@ You should have received a copy of the GNU Affero General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>.
 EOF
         printf '\n'
-        cat "$source_license"
+        printf '%s\n' "$canonical_license"
     } | base_repo_write_stream "$dry_run" "$root/LICENSE"
 }
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -316,6 +316,8 @@ load ./basectl_helpers.bash
     grep -Fq "CHANGELOG is updated for notable user-visible or release-worthy changes." "$repo_dir/.github/pull_request_template.md"
     ! grep -Fq "Demo Impact" "$repo_dir/.github/pull_request_template.md"
     grep -Fq "GNU Affero General Public License" "$repo_dir/LICENSE"
+    run grep -F "Base - a workspace control plane" "$repo_dir/LICENSE"
+    [ "$status" -eq 1 ]
 
     run bash -c 'cd "$1" && ./tests/validate.sh' _ "$repo_dir"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Move the README license note out of the opening product summary and make the v1.0.1 AGPL boundary explicit.
- Align the root LICENSE application notice years.
- Make `basectl repo init` append only canonical AGPL terms so generated repos do not inherit Base-specific notice text.

## Validation
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --cached --check`

## Demo Impact
None. License documentation and repo scaffolding cleanup only.

Fixes #736