### PR TITLE
Validate GitHub defaults in config doctor

### DIFF
--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -4,7 +4,7 @@ import json
 import sys
 from pathlib import Path
 
-from base_cli.config import load_user_config, read_user_config, user_config_path
+from base_cli.config import UserConfig, load_user_config, read_user_config, user_config_path
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -80,6 +80,12 @@ def doctor_config_command() -> int:
         print_finding("error", "schema", str(exc))
         return 1
 
+    print_workspace_findings(user_config)
+    print_github_findings(user_config)
+    return 0
+
+
+def print_workspace_findings(user_config: UserConfig) -> None:
     if user_config.workspace.root is None:
         print_finding(
             "warn",
@@ -91,6 +97,8 @@ def doctor_config_command() -> int:
     else:
         print_finding("warn", "workspace", f"workspace.root '{user_config.workspace.root}' is not a directory.")
 
+
+def print_github_findings(user_config: UserConfig) -> None:
     if user_config.github.default_owner is None:
         print_finding(
             "ok",
@@ -108,7 +116,6 @@ def doctor_config_command() -> int:
         )
     else:
         print_finding("ok", "github_proto", f"github.clone_protocol is '{user_config.github.clone_protocol}'.")
-    return 0
 
 
 def safe_resolve(path: Path) -> Path:

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -90,6 +90,24 @@ def doctor_config_command() -> int:
         print_finding("ok", "workspace", f"workspace.root points to '{user_config.workspace.root}'.")
     else:
         print_finding("warn", "workspace", f"workspace.root '{user_config.workspace.root}' is not a directory.")
+
+    if user_config.github.default_owner is None:
+        print_finding(
+            "ok",
+            "github_owner",
+            "github.default_owner is not configured; short repo clone names require --owner.",
+        )
+    else:
+        print_finding("ok", "github_owner", f"github.default_owner is '{user_config.github.default_owner}'.")
+
+    if user_config.github.clone_protocol is None:
+        print_finding(
+            "ok",
+            "github_proto",
+            "github.clone_protocol is not configured; repo clone defaults to 'ssh'.",
+        )
+    else:
+        print_finding("ok", "github_proto", f"github.clone_protocol is '{user_config.github.clone_protocol}'.")
     return 0
 
 

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -112,6 +112,8 @@ class BaseConfigCommandTests(unittest.TestCase):
         self.assertIn("Config YAML is valid", output)
         self.assertIn("Config contains 1 top-level key", output)
         self.assertIn("workspace.root is not configured", output)
+        self.assertIn("github.default_owner is not configured", output)
+        self.assertIn("github.clone_protocol is not configured", output)
 
     def test_doctor_config_reports_configured_workspace_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -130,6 +132,53 @@ class BaseConfigCommandTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn("workspace.root points to", output)
         self.assertIn(str(workspace), output)
+
+    def test_doctor_config_reports_configured_github_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(root)
+                path.parent.mkdir(parents=True)
+                path.write_text(
+                    "github:\n  default_owner: codeforester\n  clone_protocol: https\n",
+                    encoding="utf-8",
+                )
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        output = stdout.getvalue()
+        self.assertEqual(status, 0)
+        self.assertIn("github.default_owner is 'codeforester'", output)
+        self.assertIn("github.clone_protocol is 'https'", output)
+
+    def test_doctor_config_reports_invalid_github_default_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(root)
+                path.parent.mkdir(parents=True)
+                path.write_text("github:\n  default_owner: bad_owner!\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        self.assertEqual(status, 1)
+        self.assertIn("github.default_owner must start with a letter or digit", stdout.getvalue())
+
+    def test_doctor_config_reports_invalid_github_clone_protocol(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(root)
+                path.parent.mkdir(parents=True)
+                path.write_text("github:\n  clone_protocol: ftp\n", encoding="utf-8")
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.doctor_config_command()
+
+        self.assertEqual(status, 1)
+        self.assertIn("github.clone_protocol must be 'ssh' or 'https'", stdout.getvalue())
 
     def test_doctor_config_reports_invalid_workspace_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -127,6 +127,10 @@ URLs. The actual clone delegates to `gh repo clone <owner/repo> <path>` so the
 GitHub CLI remains responsible for GitHub authentication and its own transport
 behavior.
 
+`basectl config doctor` validates these GitHub defaults before clone time. It
+reports invalid owner names or unsupported clone protocols as config schema
+errors while treating omitted GitHub defaults as valid.
+
 ## IDE Preferences
 
 User-local IDE preferences can add machine-specific IDE behavior without

--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 from pathlib import Path
+import re
 from typing import Any
 
 from .ide_schema import SUPPORTED_IDES
@@ -31,10 +32,17 @@ class UserWorkspaceConfig:
 
 
 @dataclass(frozen=True)
+class UserGithubConfig:
+    default_owner: str | None
+    clone_protocol: str | None
+
+
+@dataclass(frozen=True)
 class UserConfig:
     raw: dict[str, Any]
     ide: UserIdeConfig
     workspace: UserWorkspaceConfig = UserWorkspaceConfig(root=None)
+    github: UserGithubConfig = UserGithubConfig(default_owner=None, clone_protocol=None)
 
 
 def user_config_path(home: Path | None = None) -> Path:
@@ -71,6 +79,7 @@ def read_user_config(home: Path | None = None) -> UserConfig:
     return UserConfig(
         raw=raw,
         workspace=_read_user_workspace_config(path, raw.get("workspace")),
+        github=_read_user_github_config(path, raw.get("github")),
         ide=_read_user_ide_config(path, raw.get("ide")),
     )
 
@@ -89,16 +98,63 @@ def _read_user_workspace_config(path: Path, workspace_data: Any) -> UserWorkspac
     return UserWorkspaceConfig(root=_optional_path(path, "workspace.root", workspace_data.get("root")))
 
 
+def _read_user_github_config(path: Path, github_data: Any) -> UserGithubConfig:
+    if github_data is None:
+        return UserGithubConfig(default_owner=None, clone_protocol=None)
+    if not isinstance(github_data, dict):
+        raise ValueError(f"{path}: github must be a mapping when provided.")
+
+    allowed_keys = {"default_owner", "clone_protocol"}
+    unknown_keys = sorted(set(github_data) - allowed_keys)
+    if unknown_keys:
+        raise ValueError(f"{path}: github has unsupported keys: {', '.join(unknown_keys)}.")
+
+    return UserGithubConfig(
+        default_owner=_optional_github_owner(path, github_data.get("default_owner")),
+        clone_protocol=_optional_github_clone_protocol(path, github_data.get("clone_protocol")),
+    )
+
+
+def _optional_github_owner(path: Path, value: Any) -> str | None:
+    owner = _optional_non_empty_string(path, "github.default_owner", value)
+    if owner is None:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]*", owner):
+        raise ValueError(
+            f"{path}: github.default_owner must start with a letter or digit and contain only "
+            "letters, digits, and dash."
+        )
+    return owner
+
+
+def _optional_github_clone_protocol(path: Path, value: Any) -> str | None:
+    protocol = _optional_non_empty_string(path, "github.clone_protocol", value)
+    if protocol is None:
+        return None
+    if protocol not in {"ssh", "https"}:
+        raise ValueError(f"{path}: github.clone_protocol must be 'ssh' or 'https'.")
+    return protocol
+
+
 def _optional_path(path: Path, key: str, value: Any) -> Path | None:
+    if value is None:
+        return None
+    candidate = _optional_non_empty_string(path, key, value)
+    if candidate is None:
+        return None
+
+    candidate_path = Path(candidate).expanduser()
+    if not candidate_path.is_absolute():
+        raise ValueError(f"{path}: {key} must be an absolute path or start with '~'.")
+    return candidate_path.resolve(strict=False)
+
+
+def _optional_non_empty_string(path: Path, key: str, value: Any) -> str | None:
     if value is None:
         return None
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{path}: {key} must be a non-empty string when provided.")
-
-    candidate = Path(value).expanduser()
-    if not candidate.is_absolute():
-        raise ValueError(f"{path}: {key} must be an absolute path or start with '~'.")
-    return candidate.resolve(strict=False)
+    return value.strip()
 
 
 def _read_user_ide_config(path: Path, ide_data: Any) -> UserIdeConfig:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -286,6 +286,59 @@ class BaseCliTests(unittest.TestCase):
             config = read_user_config(home)
 
         self.assertEqual(config.workspace.root, workspace.resolve(strict=False))
+        self.assertIsNone(config.github.default_owner)
+        self.assertIsNone(config.github.clone_protocol)
+
+    def test_read_user_config_parses_github_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "\n".join(
+                    [
+                        "github:",
+                        "  default_owner: codeforester",
+                        "  clone_protocol: https",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            config = read_user_config(home)
+
+        self.assertEqual(config.github.default_owner, "codeforester")
+        self.assertEqual(config.github.clone_protocol, "https")
+
+    def test_read_user_config_rejects_non_mapping_github(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github: true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "github must be a mapping"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_invalid_github_default_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github:\n  default_owner: bad_owner!\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "github.default_owner must start with"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_invalid_github_clone_protocol(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github:\n  clone_protocol: ftp\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "github.clone_protocol must be 'ssh' or 'https'"):
+                read_user_config(home)
 
     def test_read_user_config_rejects_non_mapping_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -499,6 +552,28 @@ class BaseCliTests(unittest.TestCase):
         self.assertEqual(seen["vscode"].extra_extensions, ("github.copilot",))
         self.assertEqual(seen["config"]["workspace"]["root"], str(workspace))
         self.assertTrue(seen["config"]["ide"]["enabled"])
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_context_exposes_github_typed_user_config(self) -> None:
+        app = base_cli.App(name="typed-config-github", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["github"] = ctx.user_config.github
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github:\n  default_owner: codeforester\n  clone_protocol: ssh\n", encoding="utf-8")
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["github"].default_owner, "codeforester")
+        self.assertEqual(seen["github"].clone_protocol, "ssh")
 
     def test_log_debug_enables_python_debug_logging(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -286,59 +286,6 @@ class BaseCliTests(unittest.TestCase):
             config = read_user_config(home)
 
         self.assertEqual(config.workspace.root, workspace.resolve(strict=False))
-        self.assertIsNone(config.github.default_owner)
-        self.assertIsNone(config.github.clone_protocol)
-
-    def test_read_user_config_parses_github_defaults(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home = Path(tmpdir)
-            path = user_config_path(home)
-            path.parent.mkdir(parents=True)
-            path.write_text(
-                "\n".join(
-                    [
-                        "github:",
-                        "  default_owner: codeforester",
-                        "  clone_protocol: https",
-                    ]
-                ),
-                encoding="utf-8",
-            )
-
-            config = read_user_config(home)
-
-        self.assertEqual(config.github.default_owner, "codeforester")
-        self.assertEqual(config.github.clone_protocol, "https")
-
-    def test_read_user_config_rejects_non_mapping_github(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home = Path(tmpdir)
-            path = user_config_path(home)
-            path.parent.mkdir(parents=True)
-            path.write_text("github: true\n", encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, "github must be a mapping"):
-                read_user_config(home)
-
-    def test_read_user_config_rejects_invalid_github_default_owner(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home = Path(tmpdir)
-            path = user_config_path(home)
-            path.parent.mkdir(parents=True)
-            path.write_text("github:\n  default_owner: bad_owner!\n", encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, "github.default_owner must start with"):
-                read_user_config(home)
-
-    def test_read_user_config_rejects_invalid_github_clone_protocol(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home = Path(tmpdir)
-            path = user_config_path(home)
-            path.parent.mkdir(parents=True)
-            path.write_text("github:\n  clone_protocol: ftp\n", encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, "github.clone_protocol must be 'ssh' or 'https'"):
-                read_user_config(home)
 
     def test_read_user_config_rejects_non_mapping_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -552,28 +499,6 @@ class BaseCliTests(unittest.TestCase):
         self.assertEqual(seen["vscode"].extra_extensions, ("github.copilot",))
         self.assertEqual(seen["config"]["workspace"]["root"], str(workspace))
         self.assertTrue(seen["config"]["ide"]["enabled"])
-
-    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
-    def test_context_exposes_github_typed_user_config(self) -> None:
-        app = base_cli.App(name="typed-config-github", log_to_file=False)
-        seen = {}
-
-        @app.command()
-        def main(ctx: base_cli.Context) -> None:
-            seen["github"] = ctx.user_config.github
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home = Path(tmpdir)
-            path = user_config_path(home)
-            path.parent.mkdir(parents=True)
-            path.write_text("github:\n  default_owner: codeforester\n  clone_protocol: ssh\n", encoding="utf-8")
-            from base_cli.testing import invoke
-
-            result = invoke(app, [], home=home)
-
-        self.assertEqual(result.exit_code, 0, result.output)
-        self.assertEqual(seen["github"].default_owner, "codeforester")
-        self.assertEqual(seen["github"].clone_protocol, "ssh")
 
     def test_log_debug_enables_python_debug_logging(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/python/base_cli/tests/test_user_config_github.py
+++ b/lib/python/base_cli/tests/test_user_config_github.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import base_cli
+from base_cli.config import read_user_config, user_config_path
+
+
+class GithubUserConfigTests(unittest.TestCase):
+    def test_read_user_config_defaults_github_settings_to_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = read_user_config(Path(tmpdir))
+
+        self.assertIsNone(config.github.default_owner)
+        self.assertIsNone(config.github.clone_protocol)
+
+    def test_read_user_config_parses_github_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "\n".join(
+                    [
+                        "github:",
+                        "  default_owner: codeforester",
+                        "  clone_protocol: https",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            config = read_user_config(home)
+
+        self.assertEqual(config.github.default_owner, "codeforester")
+        self.assertEqual(config.github.clone_protocol, "https")
+
+    def test_read_user_config_rejects_non_mapping_github(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github: true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "github must be a mapping"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_invalid_github_default_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github:\n  default_owner: bad_owner!\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "github.default_owner must start with"):
+                read_user_config(home)
+
+    def test_read_user_config_rejects_invalid_github_clone_protocol(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github:\n  clone_protocol: ftp\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "github.clone_protocol must be 'ssh' or 'https'"):
+                read_user_config(home)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_context_exposes_github_typed_user_config(self) -> None:
+        app = base_cli.App(name="typed-config-github", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["github"] = ctx.user_config.github
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text("github:\n  default_owner: codeforester\n  clone_protocol: ssh\n", encoding="utf-8")
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["github"].default_owner, "codeforester")
+        self.assertEqual(seen["github"].clone_protocol, "ssh")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add typed `github` defaults to Base user config parsing.
- Validate `github.default_owner` and `github.clone_protocol` through `basectl config doctor`.
- Document that `config doctor` now catches invalid GitHub defaults before `repo clone`.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py cli/python/base_config/tests/test_engine.py -q`
- `BASE_CACHE_DIR=/private/tmp/base-793-cache env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## AI Context
- Not updated. This narrows validation for an already documented local config surface and does not change the public command shape.

Fixes #793
