### PR TITLE
Add Project intake workflow fallback

### DIFF
--- a/.github/workflows/project-intake.yml
+++ b/.github/workflows/project-intake.yml
@@ -1,0 +1,133 @@
+name: Project Intake
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to reconcile into the repo Project.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  sync:
+    name: Sync issue Project fields
+    runs-on: ubuntu-latest
+    env:
+      BASE_PROJECT_OWNER: ${{ github.repository_owner }}
+      BASE_PROJECT_TITLE: ${{ github.event.repository.name }}
+      BASE_PROJECT_ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+      BASE_PROJECT_DEFAULT_OPEN_STATUS: Backlog
+      BASE_PROJECT_DEFAULT_CLOSED_STATUS: Done
+      BASE_PROJECT_DEFAULT_PRIORITY: P2
+      BASE_PROJECT_DEFAULT_SIZE: S
+      BASE_PROJECT_DEFAULT_AREA: Product
+      BASE_PROJECT_DEFAULT_INITIATIVE: Adoption Polish
+      GH_TOKEN: ${{ secrets.BASE_PROJECT_TOKEN || github.token }}
+    steps:
+      - name: Reconcile Project item
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          issue_number="${BASE_PROJECT_ISSUE_NUMBER:-}"
+          if [[ -z "$issue_number" ]]; then
+            echo "::error::Issue number was not provided by the event or workflow_dispatch input."
+            exit 1
+          fi
+
+          issue_json="$(gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" --json state,url)"
+          issue_state="$(jq -r '.state' <<<"$issue_json")"
+          issue_url="$(jq -r '.url' <<<"$issue_json")"
+
+          project_number="$(
+            gh project list --owner "$BASE_PROJECT_OWNER" --format json --limit 100 |
+              jq -r --arg title "$BASE_PROJECT_TITLE" \
+                '.projects[] | select(.title == $title) | .number' |
+              head -n 1
+          )"
+          if [[ -z "$project_number" ]]; then
+            echo "::error::GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'."
+            exit 1
+          fi
+
+          project_id="$(gh project view "$project_number" --owner "$BASE_PROJECT_OWNER" --format json --jq '.id')"
+          item_id="$(gh project item-add "$project_number" --owner "$BASE_PROJECT_OWNER" --url "$issue_url" --format json --jq '.id')"
+          item_json="$(
+            gh project item-list "$project_number" --owner "$BASE_PROJECT_OWNER" --format json --limit 1000 |
+              jq --arg id "$item_id" '.items[] | select(.id == $id)'
+          )"
+          fields_json="$(gh project field-list "$project_number" --owner "$BASE_PROJECT_OWNER" --format json)"
+
+          field_id_for() {
+            local field_name="$1"
+
+            jq -r --arg name "$field_name" \
+              '.fields[] | select(.name == $name) | .id' <<<"$fields_json" |
+              head -n 1
+          }
+
+          option_id_for() {
+            local field_name="$1"
+            local option_name="$2"
+
+            jq -r --arg name "$field_name" --arg option "$option_name" \
+              '.fields[] | select(.name == $name) | .options[]? | select(.name == $option) | .id' \
+              <<<"$fields_json" |
+              head -n 1
+          }
+
+          set_single_select() {
+            local field_name="$1"
+            local option_name="$2"
+            local field_id
+            local option_id
+
+            [[ -n "$option_name" ]] || return 0
+
+            field_id="$(field_id_for "$field_name")"
+            option_id="$(option_id_for "$field_name" "$option_name")"
+            if [[ -z "$field_id" || -z "$option_id" ]]; then
+              echo "::error::Project field '$field_name' option '$option_name' was not found."
+              exit 1
+            fi
+
+            gh project item-edit \
+              --id "$item_id" \
+              --project-id "$project_id" \
+              --field-id "$field_id" \
+              --single-select-option-id "$option_id" \
+              >/dev/null
+          }
+
+          set_single_select_if_missing() {
+            local field_name="$1"
+            local item_key="$2"
+            local option_name="$3"
+            local current_value
+
+            current_value="$(jq -r --arg key "$item_key" '.[$key] // ""' <<<"$item_json")"
+            if [[ -n "$current_value" ]]; then
+              return 0
+            fi
+
+            set_single_select "$field_name" "$option_name"
+          }
+
+          status_value="$BASE_PROJECT_DEFAULT_OPEN_STATUS"
+          if [[ "$issue_state" == "CLOSED" ]]; then
+            status_value="$BASE_PROJECT_DEFAULT_CLOSED_STATUS"
+          fi
+
+          set_single_select Status "$status_value"
+          set_single_select_if_missing Priority priority "$BASE_PROJECT_DEFAULT_PRIORITY"
+          set_single_select_if_missing Size size "$BASE_PROJECT_DEFAULT_SIZE"
+          set_single_select_if_missing Area area "$BASE_PROJECT_DEFAULT_AREA"
+          set_single_select_if_missing Initiative initiative "$BASE_PROJECT_DEFAULT_INITIATIVE"
+
+          printf 'Synced issue #%s into Project %s.\n' "$issue_number" "$BASE_PROJECT_TITLE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- Added a generated Project intake workflow so Base-managed repos can
+  idempotently add externally-created issues to their repo Project and apply
+  default Project fields.
+
 ## [1.0.1] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -442,6 +442,11 @@ labels documented in [Repository Baseline](docs/repo-baseline.md).
 When `.github/base-project.yml` exists, `repo configure` also adds missing
 repo-specific `Area` and `Initiative` Project options from that file and applies
 its `issue_defaults` to Project issue items that are missing those values.
