### PR TITLE
Support configured workspace manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,17 @@ workspace:
   root: ~/work
 ```
 
-Edit that value if your repositories live under a different shared directory.
+Edit `workspace.root` if your repositories live under a different shared
+directory. You may also add an optional workspace manifest:
+
+```yaml
+workspace:
+  root: ~/work
+  manifest: ~/work/base-workspace/workspace.yaml
+```
+
+When `workspace.manifest` is set, workspace commands use it unless
+`--manifest <path>` is supplied for a single command.
 
 After Base is installed, the common development loop is:
 
@@ -431,16 +441,19 @@ validity and whether the Base-managed project virtual environment is present.
 Check and doctor run project diagnostics across discovered projects and keep
 invalid project manifests visible as per-project findings.
 
-Use `--manifest <path>` with `basectl workspace status`, `check`, or `doctor`
-to include expected repositories from a local workspace manifest. Missing
-required repositories are errors, missing optional repositories are warnings,
-and Base-managed projects outside the manifest stay visible as warnings.
+Set `workspace.manifest` in `~/.base.d/config.yaml`, or use `--manifest <path>`
+with `basectl workspace status`, `check`, or `doctor`, to include expected
+repositories from a local workspace manifest. The command-line `--manifest`
+value takes precedence over the configured manifest. Missing required
+repositories are errors, missing optional repositories are warnings, and
+Base-managed projects outside the manifest stay visible as warnings.
 
-Use `basectl workspace clone --manifest <path>` to materialize the missing
-required repositories from that manifest. The command keeps existing
-repositories visible, delegates each repository operation to `basectl repo clone`,
-and supports `--dry-run` for a no-write preview. Optional repositories
-are reported but skipped unless `--include-optional` is supplied.
+Use `basectl workspace clone --manifest <path>`, or configure
+`workspace.manifest`, to materialize the missing required repositories from that
+manifest. The command keeps existing repositories visible, delegates each
+repository operation to `basectl repo clone`, and supports `--dry-run` for a
+no-write preview. Optional repositories are reported but skipped unless
+`--include-optional` is supplied.
 
 Start a new Base-managed repository with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -138,16 +138,17 @@ such command directories exist. Optional utility CLIs such as `caff` and
   when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
   project names and paths.
 - `basectl workspace status` reports a read-only workspace summary across
-  discovered projects, or across expected repositories when `--manifest <path>`
-  is supplied.
+  discovered projects, or across expected repositories when
+  `workspace.manifest` is configured or `--manifest <path>` is supplied.
 - `basectl workspace check` and `basectl workspace doctor` run read-only
-  project checks and diagnostics across discovered projects. With
-  `--manifest <path>`, they also report missing expected repositories and
-  discovered Base-managed projects outside the manifest.
-- `basectl workspace clone --manifest <path>` materializes missing required
-  repositories from a workspace manifest by delegating to `basectl repo clone`.
+  project checks and diagnostics across discovered projects. With a configured
+  workspace manifest or `--manifest <path>`, they also report missing expected
+  repositories and discovered Base-managed projects outside the manifest.
+- `basectl workspace clone` materializes missing required repositories from a
+  configured or explicit workspace manifest by delegating to `basectl repo clone`.
   Optional repositories are reported but skipped unless `--include-optional` is
-  supplied, and `--dry-run` previews the delegated clone work.
+  supplied, `--dry-run` previews the delegated clone work, and explicit
+  `--manifest <path>` takes precedence over `workspace.manifest`.
 - `basectl version` prints the installed Base version from the repo-root `VERSION` file.
 - basectl-specific bootstrap subcommands live under `cli/bash/commands/basectl/subcommands/`.
 - basectl tests live under `cli/bash/commands/basectl/tests/`.

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -11,6 +11,7 @@ Usage:
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
+                      Overrides workspace.manifest from ~/.base.d/config.yaml.
   --format <format>   Output format for the workspace command: text or json.
   --include-optional  Include optional workspace manifest repositories when cloning.
   --dry-run           Show planned workspace clone work without cloning repositories.

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -291,7 +291,7 @@ def workspace_status_command(
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
-        manifest = resolve_workspace_manifest(workspace_manifest)
+        manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, workspace_manifest))
         statuses = workspace_project_statuses(workspace_root, manifest)
     except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
@@ -317,7 +317,7 @@ def workspace_check_command(
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
-        manifest = resolve_workspace_manifest(workspace_manifest)
+        manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, workspace_manifest))
         results = workspace_project_check_results(ctx, workspace_root, manifest)
     except (ProjectDiscoveryError, ManifestError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
@@ -343,7 +343,7 @@ def workspace_doctor_command(
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
-        manifest = resolve_workspace_manifest(workspace_manifest)
+        manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, workspace_manifest))
         results = workspace_project_check_results(ctx, workspace_root, manifest)
     except (ProjectDiscoveryError, ManifestError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
@@ -363,7 +363,7 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCommandOpti
 
     try:
         workspace_root = resolve_workspace_root(ctx, options.workspace)
-        manifest = require_workspace_clone_manifest(options.workspace_manifest)
+        manifest = require_workspace_clone_manifest(ctx, options.workspace_manifest)
     except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
         return 1
@@ -397,10 +397,20 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCommandOpti
     return 0
 
 
-def require_workspace_clone_manifest(workspace_manifest: str | None) -> WorkspaceManifest:
-    if workspace_manifest is None:
+def effective_workspace_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> str | None:
+    if workspace_manifest is not None:
+        return workspace_manifest
+    configured_manifest = ctx.user_config.workspace.manifest
+    if configured_manifest is None:
+        return None
+    return str(configured_manifest)
+
+
+def require_workspace_clone_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> WorkspaceManifest:
+    effective_manifest = effective_workspace_manifest(ctx, workspace_manifest)
+    if effective_manifest is None:
         raise ProjectUsageError("workspace clone requires --manifest <path>.")
-    manifest = resolve_workspace_manifest(workspace_manifest)
+    manifest = resolve_workspace_manifest(effective_manifest)
     if manifest is None:
         raise ProjectUsageError("workspace clone requires --manifest <path>.")
     return manifest

--- a/cli/python/base_projects/tests/test_workspace_clone.py
+++ b/cli/python/base_projects/tests/test_workspace_clone.py
@@ -54,9 +54,18 @@ printf 'fake basectl %s\\n' "$repo"
     basectl.chmod(0o755)
 
 
-def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
+def invoke_engine(
+    args: list[str],
+    base_home: Path,
+    home: Path,
+    user_config: str | None = None,
+) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
+    if user_config is not None:
+        config_path = home / ".base.d" / "config.yaml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(user_config, encoding="utf-8")
     env = {
         "HOME": str(home),
         "BASE_HOME": str(base_home),
@@ -193,6 +202,45 @@ repos:
             )
             self.assertTrue((workspace / "api" / "base_manifest.yaml").is_file())
             self.assertTrue((workspace / "optional-tool" / "base_manifest.yaml").is_file())
+
+    def test_workspace_clone_uses_configured_manifest_when_flag_is_omitted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            state_file = root / "basectl-calls"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_fake_basectl(base_home, state_file)
+            write_workspace_manifest(
+                manifest_path,
+                """
+schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: api
+    url: https://github.com/codeforester/api.git
+""",
+            )
+
+            status, stdout, stderr = invoke_engine(
+                ["clone", "--workspace", str(workspace), "--dry-run"],
+                base_home,
+                home,
+                user_config=f"workspace:\n  manifest: {manifest_path}\n",
+            )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(stderr, "")
+            self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
+            self.assertEqual(
+                state_file.read_text(encoding="utf-8").splitlines(),
+                [f"repo clone codeforester/api --path {(workspace / 'api').resolve()} --dry-run"],
+            )
 
     def test_workspace_clone_requires_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/tests/test_workspace_status_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_status_manifest.py
@@ -43,9 +43,18 @@ def write_workspace_manifest(path: Path) -> None:
     )
 
 
-def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
+def invoke_engine(
+    args: list[str],
+    base_home: Path,
+    home: Path,
+    user_config: str | None = None,
+) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
+    if user_config is not None:
+        config_path = home / ".base.d" / "config.yaml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(user_config, encoding="utf-8")
     env = {
         "HOME": str(home),
         "BASE_HOME": str(base_home),
@@ -143,3 +152,72 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
         self.assertEqual(projects_by_repo["api"]["repo"], "missing")
         self.assertEqual(projects_by_repo["optional-tool"]["status"], "warn")
         self.assertEqual(projects_by_repo["optional-tool"]["required"], False)
+
+    def test_workspace_status_uses_configured_manifest_when_flag_is_omitted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_workspace_manifest(manifest_path)
+
+            status, stdout, stderr = invoke_engine(
+                ["status", "--workspace", str(workspace)],
+                base_home,
+                home,
+                user_config=f"workspace:\n  manifest: {manifest_path}\n",
+            )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
+        self.assertIn("api                  error", stdout)
+
+    def test_workspace_status_manifest_flag_overrides_configured_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            configured_manifest = root / "configured.yaml"
+            cli_manifest = root / "cli.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_workspace_manifest(configured_manifest)
+            cli_manifest.write_text(
+                "\n".join(
+                    [
+                        "schema_version: 1",
+                        "workspace:",
+                        "  name: cli-suite",
+                        "repos:",
+                        "  - name: cli-only",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "status",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(cli_manifest),
+                ],
+                base_home,
+                home,
+                user_config=f"workspace:\n  manifest: {configured_manifest}\n",
+            )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace manifest: {cli_manifest.resolve()} (cli-suite)", stdout)
+        self.assertIn("cli-only             error", stdout)
+        self.assertNotIn("demo-suite", stdout)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -542,9 +542,11 @@ each project's `base_manifest.yaml`: the workspace manifest says which
 repositories should belong together, while project manifests say how each
 repository participates in Base.
 
-Workspace commands operate on discovered local projects by default. Supplying
-`--manifest <path>` adds expected-repository awareness without changing the
-default discovered-project behavior. See [Workspace Manifest](workspace-manifest.md).
+Workspace commands operate on discovered local projects by default. Configuring
+`workspace.manifest` or supplying `--manifest <path>` adds expected-repository
+awareness without changing the default discovered-project behavior. The
+command-line manifest takes precedence over user config. See
+[Workspace Manifest](workspace-manifest.md).
 
 ### Caching project definitions
 
@@ -583,9 +585,10 @@ basectl workspace doctor
 Workspace commands are intentionally read-only. `basectl workspace status`
 reports project manifest state, virtual environment state, and Git state across
 discovered projects, including invalid manifests without stopping the whole
-scan. With `--manifest <path>`, workspace commands also report missing required
-repositories, missing optional repositories, and discovered Base-managed
-projects outside the expected repo set. `basectl workspace check` and
+scan. With `workspace.manifest` or `--manifest <path>`, workspace commands also
+report missing required repositories, missing optional repositories, and
+discovered Base-managed projects outside the expected repo set. `basectl
+workspace check` and
 `basectl workspace doctor` run project checks and diagnostics across discovered
 projects. JSON output is part of the contract so automation and future CI smoke
 checks can use the same data.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -53,10 +53,10 @@ inspect the resolved command contract first.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl workspace status` | Show read-only workspace project status. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
