### PR TITLE
Fix basectl gh transient auth status failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
   `basectl setup <project>`, while omitting the project keeps the existing
   Base update behavior.
 
+### Fixed
+
+- Fixed `basectl gh` to run the requested GitHub command before using
+  `gh auth status` diagnostics, avoiding false failures when the status probe
+  is transiently unavailable.
+
 ## [1.0.1] - 2026-06-15
 
 ### Added

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -60,19 +60,38 @@ base_gh_require_command() {
     }
 }
 
-base_gh_require_auth() {
+base_gh_auth_status_diagnostics() {
     local auth_output line
 
     base_gh_require_command gh || return 1
 
     auth_output="$(gh auth status -h github.com 2>&1)" || {
-        base_gh_error "GitHub CLI authentication or GitHub API access is not ready."
         while IFS= read -r line || [[ -n "$line" ]]; do
             [[ -n "$line" ]] && base_gh_error "gh auth status: $line"
         done <<<"$auth_output"
         base_gh_error "Run 'gh auth login -h github.com' and retry."
         return 1
     }
+}
+
+base_gh_report_command_failure() {
+    local status="$1"
+    shift
+
+    base_gh_error "GitHub command failed: gh $*"
+    base_gh_auth_status_diagnostics || true
+    return "$status"
+}
+
+base_gh_run() {
+    local status
+
+    base_gh_require_command gh || return 1
+    gh "$@"
+    status=$?
+    ((status == 0)) && return 0
+    base_gh_report_command_failure "$status" "$@"
+    return "$status"
 }
 
 base_gh_args_request_help() {
@@ -242,8 +261,7 @@ base_gh_do_issue() {
                 base_gh_usage
                 return 0
             fi
-            base_gh_require_auth || return 1
-            gh issue list "$@"
+            base_gh_run issue list "$@"
             ;;
         create)
             base_gh_issue_create "$@"
@@ -321,20 +339,19 @@ base_gh_issue_create() {
     }
     category="${category:-enhancement}"
     base_gh_validate_category "$category" || return 1
-    base_gh_require_auth || return 1
 
     [[ -n "$github_repo" ]] || github_repo="$(base_gh_infer_github_repo || true)"
     if [[ -n "$body" ]]; then
         if [[ -n "$github_repo" ]]; then
-            issue_output="$(gh issue create --title "$title" --body "$body" --label "$category" --assignee codeforester --repo "$github_repo")" || return $?
+            issue_output="$(base_gh_run issue create --title "$title" --body "$body" --label "$category" --assignee codeforester --repo "$github_repo")" || return $?
         else
-            issue_output="$(gh issue create --title "$title" --body "$body" --label "$category" --assignee codeforester)" || return $?
+            issue_output="$(base_gh_run issue create --title "$title" --body "$body" --label "$category" --assignee codeforester)" || return $?
         fi
     else
         if [[ -n "$github_repo" ]]; then
-            issue_output="$(gh issue create --title "$title" --label "$category" --assignee codeforester --repo "$github_repo")" || return $?
+            issue_output="$(base_gh_run issue create --title "$title" --label "$category" --assignee codeforester --repo "$github_repo")" || return $?
         else
-            issue_output="$(gh issue create --title "$title" --label "$category" --assignee codeforester)" || return $?
+            issue_output="$(base_gh_run issue create --title "$title" --label "$category" --assignee codeforester)" || return $?
         fi
     fi
     printf '%s\n' "$issue_output"
@@ -398,7 +415,7 @@ base_gh_issue_start() {
 
     base_gh_require_git_repo || return 1
     if [[ -z "$category" || -z "$title" ]]; then
-        base_gh_require_auth || return 1
+        base_gh_require_command gh || return 1
     fi
     if [[ -z "$category" ]]; then
         category="$(base_gh_issue_category_from_labels "$issue")" || return 1
@@ -427,50 +444,45 @@ base_gh_do_pr() {
                 base_gh_usage
                 return 0
             fi
-            base_gh_require_auth || return 1
             base_gh_require_git_repo || return 1
             issue="$(base_gh_current_issue_from_branch || true)"
             if [[ -n "$issue" ]]; then
                 body_file="$(mktemp "${TMPDIR:-/tmp}/basectl-gh-pr.XXXXXX")" || return 1
                 printf 'Fixes #%s\n' "$issue" > "$body_file"
-                gh pr create --fill --body-file "$body_file" "$@"
+                base_gh_run pr create --fill --body-file "$body_file" "$@"
                 status=$?
                 rm -f "$body_file"
                 return "$status"
             fi
-            gh pr create --fill "$@"
+            base_gh_run pr create --fill "$@"
             ;;
         status)
             if base_gh_args_request_help "$@"; then
                 base_gh_usage
                 return 0
             fi
-            base_gh_require_auth || return 1
-            gh pr status "$@"
+            base_gh_run pr status "$@"
             ;;
         checks)
             if base_gh_args_request_help "$@"; then
                 base_gh_usage
                 return 0
             fi
-            base_gh_require_auth || return 1
-            gh pr checks "$@"
+            base_gh_run pr checks "$@"
             ;;
         ready)
             if base_gh_args_request_help "$@"; then
                 base_gh_usage
                 return 0
             fi
-            base_gh_require_auth || return 1
-            gh pr ready "$@"
+            base_gh_run pr ready "$@"
             ;;
         merge)
             if base_gh_args_request_help "$@"; then
                 base_gh_usage
                 return 0
             fi
