### PR TITLE
Make basectl update project-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and Base versions are tracked in the repo-root `VERSION` file.
   idempotently add externally-created issues to their repo Project and apply
   default Project fields.
 
+### Changed
+
+- Changed `basectl update` to accept an optional project name, so
+  `basectl update <project>` updates that project checkout and then runs
+  `basectl setup <project>`, while omitting the project keeps the existing
+  Base update behavior.
+
 ## [1.0.1] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -880,8 +880,8 @@ exec "$SHELL" -l
 
 Homebrew installs the Base files. `basectl setup` still prepares the local Base
 runtime under `~/.base.d/base/.venv`, and `basectl update-profile` adds Base to
-your shell startup path. When installed through Homebrew, `basectl update`
-hands off to Homebrew and runs setup afterward. This is equivalent to:
+your shell startup path. When installed through Homebrew, `basectl update` for
+Base hands off to Homebrew and runs setup afterward. This is equivalent to:
 
 ```bash
 brew upgrade codeforester/base/base
@@ -1037,23 +1037,25 @@ run `basectl update-profile --no-defaults` to disable them again. Plain
 `BASE_PROFILE_VERSION` records the schema version of this Base-managed file. It
 is reserved for future migrations and is not intended to be edited by users.
 
-Update Base itself with:
+Update Base or a Base-managed project checkout with:
 
 ```bash
 basectl update
+basectl update bankbuddy
 ```
 
-This command is intentionally conservative. In a source checkout, it only runs
-from the Base repository's default branch, requires tracked Base files to be
-clean, pulls the latest changes through Git, and then runs `basectl setup`.
-Untracked files do not block the update; Git still stops the pull if an
-incoming tracked file would overwrite them.
+Omitting the project is equivalent to `basectl update base`. This command is
+intentionally conservative. In a source checkout, it only runs from the selected
+project repository's default branch, requires tracked project files to be clean,
+pulls the latest changes through Git, and then runs `basectl setup <project>`.
+Untracked files do not block the update; Git still stops the pull if an incoming
+tracked file would overwrite them.
 
-In a Homebrew-managed install, `basectl update` runs only the Base package
-upgrade, `brew upgrade codeforester/base/base`, and then runs `basectl setup`
-with inherited Base environment variables cleared. `basectl update --dry-run`
-prints the Git or Homebrew handoff it would perform without changing files or
-packages.
+In a Homebrew-managed install, the Base update path remains Base-only:
+`basectl update` runs the Base package upgrade,
+`brew upgrade codeforester/base/base`, and then runs `basectl setup base` with
+inherited Base environment variables cleared. `basectl update --dry-run` prints
+the Git or Homebrew handoff it would perform without changing files or packages.
 
 Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
 is user-managed and may be hand-edited. It is intended for simple,

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -125,9 +125,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   stable file headings and use `INDEX.md` ordering when available. Zip exports
   contain only files from `.ai-context`.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
-- `basectl update` updates source checkouts through Git, updates Homebrew
-  installs with `brew upgrade codeforester/base/base`, and then runs
-  `basectl setup`.
+- `basectl update [project]` updates the selected project checkout through Git
+  and then runs `basectl setup <project>`. Omitting the project selects `base`;
+  Homebrew-managed Base installs still hand off only the Base package to
+  `brew upgrade codeforester/base/base`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`
   when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
   project names and paths.

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -11,7 +11,7 @@ source "$_base_setup_common_path"
 base_update_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl update [options]
+  basectl update [project] [options]
 
 Options:
   --dry-run   Show what would happen without pulling or running setup.
@@ -19,14 +19,15 @@ Options:
   -h, --help  Show this help text.
 
 Purpose:
-  Update Base from Git for source checkouts, or through Homebrew for Homebrew
-  installs, then run basectl setup.
+  Update a Base-managed project from Git, or update Base through Homebrew for
+  Homebrew installs, then run basectl setup for the selected project.
 
 Notes:
-  - The repository must be on its default branch.
-  - Tracked Base files must be clean; untracked files are left to Git's normal
+  - When project is omitted, Base updates project 'base'.
+  - The selected project repository must be on its default branch.
+  - Tracked project files must be clean; untracked files are left to Git's normal
     pull-time overwrite protection.
-  - Homebrew installs update only the Base formula:
+  - Homebrew installs update only project 'base' through the Base formula:
     brew upgrade codeforester/base/base
 EOF
 }