+`repo init` also seeds `.github/workflows/project-intake.yml`, a visible
+fallback for issues created outside `basectl gh issue create`. Set a
+`BASE_PROJECT_TOKEN` Actions secret with Project write access so that workflow
+can add issue items and apply the repo Project defaults on issue open, reopen,
+and close events.
 Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -89,8 +89,11 @@ such command directories exist. Optional utility CLIs such as `caff` and
   `base-project-template`, linked to the repository, and backfilled with
   repository issues. When `.github/base-project.yml` exists, repo-specific
   `Area` and `Initiative` options are added from that file and `issue_defaults`
-  are applied to missing Project item field values. Use `--no-project` to skip
-  Project setup, `--project <title>` to override the Project title, or
+  are applied to missing Project item field values. `repo init` also seeds a
+  Project intake workflow that can add externally-created issues to the
+  repo-named Project when `BASE_PROJECT_TOKEN` has Project write access. Use
+  `--no-project` to skip Project setup, `--project <title>` to override the
+  Project title, or
   `--initiative-option <name>` to seed repository-specific Initiative values.
   Use `--copy-project-fields-from <title>` during migration to copy missing
   issue item field values from an existing Project before config defaults fill

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -15,6 +15,7 @@ BASE_REPO_BASELINE_FILES=(
     .gitignore
     base_manifest.yaml
     tests/validate.sh
+    .github/workflows/project-intake.yml
     .github/workflows/tests.yml
 )
 
@@ -834,6 +835,7 @@ required_files=(
   .github/base-project.yml
   LICENSE
   base_manifest.yaml
+  .github/workflows/project-intake.yml
   .github/workflows/tests.yml
 )
 
@@ -866,6 +868,147 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate repository baseline
         run: ./tests/validate.sh
