### PR TITLE
Document manifest command trust model

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,13 @@ delegation-first: use mature tools for the domains they already own, and keep
 Base responsible for workspace orchestration, project discovery, the project
 virtual environment, and diagnostics.
 
+Manifest-declared commands are trusted project code. Base executes
+`test.command`, `build.targets.*.command`, and `commands.*` as shell command
+strings from the project root, so shell metacharacters are honored. Review
+manifests from unfamiliar repositories before running `basectl test`,
+`basectl build`, or `basectl run`; use `--dry-run` and `--list` first when you
+only want to inspect the resolved command contract.
+
 The optional top-level `brewfile` field points to a Homebrew `Brewfile` relative
 to the project root. When present, `basectl setup` runs
 `brew bundle --file=<project-root>/<brewfile>` before reconciling artifacts. Use

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -26,6 +26,11 @@ Run `basectl --help` or `basectl <command> --help` for full usage.
 | `basectl build <project> --list` | List build targets declared by a project manifest. | `--workspace <path>` |
 | `basectl demo [project]` | Run a project-owned demo script. | `--workspace <path>`, `--dry-run`, `-- <args>` |
 
+Manifest-declared `test`, `run`, and `build` commands are project-owned shell
+command strings executed from the project root. Review manifests from
+unfamiliar repositories before running them; use `--dry-run` or `--list` to
+inspect the resolved command contract first.
+
 ## Diagnostics And Logs
 
 | Command | What it does | Important flags |

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -85,6 +85,13 @@ Base validates runner values when reading the manifest. `basectl check` and
 `basectl doctor` warn if `uv` is unavailable. Actual command invocation fails
 clearly when `runner: uv` is selected and `uv` is not on `PATH`.
 
+Command strings remain trusted project code with or without a runner. Base
+does not parse them into a restricted argument array; shell syntax in
+`test.command`, `commands.*.command`, `build.targets.*.command`, and
+`demo.script` is project-owned behavior. Review manifests from unfamiliar
+repositories before running them, and use `--dry-run` or listing commands first
+when you only need to inspect the resolved invocation.
+
 ## Relationship To `pyproject.toml`
 
 `pyproject.toml` remains the Python project's packaging contract. Base observes


### PR DESCRIPTION
## Summary
- Document that manifest-declared test/build/run commands are trusted project-owned shell strings.
- Point users to `--dry-run` and `--list` before running commands from unfamiliar repositories.
- Clarify that command runners such as `runner: uv` do not turn commands into a restricted argument-array model.

## Validation
- `git diff --check`

## AI Context
- Not updated. This documents an existing trust boundary without changing behavior or command surface.

Fixes #797