### PR TITLE
Allow onboard to target a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,10 +746,11 @@ basectl check example
 basectl doctor example
 ```
 
-`basectl onboard` provides a guided checklist for technically-adjacent users who
-want a first Base setup flow around check, setup, profile refresh, doctor, and
-project discovery. Product-specific onboarding should still live in project
-installers that call Base internally. See
+`basectl onboard [project]` provides a guided checklist for technically-adjacent
+users who want a first Base setup flow around check, setup, profile refresh,
+doctor, and project discovery. It defaults to `base`, and can target another
+Base-managed project for the check/setup/doctor steps. Product-specific
+onboarding should still live in project installers that call Base internally. See
 [docs/basectl-onboard.md](docs/basectl-onboard.md).
 
 Base can also bootstrap supported IDEs for participating projects through the
@@ -982,9 +983,9 @@ to `PATH`, so `basectl` can be run without spelling out the full path. Use
 `basectl version` or `basectl --version` to report the installed Base version.
 
 Project-specific onboarding should live in project installers that call Base
-internally. Base intentionally does not provide `basectl onboard <project>` for
-product-specific setup; that flow belongs in scripts such as
-`banyanlabs/install.sh`. See [Project Installers](docs/project-installers.md)
+internally. `basectl onboard [project]` can run Base's setup/check/doctor flow
+for a selected project, but product-specific setup still belongs in scripts such
+as `banyanlabs/install.sh`. See [Project Installers](docs/project-installers.md)
 for the recommended boundary.
 
 ## Documentation

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -41,7 +41,7 @@ Commands:
     Diagnose the local Base CLI environment and optional project artifacts.
   gh <area> <command> [options]
     Manage GitHub issues, PRs, branches, and repository hygiene.
-  onboard [options]
+  onboard [project] [options]
     Guide a user through the first Base setup checklist.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -11,7 +11,7 @@ source "$_base_setup_common_path"
 base_onboard_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl onboard [options]
+  basectl onboard [project] [options]
 
 Options:
   --profile <list>  Include named prerequisite profiles. Known profiles: dev, sre, ai.
@@ -24,6 +24,9 @@ Options:
 Purpose:
   Guide a user through the first Base setup by orchestrating check, setup,
   update-profile, doctor, and project discovery commands.
+
+Project:
+  Defaults to 'base'. The selected project is passed to check, setup, and doctor.
 EOF
 }
 
@@ -96,14 +99,16 @@ base_onboard_execute() {
 base_onboard_subcommand_main() {
     local dry_run=0
     local no_profile=0
+    local project="base"
+    local project_explicit=0
     local verbose=0
     local yes=0
     local check_status=0
     local profile_status=0
     local setup_status=0
-    local check_args=(check base)
-    local doctor_args=(doctor base)
-    local setup_args=(setup base)
+    local check_args=()
+    local doctor_args=()
+    local setup_args=()
     local profile_args=(update-profile)
     local projects_args=(projects list)
 
@@ -138,14 +143,27 @@ base_onboard_subcommand_main() {
                 base_onboard_subcommand_usage
                 return 0
                 ;;
-            *)
+            -*)
                 print_error "Unknown option '$1'."
                 base_onboard_subcommand_usage >&2
                 return 1
                 ;;
+            *)
+                if ((project_explicit)); then
+                    print_error "The onboard command accepts at most one project."
+                    base_onboard_subcommand_usage >&2
+                    return 1
+                fi
+                project="$1"
+                project_explicit=1
+                ;;
         esac
         shift
     done
+
+    check_args=(check "$project")
+    setup_args=(setup "$project")
+    doctor_args=(doctor "$project")
 
     if setup_profiles_enabled; then
         check_args+=(--profile "$(setup_profiles_csv)")
@@ -164,7 +182,7 @@ base_onboard_subcommand_main() {
         profile_args+=(--dry-run)
     fi
 
-    printf '%s\n' "Base onboard will verify project 'base' and guide the setup steps it can reconcile."
+    printf '%s\n' "Base onboard will verify project '$project' and guide the setup steps it can reconcile."
 
     base_onboard_print_heading "Check"
     printf '%s\n' "Base will check the current machine state before making changes."
@@ -227,5 +245,5 @@ base_onboard_subcommand_main() {
     fi
 
     base_onboard_print_heading "Next Steps"
-    printf '%s\n' "Run 'basectl' to enter the nearest Base project shell, or 'basectl activate base' to start with Base itself."
+    printf "%s\n" "Run 'basectl' to enter the nearest Base project shell, or 'basectl activate $project' to start with '$project'."
 }

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -107,6 +107,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "onboard_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl onboard ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "onboard_projects=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl onboard --profile ""); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -202,6 +206,7 @@ EOF
     [[ "$output" == *"workspace_commands=status check doctor clone"* ]]
     [[ "$output" == *"workspace_options=--workspace --manifest --format --include-optional --dry-run"* ]]
     [[ "$output" == *"onboard_options=--profile --dry-run --yes --no-profile"* ]]
+    [[ "$output" == *"onboard_projects=base demo"* ]]
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -22,7 +22,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"gh <area> <command> [options]"* ]]
-    [[ "$output" == *"onboard [options]"* ]]
+    [[ "$output" == *"onboard [project] [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
     [[ "$output" == *"workspace <status|check|doctor|clone> [options]"* ]]
@@ -49,7 +49,7 @@ load ./basectl_helpers.bash
     ! grep -Fqx '  shell' <<<"$output"
     grep -Fqx '  version' <<<"$output"
     grep -Fqx '  gh <area> <command> [options]' <<<"$output"
-    grep -Fqx '  onboard [options]' <<<"$output"
+    grep -Fqx '  onboard [project] [options]' <<<"$output"
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  export-context [project] [options]' <<<"$output"

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -8,11 +8,12 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl onboard [options]"* ]]
+    [[ "$output" == *"basectl onboard [project] [options]"* ]]
     [[ "$output" == *"--profile <list>"* ]]
     [[ "$output" != *"--dev"* ]]
     [[ "$output" == *"--dry-run"* ]]
     [[ "$output" == *"--no-profile"* ]]
+    [[ "$output" == *"Defaults to 'base'."* ]]
 }
 
 @test "basectl onboard dry-run shows planned commands without prompting" {
@@ -54,6 +55,40 @@ load ./basectl_helpers.bash
     [[ "$output" == *"[DRY-RUN] Would run basectl setup base --profile dev\\,sre\\,ai --dry-run"* ]]
     [[ "$output" == *"[DRY-RUN] Would run basectl doctor base --profile dev\\,sre\\,ai"* ]]
     [[ "$output" != *"unexpected run"* ]]
+}
+
+@test "basectl onboard dry-run targets an explicit project" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() { printf "unexpected run: %s\n" "$*" >&2; return 99; }
+            base_onboard_subcommand_main bankbuddy --dry-run --profile dev
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base onboard will verify project 'bankbuddy'"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl check bankbuddy --profile dev"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl setup bankbuddy --profile dev --dry-run"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl doctor bankbuddy --profile dev"* ]]
+    [[ "$output" == *"basectl activate bankbuddy"* ]]
+    [[ "$output" != *"unexpected run"* ]]
+}
+
+@test "basectl onboard rejects multiple projects" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_subcommand_main bankbuddy base-demo --dry-run
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"The onboard command accepts at most one project."* ]]
 }
 
 @test "basectl onboard rejects unknown profiles" {

--- a/docs/basectl-onboard.md
+++ b/docs/basectl-onboard.md
@@ -1,6 +1,7 @@
 # `basectl onboard`
 
-`basectl onboard` is the guided setup experience for Base itself.
+`basectl onboard` is the guided setup experience for Base itself and for
+Base-managed project setup primitives.
 
 It helps technically-adjacent users through the first Base setup without
 turning `basectl setup` into an interactive, hand-holding command. The setup
@@ -12,11 +13,11 @@ slower, friendlier, and more explanatory because that is its purpose.
 `basectl onboard` runs a checklist-style first-run flow around existing Base
 commands:
 
-1. runs `basectl check`
-2. prompts before running `basectl setup`
+1. runs `basectl check [project]`
+2. prompts before running `basectl setup [project]`
 3. prompts before running `basectl update-profile`, unless profile updates are
    disabled
-4. runs `basectl doctor`
+4. runs `basectl doctor [project]`
 5. lists discovered projects with `basectl projects list`
 6. suggests the next interactive shell step
 
@@ -27,7 +28,7 @@ when you want the scriptable reconciler.
 ## Usage
 
 ```bash