-| `basectl workspace check` | Run read-only checks across workspace projects. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
-| `basectl workspace doctor` | Run read-only diagnostics across workspace projects. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
-| `basectl workspace clone` | Clone or validate expected repositories from a workspace manifest. | `--workspace <path>`, `--manifest <path>`, `--include-optional`, `--dry-run` |
+| `basectl workspace status` | Show read-only workspace project status. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
+| `basectl workspace check` | Run read-only checks across workspace projects. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
+| `basectl workspace doctor` | Run read-only diagnostics across workspace projects. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
+| `basectl workspace clone` | Clone or validate expected repositories from a workspace manifest. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--include-optional`, `--dry-run` |
 
 ## Repository And GitHub Workflow
 

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -84,6 +84,7 @@ needs a workspace scan:
 ```yaml
 workspace:
   root: ~/work
+  manifest: ~/work/base-workspace/workspace.yaml
 ```
 
 Project discovery uses this order:
@@ -102,9 +103,13 @@ edit that value to make commands such as
 `basectl projects list`, `basectl activate <project>`, and
 `basectl test <project>` independent of how Base itself was installed.
 
-`workspace.root` must be an absolute path or start with `~`. Base does not
-create the workspace directory automatically; `basectl config doctor` reports
-whether the configured path exists.
+`workspace.manifest` is optional. When set, `basectl workspace status`,
+`check`, `doctor`, and `clone` use that manifest unless the command supplies
+`--manifest <path>`. The command-line flag always takes precedence.
+
+`workspace.root` and `workspace.manifest` must be absolute paths or start with
+`~`. Base does not create the workspace directory automatically; `basectl config
+doctor` reports whether the configured path exists.
 
 ## GitHub Defaults
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -225,7 +225,7 @@ exec "$SHELL" -l
 
 | Path | Purpose |
 |---|---|
-| `~/.base.d/config.yaml` | Machine-local config (workspace root, log level) |
+| `~/.base.d/config.yaml` | Machine-local config (workspace root, workspace manifest, log level) |
 | `~/.base.d/<project>/.venv` | Per-project Python virtual environment |
 | `~/Library/Caches/base/` | Runtime logs, temp files, project discovery cache |
 | `~/.baserc` | User preferences (e.g., `BASE_DEBUG=1`) |

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -4,10 +4,12 @@ Base uses "workspace" in a precise way: a workspace is a local directory that
 contains sibling repositories. A workspace manifest is an optional local file
 that describes which repositories are expected to belong to that workspace.
 
-Workspace status, check, and doctor commands can use a manifest when the user
-supplies `--manifest <path>`. Without that flag, those commands keep their
-discovered-project behavior. `basectl workspace clone` requires an explicit
-manifest because it uses the manifest as the checkout plan.
+Workspace status, check, doctor, and clone commands can use a manifest when the
+user configures `workspace.manifest` in `~/.base.d/config.yaml` or supplies
+`--manifest <path>`. The command-line flag takes precedence over the configured
+manifest. Without either source, status, check, and doctor keep their
+discovered-project behavior, while `basectl workspace clone` reports that a
+manifest is required.
 
 ## Vocabulary
 
@@ -17,6 +19,7 @@ Base where to scan for repositories:
 ```yaml
 workspace:
   root: ~/work
