### PR TITLE
Refresh clone command discovery

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -21,13 +21,13 @@ the canonical current command list.
   Zip bundle for manual upload or copy/paste into AI tools.
 - `basectl projects list` - list Base-managed projects discovered in the
   workspace.
-- `basectl workspace <status|check|doctor>` - show read-only workspace project
-  status, checks, or diagnostics.
-- `basectl repo <init|check|configure|agent-guidance|installer-template>` -
-  create repository baselines, configure GitHub repository settings and default
-  branch protection, repair missing Project intake support files, configure
-  standard GitHub Project metadata, seed agent guidance, and write installer
-  templates.
+- `basectl workspace <status|check|doctor|clone>` - show read-only workspace project
+  status, checks, diagnostics, or clone expected repositories from a manifest.
+- `basectl repo <init|clone|check|configure|agent-guidance|installer-template>` -
+  create repository baselines, clone GitHub repositories into the configured
+  workspace, configure GitHub repository settings and default branch protection,
+  repair missing Project intake support files, configure standard GitHub Project
+  metadata, seed agent guidance, and write installer templates.
 - `basectl ci <setup|check|doctor> <project>` - run Base setup/check/doctor in
   non-interactive CI.
 - `basectl release <check|plan|notes|publish>` - inspect release readiness,
@@ -47,7 +47,9 @@ the canonical current command list.
 - `basectl onboard` - guide a user through the first Base setup checklist.
 - `basectl update-profile` - create or update Base-managed Bash/Zsh startup
   snippets.
-- `basectl update` - update Base from Git and run setup.
+- `basectl update [project]` - update Base or a named project using the
+  configured Git checkout or Homebrew-managed Base handoff, then run setup for
+  the selected project.
 - `basectl version` - show the installed Base version.
 - `basectl help` - show command help.
 

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -25,8 +25,8 @@ Commands:
     Run a project's declared interactive demo.
   run <project> <command> [options]
     Run a project's declared command.
-  repo <init|check|configure|agent-guidance|installer-template> [options]
-    Create repository baselines, agent guidance, and project installer templates.
+  repo <init|clone|check|configure|agent-guidance|installer-template> [options]
+    Create, clone, check, and configure repository baselines and guidance.
   ci <setup|check|doctor> <project> [options]
     Run Base setup, checks, and diagnostics in non-interactive CI.
   release <check|plan|notes|publish> --version <version> [options]
@@ -50,7 +50,7 @@ Commands:
   projects list [options]
     List Base-managed projects discovered in the workspace.
   workspace <status|check|doctor|clone> [options]
-    Show read-only workspace project status, checks, or diagnostics.
+    Show workspace status, run checks/diagnostics, or clone manifest repos.
   version
     Show the installed Base version.
   help

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -14,7 +14,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"export-context [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
-    [[ "$output" == *"repo <init|check|configure|agent-guidance|installer-template> [options]"* ]]
+    [[ "$output" == *"repo <init|clone|check|configure|agent-guidance|installer-template> [options]"* ]]
     [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
     [[ "$output" == *"release <check|plan|notes|publish> --version <version> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
@@ -53,7 +53,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  export-context [project] [options]' <<<"$output"
-    grep -Fqx '  repo <init|check|configure|agent-guidance|installer-template> [options]' <<<"$output"
+    grep -Fqx '  repo <init|clone|check|configure|agent-guidance|installer-template> [options]' <<<"$output"
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
@@ -61,6 +61,14 @@ load ./basectl_helpers.bash
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
+}
+
+@test "AI command context includes current clone and update surfaces" {
+    local commands_file="$BASE_REPO_ROOT/.ai-context/COMMANDS.md"
+
+    grep -Fqx -- "- \`basectl workspace <status|check|doctor|clone>\` - show read-only workspace project" "$commands_file"
+    grep -Fqx -- "- \`basectl repo <init|clone|check|configure|agent-guidance|installer-template>\` -" "$commands_file"
+    grep -Fqx -- "- \`basectl update [project]\` - update Base or a named project using the" "$commands_file"
 }
 
 @test "basectl config prints help" {


### PR DESCRIPTION
## Summary
- Add `repo clone` to the top-level `basectl --help` repo command summary.
- Refresh `.ai-context/COMMANDS.md` for workspace clone, repo clone, and current update behavior.
- Add a help regression test that keeps the AI command context aligned with public clone/update surfaces.

## Validation
- `env -u BASE_HOME bats cli/bash/commands/basectl/tests/help.bats`
- `BASE_CACHE_DIR=/private/tmp/base-792-cache env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## AI Context
- Updated `.ai-context/COMMANDS.md` because the public command surface changed.

Fixes #792