-            base_gh_require_auth || return 1
-            gh pr merge "$@"
+            base_gh_run pr merge "$@"
             ;;
         -h|--help|help|"")
             base_gh_usage
@@ -559,7 +571,7 @@ base_gh_branch_merged_to_ref() {
 
 base_gh_prune_github_ready() {
     if [[ -z "${_base_gh_prune_github_ready+x}" ]]; then
-        if command -v gh >/dev/null 2>&1 && gh auth status -h github.com >/dev/null 2>&1; then
+        if command -v gh >/dev/null 2>&1; then
             _base_gh_prune_github_ready=1
         else
             _base_gh_prune_github_ready=0
@@ -697,7 +709,7 @@ base_gh_branch_prune_github_branches() {
 
     printf 'GitHub branches\n'
     if ! base_gh_prune_github_ready; then
-        printf 'SKIP   GitHub branch cleanup requires authenticated gh. Run `gh auth login -h github.com` and retry.\n'
+        printf 'SKIP   GitHub branch cleanup requires the GitHub CLI `gh` on PATH.\n'
         printf 'Summary: 0 %s, 0 skipped worktree, 0 skipped unmerged, 0 failed.\n' \
             "$([[ "$dry_run" -eq 1 ]] && printf 'would delete remotely' || printf 'deleted remotely')"
         return 0

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -42,6 +42,37 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Repair branch pruning --label bug --assignee codeforester --repo codeforester/base" ]
 }
 
+@test "basectl gh issue create continues when auth status is transiently unavailable" {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    printf 'github.com\n' >&2
+    printf '  X failed to reach api.github.com\n' >&2
+    exit 1
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+if [[ "$1" == "issue" && "$2" == "create" ]]; then
+    printf 'https://github.com/codeforester/base/issues/749\n'
+fi
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue create --category bug --title "Make auth preflight resilient" --no-project
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"https://github.com/codeforester/base/issues/749"* ]]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Make auth preflight resilient --label bug --assignee codeforester --repo codeforester/base" ]
+}
+
 @test "basectl gh issue create updates repo project metadata when repo is known" {
     local repo
     local repo_root
@@ -150,13 +181,17 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/wrapper-args")" = "--project base base_github_projects project doctor --project Base Roadmap --owner codeforester" ]
 }
 
-@test "basectl gh issue list reports missing gh authentication clearly" {
+@test "basectl gh issue list reports command failure with auth diagnostics" {
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$*" == "auth status -h github.com" ]]; then
     printf 'github.com\n' >&2
     printf '  X failed to reach api.github.com\n' >&2
     printf '  - check your internet connection or GitHub API access\n' >&2
+    exit 1
+fi
+if [[ "$*" == "issue list" ]]; then
+    printf 'HTTP 401: Bad credentials\n' >&2
     exit 1
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -175,11 +210,11 @@ EOF
         '
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"GitHub CLI authentication or GitHub API access is not ready."* ]]
+    [[ "$output" == *"HTTP 401: Bad credentials"* ]]
+    [[ "$output" == *"GitHub command failed: gh issue list"* ]]
     [[ "$output" == *"gh auth status: github.com"* ]]
     [[ "$output" == *"gh auth status:   X failed to reach api.github.com"* ]]
     [[ "$output" == *"gh auth status:   - check your internet connection or GitHub API access"* ]]
-    [[ "$output" == *"gh auth login -h github.com"* ]]
     [[ "$output" != *"unexpected gh args"* ]]
 }
 
@@ -363,10 +398,13 @@ EOF
     remote="$TEST_TMPDIR/remote.git"
     create_tracked_repo_with_upstream "$repo" "$remote" "README.md" "hello"
     git -C "$repo" update-ref refs/remotes/origin/stale-branch HEAD
-
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$*" == "auth status -h github.com" ]]; then
+    printf 'unexpected auth status preflight\n' >&2
+    exit 99
+fi
+if [[ "$*" == "pr list --head stale-branch --state merged --json number --jq length" ]]; then
     exit 1
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -388,10 +426,12 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Local branches"* ]]
     [[ "$output" == *"GitHub branches"* ]]
-    [[ "$output" == *"SKIP   GitHub branch cleanup requires authenticated gh."* ]]
+    [[ "$output" == *"No merged GitHub remote branches found."* ]]
     [[ "$output" == *"Remote tracking refs"* ]]
     [[ "$output" == *"PRUNE origin/stale-branch"* ]]
     [[ "$output" == *"Note: remote-tracking ref cleanup prunes stale local origin/* refs after GitHub branch cleanup."* ]]
+    [[ "$output" != *"unexpected auth status preflight"* ]]
+    [[ "$output" != *"GitHub branch cleanup requires authenticated gh"* ]]
     [[ "$output" != *"Pruning origin"* ]]
     [[ "$output" != *"URL:"* ]]
     ! git -C "$repo" show-ref --verify --quiet refs/remotes/origin/stale-branch


### PR DESCRIPTION
## Summary

- Run real `gh` operations directly instead of treating `gh auth status` as a hard preflight.
- Keep `gh auth status` as best-effort diagnostics after actual `gh` command failures.
- Add a regression proving `basectl gh issue create` still succeeds when the status probe is transiently unavailable.

## Issue

Fixes #749

## Validation

- `bats cli/bash/commands/basectl/tests/gh.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact

None.

## Notes

AI context unchanged; this is a narrow `basectl gh` error-handling fix with changelog coverage.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`