### PR TITLE
Repair Project intake fallback during repo configure

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -25,8 +25,9 @@ the canonical current command list.
   status, checks, or diagnostics.
 - `basectl repo <init|check|configure|agent-guidance|installer-template>` -
   create repository baselines, configure GitHub repository settings and default
-  branch protection, configure standard GitHub Project metadata, seed agent
-  guidance, and write installer templates.
+  branch protection, repair missing Project intake support files, configure
+  standard GitHub Project metadata, seed agent guidance, and write installer
+  templates.
 - `basectl ci <setup|check|doctor> <project>` - run Base setup/check/doctor in
   non-interactive CI.
 - `basectl release <check|plan|notes|publish>` - inspect release readiness,

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -19,6 +19,11 @@ status through `In Progress`, `In Review`, and `Done` as the work advances.
 Base roadmap Project metadata uses five fields: `Status`, `Priority`, `Area`,
 `Size`, and `Initiative`.
 
+Base-managed repositories should carry `.github/workflows/project-intake.yml`
+as the fallback for issues created outside `basectl gh issue create`.
+`basectl repo init` seeds it for new repositories, and `basectl repo configure`
+creates it when missing from older repositories.
+
 ## Branch And Worktree Flow
 
 Use a dedicated worktree for PR work. Branch names follow:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made `basectl repo configure` create missing Project intake support files for
+  older Base-managed repositories.
 - Made `basectl repo init` generate repo-specific AGPL license files without
   copying Base's own application notice into new repositories.
 - Made `basectl repo configure` apply `.github/base-project.yml`

--- a/README.md
+++ b/README.md
@@ -443,10 +443,11 @@ When `.github/base-project.yml` exists, `repo configure` also adds missing
 repo-specific `Area` and `Initiative` Project options from that file and applies
 its `issue_defaults` to Project issue items that are missing those values.
 `repo init` also seeds `.github/workflows/project-intake.yml`, a visible
-fallback for issues created outside `basectl gh issue create`. Set a
-`BASE_PROJECT_TOKEN` Actions secret with Project write access so that workflow
-can add issue items and apply the repo Project defaults on issue open, reopen,
-and close events.
+fallback for issues created outside `basectl gh issue create`. `repo configure`
+creates the workflow when it is missing from older Base-managed repositories.
+Set a `BASE_PROJECT_TOKEN` Actions secret with Project write access so that
+workflow can add issue items and apply the repo Project defaults on issue open,
+reopen, and close events.
 Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1029,6 +1029,17 @@ project:
 EOF
 }
 
+base_repo_write_project_support_files() {
+    local dry_run="$1"
+    local root="$2"
+    local status=0
+
+    base_repo_write_project_config "$dry_run" "$root" || status=1
+    base_repo_write_project_intake_workflow "$dry_run" "$root" || status=1
+
+    return "$status"
+}
+
 base_repo_write_baseline() {
     local copyright_holder="$4"
     local description="$3"
@@ -2163,6 +2174,10 @@ base_repo_configure() {
         log_error "Pass --repo <owner/name> to configure a GitHub repository explicitly."
         return 1
     }
+
+    if ((configure_project)); then
+        base_repo_write_project_support_files "$dry_run" "$path" || return 1
+    fi
 
     base_repo_configure_github "$dry_run" "$github_repo" "$protect_default_branch" || return 1
     if ((configure_project)); then

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -542,6 +542,25 @@ EOF
     [[ "$output" == *"--config $repo_dir/.github/base-project.yml"* ]]
 }
 
