### PR TITLE
Fix Homebrew Base runtime env isolation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -119,6 +119,33 @@ type -a basectl
 When testing a specific install route, use the absolute `basectl` path for that
 route instead of relying on `PATH`.
 
+### How do I validate Homebrew Base from a source-managed shell?
+
+Use an isolated `HOME` and clear the Base runtime contract before invoking the
+Homebrew-managed executable. This keeps an active source checkout, runtime
+shell, or project activation from leaking into the consumer install test:
+
+```bash
+brew_home=/tmp/base-brew-home
+mkdir -p "$brew_home"
+
+HOME="$brew_home" env -u BASE_HOME \
+  -u BASE_PROJECT \
+  -u BASE_PROJECT_ROOT \
+  -u BASE_PROJECT_MANIFEST \
+  -u BASE_PROJECT_VENV_DIR \
+  /usr/local/bin/basectl setup
+
+HOME="$brew_home" env -u BASE_HOME \
+  -u BASE_PROJECT \
+  -u BASE_PROJECT_ROOT \
+  -u BASE_PROJECT_MANIFEST \
+  -u BASE_PROJECT_VENV_DIR \
+  /usr/local/bin/basectl test base
+```
+
+Use `/opt/homebrew/bin/basectl` on Apple Silicon Homebrew installs.
+
 ### If I have both installs, which one should bootstrap prefer?
 
 Bootstrap should not silently take over an existing setup. If no mode is

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -776,7 +776,7 @@ setup_resolve_project_manifest() {
 setup_project_venv_dir() {
     local project="$1"
 
-    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+    if [[ "$project" != base && -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
         printf '%s\n' "$BASE_PROJECT_VENV_DIR"
         return 0
     fi
@@ -1014,6 +1014,7 @@ setup_run_project_bootstrap_layer() {
     local output_format="$3"
     local python_bin venv_dir
     local args=()
+    local project_env_args=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
         log_info "[DRY-RUN] Would bootstrap project Python runtime after PyYAML is installed."
@@ -1034,7 +1035,15 @@ setup_run_project_bootstrap_layer() {
     fi
 
     setup_ensure_cached_paths
-    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" "$python_bin" -m base_setup "${args[@]}"
+    if [[ "$project" == base ]]; then
+        project_env_args=(
+            -u BASE_PROJECT
+            -u BASE_PROJECT_ROOT
+            -u BASE_PROJECT_MANIFEST
+            -u BASE_PROJECT_VENV_DIR
+        )
+    fi
+    env "${project_env_args[@]}" BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" "$python_bin" -m base_setup "${args[@]}"
 }
 
 setup_run_project_artifact_layer() {
@@ -1042,6 +1051,7 @@ setup_run_project_artifact_layer() {
     local output_format="$2"
     local exit_code manifest_path precheck_json project project_venv_dir python_bin remote_network resolved_name resolved_root resolve_output venv_dir
     local args=()
+    local project_env_args=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
         log_info "[DRY-RUN] Would run Python project setup layer after PyYAML is installed."
@@ -1072,6 +1082,14 @@ setup_run_project_artifact_layer() {
             project=base
         fi
         manifest_path="$resolve_output"
+    fi
+    if [[ "$project" == base ]]; then
+        project_env_args=(
+            -u BASE_PROJECT
+            -u BASE_PROJECT_ROOT
+            -u BASE_PROJECT_MANIFEST
+            -u BASE_PROJECT_VENV_DIR
+        )
     fi
 
     if setup_is_dry_run; then
@@ -1151,7 +1169,7 @@ setup_run_project_artifact_layer() {
         return 1
     fi
 
-    "$BASE_HOME/bin/base-wrapper" --project "$project" base_setup "${args[@]}"
+    env "${project_env_args[@]}" "$BASE_HOME/bin/base-wrapper" --project "$project" base_setup "${args[@]}"
     exit_code=$?
 
     if ((exit_code)) && [[ "$action" == setup ]]; then

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -98,6 +98,28 @@ EOF
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
+@test "basectl setup base ignores inherited project virtualenv" {
+    local inherited_venv="$TEST_TMPDIR/inherited-base-venv"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_project_setup_venv_stub "$venv_dir"
+    create_project_setup_venv_stub "$inherited_venv"
+
+    run_base_command BASE_PROJECT_VENV_DIR="$inherited_venv" setup
+
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_STATE_DIR/project-setup-python" ]
+    [[ "$(cat "$TEST_STATE_DIR/project-setup-python")" == *"$venv_dir/bin/python"* ]]
+    [[ "$(cat "$TEST_STATE_DIR/project-setup-python")" != *"$inherited_venv/bin/python"* ]]
+}
+
 @test "basectl setup installs missing dependencies and creates the Base virtual environment" {
     local installer
     local venv_dir="$TEST_HOME/.base.d/base/.venv"

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -530,6 +530,7 @@ fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     shift 2
     printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-args"
+    printf '%s\n' "$0" >> "$BASE_SETUP_TEST_STATE_DIR/project-setup-python"
     printf '%s\n' "${BASE_PROJECT:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-project"
     printf '%s\n' "${BASE_CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-base-ci"
     printf '%s\n' "${CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-ci"

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -186,6 +186,30 @@ EOF
     [[ "$output" != *"ERROR:   exec env"* ]]
 }
 
+@test "Base-managed Bash startup skips mismatched snippet inside active Base runtime" {
+    local runtime_base="$TEST_TMPDIR/homebrew/Cellar/base/1.0.2/libexec"
+    local source_base="$TEST_TMPDIR/work/base"
+
+    create_fake_shell_base "$runtime_base"
+    create_fake_shell_base "$source_base"
+
+    run env -u BASE_PLATFORM_TOOLS_HOME -u BASE_PLATFORM_TOOLS_BIN_DIR \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -i -c '\
+            readonly BASE_HOME="$1"; \
+            export BASE_SHELL=1; \
+            source "$2"; \
+            printf "BASE_HOME=%s\n" "$BASE_HOME"' \
+        bash "$runtime_base" "$source_base/lib/shell/bashrc"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"INFO: This shell is already running Base from '$runtime_base'; skipping Base profile snippet for '$source_base'."* ]]
+    [[ "$output" == *"BASE_HOME=$runtime_base"* ]]
+    [[ "$output" != *"Run basectl update-profile"* ]]
+    [[ "$output" != *"Start a fresh shell without stale Base runtime variables"* ]]
+}
+
 @test "Base-managed Bash startup detects sibling Base Platform Tools without profile rewrite" {
     local workspace="$TEST_TMPDIR/fake-workspace"
     local fake_base="$workspace/base"

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -56,7 +56,8 @@ Before starting either install path:
 1. Use a supported macOS account that can install developer tools and Homebrew
    packages.
 2. Open a fresh terminal without inherited Base variables such as `BASE_HOME`,
-   `BASE_PROJECT`, `BASE_PROJECT_ROOT`, or `PYTHONPATH`.
+   `BASE_PROJECT`, `BASE_PROJECT_ROOT`, `BASE_PROJECT_MANIFEST`,
+   `BASE_PROJECT_VENV_DIR`, or `PYTHONPATH`.
 3. Confirm network access to GitHub and Homebrew.
 4. Decide whether this is a clean install, upgrade, or reinstall. For a clean
    install, remove or avoid previous Base shell startup sections and managed
@@ -104,6 +105,31 @@ basectl setup
 basectl update-profile
 exec "$SHELL" -l
 ```
+
+When validating Homebrew Base from a shell that may already be inside a source
+checkout or Base runtime shell, use the Homebrew-managed `basectl` path and
+clear the Base runtime contract. For example, on Intel Homebrew:
+
+```bash
+brew_home=/tmp/base-brew-home
+mkdir -p "$brew_home"
+
+HOME="$brew_home" env -u BASE_HOME \
+  -u BASE_PROJECT \
+  -u BASE_PROJECT_ROOT \
+  -u BASE_PROJECT_MANIFEST \
+  -u BASE_PROJECT_VENV_DIR \
+  /usr/local/bin/basectl setup
+
+HOME="$brew_home" env -u BASE_HOME \
+  -u BASE_PROJECT \
+  -u BASE_PROJECT_ROOT \
+  -u BASE_PROJECT_MANIFEST \
+  -u BASE_PROJECT_VENV_DIR \
+  /usr/local/bin/basectl test base
+```
+
+Use `/opt/homebrew/bin/basectl` for Apple Silicon Homebrew.
 
 Accept the install when:
 

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -58,20 +58,25 @@ base_bashrc_print_stale_base_home_recovery() {
     printf '    "$SHELL" -l\n' >&2
 }
 
+base_bashrc_print_active_runtime_skip() {
+    printf "INFO: This shell is already running Base from '%s'; skipping Base profile snippet for '%s'.\n" "$BASE_HOME" "$1" >&2
+    printf 'INFO: Exit this Base runtime shell before switching to another Base install.\n' >&2
+}
+
 base_bashrc_source_baserc_guard || return $?
 base_baserc_guard_source base_bashrc_debug || return $?
 
 if [[ $- != *i* ]]; then
     base_bashrc_debug "non-interactive shell; skipping"
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
-    unset -f base_bashrc_print_stale_base_home_recovery
+    unset -f base_bashrc_print_stale_base_home_recovery base_bashrc_print_active_runtime_skip
     return 0
 fi
 
 if [[ -n "${__base_bashrc_sourced__:-}" ]]; then
     base_bashrc_debug "already sourced; skipping"
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
-    unset -f base_bashrc_print_stale_base_home_recovery
+    unset -f base_bashrc_print_stale_base_home_recovery base_bashrc_print_active_runtime_skip
     return 0
 fi
 readonly __base_bashrc_sourced__=1
@@ -92,6 +97,10 @@ base_bashrc_set_base_home() {
             return 0
         fi
         if base_bashrc_var_is_readonly BASE_HOME; then
+            if [[ -n "${BASE_SHELL:-}" ]]; then
+                base_bashrc_print_active_runtime_skip "$base_home"
+                return 2
+            fi
             printf "ERROR: BASE_HOME is readonly and points at '%s', not '%s'.\n" "$BASE_HOME" "$base_home" >&2
             base_bashrc_print_stale_base_home_recovery
             return 1
@@ -190,19 +199,34 @@ base_bashrc_source_completions() {
     source "$completion_file"
 }
 
-base_bashrc_set_base_home || {
+base_bashrc_set_base_home
+base_bashrc_status=$?
+if ((base_bashrc_status == 2)); then
+    unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
+    unset -f base_bashrc_print_stale_base_home_recovery base_bashrc_print_active_runtime_skip
+    unset -f base_bashrc_source_platform_tools_helper base_bashrc_configure_path base_bashrc_source_defaults
+    unset -f base_bashrc_source_completions
+    unset -f base_bashrc_set_base_home
+    unset base_bashrc_status
+    return 0
+elif ((base_bashrc_status)); then
     printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
-    unset -f base_bashrc_print_stale_base_home_recovery
+    unset -f base_bashrc_print_stale_base_home_recovery base_bashrc_print_active_runtime_skip
+    unset -f base_bashrc_source_platform_tools_helper base_bashrc_configure_path base_bashrc_source_defaults
+    unset -f base_bashrc_source_completions
+    unset -f base_bashrc_set_base_home
+    unset base_bashrc_status
     return 1
-}
+fi
+unset base_bashrc_status
 base_bashrc_configure_path || return $?
 base_bashrc_source_defaults || return 1
 base_bashrc_source_completions || return 1
 base_bashrc_debug "complete"
 
 unset -f base_bashrc_snippet_dir base_bashrc_var_is_readonly base_bashrc_set_base_home
-unset -f base_bashrc_print_stale_base_home_recovery
+unset -f base_bashrc_print_stale_base_home_recovery base_bashrc_print_active_runtime_skip
 unset -f base_bashrc_source_platform_tools_helper base_bashrc_configure_path base_bashrc_source_defaults
 unset -f base_bashrc_source_completions
 unset -f base_bashrc_source_baserc_guard base_bashrc_debug


### PR DESCRIPTION
## Summary
- Skip mismatched Base profile snippets cleanly when they are sourced inside an already-active Base runtime shell, preserving the active runtime `BASE_HOME`.
- Ignore inherited project runtime variables for `basectl setup base`, so isolated Homebrew validation uses `$HOME/.base.d/base/.venv`.
- Document Homebrew/source validation with an isolated HOME and cleared Base runtime environment.

## Validation
- `git diff --check`
- `bash -n lib/shell/bashrc`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bats cli/bash/commands/basectl/tests/update-profile.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `env -u BASE_HOME -u BASE_PROJECT -u BASE_PROJECT_ROOT -u BASE_PROJECT_MANIFEST -u BASE_PROJECT_VENV_DIR ./bin/base-test`

## Demo Impact
- None.

Closes #811
Closes #812