### PR TITLE
Report Python CLI usage errors cleanly

### DIFF
--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
-import click
 from base_cli.paths import base_cache_root
 
 
@@ -21,12 +20,7 @@ class CleanCandidate:
 
 
 def main(argv: list[str] | None = None) -> int:
-    try:
-        result = app.click_command.main(args=argv, standalone_mode=False)
-    except click.ClickException as exc:
-        exc.show()
-        return int(exc.exit_code)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -72,8 +72,7 @@ AI_REMOTE_INSTALLER_ALLOWLIST = (
 
 
 def main(argv: list[str] | None = None) -> int:
-    result = app.click_command.main(args=argv, standalone_mode=False)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -56,6 +56,13 @@ class DevManifestTests(unittest.TestCase):
         self.assertEqual(exc.exception.code, 7)
         main_mock.assert_called_once_with()
 
+    def test_main_reports_missing_action_without_traceback(self) -> None:
+        status, _stdout, stderr = run_engine([])
+
+        self.assertEqual(status, 2)
+        self.assertIn("Missing argument", stderr)
+        self.assertNotIn("Traceback", stderr)
+
     def test_dev_manifest_declares_supported_developer_tools(self) -> None:
         manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
         artifacts = {(artifact.artifact_type, artifact.name, artifact.version) for artifact in manifest.artifacts}

--- a/cli/python/base_export_context/engine.py
+++ b/cli/python/base_export_context/engine.py
@@ -44,8 +44,7 @@ class ExportContextOptions:
 
 
 def main(argv: list[str] | None = None) -> int:
-    result = app.click_command.main(args=argv, standalone_mode=False)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/cli/python/base_export_context/tests/test_engine.py
+++ b/cli/python/base_export_context/tests/test_engine.py
@@ -32,6 +32,17 @@ def invoke_engine(args: list[str], project_root: Path) -> tuple[int, str, str]:
 
 
 class ExportContextTests(unittest.TestCase):
+    def test_main_reports_unknown_option_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+
+            status, _stdout, stderr = invoke_engine(["--bad-option"], project_root)
+
+        self.assertEqual(status, 2)
+        self.assertIn("No such option", stderr)
+        self.assertNotIn("Traceback", stderr)
+
     def test_markdown_print_uses_index_order_then_remaining_markdown_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "demo"

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from pathlib import Path
 
 import base_cli
-import click
 from base_cli.paths import base_cache_root
 
 
@@ -41,12 +40,7 @@ class LogCommandOptions:
 
 
 def main(argv: list[str] | None = None) -> int:
-    try:
-        result = app.click_command.main(args=argv, standalone_mode=False)
-    except click.ClickException as exc:
-        exc.show()
-        return int(exc.exit_code)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -61,8 +61,7 @@ class WorkspaceCommandOptions:
 
 
 def main(argv: list[str] | None = None) -> int:
-    result = app.click_command.main(args=argv, standalone_mode=False)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -150,6 +150,17 @@ def run_engine_with_home(args: list[str], base_home: Path, home: Path) -> tuple[
 
 
 class ProjectDiscoveryTests(unittest.TestCase):
+    def test_main_reports_config_errors_without_traceback(self) -> None:
+        status, _stdout, stderr = run_engine(
+            ["list"],
+            Path(__file__).resolve().parents[4],
+            user_config="workspace: [not-a-mapping]\n",
+        )
+
+        self.assertEqual(status, 1)
+        self.assertIn("workspace must be a mapping", stderr)
+        self.assertNotIn("Traceback", stderr)
+
     def test_discovers_projects_under_workspace_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -63,8 +63,7 @@ class ReleaseFinding:
 
 
 def main(argv: list[str] | None = None) -> int:
-    result = app.click_command.main(args=argv, standalone_mode=False)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -55,8 +55,7 @@ class ManifestAction:
 
 
 def main(argv: list[str] | None = None) -> int:
-    result = app.click_command.main(args=argv, standalone_mode=False)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -18,6 +18,16 @@ from base_setup.process import format_command
 from base_setup.registry import get_artifact_definition
 from base_setup.tests.helpers import fake_context, run_engine
 
+
+class BaseSetupMainTests(unittest.TestCase):
+    def test_main_reports_unknown_option_without_traceback(self) -> None:
+        status, _stdout, stderr = run_engine(["--bad-option"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("No such option", stderr)
+        self.assertNotIn("Traceback", stderr)
+
+
 class ArtifactMergeTests(unittest.TestCase):
 
     def test_merge_artifacts_keeps_defaults_and_manifest_artifacts(self) -> None:

--- a/lib/python/base_cli/__init__.py
+++ b/lib/python/base_cli/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .app import App, argument, command, option
+from .app import App, argument, command, option, run_app
 from .context import Context, get_current_context
 from .exit_codes import ExitCode
 from .logging import log_critical, log_debug, log_error, log_info, log_warning
@@ -18,4 +18,5 @@ __all__ = [
     "log_info",
     "log_warning",
     "option",
+    "run_app",
 ]

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -106,7 +106,10 @@ class App:
         @functools.wraps(func)
         def wrapper(**kwargs: Any):
             standard = _pop_standard_options(kwargs)
-            context = self._create_context(standard, sensitive_options, dry_run=bool(kwargs.get(dry_run_parameter)))
+            try:
+                context = self._create_context(standard, sensitive_options, dry_run=bool(kwargs.get(dry_run_parameter)))
+            except (RuntimeError, ValueError) as exc:
+                raise click.ClickException(str(exc)) from exc
             token = set_current_context(context)
             try:
                 log_invocation(context.log, sys.argv, sensitive_options)
@@ -180,6 +183,21 @@ class App:
             user_config=user_config,
             dry_run=dry_run,
         )
+
+
+def run_app(app: App, argv: list[str] | None = None) -> int:
+    try:
+        click = _require_click()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = app.click_command.main(args=argv, standalone_mode=False)
+    except click.ClickException as exc:
+        exc.show()
+        return int(exc.exit_code)
+    return int(result or 0)
 
 
 def command(*args: Any, **kwargs: Any):

--- a/lib/python/base_cli/tests/test_app_run.py
+++ b/lib/python/base_cli/tests/test_app_run.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+import base_cli
+from base_cli.config import user_config_path
+
+
+class RunAppTests(unittest.TestCase):
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_run_app_reports_config_errors_without_traceback(self) -> None:
+        app = base_cli.App(name="bad-config", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["called"] = True
+            del ctx
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            config_path = user_config_path(home)
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text("workspace: [not-a-mapping]\n", encoding="utf-8")
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(home),
+                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
+                },
+            ), redirect_stderr(stderr):
+                status = base_cli.run_app(app, [])
+
+        self.assertEqual(status, 1)
+        self.assertEqual(seen, {})
+        self.assertIn("workspace must be a mapping", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_run_app_preserves_unexpected_command_exceptions(self) -> None:
+        app = base_cli.App(name="boom", log_to_file=False)
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+            raise RuntimeError("boom")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(home),
+                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
+                },
+            ):
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    base_cli.run_app(app, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -796,59 +796,6 @@ class BaseCliTests(unittest.TestCase):
         self.assertEqual(Path.cwd(), original_cwd)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
-    def test_run_app_reports_config_errors_without_traceback(self) -> None:
-        app = base_cli.App(name="bad-config", log_to_file=False)
-        seen = {}
-
-        @app.command()
-        def main(ctx: base_cli.Context) -> None:
-            seen["called"] = True
-            del ctx
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home = Path(tmpdir)
-            config_path = user_config_path(home)
-            config_path.parent.mkdir(parents=True)
-            config_path.write_text("workspace: [not-a-mapping]\n", encoding="utf-8")
-            stderr = io.StringIO()
-            with mock.patch.dict(
-                os.environ,
-                {
-                    "HOME": str(home),
-                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
-                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
-                },
-            ), redirect_stderr(stderr):
-                status = base_cli.run_app(app, [])
-
-        self.assertEqual(status, 1)
-        self.assertEqual(seen, {})
-        self.assertIn("workspace must be a mapping", stderr.getvalue())
-        self.assertNotIn("Traceback", stderr.getvalue())
-
-    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
-    def test_run_app_preserves_unexpected_command_exceptions(self) -> None:
-        app = base_cli.App(name="boom", log_to_file=False)
-
-        @app.command()
-        def main(ctx: base_cli.Context) -> None:
-            del ctx
-            raise RuntimeError("boom")
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            home = Path(tmpdir)
-            with mock.patch.dict(
-                os.environ,
-                {
-                    "HOME": str(home),
-                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
-                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
-                },
-            ):
-                with self.assertRaisesRegex(RuntimeError, "boom"):
-                    base_cli.run_app(app, [])
-
-    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_testing_invoke_defaults_base_cache_dir_under_home(self) -> None:
         app = base_cli.App(name="cache-default")
         seen = {}

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -796,6 +796,59 @@ class BaseCliTests(unittest.TestCase):
         self.assertEqual(Path.cwd(), original_cwd)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_run_app_reports_config_errors_without_traceback(self) -> None:
+        app = base_cli.App(name="bad-config", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["called"] = True
+            del ctx
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            config_path = user_config_path(home)
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text("workspace: [not-a-mapping]\n", encoding="utf-8")
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(home),
+                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
+                },
+            ), redirect_stderr(stderr):
+                status = base_cli.run_app(app, [])
+
+        self.assertEqual(status, 1)
+        self.assertEqual(seen, {})
+        self.assertIn("workspace must be a mapping", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_run_app_preserves_unexpected_command_exceptions(self) -> None:
+        app = base_cli.App(name="boom", log_to_file=False)
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+            raise RuntimeError("boom")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(home),
+                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
+                },
+            ):
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    base_cli.run_app(app, [])
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_testing_invoke_defaults_base_cache_dir_under_home(self) -> None:
         app = base_cli.App(name="cache-default")
         seen = {}


### PR DESCRIPTION
## Summary
- Add shared `base_cli.run_app()` entrypoint handling for App-based Python CLIs.
- Convert config/bootstrap failures during context creation into concise Click errors.
- Update App-based package mains to use the shared helper while preserving unexpected command exceptions for developer debugging.
- Add regression coverage for malformed user config and direct package Click usage errors.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py cli/python/base_dev/tests/test_engine.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_projects/tests/test_engine.py cli/python/base_export_context/tests/test_engine.py -q`
- Manual malformed-config check: `./bin/basectl projects list` with `workspace: [not-a-mapping]`
- Manual direct usage check: `python -m base_dev`
- `BASE_CACHE_DIR=/private/tmp/base-791-cache env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## AI Context
- Not updated. This is an internal CLI error-reporting consistency fix and does not change the public command surface.

Fixes #791