+  manifest: ~/work/base-workspace/workspace.yaml
 ```
 
 A discovered repository is a direct child of the workspace root. Base scans
@@ -192,7 +195,9 @@ basectl workspace check
 basectl workspace doctor
 ```
 
-With `--manifest`, those commands add expected-repo awareness:
+With `workspace.manifest` configured, those commands add expected-repo
+awareness. `--manifest <path>` does the same for a single command and overrides
+the configured manifest:
 
 ```bash
 basectl workspace status --manifest ~/work/workspace.yaml
@@ -200,17 +205,20 @@ basectl workspace check --manifest ~/work/workspace.yaml
 basectl workspace doctor --manifest ~/work/workspace.yaml
 ```
 
-Without `--manifest`, commands report discovered local projects only.
+Without a configured manifest or `--manifest`, commands report discovered local
+projects only.
 
-With `--manifest`, commands report both expected repositories and discovered
-projects, including missing expected repositories and extra discovered projects.
+With a configured or explicit manifest, commands report both expected
+repositories and discovered projects, including missing expected repositories
+and extra discovered projects.
 
-The explicit clone path requires a manifest:
+The clone path requires a manifest from either config or the command line:
 
 ```bash
 basectl workspace clone --manifest ~/work/workspace.yaml --dry-run
 basectl workspace clone --manifest ~/work/workspace.yaml
 basectl workspace clone --manifest ~/work/workspace.yaml --include-optional
+basectl workspace clone --dry-run
 ```
 
 By default it clones missing required repositories and skips missing optional

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -307,7 +307,8 @@ Command-line standard options are applied after config is loaded. For example,
 
 `ctx.config` exposes the merged raw configuration after user, project,
 explicit, and environment layers are applied. `ctx.user_config` exposes only the
