### PR TITLE
Refresh stale product and contributor guidance

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -434,7 +434,7 @@ cli/bash/commands/basectl/
     setup.sh
     check.sh
   tests/
-    basectl.bats
+    help.bats
     setup.bats
 ```
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -246,7 +246,7 @@ Run everything locally with `basectl test base` or `bin/base-test`.
 
 ## Current Status
 
-Base **0.4.4** (June 2026) covers: setup, check, doctor, project discovery,
+Base **1.0.2** (June 2026) covers: setup, check, doctor, project discovery,
 workspace status, project activation (subshell), test execution, build targets,
 named commands, demo scripts, repository baseline creation, guarded GitHub release
 publishing, AI context export, `basectl ci` for non-interactive CI, IDE

--- a/skills.md
+++ b/skills.md
@@ -118,9 +118,11 @@ Use this workflow when adding or changing a `basectl <command>` feature.
 - Validate focused command behavior with:
 
 ```bash
-bats cli/bash/commands/basectl/tests/basectl.bats
+bats cli/bash/commands/basectl/tests/help.bats
 bats cli/bash/commands/basectl/tests/setup.bats
 ```
+
+Swap `setup.bats` for the focused subcommand test file you changed.
 
 ## Add a Bash command
 


### PR DESCRIPTION
## Summary
- Update the technical overview current status from 0.4.4 to 1.0.2.
- Replace stale basectl.bats guidance with existing focused Bats files.
- Clarify the basectl subcommand test example in contributor guidance.

## Validation
- git diff --check origin/master...HEAD
- rg -n "Base \\*\\*0\\.4\\.4\\*\\*|cli/bash/commands/basectl/tests/basectl\\.bats" STANDARDS.md docs/technical-overview.md skills.md
- test -f cli/bash/commands/basectl/tests/help.bats
- test -f cli/bash/commands/basectl/tests/setup.bats

## Demo Impact
- None. Documentation-only change.

Fixes #818