### PR TITLE
Support uv-managed Python projects

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -67,6 +67,9 @@ Base orchestrates mature tools instead of replacing them:
 - Homebrew owns ordinary macOS packages and Brewfiles.
 - `mise` owns language/runtime installation when a project declares a mise
   config.
+- uv owns Python dependency resolution, lockfiles, and project-local `.venv`
+  environments when a manifest declares `python.manager: uv`; individual
+  commands can opt into `uv run` with `runner: uv`.
 - IDEs own editor behavior; Base can install apps/extensions/settings
   additively.
 - Docker, `just`, Taskfile, Devbox, Nix, and similar tools can be project-level

--- a/.ai-context/DECISIONS.md
+++ b/.ai-context/DECISIONS.md
@@ -47,6 +47,9 @@ architecture discussion.
   runners, and similar tools. It should not replace them.
 - Ordinary Homebrew packages should move toward Brewfile delegation unless Base
   needs special handling.
+- uv support is explicit: `python.manager: uv` opts a project into uv-managed
+  setup and `.venv` ownership, while command-level `runner: uv` is independent
+  and may be used in composite projects.
 - Build tool provisioning should be profile-driven or project-declared, not
   hardcoded inside `basectl build`.
 - New tool families such as AI developer tools should stay explicit and

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -13,8 +13,10 @@ The current command surface covers:
 - checks and doctor diagnostics
 - project discovery
 - project activation
-- declared project test, build, run, and demo commands
+- declared project test, build, run, and demo commands, including explicit
+  `runner: uv` delegation
 - mise integration
+- explicit uv-managed Python project setup through `python.manager: uv`
 - cleanup and logs
 - local config inspection
 - onboarding
@@ -28,9 +30,10 @@ The current command surface covers:
 ## Active Development Direction
 
 The `v1.0.0` milestone is complete. Post-1.0 work is tracked toward `v1.1.0`,
-with Linux runtime support, uv-managed Python project behavior, Docker/service
-artifacts, and shell stdlib hardening remaining outside the 1.0 release
-contract.
+with Linux runtime support, Docker/service artifacts, and shell stdlib
+hardening remaining outside the 1.0 release contract. uv-managed Python project
+behavior is now implemented after 1.0 through the explicit
+`python.manager: uv` contract.
 
 The Homebrew bottle and consumer upgrade contract has passed the #526 rehearsal.
 Supported macOS installs should continue to use bottled Homebrew packages, with
@@ -52,6 +55,7 @@ Recent released work includes:
 - stale readonly `BASE_HOME` recovery guidance after Homebrew upgrades
 - Homebrew `basectl update` handoff and package-aware `basectl test base`
 - Base `1.0.1` AGPL license cleanup and release artifacts
+- explicit uv-managed Python setup and command runner support
 
 ## Recent Merged Changes
 
@@ -60,7 +64,7 @@ Recent commits on `master` include:
 - public evaluator documentation through `docs/why-base.md`
 - AGPL license cleanup and generated-license correction for `basectl repo init`
 - Homebrew and source checkout install-path clarification
-- uv ecosystem boundary documentation
+- uv ecosystem boundary documentation and explicit uv-managed project support
 - repo Project metadata handoff and command-specific `basectl repo` help
 - shell stdlib dry-run safety fixes from BankBuddy dogfooding
 - Homebrew bottle and upgrade-path release process hardening

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added a generated Project intake workflow so Base-managed repos can
   idempotently add externally-created issues to their repo Project and apply
   default Project fields.
+- Added explicit uv-managed Python project support with `python.manager: uv`,
+  delegated `uv sync` setup, uv diagnostics, and command-level `runner: uv`
+  support for test, run, demo, and build commands.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -266,11 +266,11 @@ an integer compatibility marker for the manifest contract, not a Base release
 number. Base rejects manifests with a newer schema version than it understands
 and asks the user to upgrade Base.
 
-The manifest intentionally describes what the project needs, not arbitrary
-commands to execute. Base's direction is delegation-first: use mature tools for
-the domains they already own, and keep Base responsible for workspace
-orchestration, project discovery, the project virtual environment, and
-diagnostics.
+The manifest intentionally describes what the project needs and which
+project-owned commands Base should expose. Base's direction is
+delegation-first: use mature tools for the domains they already own, and keep
+Base responsible for workspace orchestration, project discovery, the project
+virtual environment, and diagnostics.
 
 The optional top-level `brewfile` field points to a Homebrew `Brewfile` relative
 to the project root. When present, `basectl setup` runs
@@ -313,6 +313,23 @@ commands:
   dev: mise run dev
   lint: mise run lint
 ```
+
+Commands may declare a generic `runner`. The first supported runner is `uv`:
+
+```yaml
+test:
+  command: pytest
+  runner: uv
+
+commands:
+  taxbuddy:
+    command: taxbuddy
+    runner: uv
+```
+
+`runner: uv` routes that command through `uv run -- ...`. It is independent of
+the project-level Python manager, so composite projects can use uv for one
+Python utility while keeping other commands in Go, Node, shell, or `mise`.
 
 For a polyglot project such as `banyanlabs`, keep Base at the workspace
 orchestration layer and let the language-native tools own their usual files.
@@ -365,10 +382,18 @@ PyPI package names and install into the project virtual environment at
 delegation. Pinned Homebrew versions fail clearly until Base grows explicit
 versioned tool support.
 
-A future structured `python:` manifest section can make project venv and
-requirement-file behavior clearer when `python-package` artifact rows become too
-limited. The current supported contract remains `python-package`; the future
-shape is documented in [Python Manifest Section](docs/python-manifest.md).
+The optional structured `python:` manifest section supports uv-managed Python
+projects:
+
+```yaml
+python:
+  manager: uv
+```
+
+For uv-managed projects, Base delegates setup to `uv sync`, uses the
+project-local `.venv` for activation and project commands, and skips
+Base-managed `python-package` reconciliation. See
+[Python Manifest Section](docs/python-manifest.md).
 
 Artifacts may include `bootstrap: true` when they are part of the minimum Python
 runtime contract needed before Base can reconcile a project's remaining
@@ -564,6 +589,9 @@ The `commands` map is intentionally small and declarative:
 ```yaml
 commands:
   dev: uvicorn app:app --reload
