### PR TITLE
Gate repo clone baseline hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Made `basectl repo init` print visible next steps when GitHub setup is skipped
   because no repository was provided or inferred.
+- Made `basectl repo clone` print the Base baseline check hint only when the
+  cloned repository contains `base_manifest.yaml`.
 - Clarified `basectl repo init` and `repo configure` help to say Base-managed
   GitHub settings are safe to re-run and do not remove outside settings.
 - Made live `basectl repo configure` runs print a structured action summary for

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -2535,7 +2535,11 @@ base_repo_clone_with_gh() {
         log_error "Failed to clone GitHub repository '$repo' into '$target'."
         return 1
     }
-    printf "Run basectl repo check '%s' after the clone if the repository has adopted the Base baseline.\n" "$target"
+    printf "Cloned '%s' to '%s'.\n" "$repo" "$target"
+    if [[ -f "$target/base_manifest.yaml" ]]; then
+        printf "Run 'basectl repo check %s' to verify the Base baseline.\n" \
+            "$(base_repo_pretty_arg "$target")"
+    fi
 }
 
 base_repo_clone() {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -171,7 +171,7 @@ EOF
     [[ "$output" == *"Destination '$repo_dir' already exists but is not a matching Git checkout."* ]]
 }
 
-@test "basectl repo clone delegates to gh repo clone" {
+@test "basectl repo clone delegates to gh repo clone without Base baseline hint" {
     local repo_dir="$TEST_TMPDIR/workspace/base-demo"
 
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
@@ -194,7 +194,36 @@ EOF
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "repo clone codeforester/base-demo $repo_dir" ]
     [[ "$output" == *"Cloning GitHub repository 'codeforester/base-demo' into '$repo_dir'."* ]]
-    [[ "$output" == *"Run basectl repo check '$repo_dir' after the clone if the repository has adopted the Base baseline."* ]]
+    [[ "$output" == *"Cloned 'codeforester/base-demo' to '$repo_dir'."* ]]
+    [[ "$output" != *"Base baseline"* ]]
+    [[ "$output" != *"basectl repo check"* ]]
+}
+
+@test "basectl repo clone prints Base baseline hint for Base-managed repos" {
+    local repo_dir="$TEST_TMPDIR/workspace/base-demo"
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+if [[ "$1" == "repo" && "$2" == "clone" ]]; then
+    mkdir -p "$4/.git"
+    touch "$4/base_manifest.yaml"
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo clone codeforester/base-demo --path "$repo_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "repo clone codeforester/base-demo $repo_dir" ]
+    [[ "$output" == *"Cloned 'codeforester/base-demo' to '$repo_dir'."* ]]
+    [[ "$output" == *"Run 'basectl repo check $repo_dir' to verify the Base baseline."* ]]
 }
 
 @test "basectl repo configure prints command-specific help" {


### PR DESCRIPTION
## Summary
- Print a plain clone confirmation for repositories that do not contain `base_manifest.yaml`.
- Keep the `basectl repo check` hint only for cloned Base-managed repositories.
- Add clone-path Bats coverage and an Unreleased changelog entry.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats --filter "repo clone"
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. CLI output-only workflow improvement.

Closes #776