### PR TITLE
List workspace clone in basectl help

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -49,7 +49,7 @@ Commands:
     Update Base from Git and run setup.
   projects list [options]
     List Base-managed projects discovered in the workspace.
-  workspace <status|check|doctor> [options]
+  workspace <status|check|doctor|clone> [options]
     Show read-only workspace project status, checks, or diagnostics.
   version
     Show the installed Base version.

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -25,7 +25,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"onboard [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
-    [[ "$output" == *"workspace <status|check|doctor> [options]"* ]]
+    [[ "$output" == *"workspace <status|check|doctor|clone> [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
@@ -57,7 +57,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
-    grep -Fqx '  workspace <status|check|doctor> [options]' <<<"$output"
+    grep -Fqx '  workspace <status|check|doctor|clone> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]


### PR DESCRIPTION
## Summary
- Add `clone` to the top-level `basectl workspace` help entry.
- Update help tests to match the workspace subcommand surface.

## Validation
- `bats cli/bash/commands/basectl/tests/help.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
- None. Help text only.

Closes #758