-basectl onboard [options]
+basectl onboard [project] [options]
 ```
 
 Options:
@@ -41,27 +42,30 @@ Options:
   -h, --help       Show help text.
 ```
 
-The command defaults to the `base` project. Project-specific guided onboarding
-remains a project installer responsibility.
+The command defaults to the `base` project. Passing a project name threads that
+project through `check`, `setup`, and `doctor`. Product-specific guided
+onboarding remains a project installer responsibility.
 
 ## Scope Boundary
 
-Base should not grow `basectl onboard <project>` as a product-specific guided
-installer. Project onboarding belongs in the project repository, where the
-installer can speak in that product's language, clone or update that product's
-repo, explain product-specific prerequisites, and call Base for the workspace
-mechanics it owns.
+`basectl onboard [project]` is not a product-specific guided installer. It can
+target Base's generic project setup/check/doctor flow, but product onboarding
+belongs in the project repository, where the installer can speak in that
+product's language, clone or update that product's repo, explain
+product-specific prerequisites, and call Base for the workspace mechanics it
+owns.
 
 The stable split is:
 
-- `basectl onboard` guides first-run Base setup.
+- `basectl onboard [project]` guides first-run Base setup and optional
+  Base-managed project reconciliation.
 - `basectl setup <project>` reconciles a Base-managed project from its manifest.
 - `<project>/install.sh` or a packaged project installer guides product-specific
   onboarding and calls Base internally.
 
 Future workspace or team onboarding should start from a workspace manifest