@@ -148,11 +149,12 @@ base_update_run_homebrew_setup() {
 }
 
 base_update_homebrew_install() {
-    local dry_run="$1"
+    local base_home="$1"
+    local dry_run="$2"
     local package
 
     package="$(base_update_homebrew_package)"
-    log_info "Detected Homebrew-managed Base install at '$BASE_HOME'."
+    log_info "Detected Homebrew-managed Base install at '$base_home'."
 
     if ((dry_run)); then
         log_info "[DRY-RUN] Would run: brew upgrade $package"
@@ -169,7 +171,7 @@ base_update_homebrew_install() {
     base_update_run_homebrew_upgrade "$package" || return $?
 
     log_info "Running basectl setup after Homebrew upgrade."
-    base_update_run_homebrew_setup "$BASE_HOME" "$package" || return $?
+    base_update_run_homebrew_setup "$base_home" "$package" || return $?
 
     log_info "Base update is complete."
 }
@@ -215,7 +217,40 @@ base_update_has_untracked_files() {
 }
 
 base_update_run_setup() {
-    "$BASE_HOME/bin/basectl" setup
+    local base_home="$1"
+    local project="$2"
+
+    "$base_home/bin/basectl" setup "$project"
+}
+
+base_update_resolve_project() {
+    local base_home="$1"
+    local project="$2"
+    local wrapper="$base_home/bin/base-wrapper"
+    local resolve_output resolved_name resolved_root resolved_manifest
+
+    if [[ -z "$project" ]]; then
+        project=base
+    fi
+
+    if [[ "$project" == base ]]; then
+        printf '%s\t%s\t%s\n' base "$base_home" "$base_home/base_manifest.yaml"
+        return 0
+    fi
+
+    [[ -x "$wrapper" ]] || {
+        log_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+
+    resolve_output="$("$wrapper" --project base base_projects resolve "$project")" || return $?
+    IFS=$'\t' read -r resolved_name resolved_root resolved_manifest <<<"$resolve_output"
+    [[ "$resolved_name" == "$project" && -n "$resolved_root" && -n "$resolved_manifest" ]] || {
+        log_error "Unable to resolve Base project '$project'."
+        return 1
+    }
+
+    printf '%s\t%s\t%s\n' "$resolved_name" "$resolved_root" "$resolved_manifest"
 }
 
 base_update_head_revision() {
@@ -225,8 +260,15 @@ base_update_head_revision() {
 
 base_update_subcommand_main() {
     local after_revision
+    local base_home="${BASE_HOME:?}"
     local before_revision
     local branch
+    local manifest_path
+    local project=base
+    local project_arg=""
+    local repo
+    local resolve_output
+    local resolved_project
     local update_branch
     local dry_run=0
 
@@ -242,68 +284,84 @@ base_update_subcommand_main() {
             -v)
                 setup_enable_debug_logging
                 ;;
-            *)
+            --*)
                 print_error "Unknown option '$1'."
                 base_update_subcommand_usage >&2
                 return 1
+                ;;
+            *)
+                if [[ -n "$project_arg" ]]; then
+                    print_error "The 'update' command accepts at most one project name."
+                    base_update_subcommand_usage >&2
+                    return 1
+                fi
+                project_arg="$1"
+                project="$1"
                 ;;
         esac
         shift
     done
 
-    log_debug "Running 'basectl update'."
-
-    branch="$(base_update_current_branch "$BASE_HOME")" || {
-        if base_update_is_homebrew_install "$BASE_HOME"; then
-            base_update_homebrew_install "$dry_run"
-            return $?
-        fi
-        log_error "Base home '$BASE_HOME' is not a Git repository."
+    resolve_output="$(base_update_resolve_project "$base_home" "$project")" || return $?
+    IFS=$'\t' read -r resolved_project repo manifest_path <<<"$resolve_output"
+    [[ -n "$resolved_project" && -n "$repo" && -n "$manifest_path" ]] || {
+        log_error "Unable to resolve Base project '$project'."
         return 1
     }
-    update_branch="$(base_update_default_branch "$BASE_HOME")" || {
-        log_error "Unable to determine the Base repository default branch."
+
+    log_debug "Running 'basectl update' for project '$resolved_project'."
+
+    branch="$(base_update_current_branch "$repo")" || {
+        if [[ "$resolved_project" == base ]] && base_update_is_homebrew_install "$base_home"; then
+            base_update_homebrew_install "$base_home" "$dry_run"
+            return $?
+        fi
+        log_error "Project '$resolved_project' repository '$repo' is not a Git repository."
+        return 1
+    }
+    update_branch="$(base_update_default_branch "$repo")" || {
+        log_error "Unable to determine the default branch for project '$resolved_project'."
         return 1
     }
     if [[ "$branch" != "$update_branch" ]]; then
-        log_error "Base update only runs on default branch '$update_branch'; current branch is '$branch'."
+        log_error "Project '$resolved_project' update only runs on default branch '$update_branch'; current branch is '$branch'."
         return 1
     fi
 
-    if ! base_update_worktree_clean "$BASE_HOME"; then
-        log_error "Base repository has tracked local changes. Commit, stash, or remove them before running basectl update."
+    if ! base_update_worktree_clean "$repo"; then
+        log_error "Project '$resolved_project' repository has tracked local changes. Commit, stash, or remove them before running basectl update."
         return 1
     fi
-    if base_update_has_untracked_files "$BASE_HOME"; then
-        log_warn "Base repository has untracked files. Continuing because tracked files are clean."
+    if base_update_has_untracked_files "$repo"; then
+        log_warn "Project '$resolved_project' repository has untracked files. Continuing because tracked files are clean."
     fi
 
     if ((dry_run)); then
-        log_info "[DRY-RUN] Would update Base repository at '$BASE_HOME'."
-        log_info "[DRY-RUN] Would run 'basectl setup' after updating."
+        log_info "[DRY-RUN] Would update project '$resolved_project' repository at '$repo'."
+        log_info "[DRY-RUN] Would run 'basectl setup $resolved_project' after updating."
         return 0
     fi
 
     base_update_source_git_library || return 1
-    before_revision="$(base_update_head_revision "$BASE_HOME")" || {
-        log_error "Unable to read current Base repository revision."
+    before_revision="$(base_update_head_revision "$repo")" || {
+        log_error "Unable to read current revision for project '$resolved_project'."
         return 1
     }
 
-    log_info "Updating Base repository at '$BASE_HOME'."
-    git_update_repo "$BASE_HOME" "" "$update_branch" || return 1
-    after_revision="$(base_update_head_revision "$BASE_HOME")" || {
-        log_error "Unable to read updated Base repository revision."
+    log_info "Updating project '$resolved_project' repository at '$repo'."
+    git_update_repo "$repo" "" "$update_branch" || return 1
+    after_revision="$(base_update_head_revision "$repo")" || {
+        log_error "Unable to read updated revision for project '$resolved_project'."
         return 1
     }
 
     if [[ "$before_revision" == "$after_revision" ]]; then
-        log_info "Base repository is already up to date on '$update_branch' at '$after_revision'."
+        log_info "Project '$resolved_project' repository is already up to date on '$update_branch' at '$after_revision'."
     else
-        log_info "Base repository updated from '$before_revision' to '$after_revision' on '$update_branch'."
+        log_info "Project '$resolved_project' repository updated from '$before_revision' to '$after_revision' on '$update_branch'."
     fi
 
-    log_info "Running basectl setup after update."
-    base_update_run_setup || return $?
-    log_info "Base update is complete."
+    log_info "Running basectl setup $resolved_project after update."
+    base_update_run_setup "$base_home" "$resolved_project" || return $?
+    log_info "Project '$resolved_project' update is complete."
 }

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -59,10 +59,18 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "export_context_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl update ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "update_projects=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl check --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "check_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl update --); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "update_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl check --profile ""); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -182,7 +190,9 @@ EOF
     [[ "$output" == *"build_projects=base demo"* ]]
     [[ "$output" == *"run_projects=base demo"* ]]
     [[ "$output" == *"export_context_projects=base demo"* ]]
+    [[ "$output" == *"update_projects=base demo"* ]]
     [[ "$output" == *"check_options=--profile --format"* ]]
+    [[ "$output" == *"update_options=--dry-run"* ]]
     [[ "$output" == *"check_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"test_options=--workspace --dry-run"* ]]
     [[ "$output" == *"build_options=--workspace --dry-run --list"* ]]

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -8,9 +8,10 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl update [options]"* ]]
-    [[ "$output" == *"Update Base from Git for source checkouts, or through Homebrew"* ]]
-    [[ "$output" == *"Tracked Base files must be clean"* ]]
+    [[ "$output" == *"basectl update [project] [options]"* ]]
+    [[ "$output" == *"Update a Base-managed project from Git, or update Base through Homebrew"* ]]
+    [[ "$output" == *"When project is omitted, Base updates project 'base'."* ]]
+    [[ "$output" == *"Tracked project files must be clean"* ]]
     [[ "$output" == *"brew upgrade codeforester/base/base"* ]]
 }
 
@@ -29,8 +30,47 @@ load ./basectl_helpers.bash
         '
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"[DRY-RUN] Would update Base repository at '$BASE_REPO_ROOT'."* ]]
-    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup' after updating."* ]]
+    [[ "$output" == *"[DRY-RUN] Would update project 'base' repository at '$BASE_REPO_ROOT'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup base' after updating."* ]]
+}
+
+@test "basectl update dry-run resolves a named project" {
+    local project_root="$TEST_TMPDIR/demo"
+
+    mkdir -p "$project_root"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_PROJECT_ROOT="$project_root" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_resolve_project() { printf "demo\t%s\t%s\n" "$BASE_TEST_PROJECT_ROOT" "$BASE_TEST_PROJECT_ROOT/base_manifest.yaml"; }
+            base_update_current_branch() { printf "%s\n" main; }
+            base_update_default_branch() { printf "%s\n" main; }
+            base_update_worktree_clean() { return 0; }
+            base_update_has_untracked_files() { return 1; }
+            base_update_subcommand_main --dry-run demo
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would update project 'demo' repository at '$project_root'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup demo' after updating."* ]]
+}
+
+@test "basectl update rejects multiple project arguments" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_subcommand_main demo other
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"The 'update' command accepts at most one project name."* ]]
 }
 
 @test "basectl update dry-run reports Homebrew handoff without running brew" {
@@ -176,7 +216,7 @@ EOF
         '
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Base repository has tracked local changes."* ]]
+    [[ "$output" == *"Project 'base' repository has tracked local changes."* ]]
     [[ "$output" != *"git library should not load"* ]]
     [[ "$output" != *"git update should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
@@ -209,10 +249,10 @@ EOF
         '
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Base repository has untracked files. Continuing because tracked files are clean."* ]]
+    [[ "$output" == *"Project 'base' repository has untracked files. Continuing because tracked files are clean."* ]]
     [[ "$output" == *"git update repo=$repo branch=master"* ]]
     [[ "$output" == *"setup ran"* ]]
-    [[ "$output" == *"Base update is complete."* ]]
+    [[ "$output" == *"Project 'base' update is complete."* ]]
 }
 
 @test "basectl update refuses non-default branches" {
@@ -230,7 +270,7 @@ EOF
         '
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Base update only runs on default branch 'main'; current branch is 'feature/example'."* ]]
+    [[ "$output" == *"Project 'base' update only runs on default branch 'main'; current branch is 'feature/example'."* ]]
     [[ "$output" != *"clean should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
 }
@@ -254,11 +294,11 @@ EOF
         '
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Updating Base repository at '$BASE_REPO_ROOT'."* ]]
-    [[ "$output" == *"Base repository is already up to date on 'master' at 'abc1234'."* ]]
-    [[ "$output" == *"Running basectl setup after update."* ]]
+    [[ "$output" == *"Updating project 'base' repository at '$BASE_REPO_ROOT'."* ]]
+    [[ "$output" == *"Project 'base' repository is already up to date on 'master' at 'abc1234'."* ]]
+    [[ "$output" == *"Running basectl setup base after update."* ]]
     [[ "$output" == *"setup ran"* ]]
-    [[ "$output" == *"Base update is complete."* ]]
+    [[ "$output" == *"Project 'base' update is complete."* ]]
 }
 
 @test "basectl update reports changed revisions" {
@@ -289,7 +329,48 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"git update repo=$BASE_REPO_ROOT branch=main"* ]]
-    [[ "$output" == *"Base repository updated from 'old1234' to 'new5678' on 'main'."* ]]
+    [[ "$output" == *"Project 'base' repository updated from 'old1234' to 'new5678' on 'main'."* ]]
     [[ "$output" == *"setup ran"* ]]
-    [[ "$output" == *"Base update is complete."* ]]
+    [[ "$output" == *"Project 'base' update is complete."* ]]
+}
+
+@test "basectl update runs Git update and setup for a named project" {
+    local project_root="$TEST_TMPDIR/demo"
+
+    mkdir -p "$project_root"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_PROJECT_ROOT="$project_root" \
+        BASE_TEST_AFTER_UPDATE="$TEST_TMPDIR/after-update" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_resolve_project() { printf "demo\t%s\t%s\n" "$BASE_TEST_PROJECT_ROOT" "$BASE_TEST_PROJECT_ROOT/base_manifest.yaml"; }
+            base_update_current_branch() { printf "%s\n" main; }
+            base_update_default_branch() { printf "%s\n" main; }
+            base_update_worktree_clean() { return 0; }
+            base_update_has_untracked_files() { return 1; }
+            base_update_source_git_library() { :; }
+            git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
+            base_update_head_revision() {
+                if [[ -f "$BASE_TEST_AFTER_UPDATE" ]]; then
+                    printf "%s\n" new5678
+                else
+                    touch "$BASE_TEST_AFTER_UPDATE"
+                    printf "%s\n" old1234
+                fi
+            }
+            base_update_run_setup() { printf "setup project=%s\n" "$2"; }
+            base_update_subcommand_main demo
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Updating project 'demo' repository at '$project_root'."* ]]
+    [[ "$output" == *"git update repo=$project_root branch=main"* ]]
+    [[ "$output" == *"Project 'demo' repository updated from 'old1234' to 'new5678' on 'main'."* ]]
+    [[ "$output" == *"Running basectl setup demo after update."* ]]
+    [[ "$output" == *"setup project=demo"* ]]
+    [[ "$output" == *"Project 'demo' update is complete."* ]]
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -9,7 +9,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 |---|---|---|
 | `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv` |
 | `basectl update-profile` | Create or update Base-managed Bash and Zsh startup snippets. | `--defaults`, `--no-defaults`, `--dry-run` |
-| `basectl update` | Update source checkouts through Git or Homebrew installs through `brew upgrade`, then run setup. | `--dry-run` |
+| `basectl update [project]` | Update a Base-managed project checkout through Git, or update Base through Homebrew when Base is Homebrew-managed, then run setup for the selected project. | `--dry-run` |
 | `basectl onboard` | Guide first-run setup by orchestrating setup, shell profile, doctor, and project discovery checks. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
 | `basectl version` | Show the installed Base version. | none |
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -146,7 +146,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 |---|---|
 | `basectl setup [project] [--profile dev\|sre\|ai]` | Install / reconcile prerequisites |
 | `basectl update-profile [--defaults]` | Wire shell startup files |
-| `basectl update [--dry-run]` | Upgrade Base (git pull or brew upgrade) |
+| `basectl update [project] [--dry-run]` | Upgrade Base or a Base-managed project checkout |
 | `basectl onboard` | Guided first-run checklist |
 
 ### Daily Loop

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -247,7 +247,7 @@ _base_basectl_completion() {
             _base_basectl_completion_compgen "--defaults --no-defaults --dry-run -v -h --help" "$cur"
             ;;
         update)
-            _base_basectl_completion_compgen "--dry-run -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options "--dry-run -v -h --help" "$cur"
             ;;
     esac
 }

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -375,7 +375,12 @@ _base_basectl_completion() {
             ;;
         update)
             _arguments '--dry-run[Log without pulling or running setup]' '-v[Enable DEBUG logging]' \
-                '(-h --help)'{-h,--help}'[Show help text]'
+                '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
             ;;
     esac
 }


### PR DESCRIPTION
## Summary
- Add optional `basectl update [project]` resolution, with omitted project preserving the existing Base update path.
- Update the selected project repository and run `basectl setup <project>` after source checkout updates.
- Keep Homebrew-managed Base update behavior Base-only, and update completion/docs for the new project argument.

## Validation
- `bats cli/bash/commands/basectl/tests/update.bats`
- `bats cli/bash/commands/basectl/tests/completions.bats lib/shell/completions/tests/completions.bats`
- `shellcheck cli/bash/commands/basectl/subcommands/update.sh`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test` - Python 426 passed, 1 skipped; BATS 1..477 all ok

## Demo Impact
- None. The update command can now target demo/project repositories explicitly; no demo script changes.

Closes #709