+EOF
+}
+
+base_repo_write_project_intake_workflow() {
+    local dry_run="$1"
+    local root="$2"
+
+    base_repo_write_stream "$dry_run" "$root/.github/workflows/project-intake.yml" <<'EOF'
+name: Project Intake
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to reconcile into the repo Project.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  sync:
+    name: Sync issue Project fields
+    runs-on: ubuntu-latest
+    env:
+      BASE_PROJECT_OWNER: ${{ github.repository_owner }}
+      BASE_PROJECT_TITLE: ${{ github.event.repository.name }}
+      BASE_PROJECT_ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+      BASE_PROJECT_DEFAULT_OPEN_STATUS: Backlog
+      BASE_PROJECT_DEFAULT_CLOSED_STATUS: Done
+      BASE_PROJECT_DEFAULT_PRIORITY: P2
+      BASE_PROJECT_DEFAULT_SIZE: S
+      BASE_PROJECT_DEFAULT_AREA: Product
+      BASE_PROJECT_DEFAULT_INITIATIVE: Adoption Polish
+      GH_TOKEN: ${{ secrets.BASE_PROJECT_TOKEN || github.token }}
+    steps:
+      - name: Reconcile Project item
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          issue_number="${BASE_PROJECT_ISSUE_NUMBER:-}"
+          if [[ -z "$issue_number" ]]; then
+            echo "::error::Issue number was not provided by the event or workflow_dispatch input."
+            exit 1
+          fi
+
+          issue_json="$(gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" --json state,url)"
+          issue_state="$(jq -r '.state' <<<"$issue_json")"
+          issue_url="$(jq -r '.url' <<<"$issue_json")"
+
+          project_number="$(
+            gh project list --owner "$BASE_PROJECT_OWNER" --format json --limit 100 |
+              jq -r --arg title "$BASE_PROJECT_TITLE" \
+                '.projects[] | select(.title == $title) | .number' |
+              head -n 1
+          )"
+          if [[ -z "$project_number" ]]; then
+            echo "::error::GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'."
+            exit 1
+          fi
+
+          project_id="$(gh project view "$project_number" --owner "$BASE_PROJECT_OWNER" --format json --jq '.id')"
+          item_id="$(gh project item-add "$project_number" --owner "$BASE_PROJECT_OWNER" --url "$issue_url" --format json --jq '.id')"
+          item_json="$(
+            gh project item-list "$project_number" --owner "$BASE_PROJECT_OWNER" --format json --limit 1000 |
+              jq --arg id "$item_id" '.items[] | select(.id == $id)'
+          )"
+          fields_json="$(gh project field-list "$project_number" --owner "$BASE_PROJECT_OWNER" --format json)"
+
+          field_id_for() {
+            local field_name="$1"
+
+            jq -r --arg name "$field_name" \
+              '.fields[] | select(.name == $name) | .id' <<<"$fields_json" |
+              head -n 1
+          }
+
+          option_id_for() {
+            local field_name="$1"
+            local option_name="$2"
+
+            jq -r --arg name "$field_name" --arg option "$option_name" \
+              '.fields[] | select(.name == $name) | .options[]? | select(.name == $option) | .id' \
+              <<<"$fields_json" |
+              head -n 1
+          }
+
+          set_single_select() {
+            local field_name="$1"
+            local option_name="$2"
+            local field_id
+            local option_id
+
+            [[ -n "$option_name" ]] || return 0
+
+            field_id="$(field_id_for "$field_name")"
+            option_id="$(option_id_for "$field_name" "$option_name")"
+            if [[ -z "$field_id" || -z "$option_id" ]]; then
+              echo "::error::Project field '$field_name' option '$option_name' was not found."
+              exit 1
+            fi
+
+            gh project item-edit \
+              --id "$item_id" \
+              --project-id "$project_id" \
+              --field-id "$field_id" \
+              --single-select-option-id "$option_id" \
+              >/dev/null
+          }
+
+          set_single_select_if_missing() {
+            local field_name="$1"
+            local item_key="$2"
+            local option_name="$3"
+            local current_value
+
+            current_value="$(jq -r --arg key "$item_key" '.[$key] // ""' <<<"$item_json")"
+            if [[ -n "$current_value" ]]; then
+              return 0
+            fi
+
+            set_single_select "$field_name" "$option_name"
+          }
+
+          status_value="$BASE_PROJECT_DEFAULT_OPEN_STATUS"
+          if [[ "$issue_state" == "CLOSED" ]]; then
+            status_value="$BASE_PROJECT_DEFAULT_CLOSED_STATUS"
+          fi
+
+          set_single_select Status "$status_value"
+          set_single_select_if_missing Priority priority "$BASE_PROJECT_DEFAULT_PRIORITY"
+          set_single_select_if_missing Size size "$BASE_PROJECT_DEFAULT_SIZE"
+          set_single_select_if_missing Area area "$BASE_PROJECT_DEFAULT_AREA"
+          set_single_select_if_missing Initiative initiative "$BASE_PROJECT_DEFAULT_INITIATIVE"
+
+          printf 'Synced issue #%s into Project %s.\n' "$issue_number" "$BASE_PROJECT_TITLE"
 EOF
 }
 
