### PR TITLE
Add workspace-aware repo clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Added
 
+- Added `basectl repo clone` for workspace-aware cloning of one GitHub
+  repository into the configured Base workspace.
 - Added a generated Project intake workflow so Base-managed repos can
   idempotently add externally-created issues to their repo Project and apply
   default Project fields.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Current implemented commands include:
 - `basectl update`
 - `basectl projects list`
 - `basectl repo init <name>`
+- `basectl repo clone <name-or-owner/name>`
 - `basectl repo check [path]`
 - `basectl repo configure [path]`
 - `basectl repo agent-guidance [path]`
@@ -419,6 +420,19 @@ existing `origin` remote can be inferred. Newly created GitHub repositories are
 private by default; pass `--public` when a public repository is intentional. Use
 `--no-configure` to skip the GitHub step, or rerun it later with
 `basectl repo configure`.
+
+Clone an existing GitHub repository into the configured workspace with:
+
+```bash
+basectl repo clone codeforester/example
+basectl repo clone example --owner codeforester
+```
+
+Short names can use `github.default_owner` from `~/.base.d/config.yaml`.
+Without `--path`, `repo clone` writes to `<workspace.root>/<repo>`, and
+`--dry-run` prints the resolved repository, destination, clone tool, and clone
+URL without touching the filesystem. Existing matching checkouts are treated as
+already satisfied; conflicting destinations fail with guidance.
 
 Check and repair the repo baseline with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -32,7 +32,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `export-context`
 - `gh`
 - `onboard`
-- `repo init/check/configure/agent-guidance/installer-template`
+- `repo init/clone/check/configure/agent-guidance/installer-template`
 - `test`
 - `build`
 - `update-profile`
@@ -82,6 +82,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   provided or an existing `origin` remote can be inferred. Without `--path`, it
   creates the repository under `workspace.root` from `~/.base.d/config.yaml`,
   then falls back to the parent directory of `BASE_HOME`.
+  `basectl repo clone <name-or-owner/name>` clones one existing GitHub
+  repository into the configured workspace, supports `--owner <owner>` for
+  short names, and treats matching existing checkouts as already satisfied.
   `basectl repo check [path]` verifies the local baseline, and
   `basectl repo configure [path]` reapplies the GitHub settings, labels,
   default branch protection, and standard repo Project setup. By default, the

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -29,6 +29,7 @@ base_repo_subcommand_usage() {
     cat <<'EOF'
 Usage:
   basectl repo init <name> [options]
+  basectl repo clone <name-or-owner/name> [options]
   basectl repo check [path] [options]
   basectl repo configure [path] [options]
   basectl repo agent-guidance [path] [options]
@@ -36,6 +37,7 @@ Usage:
 
 Commands:
   init                 Create baseline files and optionally configure GitHub.
+  clone                Clone one GitHub repository into the Base workspace.
   check                Verify the local repository baseline.
   configure            Apply GitHub settings, labels, branch protection, and Project metadata.
   agent-guidance       Seed optional repo-local agent guidance files.
@@ -79,6 +81,30 @@ Creates the standard Base-managed repository baseline, including
 .github/base-project.yml. With --pr, the first run opens a baseline PR when
 files change; rerun the same command after merge to continue GitHub-side
 configuration.
+EOF
+}
+
+base_repo_clone_usage() {
+    cat <<'EOF'
+Usage:
+  basectl repo clone <name-or-owner/name> [options]
+
+Options:
+  --owner <owner>               GitHub owner for short repository names.
+  --path <path>                 Clone destination. Defaults to workspace root plus repository name.
+  --dry-run                     Print planned clone without modifying the filesystem.
+  -v                            Enable DEBUG logging for this subcommand.
+  -h, --help                    Show this help text.
+
+Examples:
+  basectl repo clone base
+  basectl repo clone banyanlabs --owner codeforester
+  basectl repo clone codeforester/bankbuddy
+  basectl repo clone codeforester/base --path ~/work/base
+
+Short repository names require --owner <owner> or github.default_owner in
+~/.base.d/config.yaml. The optional github.clone_protocol value controls the
+reported clone URL; Base delegates the clone itself to gh repo clone.
 EOF
 }
 
