### PR TITLE
Detect agent guidance default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   because no repository was provided or inferred.
 - Made `basectl repo clone` print the Base baseline check hint only when the
   cloned repository contains `base_manifest.yaml`.
+- Made `basectl repo agent-guidance` detect the target repository default
+  branch before falling back to `main`.
 - Clarified `basectl repo init` and `repo configure` help to say Base-managed
   GitHub settings are safe to re-run and do not remove outside settings.
 - Made live `basectl repo configure` runs print a structured action summary for

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -234,7 +234,7 @@ Usage:
 Options:
   --repo <owner/name>           GitHub repository for --pr. Defaults to the target origin remote.
   --repo-name <name>            Repository name for generated agent guidance. Defaults to the target path basename.
-  --default-branch <name>       Default branch for generated agent guidance. Defaults to main.
+  --default-branch <name>       Default branch for generated agent guidance. Defaults to detected branch, then main.
   --validation-command <cmd>    Validation command for generated agent guidance. Defaults to ./tests/validate.sh.
   --pr                          Commit generated guidance files on a branch and open a draft pull request.
   --dry-run                     Print planned changes without applying them.
@@ -1654,6 +1654,31 @@ base_repo_default_branch_for_pr() {
     printf '%s\n' "$default_branch"
 }
 
+base_repo_detect_default_branch() {
+    local default_branch
+    local root="$1"
+
+    if default_branch="$(git -C "$root" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+        default_branch="${default_branch#origin/}"
+        if [[ -n "$default_branch" ]]; then
+            printf '%s\n' "$default_branch"
+            return 0
+        fi
+    fi
+
+    if git -C "$root" show-ref --verify --quiet refs/heads/main; then
+        printf '%s\n' main
+        return 0
+    fi
+
+    if git -C "$root" show-ref --verify --quiet refs/heads/master; then
+        printf '%s\n' master
+        return 0
+    fi
+
+    return 1
+}
+
 base_repo_prepare_pr_branch() {
     local branch="$3"
     local command_label="${5:-repo init --pr}"
@@ -2704,7 +2729,8 @@ base_repo_check() {
 
 base_repo_agent_guidance() {
     local create_pr=0
-    local default_branch="main"
+    local default_branch=""
+    local default_branch_explicit=0
     local dry_run=0
     local github_repo=""
     local path="."
@@ -2750,10 +2776,12 @@ base_repo_agent_guidance() {
                     return $?
                 }
                 default_branch="$2"
+                default_branch_explicit=1
                 shift 2
                 ;;
             --default-branch=*)
                 default_branch="${1#--default-branch=}"
+                default_branch_explicit=1
                 shift
                 ;;
             --validation-command)
@@ -2798,6 +2826,13 @@ base_repo_agent_guidance() {
 
     root="$(base_repo_target_path "$path")"
     [[ -n "$repo_name" ]] || repo_name="$(basename -- "$root")"
+    if [[ "$default_branch_explicit" != "1" ]]; then
+        if ! default_branch="$(base_repo_detect_default_branch "$root")"; then
+            default_branch="main"
+            printf "Note: Could not detect default branch from origin; defaulting to 'main'.\n"
+            printf "      Pass --default-branch <name> to set it explicitly.\n"
+        fi
+    fi
     [[ -n "$default_branch" ]] || {
         base_repo_agent_guidance_usage_error "Option '--default-branch' requires a non-empty value."
         return $?

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -468,6 +468,34 @@ EOF
     [[ "$output" == *"Run git -C '$repo_dir' status --short to review changes."* ]]
 }
 
+@test "basectl repo agent-guidance detects origin default branch" {
+    local repo_dir="$TEST_TMPDIR/agent-demo"
+
+    init_git_repo "$repo_dir"
+    printf '# Agent demo\n' > "$repo_dir/README.md"
+    commit_all "$repo_dir" "Initial commit"
+    git -C "$repo_dir" checkout -B trunk >/dev/null 2>&1
+    git -C "$repo_dir" update-ref refs/remotes/origin/trunk HEAD
+    git -C "$repo_dir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/trunk
+
+    run_basectl repo agent-guidance "$repo_dir" --repo-name base-demo
+
+    [ "$status" -eq 0 ]
+    grep -Fq "git worktree add -b <branch> ../base-demo-worktrees/<slug> origin/trunk" "$repo_dir/AGENTS.md"
+    [[ "$output" != *"Could not detect default branch"* ]]
+}
+
+@test "basectl repo agent-guidance falls back to main when default branch is unknown" {
+    local repo_dir="$TEST_TMPDIR/agent-demo"
+
+    run_basectl repo agent-guidance "$repo_dir" --repo-name base-demo
+
+    [ "$status" -eq 0 ]
+    grep -Fq "git worktree add -b <branch> ../base-demo-worktrees/<slug> origin/main" "$repo_dir/AGENTS.md"
+    [[ "$output" == *"Note: Could not detect default branch from origin; defaulting to 'main'."* ]]
+    [[ "$output" == *"Pass --default-branch <name> to set it explicitly."* ]]
+}
+
 @test "basectl repo agent-guidance prints command-specific help" {
     run_basectl repo agent-guidance --help
 
@@ -477,6 +505,7 @@ EOF
     [[ "$output" == *"--repo <owner/name>"* ]]
     [[ "$output" == *"--repo-name <name>"* ]]
     [[ "$output" == *"--default-branch <name>"* ]]
+    [[ "$output" == *"Defaults to detected branch, then main."* ]]
     [[ "$output" == *"--validation-command <cmd>"* ]]
     [[ "$output" == *"--pr"* ]]
     [[ "$output" == *"--dry-run"* ]]

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -232,7 +232,9 @@ development when they do not already exist:
 
 The command accepts `--repo-name <name>`, `--default-branch <name>`, and
 `--validation-command <command>` so generated examples match the repository.
-Defaults are inferred from the target path, `main`, and `./tests/validate.sh`.
+The default branch is inferred from the target Git checkout when possible and
+falls back to `main` with a note. Other defaults come from the target path and
+`./tests/validate.sh`.
 
 Existing files are left unchanged. This keeps the guidance layer safe for repos
 that already have their own instructions or pull request template.


### PR DESCRIPTION
## Summary
- Detect the target checkout default branch for generated `basectl repo agent-guidance` worktree instructions.
- Preserve explicit `--default-branch` behavior and fall back to `main` with a visible note when detection fails.
- Update help/docs, changelog, and Bats coverage for detected and fallback branches.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats --filter "agent-guidance"
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. CLI guidance-generation improvement only.

Closes #777