-design, not from project-specific product logic inside Base. A future command
-such as `basectl onboard <workspace>` would need an explicit manifest location,
+design, not from project-specific product logic inside Base. A future
+workspace-level onboarding command would need an explicit manifest location,
 clone policy, trust model, partial-failure model, and dry-run story before it
 becomes part of the product surface. See [Workspace Manifest](workspace-manifest.md).
 
@@ -86,27 +90,27 @@ boundary.
 
 `basectl onboard` orchestrates existing Base primitives:
 
-- `basectl check` for quick environment state
-- `basectl doctor` for human-readable diagnosis and suggested fixes
-- `basectl setup` for actual reconciliation
+- `basectl check [project]` for quick environment state
+- `basectl doctor [project]` for human-readable diagnosis and suggested fixes
+- `basectl setup [project]` for actual reconciliation
 - `basectl setup --profile <list>` when the user opts into Base prerequisite
   profiles
 - `basectl update-profile` for shell startup integration
 - `basectl projects list` to show discovered projects after setup
-- `basectl activate base` as the final suggested next step
+- `basectl activate <project>` as the final suggested next step
 
 It does not duplicate Homebrew, Python, venv, manifest, or shell-profile logic.
 Those responsibilities already belong to the setup/check/profile commands.
 
 ## Command Shape
 
-Initial command shape:
+Command shape:
 
 ```bash
-basectl onboard [options]
+basectl onboard [project] [options]
 ```
 