@@ -145,6 +171,12 @@ base_repo_usage_error() {
 
 base_repo_init_usage_error() {
     base_repo_init_usage >&2
+    printf 'ERROR: %s\n' "$*" >&2
+    return 2
+}
+
+base_repo_clone_usage_error() {
+    base_repo_clone_usage >&2
     printf 'ERROR: %s\n' "$*" >&2
     return 2
 }
@@ -219,6 +251,15 @@ base_repo_validate_name() {
     }
 }
 
+base_repo_validate_owner() {
+    local owner="$1"
+
+    [[ "$owner" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]] || {
+        printf 'GitHub owner must start with a letter or digit and contain only letters, digits, and dash.\n' >&2
+        return 1
+    }
+}
+
 base_repo_target_path() {
     local path="$1"
     local parent name
@@ -274,7 +315,7 @@ base_repo_expand_path() {
             printf '%s\n' "$HOME"
             ;;
         "~/"*)
-            printf '%s/%s\n' "$HOME" "${path#~/}"
+            printf '%s/%s\n' "$HOME" "${path#"~/"}"
             ;;
         *)
             printf '%s\n' "$path"
@@ -319,6 +360,40 @@ base_repo_configured_workspace_root() {
     return 1
 }
 
+base_repo_configured_github_value() {
+    local config_path="$HOME/.base.d/config.yaml"
+    local in_github=0
+    local key="$1"
+    local line value
+
+    [[ -f "$config_path" ]] || return 1
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ "$line" =~ ^[[:space:]]*(#.*)?$ ]] && continue
+
+        if [[ "$line" =~ ^github:[[:space:]]*(#.*)?$ ]]; then
+            in_github=1
+            continue
+        fi
+
+        if ((in_github)) && [[ ! "$line" =~ ^[[:space:]] ]]; then
+            return 1
+        fi
+
+        if ((in_github)) && [[ "$line" =~ ^[[:space:]]+${key}:[[:space:]]*(.*)$ ]]; then
+            value="$(base_repo_strip_config_value "${BASH_REMATCH[1]}")"
+            [[ -n "$value" ]] || {
+                log_error "$config_path: github.$key must be a non-empty value."
+                return 2
+            }
+            printf '%s\n' "$value"
+            return 0
+        fi
+    done < "$config_path"
+
+    return 1
+}
+
 base_repo_default_workspace_root() {
     local configured_root status
 
@@ -349,6 +424,69 @@ base_repo_default_target_path() {
 
     workspace_root="$(base_repo_default_workspace_root)" || return $?
     printf '%s/%s\n' "$workspace_root" "$name"
+}
+
+base_repo_default_github_owner() {
+    local owner status
+
+    owner="$(base_repo_configured_github_value default_owner)"
+    status=$?
+    case "$status" in
+        0)
+            printf '%s\n' "$owner"
+            return 0
+            ;;
+        1)
+            return 1
+            ;;
+        *)
+            return "$status"
+            ;;
+    esac
+}
+
+base_repo_clone_protocol() {
+    local protocol status
+
+    protocol="$(base_repo_configured_github_value clone_protocol)"
+    status=$?
+    case "$status" in
+        0)
+            ;;
+        1)
+            protocol="ssh"
+            ;;
+        *)
+            return "$status"
+            ;;
+    esac
+
+    case "$protocol" in
+        ssh|https)
+            printf '%s\n' "$protocol"
+            ;;
+        *)
+            log_error "$HOME/.base.d/config.yaml: github.clone_protocol must be 'ssh' or 'https'."
+            return 2
+            ;;
+    esac
+}
+
+base_repo_clone_url() {
+    local protocol="$1"
+    local repo="$2"
+
+    case "$protocol" in
+        ssh)
+            printf 'git@github.com:%s.git\n' "$repo"
+            ;;
+        https)
+            printf 'https://github.com/%s.git\n' "$repo"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 base_repo_baseline_year() {
@@ -1079,6 +1217,9 @@ base_repo_infer_github_repo() {
         git@github.com:*.git)
             remote_url="${remote_url#git@github.com:}"
             remote_url="${remote_url%.git}"
+            ;;
+        git@github.com:*)
+            remote_url="${remote_url#git@github.com:}"
             ;;
         https://github.com/*.git)
             remote_url="${remote_url#https://github.com/}"