+  audit:
+    command: pytest tests/audit
+    runner: uv
   lint: ruff check .
   format: ruff format .
 ```

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -3,6 +3,10 @@
 _base_activate_subcommand_sourced=1
 readonly _base_activate_subcommand_sourced
 
+_base_project_command_helpers_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/project_command_helpers.sh"
+# shellcheck source=/dev/null
+source "$_base_project_command_helpers_path"
+
 base_activate_subcommand_usage() {
     cat <<'EOF'
 Usage:
@@ -32,27 +36,12 @@ base_activate_resolve_project() {
     env -u BASE_PROJECT_VENV_DIR "$wrapper" --project base base_projects resolve "$project" "$@"
 }
 
-base_activate_project_uses_uv() {
-    local project_root="$1"
-
-    [[ -n "$project_root" && -f "$project_root/pyproject.toml" && -f "$project_root/uv.lock" ]]
-}
-
 base_activate_project_venv_dir() {
     local project="$1"
     local project_root="${2:-}"
+    local manifest_path="${3:-}"
 
-    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
-        printf '%s\n' "$BASE_PROJECT_VENV_DIR"
-        return 0
-    fi
-
-    if base_activate_project_uses_uv "$project_root"; then
-        printf '%s\n' "$project_root/.venv"
-        return 0
-    fi
-
-    printf '%s\n' "$HOME/.base.d/$project/.venv"
+    base_project_venv_dir "$project" "$project_root" "$manifest_path"
 }
 
 base_activate_shell_is_bash() {
@@ -124,9 +113,9 @@ base_activate_subcommand_main() {
         fatal_error "Unable to resolve project '$project'."
     }
 
-    venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root")"
+    venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
     venv_fix="Run 'basectl setup $resolved_name' first."
-    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_activate_project_uses_uv "$project_root"; then
+    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_project_uses_uv_manager "$manifest_path"; then
         venv_fix="Run 'uv sync' in '$project_root' first."
     fi
     [[ -x "$venv_dir/bin/python" ]] || {

--- a/cli/bash/commands/basectl/subcommands/build.sh
+++ b/cli/bash/commands/basectl/subcommands/build.sh
@@ -38,7 +38,8 @@ base_build_list_targets() {
     shift
     local args=("$@")
     local wrapper="$BASE_HOME/bin/base-wrapper"
-    local list_output line resolved_name project_root manifest_path target_name working_dir build_command description
+    local list_output line resolved_name project_root manifest_path target_name working_dir build_command description command_runner
+    local display_text
     local printed_header=0
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
@@ -46,7 +47,7 @@ base_build_list_targets() {
     list_output="$("$wrapper" --project base base_projects build-target-list "$project" "${args[@]}")" || return $?
     while IFS= read -r line; do
         [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description <<<"$line"
+        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description command_runner <<<"$line"
         [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" ]] || {
             fatal_error "Unable to parse build targets for project '$project'."
         }
@@ -54,12 +55,21 @@ base_build_list_targets() {
             printf "Build targets for project '%s'\n\n" "$resolved_name"
             printed_header=1
         fi
-        printf '%-20s %-40s %s\n' "$target_name" "$working_dir" "${description:-$build_command}"
+        command_runner="${command_runner:-}"
+        if [[ -n "$description" ]]; then
+            display_text="$description"
+            if [[ -n "$command_runner" ]]; then
+                display_text+=" [runner: $command_runner]"
+            fi
+        else
+            display_text="$(base_display_command_with_runner "$command_runner" "$build_command")" || return $?
+        fi
+        printf '%-20s %-40s %s\n' "$target_name" "$working_dir" "$display_text"
     done <<<"$list_output"
 }
 
 base_build_subcommand_main() {
-    local project="" wrapper resolve_output line resolved_name project_root manifest_path target_name working_dir build_command description
+    local project="" wrapper resolve_output line resolved_name project_root manifest_path target_name working_dir build_command description command_runner
     local venv_dir command_to_run display_command
     local dry_run=0 list_targets=0 workspace_requested=0
     local args=() extra_args=() targets=()
@@ -148,13 +158,13 @@ base_build_subcommand_main() {
     venv_dir=""
     while IFS= read -r line; do
         [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description <<<"$line"
+        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description command_runner <<<"$line"
         [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" && -n "$build_command" ]] || {
             fatal_error "Unable to parse build target '$target_name' for project '$project'."
         }
 
         if [[ -z "$venv_dir" ]]; then
-            venv_dir="$(base_project_venv_dir "$resolved_name")"
+            venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
             export BASE_PROJECT="$resolved_name"
             export BASE_PROJECT_ROOT="$project_root"
             export BASE_PROJECT_MANIFEST="$manifest_path"
@@ -168,8 +178,9 @@ base_build_subcommand_main() {
             fi
         fi
 
-        command_to_run="$(base_command_with_extra_args "$build_command" "${extra_args[@]}")"
-        display_command="$(base_display_command "$build_command" "${extra_args[@]}")"
+        command_runner="${command_runner:-}"
+        command_to_run="$(base_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
+        display_command="$(base_display_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
 
         if [[ "$dry_run" == "1" ]]; then
             printf '[DRY-RUN] Would build target %q for project %q in %q: %s\n' \
@@ -178,6 +189,7 @@ base_build_subcommand_main() {
         fi
 
         log_info "Building target '$target_name' for project '$resolved_name': $display_command"
+        base_validate_command_runner "$command_runner"
         (cd "$working_dir" && bash -c "$command_to_run" basectl-build "${extra_args[@]}") || return $?
     done <<<"$resolve_output"
 }

--- a/cli/bash/commands/basectl/subcommands/demo.sh
+++ b/cli/bash/commands/basectl/subcommands/demo.sh
@@ -31,7 +31,8 @@ base_demo_usage_error() {
 }
 
 base_demo_subcommand_main() {
-    local project="" wrapper resolve_output resolved_name project_root manifest_path demo_script venv_dir
+    local project="" wrapper resolve_output resolved_name project_root manifest_path demo_script command_runner venv_dir
+    local quoted_demo_script command_to_run display_command
     local dry_run=0 workspace_requested=0
     local args=() extra_args=() project_args=()
 
@@ -94,13 +95,13 @@ base_demo_subcommand_main() {
 
     [[ -n "$project" ]] && project_args+=("$project")
     resolve_output="$("$wrapper" --project base base_projects demo-script "${project_args[@]}" "${args[@]}")" || return $?
-    IFS=$'\t' read -r resolved_name project_root manifest_path demo_script <<<"$resolve_output"
+    IFS=$'\t' read -r resolved_name project_root manifest_path demo_script command_runner <<<"$resolve_output"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$demo_script" ]] || {
         fatal_error "Unable to resolve demo script for project '${project:-current project}'."
     }
 
-    venv_dir="$(base_project_venv_dir "$resolved_name")"
+    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
     export BASE_PROJECT="$resolved_name"
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"
@@ -113,12 +114,22 @@ base_demo_subcommand_main() {
         log_warn "Project virtual environment was not found at '$venv_dir'. Run 'basectl setup $resolved_name' first."
     fi
 
+    command_runner="${command_runner:-}"
+    printf -v quoted_demo_script '%q' "$demo_script"
+    command_to_run="$(base_command_with_runner "$command_runner" "$quoted_demo_script" "${extra_args[@]}")" || return $?
+    display_command="$(base_display_command_with_runner "$command_runner" "$quoted_demo_script" "${extra_args[@]}")" || return $?
+
     if [[ "$dry_run" == "1" ]]; then
-        printf '[DRY-RUN] Would run demo for project %q in %q: %q%s\n' \
-            "$resolved_name" "$project_root" "$demo_script" "$(base_format_extra_args "${extra_args[@]}")"
+        printf '[DRY-RUN] Would run demo for project %q in %q: %s\n' \
+            "$resolved_name" "$project_root" "$display_command"
         return 0
     fi
 
-    log_info "Running demo for project '$resolved_name': $demo_script$(base_format_extra_args "${extra_args[@]}")"
-    (cd "$project_root" && "$demo_script" "${extra_args[@]}")
+    log_info "Running demo for project '$resolved_name': $display_command"
+    if [[ -z "$command_runner" ]]; then
+        (cd "$project_root" && "$demo_script" "${extra_args[@]}")
+        return $?
+    fi
+    base_validate_command_runner "$command_runner"
+    (cd "$project_root" && bash -c "$command_to_run" basectl-demo "${extra_args[@]}")
 }

--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -4,11 +4,31 @@
 _base_project_command_helpers_sourced=1
 readonly _base_project_command_helpers_sourced
 
+base_project_uses_uv_manager() {
+    local manifest_path="$1"
+
+    [[ -n "$manifest_path" && -f "$manifest_path" ]] || return 1
+    awk '
+        /^[[:space:]]*#/ { next }
+        /^[^[:space:]][^:]*:/ { in_python = 0 }
+        /^[[:space:]]*python:[[:space:]]*$/ { in_python = 1; next }
+        in_python && /^[[:space:]]+manager:[[:space:]]*['\''"]?uv['\''"]?[[:space:]]*(#.*)?$/ { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' "$manifest_path"
+}
+
 base_project_venv_dir() {
     local project="$1"
+    local project_root="${2:-}"
+    local manifest_path="${3:-}"
 
     if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
         printf '%s\n' "$BASE_PROJECT_VENV_DIR"
+        return 0
+    fi
+
+    if [[ -n "$project_root" ]] && base_project_uses_uv_manager "$manifest_path"; then
+        printf '%s\n' "$project_root/.venv"
         return 0
     fi
 
@@ -41,6 +61,43 @@ base_command_with_extra_args() {
     fi
 }
 
+base_command_with_runner() {
+    local runner="$1" command="$2" command_with_args
+    shift 2
+
+    command_with_args="$(base_command_with_extra_args "$command" "$@")"
+    case "$runner" in
+        "")
+            printf '%s\n' "$command_with_args"
+            ;;
+        uv)
+            printf 'uv run -- %s\n' "$command_with_args"
+            ;;
+        *)
+            printf 'Unsupported command runner %q.\n' "$runner" >&2
+            return 2
+            ;;
+    esac
+}
+
+base_validate_command_runner() {
+    local runner="$1"
+
+    case "$runner" in
+        "")
+            return 0
+            ;;
+        uv)
+            command -v uv >/dev/null 2>&1 || {
+                fatal_error "Command runner 'uv' is not available. Install uv or remove runner: uv from the project manifest."
+            }
+            ;;
+        *)
+            fatal_error "Unsupported command runner '$runner'."
+            ;;
+    esac
+}
+
 base_display_command() {
     local command="$1"
     shift
@@ -55,4 +112,23 @@ base_display_command() {
     else
         printf '%s%s\n' "$command" "$(base_format_extra_args "$@")"
     fi
+}
+
+base_display_command_with_runner() {
+    local runner="$1" command="$2" display_command
+    shift 2
+
+    display_command="$(base_display_command "$command" "$@")"
+    case "$runner" in
+        "")
+            printf '%s\n' "$display_command"
+            ;;
+        uv)
+            printf 'uv run -- %s\n' "$display_command"
+            ;;
+        *)
+            printf 'Unsupported command runner %q.\n' "$runner" >&2
+            return 2
+            ;;
+    esac
 }

--- a/cli/bash/commands/basectl/subcommands/run.sh
+++ b/cli/bash/commands/basectl/subcommands/run.sh
@@ -38,7 +38,7 @@ base_run_list_commands() {
     local args=("$@")
     local wrapper="$BASE_HOME/bin/base-wrapper"
     local command_args=(run-commands)
-    local list_output line resolved_name project_root manifest_path command_name command_text
+    local list_output line resolved_name project_root manifest_path command_name command_text command_runner display_text
     local printed_header=0
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
@@ -47,7 +47,7 @@ base_run_list_commands() {
     list_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}")" || return $?
     while IFS= read -r line; do
         [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r resolved_name project_root manifest_path command_name command_text <<<"$line"
+        IFS=$'\t' read -r resolved_name project_root manifest_path command_name command_text command_runner <<<"$line"
         [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$command_name" ]] || {
             fatal_error "Unable to parse runnable commands for project '$project'."
         }
@@ -55,12 +55,14 @@ base_run_list_commands() {
             printf "Commands for project '%s'\n\n" "$resolved_name"
             printed_header=1
         fi
-        printf '%-20s %s\n' "$command_name" "$command_text"
+        command_runner="${command_runner:-}"
+        display_text="$(base_display_command_with_runner "$command_runner" "$command_text")" || return $?
+        printf '%-20s %s\n' "$command_name" "$display_text"
     done <<<"$list_output"
 }
 
 base_run_subcommand_main() {
-    local project="" command_name="" wrapper resolve_output resolved_name project_root manifest_path run_command venv_dir
+    local project="" command_name="" wrapper resolve_output resolved_name project_root manifest_path run_command command_runner venv_dir
     local command_to_run display_command
     local dry_run=0 list_commands=0 workspace_requested=0
     local args=() extra_args=()
@@ -150,13 +152,13 @@ base_run_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     resolve_output="$("$wrapper" --project base base_projects run-command "$project" "$command_name" "${args[@]}")" || return $?
-    IFS=$'\t' read -r resolved_name project_root manifest_path run_command <<<"$resolve_output"
+    IFS=$'\t' read -r resolved_name project_root manifest_path run_command command_runner <<<"$resolve_output"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$run_command" ]] || {
         fatal_error "Unable to resolve command '$command_name' for project '$project'."
     }
 
-    venv_dir="$(base_project_venv_dir "$resolved_name")"
+    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
     export BASE_PROJECT="$resolved_name"
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"
@@ -169,8 +171,9 @@ base_run_subcommand_main() {
         log_warn "Project virtual environment was not found at '$venv_dir'. Run 'basectl setup $resolved_name' first."
     fi
 
-    command_to_run="$(base_command_with_extra_args "$run_command" "${extra_args[@]}")"
-    display_command="$(base_display_command "$run_command" "${extra_args[@]}")"
+    command_runner="${command_runner:-}"
+    command_to_run="$(base_command_with_runner "$command_runner" "$run_command" "${extra_args[@]}")" || return $?
+    display_command="$(base_display_command_with_runner "$command_runner" "$run_command" "${extra_args[@]}")" || return $?
 
     if [[ "$dry_run" == "1" ]]; then
         printf '[DRY-RUN] Would run command %q for project %q in %q: %s\n' \
@@ -179,5 +182,6 @@ base_run_subcommand_main() {
     fi
 
     log_info "Running command '$command_name' for project '$resolved_name': $display_command"
+    base_validate_command_runner "$command_runner"
     (cd "$project_root" && bash -c "$command_to_run" basectl-run "${extra_args[@]}")
 }

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -31,7 +31,7 @@ base_test_usage_error() {
 }
 
 base_test_subcommand_main() {
-    local project="" wrapper resolve_output resolved_name project_root manifest_path test_command venv_dir
+    local project="" wrapper resolve_output resolved_name project_root manifest_path test_command command_runner venv_dir
     local command_to_run display_command
     local dry_run=0 workspace_requested=0
     local args=() extra_args=()
@@ -95,13 +95,13 @@ base_test_subcommand_main() {
     local command_args=(test-command)
     [[ -z "$project" ]] || command_args+=("$project")
     resolve_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}")" || return $?
-    IFS=$'\t' read -r resolved_name project_root manifest_path test_command <<<"$resolve_output"
+    IFS=$'\t' read -r resolved_name project_root manifest_path test_command command_runner <<<"$resolve_output"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$test_command" ]] || {
         fatal_error "Unable to resolve test command for project '$project'."
     }
 
-    venv_dir="$(base_project_venv_dir "$resolved_name")"
+    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
     export BASE_PROJECT="$resolved_name"
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"
@@ -114,8 +114,9 @@ base_test_subcommand_main() {
         log_warn "Project virtual environment was not found at '$venv_dir'. Run 'basectl setup $resolved_name' first."
     fi
 
-    command_to_run="$(base_command_with_extra_args "$test_command" "${extra_args[@]}")"
-    display_command="$(base_display_command "$test_command" "${extra_args[@]}")"
+    command_runner="${command_runner:-}"
+    command_to_run="$(base_command_with_runner "$command_runner" "$test_command" "${extra_args[@]}")" || return $?
+    display_command="$(base_display_command_with_runner "$command_runner" "$test_command" "${extra_args[@]}")" || return $?
 
     if [[ "$dry_run" == "1" ]]; then
         printf '[DRY-RUN] Would run tests for project %q in %q: %s\n' "$resolved_name" "$project_root" "$display_command"
@@ -123,5 +124,6 @@ base_test_subcommand_main() {
     fi
 
     log_info "Running tests for project '$resolved_name': $display_command"
+    base_validate_command_runner "$command_runner"
     (cd "$project_root" && bash -c "$command_to_run" basectl-test "${extra_args[@]}")
 }

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -91,7 +91,7 @@ EOF
     [[ "$output" == *"BASE_PROJECT_VENV_DIR=$TEST_TMPDIR/custom-venv"* ]]
 }
 
-@test "basectl activate prefers uv project .venv when uv lockfile is present" {
+@test "basectl activate prefers uv project .venv when python manager is uv" {
     local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
     local fake_bash="$TEST_TMPDIR/fake-bash"
@@ -113,7 +113,7 @@ printf 'BASE_PROJECT_VENV_DIR=%s\n' "$BASE_PROJECT_VENV_DIR"
 EOF
     printf '#!/usr/bin/env bash\n' > "$workspace/demo/.venv/bin/python"
     chmod +x "$base_python" "$workspace/demo/.venv/bin/python" "$fake_bash"
-    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf 'project:\n  name: demo\npython:\n  manager: uv\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     printf '[project]\nname = "demo"\n' > "$workspace/demo/pyproject.toml"
     printf 'version = 1\n' > "$workspace/demo/uv.lock"
     workspace="$(cd "$workspace" && pwd -P)"
@@ -128,6 +128,47 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_PROJECT=demo"* ]]
     [[ "$output" == *"BASE_PROJECT_VENV_DIR=$workspace/demo/.venv"* ]]
+}
+
+@test "basectl activate does not infer uv venv without python manager opt-in" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local project_python="$TEST_HOME/.base.d/demo/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo/.venv/bin"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'BASE_PROJECT_VENV_DIR=%s\n' "$BASE_PROJECT_VENV_DIR"
+EOF
+    printf '#!/usr/bin/env bash\n' > "$project_python"
+    printf '#!/usr/bin/env bash\n' > "$workspace/demo/.venv/bin/python"
+    chmod +x "$base_python" "$project_python" "$workspace/demo/.venv/bin/python" "$fake_bash"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf '[project]\nname = "demo"\n' > "$workspace/demo/pyproject.toml"
+    printf 'version = 1\n' > "$workspace/demo/uv.lock"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_ACTIVATE_SHELL="$fake_bash" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"BASE_PROJECT_VENV_DIR=$TEST_HOME/.base.d/demo/.venv"* ]]
 }
 
 @test "basectl activate guides uv projects to create the uv environment" {
@@ -145,7 +186,7 @@ printf 'unexpected activate resolver args: %s\n' "$*" >&2
 exit 1
 EOF
     chmod +x "$base_python"
-    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf 'project:\n  name: demo\npython:\n  manager: uv\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     printf '[project]\nname = "demo"\n' > "$workspace/demo/pyproject.toml"
     printf 'version = 1\n' > "$workspace/demo/uv.lock"
     workspace="$(cd "$workspace" && pwd -P)"

--- a/cli/bash/commands/basectl/tests/build.bats
+++ b/cli/bash/commands/basectl/tests/build.bats
@@ -64,6 +64,46 @@ EOF
     [[ "$(cat "$state_file")" == *"worker:demo:$workspace/demo/services/worker"* ]]
 }
 
+@test "basectl build routes uv runner targets through uv" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/build-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'python -m build' 'Build API' uv
+    exit 0
+fi
+printf 'unexpected build python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$TEST_HOME/.base.d/demo/.venv/bin/uv" <<'EOF'
+#!/usr/bin/env bash
+{
+    printf 'pwd=%s\n' "$PWD"
+    printf 'args='
+    printf '<%s>' "$@"
+    printf '\n'
+} > "${BASE_TEST_BUILD_STATE:?}"
+EOF
+    chmod +x "$python_bin" "$TEST_HOME/.base.d/demo/.venv/bin/uv"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_BUILD_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo -- --wheel
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$state_file")" == *"pwd=$workspace/demo/services/api"* ]]
+    [[ "$(cat "$state_file")" == *"args=<run><--><python><-m><build><--wheel>"* ]]
+}
+
 @test "basectl build passes explicit targets and extra args" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
@@ -158,6 +198,35 @@ EOF
     [[ "$output" == *"Build targets for project 'demo'"* ]]
     [[ "$output" == *"api"* ]]
     [[ "$output" == *"Build API"* ]]
+}
+
+@test "basectl build --list shows runner without wrapping target descriptions" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-target-list" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'python -m build' 'Build API' uv
+    exit 0
+fi
+printf 'unexpected build python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Build API [runner: uv]"* ]]
+    [[ "$output" != *"uv run -- Build API"* ]]
 }
 
 @test "basectl build reports resolver errors" {

--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -62,6 +62,47 @@ EOF
     [[ "$(cat "$state_file")" == *"args=<--non-interactive><name with spaces>"* ]]
 }
 
+@test "basectl demo routes uv runner scripts through uv" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/demo-state"
+    local script_path="$workspace/demo/demo/demo.sh"
+
+    mkdir -p "$(dirname "$python_bin")" "$(dirname "$script_path")" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo/demo.sh" uv
+    exit 0
+fi
+printf 'unexpected demo python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$TEST_HOME/.base.d/demo/.venv/bin/uv" <<'EOF'
+#!/usr/bin/env bash
+{
+    printf 'pwd=%s\n' "$PWD"
+    printf 'args='
+    printf '<%s>' "$@"
+    printf '\n'
+} > "${BASE_TEST_DEMO_STATE:?}"
+EOF
+    chmod +x "$python_bin" "$TEST_HOME/.base.d/demo/.venv/bin/uv"
+    touch "$script_path"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_DEMO_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" demo demo -- --non-interactive
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$state_file")" == *"pwd=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"args=<run><--><$workspace/demo/demo/demo.sh><--non-interactive>"* ]]
+}
+
 @test "basectl demo can resolve the current project when omitted" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/bash/commands/basectl/tests/project-command-helpers.bats
+++ b/cli/bash/commands/basectl/tests/project-command-helpers.bats
@@ -25,6 +25,23 @@ source_project_command_helpers() {
     [ "$output" = "$TEST_TMPDIR/custom-venv" ]
 }
 
+@test "project command helper resolves uv-managed project venv directories" {
+    source_project_command_helpers
+
+    local project_root="$TEST_TMPDIR/demo"
+    local manifest_path="$project_root/base_manifest.yaml"
+
+    mkdir -p "$project_root"
+    printf 'project:\n  name: demo\npython:\n  manager: uv\nartifacts: []\n' > "$manifest_path"
+    HOME="$TEST_HOME"
+    unset BASE_PROJECT_VENV_DIR
+
+    run base_project_venv_dir demo "$project_root" "$manifest_path"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$project_root/.venv" ]
+}
+
 @test "project command helper formats extra args for display" {
     source_project_command_helpers
 
@@ -48,6 +65,15 @@ source_project_command_helpers() {
     [ "$output" = 'mise run test -- "$@"' ]
 }
 
+@test "project command helper wraps uv runner commands" {
+    source_project_command_helpers
+
+    run base_command_with_runner "uv" "pytest tests/" "-k" "slow case"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = 'uv run -- pytest tests/ "$@"' ]
+}
+
 @test "project command helper displays mise extra args after separator" {
     source_project_command_helpers
 
@@ -60,4 +86,13 @@ source_project_command_helpers() {
 
     [ "$status" -eq 0 ]
     [ "$output" = "mise run test -- --watch" ]
+}
+
+@test "project command helper displays uv runner commands" {
+    source_project_command_helpers
+
+    run base_display_command_with_runner "uv" "pytest tests/" "-k" "slow case"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "uv run -- pytest tests/ -k slow\\ case" ]
 }

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -39,6 +39,107 @@ EOF
     [[ "$(cat "$state_file")" == *"path=$TEST_HOME/.base.d/demo/.venv/bin:"* ]]
 }
 
+@test "basectl run routes uv runner commands through uv" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/run-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "audit" ]]; then
+    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'pytest tests/audit' uv
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$TEST_HOME/.base.d/demo/.venv/bin/uv" <<'EOF'
+#!/usr/bin/env bash
+{
+    printf 'pwd=%s\n' "$PWD"
+    printf 'args='
+    printf '<%s>' "$@"
+    printf '\n'
+} > "${BASE_TEST_RUN_STATE:?}"
+EOF
+    chmod +x "$python_bin" "$TEST_HOME/.base.d/demo/.venv/bin/uv"
+    printf 'project:\n  name: demo\ncommands:\n  audit:\n    command: pytest tests/audit\n    runner: uv\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_RUN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo audit -- --maxfail=1
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$state_file")" == *"pwd=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"args=<run><--><pytest><tests/audit><--maxfail=1>"* ]]
+}
+
+@test "basectl run uses project .venv for uv-managed projects" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/run-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
+    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "venv=%s\npath=%s\n" "$BASE_PROJECT_VENV_DIR" "$PATH" > "$BASE_TEST_RUN_STATE"'
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\npython:\n  manager: uv\ncommands:\n  dev: printf ok\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf '#!/usr/bin/env bash\n' > "$workspace/demo/.venv/bin/python"
+    chmod +x "$workspace/demo/.venv/bin/python"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_RUN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo dev
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$state_file")" == *"venv=$workspace/demo/.venv"* ]]
+    [[ "$(cat "$state_file")" == *"path=$workspace/demo/.venv/bin:"* ]]
+}
+
+@test "basectl run fails clearly when uv runner is missing" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "audit" ]]; then
+    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'pytest tests/audit' uv
+    exit 0
+fi
+printf 'unexpected run python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\ncommands:\n  audit:\n    command: pytest tests/audit\n    runner: uv\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo audit
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Command runner 'uv' is not available."* ]]
+}
+
 @test "basectl run dry-run prints resolved command without running it" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/bash/commands/basectl/tests/test.bats
+++ b/cli/bash/commands/basectl/tests/test.bats
@@ -39,6 +39,46 @@ EOF
     [[ "$(cat "$state_file")" == *"path=$TEST_HOME/.base.d/demo/.venv/bin:"* ]]
 }
 
+@test "basectl test routes uv runner commands through uv" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/test-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$TEST_HOME/.base.d/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'pytest tests/' uv
+    exit 0
+fi
+printf 'unexpected test python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$TEST_HOME/.base.d/demo/.venv/bin/uv" <<'EOF'
+#!/usr/bin/env bash
+{
+    printf 'pwd=%s\n' "$PWD"
+    printf 'args='
+    printf '<%s>' "$@"
+    printf '\n'
+} > "${BASE_TEST_TEST_STATE:?}"
+EOF
+    chmod +x "$python_bin" "$TEST_HOME/.base.d/demo/.venv/bin/uv"
+    printf 'project:\n  name: demo\ntest:\n  command: pytest tests/\n  runner: uv\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TEST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" test demo -- -k focused
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$state_file")" == *"pwd=$workspace/demo"* ]]
+    [[ "$(cat "$state_file")" == *"args=<run><--><pytest><tests/><-k><focused>"* ]]
+}
+
 @test "basectl test dry-run prints resolved command without running it" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -98,10 +98,18 @@ def print_build_target(
     target_config: BuildTargetConfig,
     working_dir: Path,
 ) -> None:
-    print(
-        f"{project.name}\t{project.root}\t{project.manifest_path}\t{target_name}\t"
-        f"{working_dir}\t{target_config.command}\t{target_config.description or ''}"
-    )
+    fields = [
+        project.name,
+        str(project.root),
+        str(project.manifest_path),
+        target_name,
+        str(working_dir),
+        target_config.command,
+        target_config.description or "",
+    ]
+    if target_config.runner is not None:
+        fields.append(target_config.runner)
+    print("\t".join(fields))
 
 
 def selected_build_targets(

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -38,7 +38,7 @@ from base_projects.workspace_reports import workspace_project_statuses
 from base_projects.workspace_reports import workspace_status_to_json
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
-from base_setup.manifest import BaseManifest, ManifestError, TestConfig, read_manifest
+from base_setup.manifest import BaseManifest, CommandConfig, ManifestError, TestConfig, read_manifest
 
 
 app = base_cli.App(name="base_projects")
@@ -516,7 +516,8 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
         )
         return 1
 
-    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{test_command(manifest.test)}")
+    command_config = test_command(manifest.test)
+    print(_command_output(project.name, project.root, project.manifest_path, command_config))
     return 0
 
 
@@ -539,7 +540,7 @@ def demo_script_project_command(ctx: base_cli.Context, project_name: str | None,
         ctx.log.error(str(exc))
         return 1
 
-    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{demo_script}")
+    print(_demo_output(project.name, project.root, project.manifest_path, demo_script, manifest.demo.runner))
     return 0
 
 
@@ -577,12 +578,12 @@ def run_command_project_command(
     try:
         project = resolve_named_project(ctx, project_name, workspace)
         manifest = read_manifest(project.manifest_path)
-        command_text = project_command(manifest, command_name)
+        command_config = project_command(manifest, command_name)
     except (ProjectDiscoveryError, ManifestError, ProjectCommandError) as exc:
         ctx.log.error(str(exc))
         return 1
 
-    print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{command_text}")
+    print(_command_output(project.name, project.root, project.manifest_path, command_config))
     return 0
 
 
@@ -602,8 +603,8 @@ def list_run_commands_command(ctx: base_cli.Context, project_name: str | None, w
         ctx.log.error("Project '%s' does not declare runnable commands in '%s'.", project.name, project.manifest_path)
         return 1
 
-    for command_name, command_text in commands.items():
-        print(f"{project.name}\t{project.root}\t{project.manifest_path}\t{command_name}\t{command_text}")
+    for command_name, command_config in commands.items():
+        print(_named_command_output(project.name, project.root, project.manifest_path, command_name, command_config))
     return 0
 
 
@@ -626,11 +627,11 @@ def current_project() -> Project:
     return read_project(manifest_path)
 
 
-def test_command(test_config: TestConfig) -> str:
+def test_command(test_config: TestConfig) -> CommandConfig:
     if test_config.command is not None:
-        return test_config.command
+        return CommandConfig(command=test_config.command, runner=test_config.runner)
     if test_config.mise is not None:
-        return shlex.join(["mise", "run", test_config.mise])
+        return CommandConfig(command=shlex.join(["mise", "run", test_config.mise]), runner=test_config.runner)
     raise ValueError("TestConfig must have command or mise set.")
 
 
@@ -638,15 +639,15 @@ class ProjectCommandError(RuntimeError):
     pass
 
 
-def project_commands(manifest: BaseManifest) -> dict[str, str]:
-    commands: dict[str, str] = {}
+def project_commands(manifest: BaseManifest) -> dict[str, CommandConfig]:
+    commands: dict[str, CommandConfig] = {}
     if manifest.test is not None:
         commands["test"] = test_command(manifest.test)
     commands.update(manifest.commands)
     return commands
 
 
-def project_command(manifest: BaseManifest, command_name: str) -> str:
+def project_command(manifest: BaseManifest, command_name: str) -> CommandConfig:
     commands = project_commands(manifest)
     try:
         return commands[command_name]
@@ -658,6 +659,39 @@ def project_command(manifest: BaseManifest, command_name: str) -> str:
         raise ProjectCommandError(
             f"Project '{manifest.project_name}' does not declare command '{command_name}' in '{manifest.path}'."
         ) from exc
+
+
+def _command_output(project_name: str, project_root: Path, manifest_path: Path, command: CommandConfig) -> str:
+    fields = [project_name, str(project_root), str(manifest_path), command.command]
+    if command.runner is not None:
+        fields.append(command.runner)
+    return "\t".join(fields)
+
+
+def _named_command_output(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    command_name: str,
+    command: CommandConfig,
+) -> str:
+    fields = [project_name, str(project_root), str(manifest_path), command_name, command.command]
+    if command.runner is not None:
+        fields.append(command.runner)
+    return "\t".join(fields)
+
+
+def _demo_output(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    demo_script: Path,
+    runner: str | None,
+) -> str:
+    fields = [project_name, str(project_root), str(manifest_path), str(demo_script)]
+    if runner is not None:
+        fields.append(runner)
+    return "\t".join(fields)
 
 
 def activation_source_paths(project: Project, source_paths: tuple[str, ...]) -> tuple[Path, ...]:

--- a/cli/python/base_projects/tests/test_build_targets.py
+++ b/cli/python/base_projects/tests/test_build_targets.py
@@ -68,6 +68,30 @@ def write_build_manifest_without_default(project_root: Path, name: str) -> None:
     )
 
 
+def write_build_manifest_with_runner(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "services" / "api").mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        "\n".join(
+            [
+                "project:",
+                f"  name: {name}",
+                "build:",
+                "  default:",
+                "    - package",
+                "  targets:",
+                "    package:",
+                "      working_dir: services/api",
+                "      command: python -m build",
+                "      runner: uv",
+                "      description: Build the Python package.",
+                "artifacts: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -173,6 +197,25 @@ class BuildTargetTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tworker\t{(project_root / 'services' / 'worker').resolve()}\tgo build ./cmd/worker"
             "\tBuild the worker service.\n",
+        )
+
+    def test_projects_build_targets_prints_runner_when_declared(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_build_manifest_with_runner(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["build-targets", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\tpackage\t{(project_root / 'services' / 'api').resolve()}\tpython -m build"
+            "\tBuild the Python package.\tuv\n",
         )
 
     def test_projects_build_target_list_prints_all_targets(self) -> None:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -57,10 +57,39 @@ def write_commands_manifest(project_root: Path, name: str) -> None:
     )
 
 
+def write_runner_commands_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        "\n".join(
+            [
+                "project:",
+                f"  name: {name}",
+                "test:",
+                "  command: pytest tests/",
+                "  runner: uv",
+                "commands:",
+                "  audit:",
+                "    command: pytest tests/audit",
+                "    runner: uv",
+                "artifacts: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def write_demo_manifest(project_root: Path, name: str, script: str) -> None:
     project_root.mkdir(parents=True, exist_ok=True)
     (project_root / "base_manifest.yaml").write_text(
         f"project:\n  name: {name}\ndemo:\n  script: {script}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
+def write_runner_demo_manifest(project_root: Path, name: str, script: str) -> None:
+    project_root.mkdir(parents=True, exist_ok=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\ndemo:\n  script: {script}\n  runner: uv\nartifacts: []\n",
         encoding="utf-8",
     )
 
@@ -707,6 +736,42 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
         )
 
+    def test_projects_run_command_prints_runner_when_declared(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_runner_commands_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["run-command", "demo", "audit"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            "\tpytest tests/audit\tuv\n",
+        )
+
+    def test_projects_test_command_prints_runner_when_declared(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_runner_commands_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["test-command", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            "\tpytest tests/\tuv\n",
+        )
+
     def test_projects_run_command_reports_unknown_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
@@ -740,6 +805,28 @@ class ProjectDiscoveryTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\t{script.resolve()}\n",
+        )
+
+    def test_projects_demo_script_prints_runner_when_declared(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            script = project_root / "demo" / "demo.sh"
+            script.parent.mkdir(parents=True)
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            write_runner_demo_manifest(project_root, "demo", "./demo/demo.sh")
+
+            status, stdout, stderr = run_engine(["demo-script", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\t{script.resolve()}\tuv\n",
         )
 
     def test_projects_demo_script_defaults_to_current_project(self) -> None:
@@ -815,6 +902,26 @@ class ProjectDiscoveryTests(unittest.TestCase):
             "\tdev\tuvicorn app:app --reload\n"
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             "\tlint\truff check .\n",
+        )
+
+    def test_projects_run_commands_lists_runners_when_declared(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_runner_commands_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["run-commands", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            "\ttest\tpytest tests/\tuv\n"
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            "\taudit\tpytest tests/audit\tuv\n",
         )
 
     def test_projects_run_commands_defaults_to_current_project(self) -> None:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines,too-many-public-methods
 
 import io
 import json

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -38,6 +38,9 @@ from .ide import reconcile_ide_installs
 from .ide import reconcile_ide_settings
 from .manifest import BaseManifest, ManifestError, read_manifest
 from .pyproject import check_pyproject
+from .uv import check_uv
+from .uv import manifest_uses_uv_project_manager
+from .uv import reconcile_uv_project
 
 
 app = base_cli.App(name="base_setup")
@@ -188,7 +191,7 @@ def reconcile_manifest(
     log_ide_preference_warnings(ctx, ide_preference_warning_checks(manifest, user_config))
     effective_manifest = effective_manifest_with_user_config(manifest, user_config)
 
-    artifacts = merge_artifacts(default_manifest.artifacts, effective_manifest.artifacts)
+    artifacts = setup_artifacts(default_manifest, effective_manifest)
     definitions = resolve_artifact_definitions(artifacts)
     if not effective_manifest.artifacts:
         if artifacts:
@@ -204,8 +207,10 @@ def reconcile_manifest(
     reconcile_ide_installs(ctx, effective_manifest, dry_run=dry_run)
     reconcile_ide_extensions(ctx, effective_manifest, dry_run=dry_run)
     reconcile_ide_settings(ctx, effective_manifest, dry_run=dry_run)
+    reconcile_uv_project(ctx, effective_manifest, dry_run=dry_run)
 
-    reconcile_artifacts(ctx, artifacts, definitions, effective_manifest.project_name, dry_run=dry_run)
+    if artifacts:
+        reconcile_artifacts(ctx, artifacts, definitions, effective_manifest.project_name, dry_run=dry_run)
 
     ctx.log.info("Project '%s' setup is complete.", effective_manifest.project_name)
 
@@ -336,7 +341,7 @@ def manifest_checks(
     checks: list[ArtifactCheck] = []
     user_config = read_user_config()
     effective_manifest = effective_manifest_with_user_config(manifest, user_config)
-    artifacts = merge_artifacts(default_manifest.artifacts, effective_manifest.artifacts)
+    artifacts = setup_artifacts(default_manifest, effective_manifest)
     definitions = resolve_artifact_definitions(artifacts)
 
     pre_venv_checks.extend(pre_venv_manifest_checks(effective_manifest, remote_network=remote_network))
@@ -354,6 +359,7 @@ def manifest_checks(
     checks.extend(check_ide_installs(effective_manifest))
     checks.extend(check_ide_extensions(effective_manifest))
     checks.extend(check_ide_settings(effective_manifest))
+    checks.extend(check_uv(effective_manifest))
     checks.extend(check_pyproject(effective_manifest))
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
@@ -385,6 +391,15 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         health=manifest.health,
         commands=manifest.commands,
         activate=manifest.activate,
+        python=manifest.python,
         demo=manifest.demo,
         build=manifest.build,
+        release=manifest.release,
     )
+
+
+def setup_artifacts(default_manifest: BaseManifest, manifest: BaseManifest) -> tuple:
+    artifacts = merge_artifacts(default_manifest.artifacts, manifest.artifacts)
+    if not manifest_uses_uv_project_manager(manifest):
+        return artifacts
+    return tuple(artifact for artifact in artifacts if artifact.artifact_type != "python-package")

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -26,6 +26,8 @@ COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
 GITHUB_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 HOMEBREW_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[A-Za-z0-9_.+-]+$")
 PORT_HEALTH_STATES = {"free", "listening"}
+SUPPORTED_PYTHON_MANAGERS = {"uv"}
+SUPPORTED_COMMAND_RUNNERS = {"uv"}
 
 
 class ManifestError(ValueError):
@@ -51,12 +53,20 @@ class IdeConfig:
 class TestConfig:
     command: str | None = None
     mise: str | None = None
+    runner: str | None = None
+
+
+@dataclass(frozen=True)
+class CommandConfig:
+    command: str
+    runner: str | None = None
 
 
 @dataclass(frozen=True)
 class DemoConfig:
     script: str
     description: str | None = None
+    runner: str | None = None
 
 
 @dataclass(frozen=True)
@@ -80,6 +90,7 @@ class ReleaseConfig:
     tag_prefix: str
     github: ReleaseGithubConfig
     homebrew: ReleaseHomebrewConfig | None = None
+    runner: str | None = None
 
 
 @dataclass(frozen=True)
@@ -87,6 +98,7 @@ class BuildTargetConfig:
     command: str
     working_dir: str = "."
     description: str | None = None
+    runner: str | None = None
 
 
 @dataclass(frozen=True)
@@ -115,6 +127,11 @@ class ActivateConfig:
 
 
 @dataclass(frozen=True)
+class PythonConfig:
+    manager: str | None = None
+
+
+@dataclass(frozen=True)
 class BaseManifest:
     path: Path
     project_name: str
@@ -125,8 +142,9 @@ class BaseManifest:
     test: TestConfig | None = None
     schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
     health: HealthConfig = field(default_factory=HealthConfig)
-    commands: dict[str, str] = field(default_factory=dict)
+    commands: dict[str, CommandConfig] = field(default_factory=dict)
     activate: ActivateConfig = field(default_factory=ActivateConfig)
+    python: PythonConfig = field(default_factory=PythonConfig)
     demo: DemoConfig | None = None
     build: BuildConfig | None = None
     release: ReleaseConfig | None = None
@@ -160,6 +178,7 @@ def read_manifest(path: Path) -> BaseManifest:
         "health",
         "commands",
         "activate",
+        "python",
         "demo",
         "build",
         "release",
@@ -177,6 +196,7 @@ def read_manifest(path: Path) -> BaseManifest:
     health = _read_health(path, data.get("health"))
     commands = _read_commands(path, data.get("commands"))
     activate = _read_activate(path, data.get("activate"))
+    python = _read_python(path, data.get("python"))
     demo = _read_demo(path, data.get("demo"))
     build = _read_build(path, data.get("build"))
     release = _read_release(path, data.get("release"))
@@ -194,6 +214,7 @@ def read_manifest(path: Path) -> BaseManifest:
         health=health,
         commands=commands,
         activate=activate,
+        python=python,
         demo=demo,
         build=build,
         release=release,
@@ -273,7 +294,7 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
     if not isinstance(test_data, dict):
         raise ManifestError(f"{path}: test must be a mapping when provided.")
 
-    allowed_keys = {"command", "mise"}
+    allowed_keys = {"command", "mise", "runner"}
     unknown_keys = sorted(set(test_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(f"{path}: test has unsupported keys: {', '.join(unknown_keys)}.")
@@ -292,6 +313,7 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
     return TestConfig(
         command=command.strip() if command is not None else None,
         mise=mise.strip() if mise is not None else None,
+        runner=_read_optional_runner(path, "test.runner", test_data.get("runner")),
     )
 
 
@@ -301,7 +323,7 @@ def _read_demo(path: Path, demo_data: Any) -> DemoConfig | None:
     if not isinstance(demo_data, dict):
         raise ManifestError(f"{path}: demo must be a mapping when provided.")
 
-    allowed_keys = {"script", "description"}
+    allowed_keys = {"script", "description", "runner"}
     unknown_keys = sorted(set(demo_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(f"{path}: demo has unsupported keys: {', '.join(unknown_keys)}.")
@@ -319,7 +341,9 @@ def _read_demo(path: Path, demo_data: Any) -> DemoConfig | None:
             raise ManifestError(f"{path}: demo.description must be a non-empty string when provided.")
         description = description.strip()
 
-    return DemoConfig(script=script, description=description)
+    runner = _read_optional_runner(path, "demo.runner", demo_data.get("runner"))
+
+    return DemoConfig(script=script, description=description, runner=runner)
 
 
 def _read_build(path: Path, build_data: Any) -> BuildConfig | None:
@@ -344,7 +368,7 @@ def _read_release(path: Path, release_data: Any) -> ReleaseConfig | None:
     if not isinstance(release_data, dict):
         raise ManifestError(f"{path}: release must be a mapping when provided.")
 
-    allowed_keys = {"version_file", "changelog", "tag_prefix", "github", "homebrew"}
+    allowed_keys = {"version_file", "changelog", "tag_prefix", "github", "homebrew", "runner"}
     unknown_keys = sorted(set(release_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(f"{path}: release has unsupported keys: {', '.join(unknown_keys)}.")
@@ -369,6 +393,7 @@ def _read_release(path: Path, release_data: Any) -> ReleaseConfig | None:
         tag_prefix=tag_prefix,
         github=github,
         homebrew=homebrew,
+        runner=_read_optional_runner(path, "release.runner", release_data.get("runner")),
     )
 
 
@@ -539,7 +564,7 @@ def _read_build_target(path: Path, target_name: str, target_data: Any) -> BuildT
     if not isinstance(target_data, dict):
         raise ManifestError(f"{path}: build.targets.{target_name} must be a mapping.")
 
-    allowed_keys = {"command", "working_dir", "description"}
+    allowed_keys = {"command", "working_dir", "description", "runner"}
     unknown_keys = sorted(set(target_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(
@@ -574,7 +599,9 @@ def _read_build_target(path: Path, target_name: str, target_data: Any) -> BuildT
                 f"{path}: build.targets.{target_name}.description must not contain control line breaks."
             )
 
-    return BuildTargetConfig(command=command, working_dir=working_dir, description=description)
+    runner = _read_optional_runner(path, f"build.targets.{target_name}.runner", target_data.get("runner"))
+
+    return BuildTargetConfig(command=command, working_dir=working_dir, description=description, runner=runner)
 
 
 def _read_health(path: Path, health_data: Any) -> HealthConfig:
@@ -594,13 +621,13 @@ def _read_health(path: Path, health_data: Any) -> HealthConfig:
     )
 
 
-def _read_commands(path: Path, commands_data: Any) -> dict[str, str]:
+def _read_commands(path: Path, commands_data: Any) -> dict[str, CommandConfig]:
     if commands_data is None:
         return {}
     if not isinstance(commands_data, dict):
         raise ManifestError(f"{path}: commands must be a mapping when provided.")
 
-    commands: dict[str, str] = {}
+    commands: dict[str, CommandConfig] = {}
     for command_name_data, command_data in commands_data.items():
         if not isinstance(command_name_data, str) or not command_name_data.strip():
             raise ManifestError(f"{path}: commands keys must be non-empty strings.")
@@ -611,10 +638,34 @@ def _read_commands(path: Path, commands_data: Any) -> dict[str, str]:
             raise ManifestError(f"{path}: commands.test is reserved; use top-level test.command or test.mise.")
         if command_name in commands:
             raise ManifestError(f"{path}: commands duplicates '{command_name}'.")
-        if not isinstance(command_data, str) or not command_data.strip():
-            raise ManifestError(f"{path}: commands.{command_name} must be a non-empty string.")
-        commands[command_name] = command_data.strip()
+        commands[command_name] = _read_command_config(path, f"commands.{command_name}", command_data)
     return commands
+
+
+def _read_command_config(path: Path, field_name: str, command_data: Any) -> CommandConfig:
+    if isinstance(command_data, str):
+        if not command_data.strip():
+            raise ManifestError(f"{path}: {field_name} must be a non-empty string.")
+        return CommandConfig(command=command_data.strip())
+
+    if not isinstance(command_data, dict):
+        raise ManifestError(f"{path}: {field_name} must be a non-empty string or command mapping.")
+
+    allowed_keys = {"command", "runner"}
+    unknown_keys = sorted(set(command_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: {field_name} has unsupported keys: {', '.join(unknown_keys)}.")
+
+    command = command_data.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise ManifestError(f"{path}: {field_name}.command must be a non-empty string.")
+    if _has_control_line_break(command):
+        raise ManifestError(f"{path}: {field_name}.command must not contain control line breaks.")
+
+    return CommandConfig(
+        command=command.strip(),
+        runner=_read_optional_runner(path, f"{field_name}.runner", command_data.get("runner")),
+    )
 
 
 def _read_activate(path: Path, activate_data: Any) -> ActivateConfig:
@@ -629,6 +680,41 @@ def _read_activate(path: Path, activate_data: Any) -> ActivateConfig:
         raise ManifestError(f"{path}: activate has unsupported keys: {', '.join(unknown_keys)}.")
 
     return ActivateConfig(source=_read_activate_sources(path, activate_data.get("source", [])))
+
+
+def _read_python(path: Path, python_data: Any) -> PythonConfig:
+    if python_data is None:
+        return PythonConfig()
+    if not isinstance(python_data, dict):
+        raise ManifestError(f"{path}: python must be a mapping when provided.")
+
+    allowed_keys = {"manager"}
+    unknown_keys = sorted(set(python_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: python has unsupported keys: {', '.join(unknown_keys)}.")
+
+    manager = python_data.get("manager")
+    if manager is None:
+        return PythonConfig()
+    if not isinstance(manager, str) or not manager.strip():
+        raise ManifestError(f"{path}: python.manager must be a non-empty string when provided.")
+    manager = manager.strip()
+    if manager not in SUPPORTED_PYTHON_MANAGERS:
+        supported = ", ".join(sorted(SUPPORTED_PYTHON_MANAGERS))
+        raise ManifestError(f"{path}: python.manager must be one of: {supported}.")
+    return PythonConfig(manager=manager)
+
+
+def _read_optional_runner(path: Path, field_name: str, runner_data: Any) -> str | None:
+    if runner_data is None:
+        return None
+    if not isinstance(runner_data, str) or not runner_data.strip():
+        raise ManifestError(f"{path}: {field_name} must be a non-empty string when provided.")
+    runner = runner_data.strip()
+    if runner not in SUPPORTED_COMMAND_RUNNERS:
+        supported = ", ".join(sorted(SUPPORTED_COMMAND_RUNNERS))
+        raise ManifestError(f"{path}: {field_name} must be one of: {supported}.")
+    return runner
 
 
 def _read_activate_sources(path: Path, source_data: Any) -> tuple[str, ...]:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines,too-many-public-methods
 
 import tempfile
 import unittest

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -38,6 +38,58 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.artifacts[0].version, "1.8.5")
         self.assertFalse(manifest.artifacts[0].bootstrap)
         self.assertEqual(manifest.activate.source, ())
+        self.assertIsNone(manifest.python.manager)
+
+    def test_reads_manifest_python_uv_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "python:",
+                        "  manager: uv",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.python.manager, "uv")
+
+
+    def test_rejects_invalid_manifest_python_config(self) -> None:
+        invalid_values = {
+            "scalar": "python: uv",
+            "unknown_key": "python:\n  manager: uv\n  version: '3.12'",
+            "empty_manager": "python:\n  manager: ''",
+            "non_string_manager": "python:\n  manager: 7",
+            "unsupported_manager": "python:\n  manager: poetry",
+        }
+        for name, python_yaml in invalid_values.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                python_yaml,
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(ManifestError):
+                        read_manifest(manifest_path)
+
 
 
 
@@ -250,6 +302,33 @@ class ManifestParsingTests(unittest.TestCase):
         assert manifest.demo is not None
         self.assertEqual(manifest.demo.script, "./demo/demo.sh")
         self.assertEqual(manifest.demo.description, "Interactive project walkthrough")
+        self.assertIsNone(manifest.demo.runner)
+
+
+    def test_reads_manifest_demo_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "demo:",
+                        "  script: ./demo/demo.sh",
+                        "  runner: uv",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.demo)
+        assert manifest.demo is not None
+        self.assertEqual(manifest.demo.runner, "uv")
 
 
     def test_reads_manifest_release_config(self) -> None:
@@ -289,12 +368,73 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.release.tag_prefix, "v")
         self.assertEqual(manifest.release.github.repository, "codeforester/base")
         self.assertEqual(manifest.release.github.release_title, "Base v{version}")
+        self.assertIsNone(manifest.release.runner)
         self.assertIsNotNone(manifest.release.homebrew)
         assert manifest.release.homebrew is not None
         self.assertTrue(manifest.release.homebrew.required)
         self.assertEqual(manifest.release.homebrew.tap_repository, "codeforester/homebrew-base")
         self.assertEqual(manifest.release.homebrew.formula_path, "Formula/base.rb")
         self.assertEqual(manifest.release.homebrew.package, "codeforester/base/base")
+
+    def test_reads_manifest_release_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "release:",
+                        "  runner: uv",
+                        "  github:",
+                        "    repository: codeforester/demo",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.release)
+        assert manifest.release is not None
+        self.assertEqual(manifest.release.runner, "uv")
+
+
+    def test_reads_manifest_build_target_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "build:",
+                        "  default:",
+                        "    - package",
+                        "  targets:",
+                        "    package:",
+                        "      command: python -m build",
+                        "      runner: uv",
+                        "      working_dir: services/api",
+                        "      description: Build the Python package.",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.build)
+        assert manifest.build is not None
+        self.assertEqual(manifest.build.targets["package"].command, "python -m build")
+        self.assertEqual(manifest.build.targets["package"].runner, "uv")
+
 
 
     def test_reads_manifest_release_config_without_homebrew(self) -> None:
@@ -373,6 +513,12 @@ class ManifestParsingTests(unittest.TestCase):
                 "    formula_path: Formula/base.rb\n"
                 "    package: base"
             ),
+            "unsupported_runner": (
+                "release:\n"
+                "  runner: npm\n"
+                "  github:\n"
+                "    repository: codeforester/base"
+            ),
         }
         for name, release_yaml in invalid_values.items():
             with self.subTest(name=name):
@@ -435,6 +581,7 @@ class ManifestParsingTests(unittest.TestCase):
             "newline_script": "demo:\n  script: \"demo\\n/demo.sh\"",
             "empty_description": "demo:\n  script: ./demo/demo.sh\n  description: ''",
             "non_string_description": "demo:\n  script: ./demo/demo.sh\n  description: 7",
+            "unsupported_runner": "demo:\n  script: ./demo/demo.sh\n  runner: npm",
         }
         for name, demo_yaml in invalid_values.items():
             with self.subTest(name=name):
@@ -506,13 +653,36 @@ class ManifestParsingTests(unittest.TestCase):
 
             manifest = read_manifest(manifest_path)
 
-        self.assertEqual(
-            manifest.commands,
-            {
-                "dev": "uvicorn app:app --reload",
-                "lint": "ruff check .",
-            },
-        )
+        self.assertEqual(manifest.commands["dev"].command, "uvicorn app:app --reload")
+        self.assertIsNone(manifest.commands["dev"].runner)
+        self.assertEqual(manifest.commands["lint"].command, "ruff check .")
+        self.assertIsNone(manifest.commands["lint"].runner)
+
+
+    def test_reads_manifest_commands_with_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "commands:",
+                        "  audit:",
+                        "    command: pytest tests/audit",
+                        "    runner: uv",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.commands["audit"].command, "pytest tests/audit")
+        self.assertEqual(manifest.commands["audit"].runner, "uv")
 
 
 
@@ -524,6 +694,10 @@ class ManifestParsingTests(unittest.TestCase):
             "reserved_test": "commands:\n  test: pytest",
             "empty_command": "commands:\n  lint: ''",
             "non_string_command": "commands:\n  lint: 7",
+            "mapping_missing_command": "commands:\n  lint:\n    runner: uv",
+            "mapping_empty_command": "commands:\n  lint:\n    command: ''",
+            "mapping_unknown_key": "commands:\n  lint:\n    command: ruff check .\n    cwd: src",
+            "unsupported_runner": "commands:\n  lint:\n    command: ruff check .\n    runner: npm",
         }
         for name, commands_yaml in invalid_values.items():
             with self.subTest(name=name):
@@ -609,6 +783,32 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertIsNotNone(manifest.test)
         self.assertEqual(manifest.test.command, "pytest tests/")
         self.assertIsNone(manifest.test.mise)
+        self.assertIsNone(manifest.test.runner)
+
+
+    def test_reads_manifest_test_command_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  command: pytest tests/",
+                        "  runner: uv",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.test)
+        assert manifest.test is not None
+        self.assertEqual(manifest.test.command, "pytest tests/")
+        self.assertEqual(manifest.test.runner, "uv")
 
 
 
@@ -653,6 +853,50 @@ class ManifestParsingTests(unittest.TestCase):
             )
 
             with self.assertRaisesRegex(ManifestError, "test.command must be a non-empty string"):
+                read_manifest(manifest_path)
+
+
+    def test_rejects_invalid_manifest_test_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        "  command: pytest",
+                        "  runner: npm",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "test.runner must be one of: uv"):
+                read_manifest(manifest_path)
+
+
+    def test_rejects_invalid_manifest_build_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "build:",
+                        "  targets:",
+                        "    package:",
+                        "      command: python -m build",
+                        "      runner: npm",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ManifestError, "build.targets.package.runner must be one of: uv"):
                 read_manifest(manifest_path)
 
 

--- a/cli/python/base_setup/tests/test_uv.py
+++ b/cli/python/base_setup/tests/test_uv.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from base_setup import engine
+from base_setup.manifest import ArtifactRequest, BaseManifest, read_manifest
+from base_setup.tests.helpers import fake_context
+from base_setup.uv import check_uv, reconcile_uv_project
+
+
+def write_manifest(root: Path, content: str) -> BaseManifest:
+    root.mkdir(parents=True, exist_ok=True)
+    manifest_path = root / "base_manifest.yaml"
+    manifest_path.write_text(content, encoding="utf-8")
+    return read_manifest(manifest_path)
+
+
+class UvProjectTests(unittest.TestCase):
+    def test_reconcile_uv_project_dry_run_delegates_to_uv_sync(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            reconcile_uv_project(ctx, manifest, dry_run=True)
+
+        ctx.log.info.assert_any_call("[DRY-RUN] Would run in '%s': %s", root, "uv sync")
+
+    def test_reconcile_uv_project_requires_uv_for_real_setup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = write_manifest(
+                Path(tmpdir),
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+                with self.assertRaisesRegex(RuntimeError, "uv is required"):
+                    reconcile_uv_project(ctx, manifest, dry_run=False)
+
+    def test_check_uv_warns_for_missing_uv_manager_tool(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+
+            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+                checks = check_uv(manifest)
+
+        missing_uv = [check for check in checks if check.finding_id == "BASE-P150"]
+        self.assertEqual(len(missing_uv), 1)
+        self.assertEqual(missing_uv[0].status, "warn")
+        self.assertIn("uv is not available", missing_uv[0].message)
+
+    def test_check_uv_warns_for_runner_without_python_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "commands:",
+                        "  audit:",
+                        "    command: pytest tests/audit",
+                        "    runner: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+
+            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+                checks = check_uv(manifest)
+
+        missing_uv = [check for check in checks if check.finding_id == "BASE-P150"]
+        self.assertEqual(len(missing_uv), 1)
+        self.assertIn("uv runner", missing_uv[0].message)
+
+    def test_check_uv_reports_project_files_and_stale_base_venv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "project"
+            home = Path(tmpdir) / "home"
+            stale_venv = home / ".base.d" / "demo" / ".venv"
+            stale_venv.mkdir(parents=True)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            (root / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+
+            with mock.patch.dict("os.environ", {"HOME": str(home)}), mock.patch(
+                "base_setup.uv.process.command_exists",
+                return_value=True,
+            ):
+                checks = check_uv(manifest)
+
+        findings = {check.finding_id: check for check in checks}
+        self.assertEqual(findings["BASE-P151"].status, "")
+        self.assertEqual(findings["BASE-P152"].status, "warn")
+        self.assertEqual(findings["BASE-P153"].status, "warn")
+        self.assertIn(str(stale_venv), findings["BASE-P153"].message)
+
+    def test_uv_project_setup_skips_python_package_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            default_manifest = BaseManifest(
+                path=Path("default_manifest.yaml"),
+                project_name="base-defaults",
+                brewfile=None,
+                artifacts=(ArtifactRequest("python-package", "click", "8.4.1"),),
+            )
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts:",
+                        "  - type: python-package",
+                        "    name: requests",
+                        "    version: latest",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            with mock.patch("base_setup.engine.reconcile_uv_project") as reconcile_uv, mock.patch(
+                "base_setup.engine.reconcile_artifacts"
+            ) as reconcile_artifacts:
+                engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=True)
+
+        reconcile_uv.assert_called_once_with(ctx, manifest, dry_run=True)
+        reconcile_artifacts.assert_not_called()

--- a/cli/python/base_setup/uv.py
+++ b/cli/python/base_setup/uv.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import base_cli
+
+from . import process
+from .checks import ArtifactCheck
+from .errors import ArtifactError
+from .manifest import BaseManifest
+
+
+def manifest_uses_uv_project_manager(manifest: BaseManifest) -> bool:
+    return manifest.python.manager == "uv"
+
+
+def manifest_declares_uv_runner(manifest: BaseManifest) -> bool:
+    if manifest.test is not None and manifest.test.runner == "uv":
+        return True
+    if any(command.runner == "uv" for command in manifest.commands.values()):
+        return True
+    if manifest.demo is not None and manifest.demo.runner == "uv":
+        return True
+    if manifest.release is not None and manifest.release.runner == "uv":
+        return True
+    if manifest.build is not None:
+        return any(target.runner == "uv" for target in manifest.build.targets.values())
+    return False
+
+
+def reconcile_uv_project(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
+    if not manifest_uses_uv_project_manager(manifest):
+        return
+
+    project_root = manifest.path.parent
+    command = ["uv", "sync"]
+    if dry_run:
+        process.dry_run_command(ctx, command, cwd=project_root)
+        return
+    if not process.command_exists("uv"):
+        raise ArtifactError("uv is required to set up this project. Install uv and rerun basectl setup.")
+    process.run_command(ctx, command, cwd=project_root)
+
+
+def check_uv(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+    uses_uv_manager = manifest_uses_uv_project_manager(manifest)
+    uses_uv_runner = manifest_declares_uv_runner(manifest)
+    if not uses_uv_manager and not uses_uv_runner:
+        return ()
+
+    checks: list[ArtifactCheck] = []
+    uv_available = process.command_exists("uv")
+    checks.append(uv_tool_check(uv_available, uses_uv_manager, uses_uv_runner))
+
+    if uses_uv_manager:
+        checks.append(pyproject_check(manifest.path.parent / "pyproject.toml"))
+        checks.append(uv_lock_check(manifest.path.parent / "uv.lock"))
+        stale_check = stale_base_venv_check(manifest)
+        if stale_check is not None:
+            checks.append(stale_check)
+
+    return tuple(checks)
+
+
+def uv_tool_check(uv_available: bool, uses_uv_manager: bool, uses_uv_runner: bool) -> ArtifactCheck:
+    if uv_available:
+        return ArtifactCheck(
+            name="uv",
+            ok=True,
+            message="uv is available for Base-declared uv project or command runner support.",
+            fix="",
+            finding_id="BASE-P150",
+        )
+
+    reason = "uv project manager" if uses_uv_manager else "uv runner"
+    if uses_uv_manager and uses_uv_runner:
+        reason = "uv project manager and uv runner"
+    return ArtifactCheck(
+        name="uv",
+        ok=False,
+        message=f"uv is not available, but the manifest declares {reason} support.",
+        fix="Install uv, then rerun basectl setup/check.",
+        finding_id="BASE-P150",
+        status="warn",
+    )
+
+
+def pyproject_check(pyproject_path: Path) -> ArtifactCheck:
+    if pyproject_path.is_file():
+        return ArtifactCheck(
+            name="uv pyproject",
+            ok=True,
+            message=f"uv project pyproject.toml exists at '{pyproject_path}'.",
+            fix="",
+            finding_id="BASE-P151",
+        )
+    return ArtifactCheck(
+        name="uv pyproject",
+        ok=False,
+        message=f"uv project manager is declared, but '{pyproject_path}' does not exist.",
+        fix="Create pyproject.toml or remove python.manager: uv from base_manifest.yaml.",
+        finding_id="BASE-P151",
+        status="warn",
+    )
+
+
+def uv_lock_check(lock_path: Path) -> ArtifactCheck:
+    if lock_path.is_file():
+        return ArtifactCheck(
+            name="uv lockfile",
+            ok=True,
+            message=f"uv lockfile exists at '{lock_path}'.",
+            fix="",
+            finding_id="BASE-P152",
+        )
+    return ArtifactCheck(
+        name="uv lockfile",
+        ok=False,
+        message=f"uv project manager is declared, but '{lock_path}' does not exist.",
+        fix="Run 'uv lock' or 'uv sync' from the project root.",
+        finding_id="BASE-P152",
+        status="warn",
+    )
+
+
+def stale_base_venv_check(manifest: BaseManifest) -> ArtifactCheck | None:
+    stale_venv = Path.home() / ".base.d" / manifest.project_name / ".venv"
+    if not stale_venv.exists():
+        return None
+    return ArtifactCheck(
+        name="uv stale Base venv",
+        ok=False,
+        message=f"uv project manager is declared; Base will ignore stale project venv '{stale_venv}'.",
+        fix="Remove the stale Base-managed project venv after confirming the uv project .venv is healthy.",
+        finding_id="BASE-P153",
+        status="warn",
+    )

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -130,6 +130,10 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P141` | `pyproject.toml` readability |
 | `BASE-P142` | `pyproject.toml` dependency metadata observed but not reconciled |
 | `BASE-P143` | Unsupported `[tool.base]` configuration |