-typed machine-local user config, including `workspace.root` and IDE
+typed machine-local user config, including `workspace.root`,
+`workspace.manifest`, and IDE
 preferences, so command code does not need to re-read `~/.base.d/config.yaml`
 for those structured values.
 

--- a/lib/python/base_cli/config.py
+++ b/lib/python/base_cli/config.py
@@ -29,6 +29,7 @@ class UserIdeConfig:
 @dataclass(frozen=True)
 class UserWorkspaceConfig:
     root: Path | None
+    manifest: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -90,12 +91,15 @@ def _read_user_workspace_config(path: Path, workspace_data: Any) -> UserWorkspac
     if not isinstance(workspace_data, dict):
         raise ValueError(f"{path}: workspace must be a mapping when provided.")
 
-    allowed_keys = {"root"}
+    allowed_keys = {"root", "manifest"}
     unknown_keys = sorted(set(workspace_data) - allowed_keys)
     if unknown_keys:
         raise ValueError(f"{path}: workspace has unsupported keys: {', '.join(unknown_keys)}.")
 
-    return UserWorkspaceConfig(root=_optional_path(path, "workspace.root", workspace_data.get("root")))
+    return UserWorkspaceConfig(
+        root=_optional_path(path, "workspace.root", workspace_data.get("root")),
+        manifest=_optional_path(path, "workspace.manifest", workspace_data.get("manifest")),
+    )
 
 
 def _read_user_github_config(path: Path, github_data: Any) -> UserGithubConfig:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -287,6 +287,29 @@ class BaseCliTests(unittest.TestCase):
 
         self.assertEqual(config.workspace.root, workspace.resolve(strict=False))
 
