### PR TITLE
Make GitHub workflow defaults visible

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -34,6 +34,10 @@ the canonical current command list.
   print plans/notes, and publish guarded GitHub-side release artifacts.
 - `basectl gh <area> <command>` - manage GitHub issues, PRs, branches, repo
   hygiene, and Project metadata using Base conventions.
+  - `basectl gh issue create` defaults to category `enhancement` when
+    `--category` is omitted and prints that default in command output.
+  - `basectl gh pr create` auto-injects `Fixes #<issue>` from Base branch
+    names; pass `--no-fixes` to suppress that body injection.
   - `basectl gh project doctor --project <title>` - inspect Project metadata
     fields against the Base roadmap schema.
   - `basectl gh project configure --project <title>` - create or repair the

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -44,7 +44,9 @@ clean it up after merge.
 ## Pull Requests
 
 Pull requests are issue-backed by default and scoped to one issue unless there
-is a documented exception. PR bodies should include:
+is a documented exception. `basectl gh pr create` adds `Fixes #<issue>` from
+Base branch names by default; pass `--no-fixes` only when the PR should not
+close the issue automatically. PR bodies should include:
 
 - summary of what changed and why
 - issue reference such as `Fixes #<issue>` or `Closes #<issue>`

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -8,9 +8,9 @@ base_gh_usage() {
     cat <<'EOF'
 Usage:
   basectl gh issue list [gh options...]
-  basectl gh issue create --category <bug|enhancement|documentation|ci|security> --title <title> [--body <body>] [--repo <owner/name>] [project options...]
+  basectl gh issue create [--category <bug|enhancement|documentation|ci|security>] --title <title> [--body <body>] [--repo <owner/name>] [project options...]
   basectl gh issue start <number> [--category <bug|enhancement|documentation|ci|security>] [--title <title>]
-  basectl gh pr create [gh options...]
+  basectl gh pr create [--no-fixes] [gh options...]
   basectl gh pr status [gh options...]
   basectl gh pr checks [gh options...]
   basectl gh pr ready [gh options...]
@@ -32,15 +32,21 @@ Branch naming:
 
 Issue create project options:
   --repo <owner/name>           Repository to create the issue in. Defaults to the origin remote.
+  --category <category>         Issue label category. Defaults to enhancement.
   --project <title>             Project to update. Defaults to the repository name.
   --project-owner <login>       Project owner. Defaults to the repository owner.
   --no-project                  Skip Project metadata updates.
+
+Issue categories:
+  bug, enhancement, documentation, ci, security
 
 Notes:
   - This command requires the GitHub CLI (`gh`) for GitHub operations.
   - Issues created through this command are assigned to codeforester.
   - When the GitHub repo is known, issue create also adds the issue to the
     repo-named Project and applies defaults from .github/base-project.yml.
+  - PR creation auto-injects Fixes #<issue> when the branch follows the Base
+    naming convention. Pass --no-fixes to suppress that body injection.
   - Pull request implementation work should happen in a dedicated worktree.
   - Branch and worktree pruning are dry-run by default and apply only when --yes is passed.
   - TODO planning only previews issues; TODO import creation is not enabled yet.
@@ -51,7 +57,7 @@ base_gh_issue_usage() {
     cat <<'EOF'
 Usage:
   basectl gh issue list [gh options...]
-  basectl gh issue create --category <bug|enhancement|documentation|ci|security> --title <title> [--body <body>] [--repo <owner/name>] [project options...]
+  basectl gh issue create [--category <bug|enhancement|documentation|ci|security>] --title <title> [--body <body>] [--repo <owner/name>] [project options...]
   basectl gh issue start <number> [--category <bug|enhancement|documentation|ci|security>] [--title <title>]
 
 Purpose:
@@ -62,16 +68,20 @@ Branch naming:
 
 Issue create project options:
   --repo <owner/name>           Repository to create the issue in. Defaults to the origin remote.
+  --category <category>         Issue label category. Defaults to enhancement.
   --project <title>             Project to update. Defaults to the repository name.
   --project-owner <login>       Project owner. Defaults to the repository owner.
   --no-project                  Skip Project metadata updates.
+
+Default category: enhancement.
+Categories: bug, enhancement, documentation, ci, security.
 EOF
 }
 
 base_gh_pr_usage() {
     cat <<'EOF'
 Usage:
-  basectl gh pr create [gh options...]
+  basectl gh pr create [--no-fixes] [gh options...]
   basectl gh pr status [gh options...]
   basectl gh pr checks [gh options...]
   basectl gh pr ready [gh options...]
@@ -83,6 +93,7 @@ Purpose:
 Notes:
   - PR creation links the current issue automatically when the branch follows
     <category>/<issue>-<YYYYMMDD>-<slug>.
+  - --no-fixes disables automatic Fixes #<issue> body injection for create.
   - Pull request implementation work should happen in a dedicated worktree.
 EOF
 }
@@ -447,7 +458,10 @@ base_gh_issue_create() {
         base_gh_error "Missing required --title."
         return 1
     }
-    category="${category:-enhancement}"
+    if [[ -z "$category" ]]; then
+        category="enhancement"
+        printf 'Using default --category: enhancement\n'
+    fi
     base_gh_validate_category "$category" || return 1
 
     [[ -n "$github_repo" ]] || github_repo="$(base_gh_infer_github_repo || true)"
@@ -490,6 +504,37 @@ base_gh_issue_create() {
                 --size S
         fi
     fi
+}
+
+base_gh_pr_create() {
+    local issue body_file status
+    local no_fixes=0
+    local passthrough=()
+
+    while (($#)); do
+        case "$1" in
+            --no-fixes)
+                no_fixes=1
+                ;;
+            *)
+                passthrough+=("$1")
+                ;;
+        esac
+        shift
+    done
+
+    base_gh_require_git_repo || return 1
+    issue="$(base_gh_current_issue_from_branch || true)"
+    if [[ -n "$issue" && "$no_fixes" -eq 0 ]]; then
+        body_file="$(mktemp "${TMPDIR:-/tmp}/basectl-gh-pr.XXXXXX")" || return 1
+        printf 'Fixes #%s\n' "$issue" > "$body_file"
+        printf 'Auto-linking PR to issue #%s from branch name. Pass --no-fixes to suppress.\n' "$issue"
+        base_gh_run pr create --fill --body-file "$body_file" "${passthrough[@]}"
+        status=$?
+        rm -f "$body_file"
+        return "$status"
+    fi
+    base_gh_run pr create --fill "${passthrough[@]}"
 }
 
 base_gh_issue_start() {
@@ -545,7 +590,6 @@ base_gh_issue_start() {
 
 base_gh_do_pr() {
     local command="${1:-}"
-    local issue body_file status
     shift || true
 
     case "$command" in
@@ -554,17 +598,7 @@ base_gh_do_pr() {
                 base_gh_pr_usage
                 return 0
             fi
-            base_gh_require_git_repo || return 1
-            issue="$(base_gh_current_issue_from_branch || true)"
-            if [[ -n "$issue" ]]; then
-                body_file="$(mktemp "${TMPDIR:-/tmp}/basectl-gh-pr.XXXXXX")" || return 1
-                printf 'Fixes #%s\n' "$issue" > "$body_file"
-                base_gh_run pr create --fill --body-file "$body_file" "$@"
-                status=$?
-                rm -f "$body_file"
-                return "$status"
-            fi
-            base_gh_run pr create --fill "$@"
+            base_gh_pr_create "$@"
             ;;
         status)
             if base_gh_args_request_help "$@"; then

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -27,6 +27,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl gh issue create"* ]]
     [[ "$output" == *"basectl gh issue start <number>"* ]]
     [[ "$output" == *"Issue create project options:"* ]]
+    [[ "$output" == *"Default category: enhancement."* ]]
+    [[ "$output" == *"Categories: bug, enhancement, documentation, ci, security."* ]]
     [[ "$output" != *"basectl gh pr create"* ]]
     [[ "$output" != *"basectl gh worktree prune"* ]]
 }
@@ -38,6 +40,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl gh pr create"* ]]
     [[ "$output" == *"basectl gh pr checks"* ]]
     [[ "$output" == *"basectl gh pr merge"* ]]
+    [[ "$output" == *"basectl gh pr create [--no-fixes] [gh options...]"* ]]
+    [[ "$output" == *"--no-fixes"* ]]
     [[ "$output" == *"issue-linked PR workflow"* ]]
     [[ "$output" != *"basectl gh issue create"* ]]
     [[ "$output" != *"basectl gh branch prune"* ]]
@@ -114,7 +118,34 @@ EOF
         '
 
     [ "$status" -eq 0 ]
+    [[ "$output" != *"Using default --category"* ]]
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Repair branch pruning --label bug --assignee codeforester --repo codeforester/base" ]
+}
+
+@test "basectl gh issue create announces default category" {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue create --title "Default category issue" --no-project
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using default --category: enhancement"* ]]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Default category issue --label enhancement --assignee codeforester --repo codeforester/base" ]
 }
 
 @test "basectl gh issue create continues when auth status is transiently unavailable" {
@@ -885,6 +916,7 @@ while (($#)); do
     shift
 done
 [[ -n "$body_file" ]] && cat "$body_file" > "${BASE_GH_TEST_STATE_DIR:?}/body"
+exit 0
 EOF
     chmod +x "$TEST_MOCKBIN/gh"
 
@@ -901,8 +933,55 @@ EOF
         ' bash "$repo"
 
     [ "$status" -eq 0 ]
+    [[ "$output" == *"Auto-linking PR to issue #117 from branch name. Pass --no-fixes to suppress."* ]]
     [[ "$(cat "$TEST_STATE_DIR/gh-args")" == pr\ create\ --fill\ --body-file* ]]
     [ "$(cat "$TEST_STATE_DIR/body")" = "Fixes #117" ]
+}
+
+@test "basectl gh pr create supports no-fixes opt out" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c "enhancement/117-20260528-basectl-gh-workflow" >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+body_file=""
+while (($#)); do
+    if [[ "$1" == "--body-file" ]]; then
+        body_file="$2"
+        break
+    fi
+    shift
+done
+[[ -n "$body_file" ]] && cat "$body_file" > "${BASE_GH_TEST_STATE_DIR:?}/body"
+exit 0
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main pr create --no-fixes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Auto-linking PR"* ]]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "pr create --fill" ]
+    [ ! -e "$TEST_STATE_DIR/body" ]
 }
 
 @test "basectl gh pr create help does not require authentication" {

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -69,9 +69,9 @@ inspect the resolved command contract first.
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files, optionally through a draft PR. | `--repo <owner/name>`, `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--pr`, `--dry-run` |
 | `basectl repo installer-template [path]` | Write the maintained project installer starter script to a path, defaulting to `./install.sh`, optionally through a draft PR. | `--print`, `--repo <owner/name>`, `--pr`, `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |
-| `basectl gh issue create` | Create an issue with Base category conventions, assign it, and add repo Project metadata when the repo is known. | `--category <bug\|enhancement\|documentation\|ci\|security>`, `--title <title>`, `--body <body>`, `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--no-project` |
+| `basectl gh issue create` | Create an issue with Base category conventions, assign it, and add repo Project metadata when the repo is known. Defaults to `--category enhancement` when omitted. | `--category <bug\|enhancement\|documentation\|ci\|security>`, `--title <title>`, `--body <body>`, `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--no-project` |
 | `basectl gh issue start <number>` | Start issue-backed branch naming workflow. | `--category <category>`, `--title <title>` |
-| `basectl gh pr create/status/checks/ready/merge` | Create and manage pull requests through Base's workflow wrapper. | passes through `gh` options |
+| `basectl gh pr create/status/checks/ready/merge` | Create and manage pull requests through Base's workflow wrapper. `pr create` auto-injects `Fixes #<issue>` from Base branch names unless `--no-fixes` is passed. | passes through `gh` options; `pr create` also accepts `--no-fixes` |
 | `basectl gh branch stale` | Report stale local branches. | `--days <days>` |
 | `basectl gh branch prune` | Prune safe merged branches. | `--dry-run`, `--yes`, `--remote` |
 | `basectl gh worktree prune` | Prune stale merged worktrees. | `--dry-run`, `--yes` |

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -108,6 +108,12 @@ and repository hygiene tasks. For example, prefer `basectl gh issue create`,
 over hand-written `gh` commands when those commands are available and local
 tooling is authenticated.
 
+`basectl gh issue create` defaults to the `enhancement` category when
+`--category` is omitted and prints that choice. `basectl gh pr create`
+auto-injects `Fixes #<issue>` when the current branch follows the Base
+`<category>/<issue>-<YYYYMMDD>-<slug>` convention; pass `--no-fixes` when the
+PR should not close the issue automatically.
+
 Fallbacks are allowed when `basectl gh` does not support the needed operation,
 when local GitHub CLI authentication is unavailable, or when the GitHub
 connector provides a safer structured API for the task. In those cases, use the


### PR DESCRIPTION
## Summary
- Document and print the default issue category when `basectl gh issue create` omits `--category`.
- Print the automatic PR issue-linking behavior and add `basectl gh pr create --no-fixes` to suppress it.
- Update command docs, GitHub workflow docs, and AI context for the new flag/output contract.

## Validation
- `env -u BASE_HOME bats cli/bash/commands/basectl/tests/gh.bats`
- `BASE_CACHE_DIR=/private/tmp/base-799-cache env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
- None. CLI workflow/help/docs change only.

## AI Context
- Updated `.ai-context/COMMANDS.md` and `.ai-context/WORKFLOWS.md` for the new GH workflow flag/output behavior.

Closes #799
Closes #800