+| `BASE-P150` | uv CLI availability for uv-managed projects or uv command runners |
+| `BASE-P151` | uv-managed project `pyproject.toml` presence |
+| `BASE-P152` | uv-managed project `uv.lock` presence |
+| `BASE-P153` | Stale Base-managed project virtual environment ignored by a uv-managed project |
 
 `BASE-P050` is the stable project virtual-environment readiness finding. The
 Bash setup/check path reports detailed venv health messages when a project venv
@@ -144,6 +148,12 @@ Base only inspects the `pyproject.toml` file beside the active
 configuration source and do not cause Base to install Python dependencies.
 Warnings in this range should guide users toward a valid Python project file
 without failing the Base manifest check by themselves.
+
+`BASE-P150` through `BASE-P153` are uv support diagnostics. They are warnings
+when uv tooling or expected uv project files are missing, because check/doctor
+should explain readiness without performing dependency resolution. Command
+invocation still fails hard when a command declares `runner: uv` and the `uv`
+executable is unavailable.
 
 `BASE-P080` through `BASE-P083` are read-only project Git remote diagnostics.
 They report whether the project directory is inside a Git repository, whether

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -1,7 +1,9 @@
 # Python Manifest Section
 
-Base currently supports Python dependencies through `python-package` artifact
-entries:
+Base supports two Python project shapes.
+
+The older Base-managed shape uses `python-package` artifact rows and installs
+packages into Base's project virtual environment:
 
 ```yaml
 artifacts:
@@ -10,134 +12,137 @@ artifacts:
     version: latest
 ```
 
