### PR TITLE
Summarize agent guidance file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   cloned repository contains `base_manifest.yaml`.
 - Made `basectl repo agent-guidance` detect the target repository default
   branch before falling back to `main`.
+- Made `basectl repo agent-guidance` print a visible created/unchanged summary
+  when existing guidance files are left untouched.
 - Clarified `basectl repo init` and `repo configure` help to say Base-managed
   GitHub settings are safe to re-run and do not remove outside settings.
 - Made live `basectl repo configure` runs print a structured action summary for

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -887,17 +887,106 @@ Closes #
 EOF
 }
 
+base_repo_print_agent_guidance_summary() {
+    local created=()
+    local created_count
+    local created_word
+    local total=3
+    local unchanged=()
+    local unchanged_count
+    local unchanged_word
+
+    while (($#)); do
+        case "$1" in
+            --created)
+                created+=("$2")
+                shift 2
+                ;;
+            --unchanged)
+                unchanged+=("$2")
+                shift 2
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+
+    created_count="${#created[@]}"
+    unchanged_count="${#unchanged[@]}"
+
+    if ((unchanged_count == total)); then
+        printf "Agent guidance: all %d files already exist and were left unchanged.\n" "$total"
+        printf "To overwrite, remove the files first and re-run.\n"
+        return 0
+    fi
+
+    created_word="files"
+    unchanged_word="files"
+    [[ "$created_count" == "1" ]] && created_word="file"
+    [[ "$unchanged_count" == "1" ]] && unchanged_word="file"
+
+    if ((created_count > 0 && unchanged_count > 0)); then
+        printf "Agent guidance: %d %s created, %d %s already existed and were left unchanged.\n" \
+            "$created_count" "$created_word" "$unchanged_count" "$unchanged_word"
+    elif ((created_count > 0)); then
+        printf "Agent guidance: %d %s created.\n" "$created_count" "$created_word"
+    else
+        printf "Agent guidance: no files changed.\n"
+    fi
+
+    if ((created_count > 0)); then
+        printf "  Created:   "
+        base_repo_join_csv "${created[@]}"
+        printf "\n"
+    fi
+    if ((unchanged_count > 0)); then
+        printf "  Unchanged: "
+        base_repo_join_csv "${unchanged[@]}"
+        printf "\n"
+    fi
+}
+
 base_repo_write_agent_guidance() {
+    local agents_existed=0
     local default_branch="$3"
     local dry_run="$1"
+    local pr_template_existed=0
     local repo_name="$2"
     local root="$5"
+    local summary_args=()
+    local skills_existed=0
     local status=0
     local validation_command="$4"
+
+    if [[ "$dry_run" != "1" ]]; then
+        [[ -e "$root/AGENTS.md" ]] && agents_existed=1
+        [[ -e "$root/skills.md" ]] && skills_existed=1
+        [[ -e "$root/.github/pull_request_template.md" ]] && pr_template_existed=1
+    fi
 
     base_repo_write_agent_instructions "$dry_run" "$repo_name" "$default_branch" "$validation_command" "$root" || status=1
     base_repo_write_agent_skills "$dry_run" "$repo_name" "$root" || status=1
     base_repo_write_agent_pull_request_template "$dry_run" "$root" || status=1
+
+    if [[ "$dry_run" != "1" && "$status" -eq 0 ]]; then
+        if ((agents_existed)); then
+            summary_args+=(--unchanged "AGENTS.md")
+        else
+            summary_args+=(--created "AGENTS.md")
+        fi
+        if ((skills_existed)); then
+            summary_args+=(--unchanged "skills.md")
+        else
+            summary_args+=(--created "skills.md")
+        fi
+        if ((pr_template_existed)); then
+            summary_args+=(--unchanged ".github/pull_request_template.md")
+        else
+            summary_args+=(--created ".github/pull_request_template.md")
+        fi
+        base_repo_print_agent_guidance_summary "${summary_args[@]}"
+    fi
 
     return "$status"
 }

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -465,6 +465,8 @@ EOF
     [[ "$output" == *"Created '$repo_dir/AGENTS.md'."* ]]
     [[ "$output" == *"Created '$repo_dir/skills.md'."* ]]
     [[ "$output" == *"Created '$repo_dir/.github/pull_request_template.md'."* ]]
+    [[ "$output" == *"Agent guidance: 3 files created."* ]]
+    [[ "$output" == *"Created:   AGENTS.md, skills.md, .github/pull_request_template.md"* ]]
     [[ "$output" == *"Run git -C '$repo_dir' status --short to review changes."* ]]
 }
 
@@ -645,6 +647,24 @@ EOF
     grep -Fq "Closes #" "$repo_dir/.github/pull_request_template.md"
 }
 
+@test "basectl repo agent-guidance summarizes mixed existing files" {
+    local repo_dir="$TEST_TMPDIR/custom-guidance"
+
+    mkdir -p "$repo_dir"
+    printf 'custom agents\n' > "$repo_dir/AGENTS.md"
+    printf 'custom skills\n' > "$repo_dir/skills.md"
+
+    run_basectl repo agent-guidance "$repo_dir" --repo-name custom-guidance
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$repo_dir/AGENTS.md")" = "custom agents" ]
+    [ "$(cat "$repo_dir/skills.md")" = "custom skills" ]
+    [ -f "$repo_dir/.github/pull_request_template.md" ]
+    [[ "$output" == *"Agent guidance: 1 file created, 2 files already existed and were left unchanged."* ]]
+    [[ "$output" == *"Created:   .github/pull_request_template.md"* ]]
+    [[ "$output" == *"Unchanged: AGENTS.md, skills.md"* ]]
+}
+
 @test "basectl repo agent-guidance leaves existing files unchanged" {
     local repo_dir="$TEST_TMPDIR/custom-guidance"
 
@@ -659,6 +679,8 @@ EOF
     [ "$(cat "$repo_dir/AGENTS.md")" = "custom agents" ]
     [ "$(cat "$repo_dir/skills.md")" = "custom skills" ]
     [ "$(cat "$repo_dir/.github/pull_request_template.md")" = "custom pr" ]
+    [[ "$output" == *"Agent guidance: all 3 files already exist and were left unchanged."* ]]
+    [[ "$output" == *"To overwrite, remove the files first and re-run."* ]]
 }
 
 @test "basectl repo init dry-run prints baseline and configuration plan" {

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -237,7 +237,9 @@ falls back to `main` with a note. Other defaults come from the target path and
 `./tests/validate.sh`.
 
 Existing files are left unchanged. This keeps the guidance layer safe for repos
-that already have their own instructions or pull request template.
+that already have their own instructions or pull request template. After each
+non-dry-run execution, Base prints how many guidance files were created and
+which existing files were left unchanged.
 
 Use `--pr` to commit generated guidance files on a predictable branch and open a
 draft pull request. The target path must be the root of a clean Git worktree.


### PR DESCRIPTION
## Summary
- Add a visible `basectl repo agent-guidance` summary for created and unchanged guidance files.
- Keep existing no-overwrite behavior while explaining all-existing and mixed existing-file outcomes.
- Update docs, changelog, and Bats coverage for created, mixed, and unchanged cases.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats --filter "agent-guidance"
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. CLI output-only workflow improvement.

Closes #778