+    def test_read_user_config_parses_workspace_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            workspace = home / "work"
+            manifest = workspace / "base-workspace" / "workspace.yaml"
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "\n".join(
+                    [
+                        "workspace:",
+                        f"  root: {workspace}",
+                        f"  manifest: {manifest}",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            config = read_user_config(home)
+
+        self.assertEqual(config.workspace.root, workspace.resolve(strict=False))
+        self.assertEqual(config.workspace.manifest, manifest.resolve(strict=False))
+
     def test_read_user_config_rejects_non_mapping_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
@@ -462,6 +485,7 @@ class BaseCliTests(unittest.TestCase):
         @app.command()
         def main(ctx: base_cli.Context) -> None:
             seen["config"] = ctx.config
+            seen["user_config"] = ctx.user_config
             seen["workspace_root"] = ctx.user_config.workspace.root
             seen["ide_enabled"] = ctx.user_config.ide.enabled
             seen["vscode"] = ctx.user_config.ide.preferences["vscode"]
@@ -494,6 +518,7 @@ class BaseCliTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(seen["workspace_root"], workspace.resolve())
+        self.assertIsNone(seen["user_config"].workspace.manifest)
         self.assertTrue(seen["ide_enabled"])
         self.assertFalse(seen["vscode"].install)
         self.assertEqual(seen["vscode"].extra_extensions, ("github.copilot",))


### PR DESCRIPTION
## Summary
- Add workspace.manifest to ~/.base.d/config.yaml parsing.
- Use the configured workspace manifest by default for workspace status/check/doctor/clone when --manifest is omitted.
- Document command-line precedence and the optional config key.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest lib.python.base_cli.tests.test_base_cli lib.python.base_cli.tests.test_user_config_github cli.python.base_projects.tests.test_engine cli.python.base_projects.tests.test_workspace_status_manifest cli.python.base_projects.tests.test_workspace_checks cli.python.base_projects.tests.test_workspace_clone cli.python.base_projects.tests.test_workspace_manifest
- git diff --check
- HOME=/private/tmp/base-home-821 BASE_CACHE_DIR=/private/tmp/base-cache-821 BASE_PROJECT_VENV_DIR=/Users/rameshhp/.base.d/base/.venv ./bin/basectl workspace status
- HOME=/private/tmp/base-home-821 BASE_CACHE_DIR=/private/tmp/base-cache-821 BASE_PROJECT_VENV_DIR=/Users/rameshhp/.base.d/base/.venv ./bin/basectl workspace clone --dry-run
- BASE_CACHE_DIR=/private/tmp/base-cache-821 env -u BASE_HOME ./bin/base-test

Fixes #821