-That contract remains valid. It is simple, implemented, and maps directly to the
-Base-managed project virtual environment at:
+That environment defaults to:
 
 ```text
 ~/.base.d/<project>/.venv
 ```
 
-## Decision
-
-Base should grow a structured `python:` manifest section only when the Python
-contract needs to express more than a small package list. The structured section
-is the right long-term shape because it makes the project virtual environment,
-requirement files, and inline package requirements explicit instead of encoding
-all Python behavior as generic artifact rows.
-
-The future shape should be:
+The uv-managed shape is explicit:
 
 ```yaml
 python:
-  venv: default
-  requirements:
-    - requirements.txt
-  packages:
-    - requests
-    - pytest==8.4.1
+  manager: uv
 ```
 
-This is a design target, not the current manifest contract.
-
-## Field Semantics
-
-`venv` should default to `default`, meaning Base's current project venv location:
-
-```text
-~/.base.d/<project>/.venv
-```
-
-A custom venv path should be deferred until a real project needs it. If Base
-adds it later, the path should be relative to the project root, must stay inside
-the project root unless explicitly allowed, and must not silently change the
-activation or `basectl test` contract.
-
-`requirements` should be a list of requirement file paths relative to the
-project root. Base should install them with `pip install -r <file>` and reject
-paths outside the project root.
-
-`packages` should use normal pip requirement strings such as:
-
-```text
-requests
-pytest==8.4.1
-rich>=13,<14
-```
-
-Using pip requirement strings avoids inventing a parallel Python package syntax.
-
-## Relationship To Current Artifacts
-
-`python-package` artifacts should remain supported during and after the first
-structured `python:` implementation. A migration can translate:
-
-```yaml
-artifacts:
-  - type: python-package
-    name: requests
-    version: latest
-  - type: python-package
-    name: pytest
-    version: 8.4.1
-```
-
-into:
-
-```yaml
-python:
-  packages:
-    - requests
-    - pytest==8.4.1
-```
-
-The implementation should reject duplicate requirements only when it can do so
-without guessing. Exact duplicate strings can be de-duplicated; semantically
-overlapping requirement ranges should be left to pip.
-
-## Relationship To `pyproject.toml`
-
-Base observes a same-directory `pyproject.toml` during project diagnostics when
-one exists beside `base_manifest.yaml`. This diagnostic support is read-only:
-Base reports whether the file is readable, summarizes standard `[project]`
-metadata, and warns when Python dependency metadata or unsupported `[tool.base]`
-configuration is present.
-
-`base_manifest.yaml` remains the Base source of truth. Base does not install
-packages from `[project].dependencies`, does not execute build backend hooks,
-and does not treat `[tool.base]` as an alternate manifest.
-
-Future uv-managed Python support should use an explicit `python:` manifest
-contract, tracked separately from the first read-only diagnostics slice.
-
-## Interim `uv` Activation Behavior
-
-Until the full uv-managed Python contract is implemented, `basectl activate`
-uses a conservative project-shape detector to avoid a misleading dual-venv
-shell. When the project root contains both `pyproject.toml` and `uv.lock`, and
-the caller has not set `BASE_PROJECT_VENV_DIR`, activation uses the repo-local
-uv environment at:
+When a project declares `python.manager: uv`, Base delegates Python environment
+work to uv instead of reconciling `python-package` artifacts. `basectl setup`
+runs `uv sync` from the project root, and Base treats the project-local uv
+environment as the project virtual environment:
 
 ```text
 <project-root>/.venv
 ```
 