@@ -908,6 +1051,7 @@ base_repo_write_baseline() {
     base_repo_write_gitignore "$dry_run" "$root" || status=1
     base_repo_write_manifest "$dry_run" "$name" "$root" || status=1
     base_repo_write_validate_script "$dry_run" "$root" || status=1
+    base_repo_write_project_intake_workflow "$dry_run" "$root" || status=1
     base_repo_write_tests_workflow "$dry_run" "$root" || status=1
 
     return "$status"

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -300,6 +300,7 @@ load ./basectl_helpers.bash
     [ -f "$repo_dir/base_manifest.yaml" ]
     [ -x "$repo_dir/tests/validate.sh" ]
     [ -f "$repo_dir/.github/workflows/tests.yml" ]
+    [ -f "$repo_dir/.github/workflows/project-intake.yml" ]
     grep -Fqx "0.1.0" "$repo_dir/VERSION"
     grep -Fq "name: base-demo" "$repo_dir/base_manifest.yaml"
     grep -Fq "command: ./tests/validate.sh" "$repo_dir/base_manifest.yaml"
@@ -309,6 +310,12 @@ load ./basectl_helpers.bash
     grep -Fq "area: Product" "$repo_dir/.github/base-project.yml"
     grep -Fq "initiative: Adoption Polish" "$repo_dir/.github/base-project.yml"
     grep -Fq "size: S" "$repo_dir/.github/base-project.yml"
+    grep -Fq "name: Project Intake" "$repo_dir/.github/workflows/project-intake.yml"
+    grep -Fq "BASE_PROJECT_TOKEN" "$repo_dir/.github/workflows/project-intake.yml"
+    grep -Fq "gh project item-add" "$repo_dir/.github/workflows/project-intake.yml"
+    grep -Fq "set_single_select_if_missing Priority priority" "$repo_dir/.github/workflows/project-intake.yml"
+    grep -Fq "BASE_PROJECT_DEFAULT_AREA: Product" "$repo_dir/.github/workflows/project-intake.yml"
+    grep -Fq "BASE_PROJECT_DEFAULT_INITIATIVE: Adoption Polish" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "<category>/<issue>-<YYYYMMDD>-<slug>" "$repo_dir/CONTRIBUTING.md"
     grep -Fq "git worktree add -b <branch> ../base-demo-worktrees/<slug> origin/<default-branch>" "$repo_dir/CONTRIBUTING.md"
     grep -Fq 'Update `CHANGELOG.md` only for notable user-visible or release-worthy' "$repo_dir/CONTRIBUTING.md"

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -72,7 +72,16 @@ the repository, and backfills existing repository issues. When
 and `Initiative` options from that file and applies the same file's
 `issue_defaults` to Project issue items that are missing those values.
 `basectl gh issue create` uses the defaults immediately when it adds newly
-created issues to the repo Project. Use `basectl gh project` directly for
+created issues to the repo Project.
+
+Base-managed repositories also carry `.github/workflows/project-intake.yml`.
+That workflow is a repo-visible fallback for issues created through GitHub UI,
+plain `gh issue create`, or external connectors that can bypass
+`basectl gh issue create` and GitHub's hidden Project auto-add filters. Set a
+`BASE_PROJECT_TOKEN` Actions secret with Project write access so the workflow
+can idempotently add the issue to the repo-named Project and set `Status`,
+`Priority`, `Size`, `Area`, and `Initiative` from the generated defaults on
+issue open, reopen, and close events. Use `basectl gh project` directly for
 lower-level Project inspection, schema repair, or issue field updates.
 When migrating from an existing shared Project, pass
 `--copy-project-fields-from <title>` to copy missing `Status`, `Priority`,

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -133,6 +133,7 @@ issue items that are missing those field values.
 - `.gitignore`
 - `base_manifest.yaml`
 - `tests/validate.sh`
+- `.github/workflows/project-intake.yml`
 - `.github/workflows/tests.yml`
 
 Existing files are left unchanged. This makes `repo init` useful both for a
@@ -154,6 +155,14 @@ test:
 The generated validation script checks for the required baseline files. It is
 not a replacement for project tests; it is the seed contract that lets
 `basectl test <project>` work immediately.
+
+The generated `.github/workflows/project-intake.yml` handles issue open,
+reopen, close, and manual dispatch events. It is a visible fallback for issues
+created outside `basectl gh issue create`: the workflow idempotently adds the
+issue to the repo-named Project and sets `Status`, `Priority`, `Size`, `Area`,
+and `Initiative` from the generated defaults. Set a `BASE_PROJECT_TOKEN`
+Actions secret with Project write access when `GITHUB_TOKEN` cannot update the
+user or organization Project.
 
 The generated `.github/base-project.yml` starts with the shared issue defaults
 and empty repo-specific taxonomy lists:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/project-intake.yml` so externally-created issues are idempotently added to the repo-named Project.
- Teach `basectl repo init` to generate the same workflow and include it in the baseline check/validation contract.
- Document the `BASE_PROJECT_TOKEN` requirement and the split between hidden GitHub auto-add filters, `basectl gh issue create`, and the visible fallback workflow.

## Root Cause
Issues #735 and #736 were created outside `basectl gh issue create` without labels. GitHub native automation added them to `Base Roadmap`, but the repo-named `base` Project did not receive them until `basectl repo configure` backfilled them. The public API shows the `base` Project auto-add workflow is enabled, but does not expose its hidden filter, so Base needs a repo-visible fallback instead of relying only on that opaque workflow.

## Validation
- `bats cli/bash/commands/basectl/tests/repo.bats --filter "basectl repo init creates the standard repository baseline"`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`

Closes #739