### PR TITLE
Add repo PR worktree fix hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   when existing guidance files are left untouched.
 - Made `basectl repo installer-template` write `./install.sh` by default and
   added `--print`/`--stdout` for the stdout template view.
+- Added dirty-worktree and repository-root fix hints for `basectl repo`
+  subcommands that create pull requests.
 - Clarified `basectl repo init` and `repo configure` help to say Base-managed
   GitHub settings are safe to re-run and do not remove outside settings.
 - Made live `basectl repo configure` runs print a structured action summary for

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1695,8 +1695,63 @@ base_repo_helper_pr_branch_name() {
     printf 'base/%s-%s\n' "$kind" "$name"
 }
 
+base_repo_print_pr_worktree_root_hint() {
+    local command_label="$1"
+    local provided_path="$2"
+    local repository_root="$3"
+
+    if [[ "$command_label" == "repo init --pr" ]]; then
+        log_error "repo init --pr expects --path to point at the repository root."
+    else
+        log_error "$command_label expects the target path to point at the repository root."
+    fi
+    printf "  Provided path: %s\n" "$provided_path" >&2
+    printf "  Repository root: %s\n" "$repository_root" >&2
+    if [[ "$command_label" == "repo init --pr" ]]; then
+        printf "  Fix: pass --path %s\n" "$(base_repo_pretty_arg "$repository_root")" >&2
+    else
+        printf "  Fix: pass %s as the target path.\n" "$(base_repo_pretty_arg "$repository_root")" >&2
+    fi
+}
+
+base_repo_print_pr_worktree_dirty_hint() {
+    local dirty_count=0
+    local dirty_word
+    local line
+    local root="$1"
+    local shown_count=0
+    local status_output="$2"
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -n "$line" ]] || continue
+        dirty_count=$((dirty_count + 1))
+    done <<< "$status_output"
+
+    dirty_word="files"
+    [[ "$dirty_count" == "1" ]] && dirty_word="file"
+
+    printf "  Uncommitted changes detected (%d %s).\n" "$dirty_count" "$dirty_word" >&2
+    printf "  Dirty paths:\n" >&2
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -n "$line" ]] || continue
+        if ((shown_count >= 5)); then
+            break
+        fi
+        printf "    %s\n" "$line" >&2
+        shown_count=$((shown_count + 1))
+    done <<< "$status_output"
+    if ((dirty_count > shown_count)); then
+        printf "    ... (%d more)\n" "$((dirty_count - shown_count))" >&2
+    fi
+    printf "  Fix: commit or stash your changes before running this command.\n" >&2
+    printf "    git -C %s status --short\n" "$(base_repo_pretty_arg "$root")" >&2
+    printf "    git -C %s stash\n" "$(base_repo_pretty_arg "$root")" >&2
+    printf "    git -C %s commit -am \"WIP\"\n" "$(base_repo_pretty_arg "$root")" >&2
+}
+
 base_repo_require_pr_worktree() {
     local command_label="${2:-repo init --pr}"
+    local dirty_status
     local git_root
     local root="$1"
 
@@ -1713,16 +1768,14 @@ base_repo_require_pr_worktree() {
     root="$(cd -- "$root" && pwd -P)" || return 1
 
     [[ "$git_root" == "$root" ]] || {
-        if [[ "$command_label" == "repo init --pr" ]]; then
-            log_error "repo init --pr expects --path to point at the repository root."
-        else
-            log_error "$command_label expects the target path to point at the repository root."
-        fi
+        base_repo_print_pr_worktree_root_hint "$command_label" "$root" "$git_root"
         return 1
     }
 
-    [[ -z "$(git -C "$root" status --porcelain)" ]] || {
+    dirty_status="$(git -C "$root" status --porcelain)"
+    [[ -z "$dirty_status" ]] || {
         log_error "$command_label requires a clean Git worktree at '$root'."
+        base_repo_print_pr_worktree_dirty_hint "$root" "$dirty_status"
         return 1
     }
 }

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -468,17 +468,23 @@ EOF
 }
 
 @test "basectl repo installer-template --pr requires a clean target worktree" {
+    local physical_repo_dir
     local repo_dir="$TEST_TMPDIR/dirty-installer-demo"
 
     init_git_repo "$repo_dir"
     printf '# Dirty demo\n' > "$repo_dir/README.md"
     commit_all "$repo_dir" "Initial commit"
     printf 'draft\n' > "$repo_dir/notes.txt"
+    physical_repo_dir="$(cd "$repo_dir" && pwd -P)"
 
     run_basectl repo installer-template "$repo_dir/install.sh" --repo codeforester/dirty-installer-demo --pr
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"repo installer-template --pr requires a clean Git worktree"* ]]
+    [[ "$output" == *"Uncommitted changes detected (1 file)."* ]]
+    [[ "$output" == *"?? notes.txt"* ]]
+    [[ "$output" == *"Fix: commit or stash your changes before running this command."* ]]
+    [[ "$output" == *"git -C $physical_repo_dir status --short"* ]]
     [ ! -f "$repo_dir/install.sh" ]
 }
 