-Planned options:
+Options:
 
 ```text
   --profile <list> Include named prerequisite profiles.
@@ -117,8 +121,9 @@ Planned options:
   -h, --help       Show help text.
 ```
 
-The command should default to the `base` project. Project-specific guided
-onboarding remains a project installer responsibility.
+The command defaults to the `base` project. Passing a project name targets the
+Base-managed project checks and setup steps without making Base responsible for
+product-specific onboarding.
 
 ## Experience Flow
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -10,7 +10,7 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv` |
 | `basectl update-profile` | Create or update Base-managed Bash and Zsh startup snippets. | `--defaults`, `--no-defaults`, `--dry-run` |
 | `basectl update [project]` | Update a Base-managed project checkout through Git, or update Base through Homebrew when Base is Homebrew-managed, then run setup for the selected project. | `--dry-run` |
-| `basectl onboard` | Guide first-run setup by orchestrating setup, shell profile, doctor, and project discovery checks. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
+| `basectl onboard [project]` | Guide first-run setup by orchestrating check, setup, shell profile, doctor, and project discovery. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
 | `basectl version` | Show the installed Base version. | none |
 
 ## Daily Project Loop

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -113,15 +113,15 @@ Project installers should not:
 `basectl onboard` is still useful, but it should target a different layer. Its
 command design is captured in [basectl-onboard.md](basectl-onboard.md).
 
-`basectl onboard` should be a guided Base setup experience for
-technically-adjacent users who are installing Base itself. A project installer
-should be a guided product setup experience for users installing a particular
-project.
+`basectl onboard [project]` should be a guided Base setup experience for
+technically-adjacent users who want Base to reconcile its generic machine and
+project primitives. A project installer should be a guided product setup
+experience for users installing a particular project.
 
 In short:
 
 - use `basectl setup` for direct developer setup
-- use `basectl onboard` for guided Base setup
+- use `basectl onboard [project]` for guided Base setup and generic project reconciliation
 - use `<project>/install.sh` for guided project setup
 
 Keeping these layers separate lets Base stay small and reusable while each

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -147,7 +147,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | `basectl setup [project] [--profile dev\|sre\|ai]` | Install / reconcile prerequisites |
 | `basectl update-profile [--defaults]` | Wire shell startup files |
 | `basectl update [project] [--dry-run]` | Upgrade Base or a Base-managed project checkout |
-| `basectl onboard` | Guided first-run checklist |
+| `basectl onboard [project]` | Guided first-run checklist |
 
 ### Daily Loop
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -239,7 +239,7 @@ _base_basectl_completion() {
             esac
             ;;
         onboard)
-            _base_basectl_completion_profiles_or_options \
+            _base_basectl_completion_project_profiles_or_options \
                 "$cur" \
                 "--profile --dry-run --yes --no-profile -v -h --help"
             ;;

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -370,7 +370,12 @@ _base_basectl_completion() {
                 '--yes[Accept default answers for setup and shell profile prompts]' \
                 '--no-profile[Skip shell profile updates]' \
                 '-v[Enable DEBUG logging]' \
-                '(-h --help)'{-h,--help}'[Show help text]'
+                '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
+                _describe -t projects 'Base project' project_names
+            fi
             ;;
         update-profile)
             _arguments '--defaults[Enable shell defaults]' '--no-defaults[Disable shell defaults]' \


### PR DESCRIPTION
## Summary
- Allow `basectl onboard [project]` to target check/setup/doctor for a selected project, defaulting to `base`.
- Update top-level help and Bash/Zsh completion to expose the project argument.
- Refresh onboard docs and related references so product-specific installer boundaries remain clear.

## Validation
- `bats cli/bash/commands/basectl/tests/onboard.bats`
- `bats cli/bash/commands/basectl/tests/help.bats`
- `bats cli/bash/commands/basectl/tests/completions.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
- None. Onboard command UX and documentation only.

Closes #760