-This only affects the activated shell's virtual environment path. It does not
-make Base install dependencies from `pyproject.toml`, run `uv sync`, enforce the
-lockfile, or delegate `basectl run` through `uv run`. Full uv-managed setup,
-diagnostics, and command delegation remain part of the later uv support work.
-If the repo-local uv environment does not exist yet, activation asks the user to
-run `uv sync` in the project root.
+## Command Runners
+
+Command execution is independent from the project-level Python manager. Any
+project command surface may opt into uv execution with `runner: uv`:
+
+```yaml
+test:
+  command: pytest
+  runner: uv
+
+commands:
+  taxbuddy:
+    command: taxbuddy
+    runner: uv
+
+build:
+  default:
+    - package
+  targets:
+    package:
+      command: python -m build
+      runner: uv
+
+demo:
+  script: ./demo/demo.sh
+  runner: uv
+```
+
+`runner: uv` executes the declared command through:
+
+```bash
+uv run -- <command>
+```
+
+This lets a composite project keep most commands in Go, Node, shell, `mise`, or
+other tools while routing only selected Python commands through uv. It also lets
+a fully uv-based Python project declare both:
+
+```yaml
+python:
+  manager: uv
+
+test:
+  command: pytest
+  runner: uv
+```
+
+Base validates runner values when reading the manifest. `basectl check` and
+`basectl doctor` warn if `uv` is unavailable. Actual command invocation fails
+clearly when `runner: uv` is selected and `uv` is not on `PATH`.
+
+## Relationship To `pyproject.toml`
+
+`pyproject.toml` remains the Python project's packaging contract. Base observes
+a same-directory `pyproject.toml` during diagnostics, reports whether it is
+readable, summarizes standard `[project]` metadata, and warns when dependency
+metadata or unsupported `[tool.base]` configuration is present.
+
+Base does not treat `pyproject.toml` as an alternate Base manifest. It does not
+solve dependencies, execute build backend hooks, generate lockfiles, or install
+from `[project].dependencies` directly. For uv-managed projects, those actions
+belong to uv.
+
+## Relationship To `python-package` Artifacts
+
+`python-package` artifacts remain supported for simple Base-managed Python
+project environments. They should not be used as the steady-state dependency
+model for a project that declares `python.manager: uv`.
+
+When `python.manager: uv` is present, Base skips Base-managed
+`python-package` reconciliation, including Base's default project Python
+artifacts. Non-Python artifacts such as Homebrew-managed tools still reconcile
+normally.
+
+## Activation
+
+`basectl activate <project>` uses the project-local `.venv` only when
+`python.manager: uv` is present and the caller has not set
+`BASE_PROJECT_VENV_DIR`. Base no longer infers uv activation from the mere
+presence of `pyproject.toml` and `uv.lock`.
+
+If the uv environment does not exist yet, activation asks the user to run
+`uv sync` in the project root.
+
+## Diagnostics
+
+uv support adds these project diagnostics:
+
+- `BASE-P150`: uv CLI availability for uv-managed projects or uv runners
+- `BASE-P151`: uv-managed project `pyproject.toml` presence
+- `BASE-P152`: uv-managed project `uv.lock` presence
+- `BASE-P153`: stale Base-managed project virtual environment ignored by a
+  uv-managed project
+
+These diagnostics are warning-oriented in `check` and `doctor`; they explain
+readiness without performing dependency resolution.
 
 ## Non-Goals
 