@@ -634,17 +640,23 @@ EOF
 }
 
 @test "basectl repo agent-guidance --pr requires a clean target worktree" {
+    local physical_repo_dir
     local repo_dir="$TEST_TMPDIR/dirty-agent-demo"
 
     init_git_repo "$repo_dir"
     printf '# Dirty demo\n' > "$repo_dir/README.md"
     commit_all "$repo_dir" "Initial commit"
     printf 'draft\n' > "$repo_dir/notes.txt"
+    physical_repo_dir="$(cd "$repo_dir" && pwd -P)"
 
     run_basectl repo agent-guidance "$repo_dir" --repo-name dirty-agent-demo --repo codeforester/dirty-agent-demo --pr
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"repo agent-guidance --pr requires a clean Git worktree"* ]]
+    [[ "$output" == *"Uncommitted changes detected (1 file)."* ]]
+    [[ "$output" == *"?? notes.txt"* ]]
+    [[ "$output" == *"Fix: commit or stash your changes before running this command."* ]]
+    [[ "$output" == *"git -C $physical_repo_dir status --short"* ]]
     [ ! -f "$repo_dir/AGENTS.md" ]
 }
 
@@ -1533,18 +1545,47 @@ EOF
 }
 
 @test "basectl repo init --pr requires a clean target worktree" {
+    local physical_repo_dir
     local repo_dir="$TEST_TMPDIR/dirty-demo"
 
     init_git_repo "$repo_dir"
     printf '# Dirty demo\n' > "$repo_dir/README.md"
     commit_all "$repo_dir" "Initial commit"
     printf 'draft\n' > "$repo_dir/notes.txt"
+    physical_repo_dir="$(cd "$repo_dir" && pwd -P)"
 
     run_basectl repo init dirty-demo --path "$repo_dir" --repo codeforester/dirty-demo --pr
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"repo init --pr requires a clean Git worktree"* ]]
+    [[ "$output" == *"Uncommitted changes detected (1 file)."* ]]
+    [[ "$output" == *"?? notes.txt"* ]]
+    [[ "$output" == *"Fix: commit or stash your changes before running this command."* ]]
+    [[ "$output" == *"git -C $physical_repo_dir status --short"* ]]
     [ ! -f "$repo_dir/base_manifest.yaml" ]
+}
+
+@test "basectl repo init --pr explains repository root path mismatch" {
+    local physical_repo_dir
+    local physical_subdir
+    local repo_dir="$TEST_TMPDIR/root-demo"
+    local subdir="$repo_dir/subdir"
+
+    init_git_repo "$repo_dir"
+    printf '# Root demo\n' > "$repo_dir/README.md"
+    commit_all "$repo_dir" "Initial commit"
+    mkdir -p "$subdir"
+    physical_repo_dir="$(cd "$repo_dir" && pwd -P)"
+    physical_subdir="$(cd "$subdir" && pwd -P)"
+
+    run_basectl repo init root-demo --path "$subdir" --repo codeforester/root-demo --pr
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"repo init --pr expects --path to point at the repository root."* ]]
+    [[ "$output" == *"Provided path: $physical_subdir"* ]]
+    [[ "$output" == *"Repository root: $physical_repo_dir"* ]]
+    [[ "$output" == *"Fix: pass --path $physical_repo_dir"* ]]
+    [ ! -f "$subdir/base_manifest.yaml" ]
 }
 
 @test "basectl repo init can create a public GitHub repo when requested" {


### PR DESCRIPTION
## Summary
- Add actionable dirty-worktree hints for `basectl repo` commands that create PRs.
- Show dirty path summaries plus commit/stash/status commands before returning failure.
- Add repository-root mismatch details for `repo init --pr` and cover all affected paths in Bats.

## Validation
- bats cli/bash/commands/basectl/tests/repo.bats --filter "requires a clean target worktree"
- bats cli/bash/commands/basectl/tests/repo.bats --filter "repository root path mismatch"
- bats cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. CLI diagnostic improvement only.

Closes #780