### PR TITLE
Explain skipped repo init GitHub setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Made `basectl repo init` print visible next steps when GitHub setup is skipped
+  because no repository was provided or inferred.
 - Clarified `basectl repo init` and `repo configure` help to say Base-managed
   GitHub settings are safe to re-run and do not remove outside settings.
 - Made live `basectl repo configure` runs print a structured action summary for

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1874,6 +1874,37 @@ base_repo_print_init_pr_next_steps() {
     printf "     %s\n" "$command_hint"
 }
 
+base_repo_print_init_github_skip_notice() {
+    local dry_run="$1"
+    local name="$2"
+    local root="$3"
+    local pretty_root
+
+    pretty_root="$(base_repo_pretty_arg "$root")"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would not create or configure a GitHub repository because no GitHub repo was provided or inferred. Pass --repo <owner/name> to include GitHub repository creation and configuration.\n"
+        printf "[DRY-RUN] To include GitHub setup, run:\n"
+        printf "  basectl repo init %s --path %s --repo <owner/%s>\n" \
+            "$(base_repo_pretty_arg "$name")" \
+            "$pretty_root" \
+            "$name"
+        return 0
+    fi
+
+    printf "Baseline files written to '%s'.\n" "$root"
+    printf "\n"
+    printf "GitHub repository not configured (no --repo provided and no origin remote found).\n"
+    printf "To complete GitHub setup, run:\n"
+    printf "  basectl repo configure %s --repo <owner/%s>\n" "$pretty_root" "$name"
+    printf "\n"
+    printf "Or to create the GitHub repository and configure it now:\n"
+    printf "  basectl repo init %s --path %s --repo <owner/%s>\n" \
+        "$(base_repo_pretty_arg "$name")" \
+        "$pretty_root" \
+        "$name"
+}
+
 base_repo_init_pr_rerun_command() {
     local configure="$4"
     local configure_project="$6"
@@ -2427,11 +2458,7 @@ base_repo_init() {
                     "${initiative_options[@]}" || return 1
             fi
         else
-            if [[ "$dry_run" == "1" ]]; then
-                printf "[DRY-RUN] Would not create or configure a GitHub repository because no GitHub repo was provided or inferred. Pass --repo <owner/name> to include GitHub repository creation and configuration.\n"
-            else
-                log_info "Skipping GitHub repository creation and configuration because no GitHub repo was provided or inferred."
-            fi
+            base_repo_print_init_github_skip_notice "$dry_run" "$name" "$root"
         fi
     fi
 }

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -706,6 +706,21 @@ EOF
     [[ "$output" == *"Repository baseline is present."* ]]
 }
 
+@test "basectl repo init explains when GitHub configuration is skipped" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir"
+
+    [ "$status" -eq 0 ]
+    [ -f "$repo_dir/base_manifest.yaml" ]
+    [[ "$output" == *"Baseline files written to '$repo_dir'."* ]]
+    [[ "$output" == *"GitHub repository not configured (no --repo provided and no origin remote found)."* ]]
+    [[ "$output" == *"To complete GitHub setup, run:"* ]]
+    [[ "$output" == *"basectl repo configure $repo_dir --repo <owner/base-demo>"* ]]
+    [[ "$output" == *"Or to create the GitHub repository and configure it now:"* ]]
+    [[ "$output" == *"basectl repo init base-demo --path $repo_dir --repo <owner/base-demo>"* ]]
+}
+
 @test "basectl repo init defaults copyright holder to git user name" {
     local repo_dir="$TEST_TMPDIR/git-owner"
 


### PR DESCRIPTION
## Summary
- Print visible next steps when `basectl repo init` writes local baseline files but skips GitHub setup because no repository was provided or inferred.
- Preserve the existing dry-run skip message and add the equivalent setup command there too.
- Add Bats coverage and an Unreleased changelog entry.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats --filter "GitHub configuration is skipped"
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. CLI output-only workflow improvement.

Closes #775