-The structured Python section should not turn Base into a Python packaging
-manager. Base should not:
+Base should not:
 
-- generate or own `requirements.txt`
-- replace Poetry, PDM, Hatch, uv, pip-tools, or setuptools
+- replace uv, Poetry, PDM, Hatch, pip-tools, setuptools, or pip
 - solve dependency versions
+- generate or own `uv.lock`
+- infer uv behavior just because `pyproject.toml` or `uv.lock` exists
+- automatically wrap commands in `uv run` unless the command declares
+  `runner: uv`
 - support multiple project virtual environments in one Base manifest
-- automatically migrate manifests without an explicit user action
 
-Base owns the project venv convention and setup/check/doctor orchestration.
-Python packaging tools own dependency resolution and lockfile semantics.
+Base owns project discovery, activation, setup/check/doctor orchestration, and
+the manifest command surface. Python packaging tools own Python dependency and
+lockfile semantics.

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -108,7 +108,7 @@ are available to project commands, runtime shells, and activation scripts.
 | `BASE_PROJECT` | Base | Resolved project name. Used by Base wrappers, prompts, logs, and project command dispatch. | Do not change after project resolution. Readonly in interactive Base runtime Bash shells. |
 | `BASE_PROJECT_ROOT` | Base | Physical project root directory. Project commands run from this directory. | Do not change after project resolution. Readonly in interactive Base runtime Bash shells. |
 | `BASE_PROJECT_MANIFEST` | Base | Physical path to the project's `base_manifest.yaml`. | Do not change after project resolution. Readonly in interactive Base runtime Bash shells. |
