### PR TITLE
Report repo usage errors before help hints

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -165,40 +165,37 @@ path is provided. With --pr, path is required.
 EOF
 }
 
-base_repo_usage_error() {
-    base_repo_subcommand_usage >&2
+base_repo_print_usage_error() {
+    local help_command="$1"
+    shift
+
     printf 'ERROR: %s\n' "$*" >&2
+    printf "Run '%s --help' for usage.\n" "$help_command" >&2
     return 2
+}
+
+base_repo_usage_error() {
+    base_repo_print_usage_error "basectl repo" "$@"
 }
 
 base_repo_init_usage_error() {
-    base_repo_init_usage >&2
-    printf 'ERROR: %s\n' "$*" >&2
-    return 2
+    base_repo_print_usage_error "basectl repo init" "$@"
 }
 
 base_repo_clone_usage_error() {
-    base_repo_clone_usage >&2
-    printf 'ERROR: %s\n' "$*" >&2
-    return 2
+    base_repo_print_usage_error "basectl repo clone" "$@"
 }
 
 base_repo_check_usage_error() {
-    base_repo_check_usage >&2
-    printf 'ERROR: %s\n' "$*" >&2
-    return 2
+    base_repo_print_usage_error "basectl repo check" "$@"
 }
 
 base_repo_configure_usage_error() {
-    base_repo_configure_usage >&2
-    printf 'ERROR: %s\n' "$*" >&2
-    return 2
+    base_repo_print_usage_error "basectl repo configure" "$@"
 }
 
 base_repo_installer_template_usage_error() {
-    base_repo_installer_template_usage >&2
-    printf 'ERROR: %s\n' "$*" >&2
-    return 2
+    base_repo_print_usage_error "basectl repo installer-template" "$@"
 }
 
 base_repo_agent_guidance_usage() {
@@ -221,9 +218,7 @@ EOF
 }
 
 base_repo_agent_guidance_usage_error() {
-    base_repo_agent_guidance_usage >&2
-    printf 'ERROR: %s\n' "$*" >&2
-    return 2
+    base_repo_print_usage_error "basectl repo agent-guidance" "$@"
 }
 
 base_repo_default_description() {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -2,6 +2,13 @@
 
 load ./basectl_helpers.bash
 
+line_at() {
+    local text="$1"
+    local line_number="$2"
+
+    printf '%s\n' "$text" | sed -n "${line_number}p"
+}
+
 
 @test "basectl repo prints help" {
     run_basectl repo --help
@@ -108,9 +115,10 @@ EOF
     run_basectl repo clone base-demo --dry-run
 
     [ "$status" -eq 2 ]
-    [[ "$output" == *"basectl repo clone <name-or-owner/name> [options]"* ]]
-    [[ "$output" == *"ERROR: Repository owner is required for short repo names."* ]]
-    [[ "$output" == *"Pass --owner <owner> or set github.default_owner in ~/.base.d/config.yaml."* ]]
+    [ "$(line_at "$output" 1)" = "ERROR: Repository owner is required for short repo names. Pass --owner <owner> or set github.default_owner in ~/.base.d/config.yaml." ]
+    [ "$(line_at "$output" 2)" = "Run 'basectl repo clone --help' for usage." ]
+    [[ "$output" != *"Usage:"* ]]
+    [[ "$output" != *"basectl repo clone <name-or-owner/name> [options]"* ]]
 }
 
 @test "basectl repo clone treats existing matching checkouts as satisfied" {
@@ -225,11 +233,33 @@ EOF
     run_basectl repo init --repo codeforester/bankbuddy --pr
 
     [ "$status" -eq 2 ]
-    [[ "$output" == *"basectl repo init <name> [options]"* ]]
-    [[ "$output" == *"basectl repo init bankbuddy --path . --repo codeforester/bankbuddy --pr"* ]]
-    [[ "$output" == *"ERROR: Repository name is required."* ]]
+    [ "$(line_at "$output" 1)" = "ERROR: Repository name is required." ]
+    [ "$(line_at "$output" 2)" = "Run 'basectl repo init --help' for usage." ]
+    [[ "$output" != *"Usage:"* ]]
+    [[ "$output" != *"basectl repo init <name> [options]"* ]]
+    [[ "$output" != *"basectl repo init bankbuddy --path . --repo codeforester/bankbuddy --pr"* ]]
     [[ "$output" != *"basectl repo agent-guidance"* ]]
     [[ "$output" != *"--repo-name <name>"* ]]
+}
+
+@test "basectl repo unknown command reports error before help hint" {
+    run_basectl repo mystery
+
+    [ "$status" -eq 2 ]
+    [ "$(line_at "$output" 1)" = "ERROR: Unknown repo command 'mystery'." ]
+    [ "$(line_at "$output" 2)" = "Run 'basectl repo --help' for usage." ]
+    [[ "$output" != *"Usage:"* ]]
+    [[ "$output" != *"basectl repo init <name> [options]"* ]]
+}
+
+@test "basectl repo agent-guidance missing option argument reports error before help hint" {
+    run_basectl repo agent-guidance --repo
+
+    [ "$status" -eq 2 ]
+    [ "$(line_at "$output" 1)" = "ERROR: Option '--repo' requires an argument." ]
+    [ "$(line_at "$output" 2)" = "Run 'basectl repo agent-guidance --help' for usage." ]
+    [[ "$output" != *"Usage:"* ]]
+    [[ "$output" != *"basectl repo agent-guidance [path] [options]"* ]]
 }
 
 @test "basectl repo installer-template prints the maintained template" {


### PR DESCRIPTION
## Summary
- Replace full `basectl repo` usage dumps on invalid input with error-first output and a focused `--help` hint.
- Cover top-level and subcommand usage errors so regressions are caught by Bats.

## Validation
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
- None. CLI error output only.

Closes #756