### PR TITLE
Clarify check and doctor help

### DIFF
--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -23,6 +23,10 @@ Options:
 
 Purpose:
   Verify the local Base CLI environment and, when provided, project artifacts on macOS without making changes.
+  Use check for a quick pass/fail result; use doctor for finding IDs and fix hints.
+
+See also:
+  basectl doctor [project] [options]
 
 Check does:
   1. Verify Homebrew is installed.

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -23,6 +23,10 @@ Options:
 
 Purpose:
   Diagnose the local Base CLI environment and, when provided, project artifacts.
+  Use doctor for finding IDs and fix hints; use check for a quick pass/fail result.
+
+See also:
+  basectl check [project] [options]
 EOF
 }
 

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -13,6 +13,9 @@ load ./setup_helpers.bash
     [[ "$output" == *"--profile <list>"* ]]
     [[ "$output" == *"--remote-network"* ]]
     [[ "$output" == *"Verify the local Base CLI environment and, when provided, project artifacts on macOS without making changes."* ]]
+    [[ "$output" == *"Use check for a quick pass/fail result; use doctor for finding IDs and fix hints."* ]]
+    [[ "$output" == *"See also:"* ]]
+    [[ "$output" == *"basectl doctor [project] [options]"* ]]
 }
 
 @test "basectl check passes when all required components are present" {

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -13,6 +13,9 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--remote-network"* ]]
     [[ "$output" != *"--dev"* ]]
     [[ "$output" == *"Diagnose the local Base CLI environment"* ]]
+    [[ "$output" == *"Use doctor for finding IDs and fix hints; use check for a quick pass/fail result."* ]]
+    [[ "$output" == *"See also:"* ]]
+    [[ "$output" == *"basectl check [project] [options]"* ]]
 }
 
 @test "basectl doctor reports ok findings and includes dev checks" {


### PR DESCRIPTION
## Summary
- Add reciprocal help text callouts explaining when to use `basectl check` versus `basectl doctor`.
- Add focused BATS assertions for the new help text.

## Issue

Fixes #753

## Validation
- `bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
None.

## Notes
None.