-| `BASE_PROJECT_VENV_DIR` | Shared | Project virtual environment directory. Users may set it before `basectl activate`, `basectl run`, or `basectl demo` to override the default. Activation defaults to `~/.base.d/<project>/.venv`, except uv-shaped projects with both `pyproject.toml` and `uv.lock` default to `<project-root>/.venv`. | May be set before project resolution. Do not change after Base resolves the project. Readonly in interactive Base runtime Bash shells. |
+| `BASE_PROJECT_VENV_DIR` | Shared | Project virtual environment directory. Users may set it before `basectl activate`, `basectl run`, or `basectl demo` to override the default. Base defaults to `~/.base.d/<project>/.venv`, except projects that explicitly declare `python.manager: uv` default to `<project-root>/.venv`. | May be set before project resolution. Do not change after Base resolves the project. Readonly in interactive Base runtime Bash shells. |
 
 Readonly shell attributes do not cross arbitrary process boundaries. For
 example, `basectl run` exports project variables to the project command process,

--- a/docs/superpowers/plans/2026-06-15-uv-managed-python-projects.md
+++ b/docs/superpowers/plans/2026-06-15-uv-managed-python-projects.md
@@ -1,0 +1,87 @@
+# uv-Managed Python Projects Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Base issue #359 with explicit uv-managed Python project support and generic command runners.
+
+**Architecture:** Extend the strict manifest parser with a small `python` model and command runner metadata. Keep command execution in the existing Bash project command helper layer, and keep uv setup/check behavior in the Python `base_setup` package. Activation and project venv resolution should derive the repo-local `.venv` only when the manifest explicitly declares `python.manager: uv`.
+
+**Tech Stack:** Python 3 dataclasses and unittest/pytest, Bash subcommands with BATS tests, existing Base manifest/check/doctor pipelines, Markdown docs.
+
+---
+
+### Task 1: Manifest Model
+
+**Files:**
+- Modify: `cli/python/base_setup/manifest.py`
+- Modify: `cli/python/base_setup/tests/test_manifest.py`
+
+- [x] Add `PythonConfig(manager: str | None)` and validate only `manager: uv`.
+- [x] Add `runner` support to `test`, `commands`, `demo`, `build.targets`, and `release`.
+- [x] Preserve existing scalar command syntax for `commands`.
+- [x] Reject unsupported runner values and malformed command objects.
+- [x] Run `PYTHONPATH="$PWD/lib/python:$PWD/cli/python" python -m pytest cli/python/base_setup/tests/test_manifest.py -q`.
+
+### Task 2: Project Command Resolution
+
+**Files:**
+- Modify: `cli/python/base_projects/engine.py`
+- Modify: `cli/python/base_projects/tests/test_engine.py`
+
+- [x] Return command runner metadata from `test-command`, `run-command`, `run-commands`, `demo-script`, and build target resolvers.
+- [x] Keep resolver output backward-compatible for commands without runners where practical.
+- [x] Run `PYTHONPATH="$PWD/lib/python:$PWD/cli/python" python -m pytest cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_build_targets.py -q`.
+
+### Task 3: Bash Runner Execution
+
+**Files:**
+- Modify: `cli/bash/commands/basectl/subcommands/project_command_helpers.sh`
+- Modify: `cli/bash/commands/basectl/subcommands/test.sh`
+- Modify: `cli/bash/commands/basectl/subcommands/run.sh`
+- Modify: `cli/bash/commands/basectl/subcommands/demo.sh`
+- Modify: `cli/bash/commands/basectl/subcommands/build.sh`
+- Modify: corresponding BATS tests under `cli/bash/commands/basectl/tests/`
+
+- [x] Add helper functions that format and execute runner-wrapped commands.
+- [x] Implement `runner: uv` as `uv run -- <command>`.
+- [x] Fail command invocation clearly when `uv` is missing.
+- [x] Preserve existing dry-run and extra-arg display behavior.
+- [x] Run focused BATS tests for `test`, `run`, `demo`, `build`, and helper behavior.
+
+### Task 4: uv Project Setup and Diagnostics
+
+**Files:**
+- Create: `cli/python/base_setup/uv.py`
+- Modify: `cli/python/base_setup/engine.py`
+- Modify: `cli/python/base_setup/tests/test_diagnostics.py`
+- Add or modify focused uv tests under `cli/python/base_setup/tests/`
+
+- [x] Add `reconcile_uv_project()` that delegates to `uv sync` from the project root when `python.manager: uv`.
+- [x] Add uv diagnostics for missing uv, missing `pyproject.toml`, missing `uv.lock`, declared uv runners, and stale Base-managed venvs.
+- [x] Keep check/doctor warnings non-blocking unless an existing error-level check fails.
+- [x] Run focused Python diagnostics/setup tests.
+
+### Task 5: Activation and Docs
+
+**Files:**
+- Modify: `cli/bash/commands/basectl/subcommands/activate.sh`
+- Modify: `cli/bash/commands/basectl/tests/activate.bats`
+- Modify: `README.md`
+- Modify: `docs/python-manifest.md`
+- Modify: `docs/runtime-environment.md`
+- Modify: `docs/doctor-findings.md`
+- Modify: `CHANGELOG.md`
+
+- [x] Make activation prefer project `.venv` only for explicit `python.manager: uv`.
+- [x] Update existing interim uv docs to describe the full explicit contract.
+- [x] Add stable doctor finding IDs for uv manager and uv runner diagnostics.
+- [x] Run `git diff --check`.
+
+### Task 6: Full Validation and PR
+
+**Files:**
+- All changed files.
+
+- [x] Run focused Python and BATS tests touched by this change.
+- [x] Run `env -u BASE_HOME ./bin/base-test`.
+- [ ] Open a PR with `Fixes #359`, validation evidence, demo impact, and AI context note.

