### PR TITLE
Summarize repo configure actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Made live `basectl repo configure` runs print a structured action summary for
+  repository settings, labels, branch protection, and Project metadata.
 - Made `basectl repo check` print visible success/failure summaries with counts
   and repair commands when files are missing.
 - Made `basectl repo init --pr` print next steps after opening a baseline pull

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1305,6 +1305,20 @@ base_repo_pretty_command() {
     done
 }
 
+base_repo_join_csv() {
+    local first=1
+    local item
+
+    for item in "$@"; do
+        if ((first)); then
+            first=0
+        else
+            printf ', '
+        fi
+        printf '%s' "$item"
+    done
+}
+
 base_repo_configure_label() {
     local color="$3"
     local description="$4"
@@ -1320,7 +1334,8 @@ base_repo_configure_label() {
         return 0
     fi
 
-    gh label create "$label" --repo "$repo" --color "$color" --description "$description" --force
+    gh label create "$label" --repo "$repo" --color "$color" --description "$description" --force || return 1
+    printf "  Label: %s (created or updated).\n" "$label"
 }
 
 base_repo_ensure_github_repo() {
@@ -1396,11 +1411,13 @@ base_repo_configure_default_branch_protection() {
             log_error "Unable to update Base default branch protection ruleset for '$repo'."
             return 1
         }
+        printf "  Branch protection: updated 'Base default branch protection'.\n"
     else
         printf '%s\n' "$payload" | gh api "repos/$repo/rulesets" --method POST --input - || {
             log_error "Unable to create Base default branch protection ruleset for '$repo'."
             return 1
         }
+        printf "  Branch protection: created 'Base default branch protection'.\n"
     fi
 }
 
@@ -1512,6 +1529,7 @@ base_repo_configure_project_metadata() {
     output="$("${command[@]}" 2>&1)" || status=$?
     if [[ "$status" -eq 0 ]]; then
         [[ -z "$output" ]] || printf '%s\n' "$output"
+        printf "  GitHub Project '%s': Status, Priority, Area, Size, Initiative fields configured.\n" "$project_title"
         return 0
     fi
     if [[ "$status" -eq 3 ]]; then
@@ -1526,7 +1544,9 @@ base_repo_configure_project_metadata() {
 }
 
 base_repo_configure_github() {
+    local applied_labels=()
     local dry_run="$1"
+    local labels=()
     local protect_default_branch="${3:-1}"
     local repo="$2"
     local status=0
@@ -1535,6 +1555,7 @@ base_repo_configure_github() {
         printf "[DRY-RUN] Would run: gh repo edit %s --enable-issues --enable-projects --enable-squash-merge --enable-merge-commit=false --enable-rebase-merge=false --delete-branch-on-merge --squash-merge-commit-message pr-title-description\n" "$repo"
     else
         base_repo_require_gh || return 1
+        printf "Configuring GitHub repository '%s'...\n" "$repo"
         gh repo edit "$repo" \
             --enable-issues \
             --enable-projects \
@@ -1543,14 +1564,21 @@ base_repo_configure_github() {
             --enable-rebase-merge=false \
             --delete-branch-on-merge \
             --squash-merge-commit-message pr-title-description || return 1
+        printf "  Repository settings: applied.\n"
     fi
 
-    base_repo_configure_label "$dry_run" bug "d73a4a" "Something is not working" "$repo" || status=1
-    base_repo_configure_label "$dry_run" enhancement "a2eeef" "New feature or product improvement" "$repo" || status=1
-    base_repo_configure_label "$dry_run" documentation "0075ca" "Documentation improvements" "$repo" || status=1
-    base_repo_configure_label "$dry_run" ci "0e8a16" "Continuous integration, tests, automation, or release workflows" "$repo" || status=1
-    base_repo_configure_label "$dry_run" security "ee0701" "Security hardening or vulnerability work" "$repo" || status=1
-    base_repo_configure_label "$dry_run" needs-demo "fbca04" "Change should update a project demo" "$repo" || status=1
+    base_repo_configure_label "$dry_run" bug "d73a4a" "Something is not working" "$repo" && applied_labels+=(bug) || status=1
+    base_repo_configure_label "$dry_run" enhancement "a2eeef" "New feature or product improvement" "$repo" && applied_labels+=(enhancement) || status=1
+    base_repo_configure_label "$dry_run" documentation "0075ca" "Documentation improvements" "$repo" && applied_labels+=(documentation) || status=1
+    base_repo_configure_label "$dry_run" ci "0e8a16" "Continuous integration, tests, automation, or release workflows" "$repo" && applied_labels+=(ci) || status=1
+    base_repo_configure_label "$dry_run" security "ee0701" "Security hardening or vulnerability work" "$repo" && applied_labels+=(security) || status=1
+    base_repo_configure_label "$dry_run" needs-demo "fbca04" "Change should update a project demo" "$repo" && applied_labels+=(needs-demo) || status=1
+    if [[ "$dry_run" != "1" && "${#applied_labels[@]}" -gt 0 ]]; then
+        labels=("${applied_labels[@]}")
+        printf "  Labels: "
+        base_repo_join_csv "${labels[@]}"
+        printf " (%d applied).\n" "${#labels[@]}"
+    fi
     if [[ "$protect_default_branch" == "1" ]]; then
         base_repo_configure_default_branch_protection "$dry_run" "$repo" || status=1
     fi
@@ -2927,7 +2955,11 @@ base_repo_configure() {
             "$project_schema" \
             "$(base_repo_project_config_path "$path")" \
             "$copy_project_fields_from" \
-            "${initiative_options[@]}"
+            "${initiative_options[@]}" || return 1
+    fi
+
+    if [[ "$dry_run" != "1" ]]; then
+        printf "Configuration complete.\n"
     fi
 }
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -1012,6 +1012,12 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
+    [[ "$output" == *"Configuring GitHub repository 'codeforester/base-demo'..."* ]]
+    [[ "$output" == *"  Repository settings: applied."* ]]
+    [[ "$output" == *"  Label: bug (created or updated)."* ]]
+    [[ "$output" == *"  Labels: bug, enhancement, documentation, ci, security, needs-demo (6 applied)."* ]]
+    [[ "$output" == *"  Branch protection: created 'Base default branch protection'."* ]]
+    [[ "$output" == *"Configuration complete."* ]]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     grep -Fq "label create bug --repo codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     grep -Fq "label create needs-demo --repo codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
@@ -1059,6 +1065,8 @@ EOF
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     [[ "$output" == *"Configuring GitHub Project 'base-demo' for 'codeforester/base-demo'."* ]]
     [[ "$output" == *"Running: $TEST_MOCKBIN/project-wrapper --project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from \"Base Roadmap\""* ]]
+    [[ "$output" == *"  GitHub Project 'base-demo': Status, Priority, Area, Size, Initiative fields configured."* ]]
+    [[ "$output" == *"Configuration complete."* ]]
     [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
 }
 


### PR DESCRIPTION
## Summary
- Print live `basectl repo configure` summaries for repository settings, labels, branch protection, and Project metadata.
- Report label operations as created-or-updated and include an applied-label summary.
- Add Bats coverage and an Unreleased changelog entry.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats --filter "basectl repo configure"
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. CLI output-only workflow improvement.

Closes #773