@@ -1908,6 +2049,198 @@ base_repo_init() {
     fi
 }
 
+base_repo_clone_check_destination() {
+    local actual_repo=""
+    local expected_repo="$1"
+    local target="$2"
+
+    [[ -e "$target" ]] || return 0
+
+    if [[ ! -d "$target" ]]; then
+        log_error "Destination '$target' already exists but is not a matching Git checkout."
+        return 1
+    fi
+
+    actual_repo="$(base_repo_infer_github_repo "$target" || true)"
+    if [[ "$actual_repo" == "$expected_repo" ]]; then
+        printf "Repository '%s' already exists at '%s'.\n" "$expected_repo" "$target"
+        return 2
+    fi
+
+    if [[ -n "$actual_repo" ]]; then
+        log_error "Destination '$target' already points at GitHub repository '$actual_repo'."
+        log_error "Expected '$expected_repo'."
+        return 1
+    fi
+
+    log_error "Destination '$target' already exists but is not a matching Git checkout."
+    return 1
+}
+
+base_repo_clone_with_gh() {
+    local clone_url="$4"
+    local dry_run="$1"
+    local parent
+    local repo="$2"
+    local status
+    local target="$3"
+
+    base_repo_clone_check_destination "$repo" "$target"
+    status=$?
+    case "$status" in
+        0)
+            ;;
+        2)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "Repository: %s\n" "$repo"
+        printf "Destination: %s\n" "$target"
+        printf "Tool: gh repo clone\n"
+        printf "Clone URL: %s\n" "$clone_url"
+        printf "[DRY-RUN] Would run: "
+        base_repo_pretty_command gh repo clone "$repo" "$target"
+        printf "\n"
+        return 0
+    fi
+
+    command -v gh >/dev/null 2>&1 || {
+        log_error "GitHub CLI 'gh' is required for repository clone."
+        return 1
+    }
+
+    parent="$(dirname -- "$target")"
+    base_repo_create_directory "$parent" || return 1
+    printf "Cloning GitHub repository '%s' into '%s'.\n" "$repo" "$target"
+    gh repo clone "$repo" "$target" || {
+        log_error "Failed to clone GitHub repository '$repo' into '$target'."
+        return 1
+    }
+    printf "Run basectl repo check '%s' after the clone if the repository has adopted the Base baseline.\n" "$target"
+}
+
+base_repo_clone() {
+    local clone_url
+    local dry_run=0
+    local github_repo
+    local name=""
+    local owner=""
+    local path=""
+    local protocol
+    local spec=""
+    local status
+    local target
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_repo_clone_usage
+                return 0
+                ;;
+            --owner)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_clone_usage_error "Option '--owner' requires an argument."
+                    return $?
+                }
+                owner="$2"
+                shift 2
+                ;;
+            --owner=*)
+                owner="${1#--owner=}"
+                shift
+                ;;
+            --path)
+                [[ -n "${2:-}" ]] || {
+                    base_repo_clone_usage_error "Option '--path' requires an argument."
+                    return $?
+                }
+                path="$2"
+                shift 2
+                ;;
+            --path=*)
+                path="${1#--path=}"
+                shift
+                ;;
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            -v)
+                set_log_level DEBUG
+                export LOG_DEBUG=1
+                shift
+                ;;
+            -*)
+                base_repo_clone_usage_error "Unknown repo clone option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$spec" ]]; then
+                    base_repo_clone_usage_error "The 'repo clone' command accepts exactly one repository name."
+                    return $?
+                fi
+                spec="$1"
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$spec" ]] || {
+        base_repo_clone_usage_error "Repository name is required."
+        return $?
+    }
+
+    if [[ "$spec" == */* ]]; then
+        [[ "$spec" != */*/* ]] || {
+            base_repo_clone_usage_error "Repository must be '<name>' or '<owner>/<name>'."
+            return $?
+        }
+        [[ -z "$owner" ]] || {
+            base_repo_clone_usage_error "Option '--owner' cannot be used with '<owner>/<name>'."
+            return $?
+        }
+        owner="${spec%%/*}"
+        name="${spec#*/}"
+    else
+        name="$spec"
+        if [[ -z "$owner" ]]; then
+            owner="$(base_repo_default_github_owner)"
+            status=$?
+            case "$status" in
+                0)
+                    ;;
+                1)
+                    base_repo_clone_usage_error "Repository owner is required for short repo names. Pass --owner <owner> or set github.default_owner in ~/.base.d/config.yaml."
+                    return $?
+                    ;;
+                *)
+                    return "$status"
+                    ;;
+            esac
+        fi
+    fi
+
+    base_repo_validate_owner "$owner" || return 2
+    base_repo_validate_name "$name" || return 2
+    github_repo="$owner/$name"
+    protocol="$(base_repo_clone_protocol)" || return $?
+    clone_url="$(base_repo_clone_url "$protocol" "$github_repo")" || return 1
+
+    if [[ -z "$path" ]]; then
+        path="$(base_repo_default_target_path "$name")" || return $?
+    else
+        path="$(base_repo_expand_path "$path")"
+    fi
+    target="$(base_repo_target_path "$path")"
+
+    base_repo_clone_with_gh "$dry_run" "$github_repo" "$target" "$clone_url"
+}
+
 base_repo_check() {
     local agent_guidance=0
     local path="."
@@ -2252,6 +2585,10 @@ base_repo_subcommand_main() {
         init)
             shift
             base_repo_init "$@"
+            ;;
+        clone)
+            shift
+            base_repo_clone "$@"
             ;;
         check)
             shift

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -119,6 +119,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "repo_init_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl repo clone --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "repo_clone_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl repo check --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -191,8 +195,9 @@ EOF
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
-    [[ "$output" == *"repo_commands=init check configure agent-guidance installer-template"* ]]
+    [[ "$output" == *"repo_commands=init clone check configure agent-guidance installer-template"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run"* ]]
+    [[ "$output" == *"repo_clone_options=--owner --path --dry-run"* ]]
     [[ "$output" == *"repo_check_options=--agent-guidance"* ]]
     [[ "$output" == *"repo_configure_options=--repo --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run"* ]]
     [[ "$output" == *"repo_agent_guidance_options=--repo-name --default-branch --validation-command --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -9,6 +9,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl repo init <name>"* ]]
+    [[ "$output" == *"basectl repo clone <name-or-owner/name>"* ]]
     [[ "$output" == *"basectl repo check [path]"* ]]
     [[ "$output" == *"basectl repo configure [path]"* ]]
     [[ "$output" == *"basectl repo agent-guidance [path]"* ]]
@@ -32,6 +33,154 @@ load ./basectl_helpers.bash
     [[ "$output" != *"basectl repo agent-guidance"* ]]
     [[ "$output" != *"--repo-name <name>"* ]]
     [[ "$output" != *"--agent-guidance"* ]]
+}
+
+@test "basectl repo clone prints command-specific help" {
+    run_basectl repo clone --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl repo clone <name-or-owner/name> [options]"* ]]
+    [[ "$output" == *"--owner <owner>"* ]]
+    [[ "$output" == *"--path <path>"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"basectl repo clone codeforester/base --path ~/work/base"* ]]
+    [[ "$output" != *"--copy-project-fields-from <title>"* ]]
+}
+
+@test "basectl repo clone dry-run resolves short names from user config" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+    local workspace_root="$TEST_TMPDIR/workspace-root"
+    local repo_dir="$workspace_root/base-demo"
+
+    mkdir -p "$TEST_HOME/.base.d" "$nested_dir" "$workspace_root"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<EOF
+workspace:
+  root: $workspace_root
+github:
+  default_owner: codeforester
+  clone_protocol: ssh
+EOF
+
+    cd "$nested_dir"
+    run_basectl repo clone base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository: codeforester/base-demo"* ]]
+    [[ "$output" == *"Destination: $repo_dir"* ]]
+    [[ "$output" == *"Tool: gh repo clone"* ]]
+    [[ "$output" == *"Clone URL: git@github.com:codeforester/base-demo.git"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: gh repo clone codeforester/base-demo $repo_dir"* ]]
+    [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo clone supports explicit owner and path dry-run" {
+    local repo_dir="$TEST_HOME/work/base-demo"
+
+    run_basectl repo clone base-demo --owner codeforester --path "~/work/base-demo" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository: codeforester/base-demo"* ]]
+    [[ "$output" == *"Destination: $repo_dir"* ]]
+    [[ "$output" == *"Clone URL: git@github.com:codeforester/base-demo.git"* ]]
+    [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo clone supports explicit owner slash repo and https clone protocol" {
+    local repo_dir="$TEST_TMPDIR/custom/bankbuddy"
+
+    mkdir -p "$TEST_HOME/.base.d"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<'EOF'
+github:
+  default_owner: ignored
+  clone_protocol: https
+EOF
+
+    run_basectl repo clone codeforester/bankbuddy --path "$repo_dir" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository: codeforester/bankbuddy"* ]]
+    [[ "$output" == *"Destination: $repo_dir"* ]]
+    [[ "$output" == *"Clone URL: https://github.com/codeforester/bankbuddy.git"* ]]
+}
+
+@test "basectl repo clone requires an owner for short names" {
+    run_basectl repo clone base-demo --dry-run
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"basectl repo clone <name-or-owner/name> [options]"* ]]
+    [[ "$output" == *"ERROR: Repository owner is required for short repo names."* ]]
+    [[ "$output" == *"Pass --owner <owner> or set github.default_owner in ~/.base.d/config.yaml."* ]]
+}
+
+@test "basectl repo clone treats existing matching checkouts as satisfied" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    init_git_repo "$repo_dir"
+    git -C "$repo_dir" remote add origin git@github.com:codeforester/base-demo.git
+
+    run_basectl repo clone codeforester/base-demo --path "$repo_dir"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository 'codeforester/base-demo' already exists at '$repo_dir'."* ]]
+    [[ "$output" != *"gh repo clone"* ]]
+
+    git -C "$repo_dir" remote set-url origin git@github.com:codeforester/base-demo
+
+    run_basectl repo clone codeforester/base-demo --path "$repo_dir"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository 'codeforester/base-demo' already exists at '$repo_dir'."* ]]
+}
+
+@test "basectl repo clone rejects conflicting existing checkouts" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    init_git_repo "$repo_dir"
+    git -C "$repo_dir" remote add origin git@github.com:other/base-demo.git
+
+    run_basectl repo clone codeforester/base-demo --path "$repo_dir"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Destination '$repo_dir' already points at GitHub repository 'other/base-demo'."* ]]
+    [[ "$output" == *"Expected 'codeforester/base-demo'."* ]]
+}
+
+@test "basectl repo clone rejects existing non-git destinations" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    mkdir -p "$repo_dir"
+
+    run_basectl repo clone codeforester/base-demo --path "$repo_dir"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Destination '$repo_dir' already exists but is not a matching Git checkout."* ]]
+}
+
+@test "basectl repo clone delegates to gh repo clone" {
+    local repo_dir="$TEST_TMPDIR/workspace/base-demo"
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+if [[ "$1" == "repo" && "$2" == "clone" ]]; then
+    mkdir -p "$4/.git"
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo clone codeforester/base-demo --path "$repo_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "repo clone codeforester/base-demo $repo_dir" ]
+    [[ "$output" == *"Cloning GitHub repository 'codeforester/base-demo' into '$repo_dir'."* ]]
+    [[ "$output" == *"Run basectl repo check '$repo_dir' after the clone if the repository has adopted the Base baseline."* ]]
 }
 
 @test "basectl repo configure prints command-specific help" {

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -57,6 +57,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | Command | What it does | Important flags |
 |---|---|---|
 | `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--copy-project-fields-from <title>`, `--no-project`, `--dry-run` |
+| `basectl repo clone <name-or-owner/name>` | Clone one GitHub repository into the configured Base workspace, treating matching existing checkouts as already satisfied. | `--owner <owner>`, `--path <path>`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
 | `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` to seed options and fill missing issue defaults when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files. | `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--dry-run` |

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -106,6 +106,27 @@ edit that value to make commands such as
 create the workspace directory automatically; `basectl config doctor` reports
 whether the configured path exists.
 
+## GitHub Defaults
+
+User-local GitHub defaults reduce repeated flags for workspace repository
+commands:
+
+```yaml
+github:
+  default_owner: codeforester
+  clone_protocol: ssh
+```
+
+`github.default_owner` lets short repository names resolve during
+`basectl repo clone <name>`. Without it, short names require
+`--owner <owner>`.
+
+`github.clone_protocol` controls the clone URL shown in dry-run and planning
+output. Supported values are `ssh` and `https`; when omitted, Base reports SSH
+URLs. The actual clone delegates to `gh repo clone <owner/repo> <path>` so the
+GitHub CLI remains responsible for GitHub authentication and its own transport
+behavior.
+
 ## IDE Preferences
 
 User-local IDE preferences can add machine-specific IDE behavior without

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -8,6 +8,33 @@ product-specific setup.
 
 ## Commands
 
+Clone an existing GitHub repository into the configured workspace:
+
+```bash
+basectl repo clone codeforester/base-demo
+basectl repo clone base-demo --owner codeforester
+```
+
+`repo clone` is for repositories that already exist on GitHub. Without
+`--path`, it clones to `<workspace.root>/<repo>` when `workspace.root` is set in
+`~/.base.d/config.yaml`; otherwise it falls back to the parent directory of
+`BASE_HOME`. Short repository names require `--owner <owner>` or a
+`github.default_owner` value in the user config:
+
+```yaml
+github:
+  default_owner: codeforester
+  clone_protocol: ssh
+```
+
+`github.clone_protocol` may be `ssh` or `https`; it controls the clone URL shown
+in planning output while the actual clone delegates to `gh repo clone`.
+`--dry-run` prints the resolved repository, destination, clone tool, clone URL,
+and command without modifying the filesystem. If the destination already exists
+and its `origin` points at the requested GitHub repository, Base treats the clone
+as already satisfied. If the destination exists with another origin, Base fails
+with an actionable conflict.
+
 Create a new repo baseline:
 
 ```bash

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -122,10 +122,13 @@ _base_basectl_completion() {
         repo)
             case "${COMP_WORDS[2]:-}" in
                 "")
-                    _base_basectl_completion_compgen "init check configure agent-guidance installer-template" "$cur"
+                    _base_basectl_completion_compgen "init clone check configure agent-guidance installer-template" "$cur"
                     ;;
                 init)
                     _base_basectl_completion_compgen "--path --repo --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run -v -h --help" "$cur"
+                    ;;
+                clone)
+                    _base_basectl_completion_compgen "--owner --path --dry-run -v -h --help" "$cur"
                     ;;
                 check)
                     _base_basectl_completion_compgen "--agent-guidance -v -h --help" "$cur"


### PR DESCRIPTION
## Summary
- Add `basectl repo clone <name-or-owner/name>` for cloning one existing GitHub repository into the configured Base workspace.
- Support `github.default_owner`, `github.clone_protocol`, `--owner`, `--path`, and `--dry-run` planning output.
- Treat matching existing checkouts as satisfied and reject conflicting destinations with clear errors.
- Update completions and docs for the new command.

## Validation
- `bats --filter "repo clone" cli/bash/commands/basectl/tests/repo.bats`
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `bats cli/bash/commands/basectl/tests/completions.bats`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test` (`423 passed, 1 skipped`; BATS `1..473`, exit 0)

## Demo Impact
- New command should be included in future onboarding demos when showing first repo checkout through Base.

Closes #610