--- a/docs/superpowers/specs/2026-06-15-uv-managed-python-projects-design.md
+++ b/docs/superpowers/specs/2026-06-15-uv-managed-python-projects-design.md
@@ -1,0 +1,120 @@
+# uv-Managed Python Projects Design
+
+Issue: #359
+
+## Summary
+
+Base should support uv-managed Python projects through explicit delegation. A
+project opts into full uv project behavior with `python.manager: uv`. Individual
+commands opt into uv execution with `runner: uv`. These two declarations are
+independent so composite projects can mix Go, Node, shell, Python, and uv-backed
+tools without making the whole project a uv project.
+
+## Goals
+
+- Add a structured `python:` manifest section with `manager: uv`.
+- Treat a uv-managed project as owning its repo-local `.venv`.
+- Delegate uv project setup to `uv sync`.
+- Report uv project and uv runner diagnostics through existing check/doctor
+  flows.
+- Add a generic command `runner` field, with `uv` as the first supported
+  runner.
+- Support command runners for `test`, `commands`, `demo`, `build.targets`, and
+  the manifest model used by release metadata.
+- Keep all behavior explicit; Base must not infer uv behavior merely because
+  `pyproject.toml` or `uv.lock` exists.
+
+## Non-Goals
+
+- Do not make Base a Python package manager.
+- Do not install or resolve Python dependencies directly from
+  `pyproject.toml`.
+- Do not automatically wrap all commands in `uv run`.
+- Do not require `python.manager: uv` for command-level `runner: uv`.
+- Do not force uv projects to use Base's historical
+  `~/.base.d/<project>/.venv` project venv path.
+
+## Manifest Shape
+
+Full uv project support:
+
+```yaml
+python:
+  manager: uv
+```
+
+Command-level uv execution:
+
+```yaml
+test:
+  command: pytest
+  runner: uv
+
+commands:
+  taxbuddy:
+    command: taxbuddy
+    runner: uv
+```
+
+Composite project example:
+
+```yaml
+commands:
+  api:
+    command: go run ./cmd/api
+
+  audit:
+    command: pytest tests/audit
+    runner: uv
+
+  web:
+    command: npm run dev
+```
+
+## Execution Model
+
+When `runner` is absent, Base preserves the existing shell execution behavior.
+When `runner: uv` is present, Base executes the declared command through
+`uv run`. Extra arguments are appended after `--` so command arguments do not
+get interpreted as uv options.
+
+Base validates the manifest shape eagerly. Check/doctor warn when a declared
+runner needs a missing tool. Command invocation fails hard when its runner tool
+is unavailable.
+
+## uv Project Ownership
+
+When `python.manager: uv` is present and `BASE_PROJECT_VENV_DIR` is not already
+set by the caller, the project virtual environment is:
+
+```text
+<project-root>/.venv
+```
+
+`basectl setup <project>` delegates to `uv sync` from the project root.
+`basectl activate <project>`, `basectl test`, `basectl run`, `basectl demo`, and
+`basectl build` should expose that same venv path in `BASE_PROJECT_VENV_DIR`.
+
+If a uv project also has the historical Base-managed venv under
+`~/.base.d/<project>/.venv`, Base should treat it as stale/transitional state
+and report a warning rather than using it.
+
+## Diagnostics
+
+Diagnostics should be warning-oriented unless setup or command invocation needs
+the tool immediately:
+
+- uv manager configured and uv exists: ok
+- uv manager configured and uv missing: warning in check/doctor
+- `runner: uv` declared and uv missing: warning in check/doctor
+- `runner: uv` invoked and uv missing: hard command failure
+- uv manager configured with missing `pyproject.toml`: warning
+- uv manager configured without `uv.lock`: warning
+- stale Base-managed project venv for uv project: warning
+
+## Testing
+
+Tests should cover manifest parsing, invalid manifest shapes, resolver output,
+command execution wrapping, setup delegation, uv diagnostics, and activation
+venv selection. Tests should fake `uv` with a fixture executable and must not
+perform network access or real dependency resolution.

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -138,22 +138,22 @@ How Base should coexist:
 
 - continue observing same-directory `pyproject.toml` through read-only
   diagnostics
-- preserve the current conservative activation behavior for uv-shaped projects:
-  when `pyproject.toml` and `uv.lock` are both present and the user has not
-  overridden `BASE_PROJECT_VENV_DIR`, `basectl activate` uses the repo-local
-  `.venv`
-- grow future uv support through an explicit `python:` manifest contract rather
-  than ad hoc `pyproject.toml` ownership
+- use the repo-local `.venv` only when a project explicitly declares
+  `python.manager: uv`
+- allow individual commands to declare `runner: uv` without requiring the whole
+  project to use `python.manager: uv`
 - report missing uv, missing `.venv`, or needed `uv sync` steps through
   Base-native check and doctor output when the project has opted into that
   contract
-- invoke uv transparently when delegation is added, so logs and diagnostics show
-  the underlying uv command instead of hiding it behind Base
+- invoke uv transparently, so dry-run output, logs, and diagnostics show the
+  underlying `uv sync` or `uv run -- ...` command instead of hiding it behind
+  Base
 
-Current stance: strong coexistence. Base already has conservative activation and
-read-only pyproject diagnostics for uv-shaped projects; fuller setup, check,
-run, and test delegation should wait for an explicit Python manifest contract.
-See [Python Manifest Section](python-manifest.md) for the current boundary.
+Current stance: strong coexistence. Base supports explicit uv-managed Python
+projects through `python.manager: uv` and command-level uv execution through
+`runner: uv`. Base still does not infer uv ownership from `pyproject.toml` or
+`uv.lock` alone. See [Python Manifest Section](python-manifest.md) for the
+current boundary.
 
 ### `direnv`
 


### PR DESCRIPTION
## Summary

- Add explicit `python.manager: uv` manifest support, including delegated `uv sync` setup and skipping Base-managed `python-package` reconciliation for uv-managed projects.
- Add generic command `runner: uv` support for `basectl test`, `run`, `demo`, and `build`, with runner metadata preserved through project resolvers.
- Align activation, project command virtualenv resolution, uv diagnostics, docs, changelog, and AI context with the explicit uv contract.

## Issue

Fixes #359

## Validation

- `PYTHONPATH="$PWD/lib/python:$PWD/cli/python" /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_build_targets.py -q`
  - `244 passed, 1 skipped, 82 subtests passed`
- `env -u BASE_HOME bats cli/bash/commands/basectl/tests/activate.bats cli/bash/commands/basectl/tests/project-command-helpers.bats cli/bash/commands/basectl/tests/test.bats cli/bash/commands/basectl/tests/run.bats cli/bash/commands/basectl/tests/demo.bats cli/bash/commands/basectl/tests/build.bats`
  - `58` BATS tests passed
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME ./bin/base-test`
  - Python: `446 passed, 1 skipped`
  - BATS: reached `ok 494` with exit 0

## Demo Impact

None. This changes project setup/runtime orchestration and documentation; no demo flow changes are required.

## Notes

- `python.manager: uv` is the project-level opt-in for uv-owned setup and `<project-root>/.venv`.
- `runner: uv` is intentionally independent, so composite projects can route only selected commands through `uv run -- ...`.
- Base still does not infer uv behavior from `pyproject.toml` or `uv.lock` alone.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
