### PR TITLE
Clarify TODO issue planning command

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -21,7 +21,7 @@ Usage:
   basectl gh branch stale [--days <days>]
   basectl gh branch prune [--dry-run] [--yes] [--remote]
   basectl gh worktree prune [--dry-run] [--yes]
-  basectl gh todo import [--dry-run] [--file <path>]
+  basectl gh todo plan [--file <path>]
 
 Purpose:
   Manage GitHub issues, pull requests, Project metadata, branch naming, and
@@ -43,7 +43,7 @@ Notes:
     repo-named Project and applies defaults from .github/base-project.yml.
   - Pull request implementation work should happen in a dedicated worktree.
   - Branch and worktree pruning are dry-run by default and apply only when --yes is passed.
-  - TODO import is currently a dry-run planning command.
+  - TODO planning only previews issues; TODO import creation is not enabled yet.
 EOF
 }
 
@@ -143,14 +143,17 @@ EOF
 base_gh_todo_usage() {
     cat <<'EOF'
 Usage:
-  basectl gh todo import [--dry-run] [--file <path>]
+  basectl gh todo plan [--file <path>]
 
 Purpose:
   Preview GitHub issues that would be created from TODO.md.
 
 Options:
-  --dry-run      Preview parsed TODO items. This is the only supported mode today.
   --file <path>  Read TODO items from a specific file. Defaults to TODO.md.
+
+Notes:
+  - TODO issue creation is not enabled yet. Use `basectl gh todo plan` to
+    inspect the migration plan.
 EOF
 }
 
@@ -1150,14 +1153,11 @@ base_gh_todo_infer_category() {
     esac
 }
 
-base_gh_todo_import() {
-    local file="$BASE_HOME/TODO.md" dry_run=1 line section="" title category
+base_gh_todo_plan() {
+    local file="$BASE_HOME/TODO.md" line section="" title category
 
     while (($#)); do
         case "$1" in
-            --dry-run)
-                dry_run=1
-                ;;
             --file)
                 file="${2:-}"
                 shift
@@ -1179,12 +1179,7 @@ base_gh_todo_import() {
         return 1
     }
 
-    if ((dry_run)); then
-        printf '[DRY-RUN] Issues that would be created from %s:\n' "$file"
-    else
-        base_gh_error "TODO import creation is not enabled yet; run with --dry-run."
-        return 1
-    fi
+    printf 'Issues that would be created from %s:\n' "$file"
 
     while IFS= read -r line; do
         case "$line" in
@@ -1206,7 +1201,11 @@ base_gh_do_todo() {
     shift || true
 
     case "$command" in
-        import) base_gh_todo_import "$@" ;;
+        plan) base_gh_todo_plan "$@" ;;
+        import)
+            base_gh_error "TODO import creation is not enabled yet. Run 'basectl gh todo plan' to preview TODO.md items."
+            return 1
+            ;;
         -h|--help|help|"") base_gh_todo_usage ;;
         *)
             base_gh_error "Unknown gh todo command '$command'."

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -13,6 +13,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl gh project configure --project <title>"* ]]
     [[ "$output" == *"basectl gh project issue set-fields <number>"* ]]
     [[ "$output" == *"basectl gh worktree prune"* ]]
+    [[ "$output" == *"basectl gh todo plan [--file <path>]"* ]]
+    [[ "$output" != *"basectl gh todo import"* ]]
     [[ "$output" == *"<category>/<issue>-<YYYYMMDD>-<slug>"* ]]
     [[ "$output" == *"assigned to codeforester"* ]]
 }
@@ -81,9 +83,11 @@ load ./basectl_helpers.bash
     run_basectl gh todo --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl gh todo import [--dry-run] [--file <path>]"* ]]
+    [[ "$output" == *"basectl gh todo plan [--file <path>]"* ]]
     [[ "$output" == *"Preview GitHub issues that would be created from TODO.md."* ]]
-    [[ "$output" == *"--dry-run      Preview parsed TODO items. This is the only supported mode today."* ]]
+    [[ "$output" == *"TODO issue creation is not enabled yet. Use \`basectl gh todo plan\`"* ]]
+    [[ "$output" != *"--dry-run"* ]]
+    [[ "$output" != *"basectl gh todo import"* ]]
     [[ "$output" != *"basectl gh issue create"* ]]
     [[ "$output" != *"basectl gh branch prune"* ]]
 }
@@ -926,7 +930,7 @@ EOF
     [[ "$output" != *"unexpected gh args"* ]]
 }
 
-@test "basectl gh todo import dry-run classifies TODO items" {
+@test "basectl gh todo plan classifies TODO items" {
     local todo_file
 
     todo_file="$TEST_TMPDIR/TODO.md"
@@ -946,10 +950,26 @@ EOF
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main todo import --dry-run --file "$1"
+            base_gh_subcommand_main todo plan --file "$1"
         ' bash "$todo_file"
 
     [ "$status" -eq 0 ]
+    [[ "$output" == *"Issues that would be created from $todo_file:"* ]]
     [[ "$output" == *$'bug\tDetect outdated Xcode Command Line Tools in `basectl doctor`'* ]]
     [[ "$output" == *$'enhancement\tAdd first-class `mise` integration'* ]]
+}
+
+@test "basectl gh todo import reports creation is not enabled" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main todo import
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"TODO import creation is not enabled yet."* ]]
+    [[ "$output" == *"Run 'basectl gh todo plan' to preview TODO.md items."* ]]
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -73,7 +73,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | `basectl gh project doctor` | Inspect GitHub Project metadata against the Base roadmap schema. | `--project <title>`, `--owner <login>`, `--schema base-roadmap` |
 | `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--config <path>`, `--copy-fields-from <title>`, `--dry-run` |
 | `basectl gh project issue set-fields <number>` | Add an issue to the Project if needed and update metadata fields. | `--project <title>`, `--repo <owner/name>`, `--config <path>`, field options |
-| `basectl gh todo import` | Preview migration of `TODO.md` items into GitHub Issues. | `--dry-run`, `--file <path>` |
+| `basectl gh todo plan` | Preview migration of `TODO.md` items into GitHub Issues. Creation is not enabled yet. | `--file <path>` |
 
 ## Release And Context
 


### PR DESCRIPTION
## Summary
- Expose `basectl gh todo plan` as the preview-only TODO migration command.
- Make `basectl gh todo import` report clearly that issue creation is not enabled yet.
- Update command reference and Bats coverage for the planned command surface.

## Validation
- `bats cli/bash/commands/basectl/tests/gh.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
- None. CLI help/command wording only.

Closes #759