### PR TITLE
Summarize repo check results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Made `basectl repo check` print visible success/failure summaries with counts
+  and repair commands when files are missing.
 - Made `basectl repo init --pr` print next steps after opening a baseline pull
   request, including the command to rerun after merge.
 - Clarified `basectl repo init` and `repo configure` help to distinguish local

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -2039,53 +2039,81 @@ base_repo_pr_baseline_has_changes() {
 }
 
 base_repo_check_baseline() {
-    local missing=0
+    local missing_files=()
     local path="$1"
     local rel
+    local repo_name
+    local required_count="${#BASE_REPO_BASELINE_FILES[@]}"
+    local not_executable_files=()
+    local command=()
 
     for rel in "${BASE_REPO_BASELINE_FILES[@]}"; do
         if [[ ! -f "$path/$rel" ]]; then
-            log_warn "Missing repository baseline file '$rel'."
-            missing=1
-        else
-            log_info "Repository baseline file '$rel' exists."
+            missing_files+=("$rel")
         fi
     done
 
     if [[ -f "$path/tests/validate.sh" && ! -x "$path/tests/validate.sh" ]]; then
-        log_warn "Repository baseline file 'tests/validate.sh' is not executable."
-        missing=1
+        not_executable_files+=(tests/validate.sh)
     fi
 
-    if ((missing)); then
-        log_warn "Repository baseline check found missing requirements."
+    if ((${#missing_files[@]} || ${#not_executable_files[@]})); then
+        if ((${#missing_files[@]})); then
+            printf "Repository baseline: %d of %d required files missing.\n" \
+                "${#missing_files[@]}" \
+                "$required_count"
+        else
+            printf "Repository baseline: all %d required files present, but some requirements failed.\n" \
+                "$required_count"
+        fi
+        for rel in "${missing_files[@]}"; do
+            printf "  Missing: %s\n" "$rel"
+        done
+        for rel in "${not_executable_files[@]}"; do
+            printf "  Not executable: %s\n" "$rel"
+        done
+        if ((${#missing_files[@]})); then
+            repo_name="$(basename -- "$path")"
+            command=(basectl repo init "$repo_name" --path "$path")
+            printf "Run '"
+            base_repo_pretty_command "${command[@]}"
+            printf "' to create the missing files.\n"
+        fi
         return 1
     fi
 
-    log_info "Repository baseline check passed."
+    printf "Repository baseline: all %d required files present.\n" "$required_count"
     return 0
 }
 
 base_repo_check_agent_guidance() {
-    local missing=0
+    local missing_files=()
     local path="$1"
     local rel
+    local required_count="${#BASE_REPO_AGENT_GUIDANCE_FILES[@]}"
+    local command=()
 
     for rel in "${BASE_REPO_AGENT_GUIDANCE_FILES[@]}"; do
         if [[ ! -f "$path/$rel" ]]; then
-            log_warn "Missing agent guidance file '$rel'."
-            missing=1
-        else
-            log_info "Agent guidance file '$rel' exists."
+            missing_files+=("$rel")
         fi
     done
 
-    if ((missing)); then
-        log_warn "Agent guidance baseline check found missing requirements."
+    if ((${#missing_files[@]})); then
+        printf "Agent guidance: %d of %d files missing.\n" \
+            "${#missing_files[@]}" \
+            "$required_count"
+        for rel in "${missing_files[@]}"; do
+            printf "  Missing: %s\n" "$rel"
+        done
+        command=(basectl repo agent-guidance "$path")
+        printf "Run '"
+        base_repo_pretty_command "${command[@]}"
+        printf "' to create the missing files.\n"
         return 1
     fi
 
-    log_info "Agent guidance baseline check passed."
+    printf "Agent guidance: all %d files present.\n" "$required_count"
     return 0
 }
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -786,7 +786,7 @@ EOF
     run_basectl repo check "$repo_dir"
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Repository baseline check passed."* ]]
+    [[ "$output" == *"Repository baseline: all 12 required files present."* ]]
 }
 
 @test "basectl repo check reports missing baseline files" {
@@ -798,8 +798,10 @@ EOF
     run_basectl repo check "$repo_dir"
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Missing repository baseline file 'VERSION'."* ]]
-    [[ "$output" == *"Repository baseline check found missing requirements."* ]]
+    [[ "$output" == *"Repository baseline: 11 of 12 required files missing."* ]]
+    [[ "$output" == *"Missing: VERSION"* ]]
+    [[ "$output" == *"Missing: base_manifest.yaml"* ]]
+    [[ "$output" == *"Run 'basectl repo init incomplete --path $repo_dir' to create the missing files."* ]]
 }
 
 @test "basectl repo check reports missing agent guidance only when opted in" {
@@ -811,9 +813,11 @@ EOF
     run_basectl repo check "$repo_dir" --agent-guidance
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Missing agent guidance file 'AGENTS.md'."* ]]
-    [[ "$output" == *"Missing agent guidance file 'skills.md'."* ]]
-    [[ "$output" == *"Agent guidance baseline check found missing requirements."* ]]
+    [[ "$output" == *"Repository baseline: all 12 required files present."* ]]
+    [[ "$output" == *"Agent guidance: 2 of 3 files missing."* ]]
+    [[ "$output" == *"Missing: AGENTS.md"* ]]
+    [[ "$output" == *"Missing: skills.md"* ]]
+    [[ "$output" == *"Run 'basectl repo agent-guidance $repo_dir' to create the missing files."* ]]
 }
 
 @test "basectl repo check passes with generated agent guidance when opted in" {
@@ -827,8 +831,8 @@ EOF
     run_basectl repo check "$repo_dir" --agent-guidance
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Repository baseline check passed."* ]]
-    [[ "$output" == *"Agent guidance baseline check passed."* ]]
+    [[ "$output" == *"Repository baseline: all 12 required files present."* ]]
+    [[ "$output" == *"Agent guidance: all 3 files present."* ]]
 }
 
 @test "basectl repo configure dry-run prints GitHub settings and labels" {


### PR DESCRIPTION
## Summary
- Print explicit `basectl repo check` success/failure summaries with required-file counts.
- Add missing-file lists and repair commands for baseline and agent-guidance checks.
- Update Bats coverage and the Unreleased changelog.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats --filter "basectl repo check"
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. CLI output-only workflow improvement.

Closes #772