### PR TITLE
Clarify gh prune dry-run behavior

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -112,9 +112,12 @@ Usage:
 Purpose:
   Inspect stale branches and prune merged local or GitHub branches.
 
+Note:
+  Runs in dry-run mode by default. Pass --yes to apply changes.
+
 Options:
   --days <days>  Minimum age for stale branch reporting. Defaults to 30.
-  --dry-run      Preview branches that would be deleted. This is the default.
+  --dry-run      Preview branches that would be deleted (default).
   --yes          Delete merged branches after preview.
   --remote       Also prune merged GitHub remote branches and stale origin/* refs.
 EOF
@@ -128,8 +131,11 @@ Usage:
 Purpose:
   Prune safe, merged Git worktrees and their local branches.
 
+Note:
+  Runs in dry-run mode by default. Pass --yes to apply changes.
+
 Options:
-  --dry-run      Preview worktrees that would be removed. This is the default.
+  --dry-run      Preview worktrees that would be removed (default).
   --yes          Remove safe merged worktrees after preview.
 EOF
 }
@@ -939,6 +945,9 @@ base_gh_branch_prune() {
         base_gh_branch_prune_github_branches "$dry_run" "$default_branch" || status=$?
         base_gh_branch_prune_remote_tracking_refs "$dry_run" || status=$?
     fi
+    if ((dry_run)); then
+        printf 'Run with --yes to apply these changes.\n'
+    fi
     return "$status"
 }
 
@@ -1086,6 +1095,9 @@ base_gh_worktree_prune() {
     printf 'Summary: %s %s, %s skipped current/default, %s skipped dirty, %s skipped unmerged, %s failed.\n' \
         "$removed" "$([[ "$dry_run" -eq 1 ]] && printf 'would remove' || printf 'removed')" \
         "$skipped_current" "$skipped_dirty" "$skipped_unmerged" "$failed"
+    if ((dry_run)); then
+        printf 'Run with --yes to apply these changes.\n'
+    fi
     return "$failed"
 }
 

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -59,7 +59,8 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl gh branch stale [--days <days>]"* ]]
     [[ "$output" == *"basectl gh branch prune [--dry-run] [--yes] [--remote]"* ]]
-    [[ "$output" == *"--dry-run      Preview branches that would be deleted. This is the default."* ]]
+    [[ "$output" == *"Runs in dry-run mode by default. Pass --yes to apply changes."* ]]
+    [[ "$output" == *"--dry-run      Preview branches that would be deleted (default)."* ]]
     [[ "$output" != *"basectl gh issue create"* ]]
     [[ "$output" != *"basectl gh worktree prune"* ]]
 }
@@ -70,6 +71,8 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl gh worktree prune [--dry-run] [--yes]"* ]]
     [[ "$output" == *"Prune safe, merged Git worktrees and their local branches."* ]]
+    [[ "$output" == *"Runs in dry-run mode by default. Pass --yes to apply changes."* ]]
+    [[ "$output" == *"--dry-run      Preview worktrees that would be removed (default)."* ]]
     [[ "$output" != *"basectl gh branch prune"* ]]
     [[ "$output" != *"basectl gh issue create"* ]]
 }
@@ -374,6 +377,7 @@ EOF
     [[ "$output" == *"Local branches"* ]]
     [[ "$output" == *"[DRY-RUN] DELETE merged-work"* ]]
     [[ "$output" == *"Summary: 1 would delete, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
+    [[ "$output" == *"Run with --yes to apply these changes."* ]]
     git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
 }
 
@@ -548,6 +552,7 @@ EOF
     [[ "$output" == *"GitHub branches"* ]]
     [[ "$output" == *"[DRY-RUN] DELETE-REMOTE origin/squash-remote  merged GitHub PR"* ]]
     [[ "$output" == *"Summary: 1 would delete remotely, 0 skipped worktree, 0 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Run with --yes to apply these changes."* ]]
     git -C "$repo" ls-remote --exit-code --heads origin squash-remote >/dev/null
 }
 
@@ -711,6 +716,7 @@ EOF
     [[ "$output" == *"[DRY-RUN] REMOVE "*"/merged-worktree (merged-work) and delete local branch"* ]]
     [[ "$output" == *"SKIP   "*"/repo (master)  current worktree"* ]]
     [[ "$output" == *"Summary: 1 would remove, 1 skipped current/default, 0 skipped dirty, 0 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Run with --yes to apply these changes."* ]]
     [ -d "$worktree" ]
     git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
 }


### PR DESCRIPTION
## Summary
- Add prominent dry-run-by-default notes to `basectl gh branch` and `basectl gh worktree` help.
- Add a trailing `--yes` hint to dry-run prune output.
- Cover the help text and dry-run output hints in `gh.bats`.

## Validation
- `bats cli/bash/commands/basectl/tests/gh.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
- None. CLI help and dry-run output only.

Closes #757