+@test "basectl repo configure dry-run reports missing project intake workflow" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir/.github"
+    cat > "$repo_dir/.github/base-project.yml" <<'EOF'
+project:
+  issue_defaults:
+    status: Backlog
+    priority: P2
+    size: S
+EOF
+
+    run_basectl repo configure "$repo_dir" --repo codeforester/base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/.github/workflows/project-intake.yml'."* ]]
+    [ ! -e "$repo_dir/.github/workflows/project-intake.yml" ]
+}
+
 @test "basectl repo configure can skip project metadata" {
     local repo_dir="$TEST_TMPDIR/repo"
 
@@ -657,6 +676,9 @@ EOF
             --copy-project-fields-from "Base Roadmap"
 
     [ "$status" -eq 0 ]
+    [ -f "$repo_dir/.github/workflows/project-intake.yml" ]
+    grep -Fq "name: Project Intake" "$repo_dir/.github/workflows/project-intake.yml"
+    grep -Fq "BASE_PROJECT_TOKEN" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     [[ "$output" == *"Configuring GitHub Project 'base-demo' for 'codeforester/base-demo'."* ]]
     [[ "$output" == *"Running: $TEST_MOCKBIN/project-wrapper --project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from \"Base Roadmap\""* ]]

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -77,12 +77,14 @@ created issues to the repo Project.
 Base-managed repositories also carry `.github/workflows/project-intake.yml`.
 That workflow is a repo-visible fallback for issues created through GitHub UI,
 plain `gh issue create`, or external connectors that can bypass
-`basectl gh issue create` and GitHub's hidden Project auto-add filters. Set a
-`BASE_PROJECT_TOKEN` Actions secret with Project write access so the workflow
-can idempotently add the issue to the repo-named Project and set `Status`,
-`Priority`, `Size`, `Area`, and `Initiative` from the generated defaults on
-issue open, reopen, and close events. Use `basectl gh project` directly for
-lower-level Project inspection, schema repair, or issue field updates.
+`basectl gh issue create` and GitHub's hidden Project auto-add filters.
+`basectl repo configure` creates this workflow when it is missing from older
+Base-managed repositories. Set a `BASE_PROJECT_TOKEN` Actions secret with
+Project write access so the workflow can idempotently add the issue to the
+repo-named Project and set `Status`, `Priority`, `Size`, `Area`, and
+`Initiative` from the generated defaults on issue open, reopen, and close
+events. Use `basectl gh project` directly for lower-level Project inspection,
+schema repair, or issue field updates.
 When migrating from an existing shared Project, pass
 `--copy-project-fields-from <title>` to copy missing `Status`, `Priority`,
 `Area`, `Initiative`, and `Size` issue item values into the repo Project without

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -118,6 +118,11 @@ project:
 validated by Project tooling, used by `basectl gh issue create` when it adds new
 issues to the repo Project, and applied by `repo configure` to existing Project
 issue items that are missing those field values.
+When Project metadata is enabled, `repo configure` also creates missing
+repo-owned Project support files such as `.github/base-project.yml` and
+`.github/workflows/project-intake.yml` without overwriting existing files. This
+lets older Base-managed repositories pick up the external-issue intake fallback
+without rerunning a full repository initialization.
 
 ## Local Baseline
 
@@ -163,6 +168,10 @@ issue to the repo-named Project and sets `Status`, `Priority`, `Size`, `Area`,
 and `Initiative` from the generated defaults. Set a `BASE_PROJECT_TOKEN`
 Actions secret with Project write access when `GITHUB_TOKEN` cannot update the
 user or organization Project.
+
+For older repositories that predate this workflow, rerun
+`basectl repo configure <path> --repo <owner/name>` to create the missing
+workflow while leaving existing files unchanged.
 
 The generated `.github/base-project.yml` starts with the shared issue defaults
 and empty repo-specific taxonomy lists:


### PR DESCRIPTION
## Summary
- Make `basectl repo configure` create missing Project support files, including `project-intake.yml`, when Project metadata is enabled.
- Add BATS regression coverage for dry-run reporting and real workflow creation.
- Update docs, changelog, and AI context for the expanded `repo configure` contract.

## Issue
Closes #741

## Validation
- `git diff --check`
- `bats cli/bash/commands/basectl/tests/repo.bats` (52 passed)
- `bin/basectl test base` (424 pytest passed; 464 BATS passed)

## Demo Impact
None.