### PR TITLE
Add manifest command lint diagnostics

### DIFF
--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -15,6 +15,8 @@ The current command surface covers:
 - project activation
 - declared project test, build, run, and demo commands, including explicit
   `runner: uv` delegation
+- advisory check/doctor lint warnings for missing manifest command executables
+  and project script paths
 - mise integration
 - explicit uv-managed Python project setup through `python.manager: uv`
 - cleanup and logs

--- a/README.md
+++ b/README.md
@@ -287,7 +287,10 @@ Manifest-declared commands are trusted project code. Base executes
 strings from the project root, so shell metacharacters are honored. Review
 manifests from unfamiliar repositories before running `basectl test`,
 `basectl build`, or `basectl run`; use `--dry-run` and `--list` first when you
-only want to inspect the resolved command contract.
+only want to inspect the resolved command contract. `basectl check <project>`
+and `basectl doctor <project>` include advisory command-lint warnings for
+obvious missing executables or project scripts; those warnings do not make an
+untrusted manifest safe to run.
 
 The optional top-level `brewfile` field points to a Homebrew `Brewfile` relative
 to the project root. When present, `basectl setup` runs

--- a/cli/python/base_setup/command_lint.py
+++ b/cli/python/base_setup/command_lint.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import os
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import process
+from .checks import ArtifactCheck
+from .manifest import BaseManifest
+from .uv import manifest_uses_uv_project_manager
+
+
+SHELL_BUILTINS = {
+    ".",
+    ":",
+    "[",
+    "[[",
+    "!",
+    "case",
+    "cd",
+    "command",
+    "do",
+    "done",
+    "echo",
+    "elif",
+    "else",
+    "esac",
+    "eval",
+    "exec",
+    "export",
+    "false",
+    "fi",
+    "for",
+    "function",
+    "if",
+    "printf",
+    "select",
+    "source",
+    "test",
+    "then",
+    "time",
+    "true",
+    "until",
+    "while",
+}
+
+
+@dataclass(frozen=True)
+class CommandDeclaration:
+    field: str
+    command: str
+    runner: str | None
+    working_dir: str = "."
+
+
+def check_manifest_commands(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+    checks: list[ArtifactCheck] = []
+    for declaration in command_declarations(manifest):
+        check = check_command_declaration(manifest, declaration)
+        if check is not None:
+            checks.append(check)
+    return tuple(checks)
+
+
+def command_declarations(manifest: BaseManifest) -> tuple[CommandDeclaration, ...]:
+    declarations: list[CommandDeclaration] = []
+    if manifest.test is not None and manifest.test.command is not None:
+        declarations.append(CommandDeclaration("test.command", manifest.test.command, manifest.test.runner))
+
+    for command_name, command_config in manifest.commands.items():
+        declarations.append(
+            CommandDeclaration(f"commands.{command_name}.command", command_config.command, command_config.runner)
+        )
+
+    if manifest.build is not None:
+        for target_name, target_config in manifest.build.targets.items():
+            declarations.append(
+                CommandDeclaration(
+                    f"build.targets.{target_name}.command",
+                    target_config.command,
+                    target_config.runner,
+                    target_config.working_dir,
+                )
+            )
+
+    return tuple(declarations)
+
+
+def check_command_declaration(
+    manifest: BaseManifest,
+    declaration: CommandDeclaration,
+) -> ArtifactCheck | None:
+    executable = first_executable(declaration.command)
+    if executable is None or executable in SHELL_BUILTINS or is_dynamic_executable(executable):
+        return None
+
+    if is_path_like_command(executable):
+        if Path(executable).is_absolute():
+            return check_absolute_executable_path(manifest, declaration, executable)
+        return check_project_script_path(manifest, declaration, executable)
+
+    if declaration.runner == "uv":
+        return None
+
+    if command_available(manifest, executable):
+        return None
+
+    return ArtifactCheck(
+        name=declaration.field,
+        ok=False,
+        message=(
+            f"{declaration.field} starts with executable '{executable}', but it was not found on PATH "
+            "or in the project virtual environment."
+        ),
+        fix=(
+            f"Install '{executable}', declare an appropriate runner, "
+            f"or update {declaration.field} in '{manifest.path}'."
+        ),
+        finding_id="BASE-P160",
+        status="warn",
+        details={"executable": executable, "field": declaration.field},
+    )
+
+
+def first_executable(command: str) -> str | None:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+
+    for token in tokens:
+        if is_variable_assignment(token):
+            continue
+        return token
+    return None
+
+
+def is_variable_assignment(token: str) -> bool:
+    if "=" not in token or token.startswith("="):
+        return False
+    name, _value = token.split("=", 1)
+    return name.replace("_", "A").isalnum() and not name[0].isdigit()
+
+
+def is_path_like_command(executable: str) -> bool:
+    return "/" in executable
+
+
+def is_dynamic_executable(executable: str) -> bool:
+    return executable.startswith("~") or any(character in executable for character in "$`*?[]{}")
+
+
+def check_absolute_executable_path(
+    manifest: BaseManifest,
+    declaration: CommandDeclaration,
+    executable: str,
+) -> ArtifactCheck | None:
+    executable_path = Path(executable)
+    if executable_path.is_file() and os.access(executable_path, os.X_OK):
+        return None
+
+    return ArtifactCheck(
+        name=declaration.field,
+        ok=False,
+        message=f"{declaration.field} starts with executable path '{executable}', but it is not executable.",
+        fix=(
+            f"Install or repair '{executable}', declare an appropriate runner, "
+            f"or update {declaration.field} in '{manifest.path}'."
+        ),
+        finding_id="BASE-P160",
+        status="warn",
+        details={"executable": executable, "field": declaration.field},
+    )
+
+
+def check_project_script_path(
+    manifest: BaseManifest,
+    declaration: CommandDeclaration,
+    executable: str,
+) -> ArtifactCheck | None:
+    project_root = manifest.path.parent.resolve()
+    working_dir = resolve_working_dir(project_root, declaration.working_dir)
+    if working_dir is None:
+        return None
+
+    executable_path = Path(executable)
+    resolved_path = executable_path if executable_path.is_absolute() else (working_dir / executable_path).resolve()
+    relative_display = display_path(project_root, resolved_path)
+
+    try:
+        resolved_path.relative_to(project_root)
+    except ValueError:
+        return ArtifactCheck(
+            name=declaration.field,
+            ok=False,
+            message=(
+                f"{declaration.field} references script path '{executable}', "
+                "which resolves outside the project root."
+            ),
+            fix=f"Move the script under the project root or update {declaration.field} in '{manifest.path}'.",
+            finding_id="BASE-P161",
+            status="warn",
+            details={"path": str(resolved_path), "field": declaration.field},
+        )
+
+    if not resolved_path.exists():
+        return ArtifactCheck(
+            name=declaration.field,
+            ok=False,
+            message=f"{declaration.field} references project script '{relative_display}', but it does not exist.",
+            fix=f"Create '{relative_display}' or update {declaration.field} in '{manifest.path}'.",
+            finding_id="BASE-P161",
+            status="warn",
+            details={"path": str(resolved_path), "field": declaration.field},
+        )
+    if not resolved_path.is_file():
+        return ArtifactCheck(
+            name=declaration.field,
+            ok=False,
+            message=f"{declaration.field} references project script '{relative_display}', but it is not a file.",
+            fix=f"Replace '{relative_display}' with a script file or update {declaration.field} in '{manifest.path}'.",
+            finding_id="BASE-P161",
+            status="warn",
+            details={"path": str(resolved_path), "field": declaration.field},
+        )
+    if not os.access(resolved_path, os.X_OK):
+        return ArtifactCheck(
+            name=declaration.field,
+            ok=False,
+            message=f"{declaration.field} references project script '{relative_display}', but it is not executable.",
+            fix=f"Make '{relative_display}' executable or update {declaration.field} in '{manifest.path}'.",
+            finding_id="BASE-P161",
+            status="warn",
+            details={"path": str(resolved_path), "field": declaration.field},
+        )
+    return None
+
+
+def resolve_working_dir(project_root: Path, declared_working_dir: str) -> Path | None:
+    working_dir = Path(declared_working_dir)
+    if working_dir.is_absolute():
+        return None
+
+    resolved = (project_root / working_dir).resolve()
+    try:
+        resolved.relative_to(project_root)
+    except ValueError:
+        return None
+    if not resolved.is_dir():
+        return None
+    return resolved
+
+
+def display_path(project_root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(project_root))
+    except ValueError:
+        return str(path)
+
+
+def command_available(manifest: BaseManifest, executable: str) -> bool:
+    if process.command_exists(executable):
+        return True
+
+    project_root = manifest.path.parent
+    if manifest_uses_uv_project_manager(manifest):
+        venv_bin = project_root / ".venv" / "bin" / executable
+    else:
+        venv_bin = Path.home() / ".base.d" / manifest.project_name / ".venv" / "bin" / executable
+    return venv_bin.is_file() and os.access(venv_bin, os.X_OK)

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -18,6 +18,7 @@ from .checks import check_to_json
 from .checks import checks_payload_to_json
 from .checks import doctor_status
 from .checks import print_doctor_finding
+from .command_lint import check_manifest_commands
 from .demo import check_demo
 from .delegates import check_brewfile
 from .delegates import check_mise
@@ -355,6 +356,7 @@ def manifest_checks(
     checks.extend(check_required_ports(effective_manifest))
     checks.extend(check_build(effective_manifest))
     checks.extend(check_demo(effective_manifest))
+    checks.extend(check_manifest_commands(effective_manifest))
     checks.extend(check_ide_installs(effective_manifest))
     checks.extend(check_ide_extensions(effective_manifest))
     checks.extend(check_ide_settings(effective_manifest))

--- a/cli/python/base_setup/tests/test_command_lint.py
+++ b/cli/python/base_setup/tests/test_command_lint.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+from base_setup import engine
+from base_setup.checks import doctor_status
+from base_setup.manifest import BaseManifest
+from base_setup.manifest import BuildConfig
+from base_setup.manifest import BuildTargetConfig
+from base_setup.manifest import CommandConfig
+from base_setup.manifest import TestConfig as ManifestTestConfig
+from base_setup.tests.helpers import fake_context
+
+
+def default_manifest(path: Path) -> BaseManifest:
+    return BaseManifest(
+        path=path,
+        project_name="base-defaults",
+        brewfile=None,
+        artifacts=(),
+    )
+
+
+class CommandLintDiagnosticsTests(unittest.TestCase):
+    def test_manifest_checks_warn_for_missing_test_command_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                test=ManifestTestConfig(command="base-missing-tool-817 --flag"),
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        lint_checks = [check for check in checks if check.finding_id == "BASE-P160"]
+        self.assertEqual(len(lint_checks), 1)
+        self.assertEqual(lint_checks[0].status, "warn")
+        self.assertEqual(doctor_status(lint_checks[0]), "warn")
+        self.assertEqual(lint_checks[0].name, "test.command")
+        self.assertIn("base-missing-tool-817", lint_checks[0].message)
+
+    def test_manifest_checks_warn_for_missing_project_script_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                commands={
+                    "audit": CommandConfig(command="./scripts/audit.sh --strict"),
+                },
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        lint_checks = [check for check in checks if check.finding_id == "BASE-P161"]
+        self.assertEqual(len(lint_checks), 1)
+        self.assertEqual(lint_checks[0].status, "warn")
+        self.assertEqual(lint_checks[0].name, "commands.audit.command")
+        self.assertIn("scripts/audit.sh", lint_checks[0].message)
+        self.assertIn("Create", lint_checks[0].fix)
+
+    def test_manifest_checks_warn_for_missing_build_target_script_from_working_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "services" / "api").mkdir(parents=True)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                build=BuildConfig(
+                    default=("api",),
+                    targets={
+                        "api": BuildTargetConfig(
+                            command="./build.sh",
+                            working_dir="services/api",
+                        ),
+                    },
+                ),
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        lint_checks = [check for check in checks if check.finding_id == "BASE-P161"]
+        self.assertEqual(len(lint_checks), 1)
+        self.assertEqual(lint_checks[0].status, "warn")
+        self.assertEqual(lint_checks[0].name, "build.targets.api.command")
+        self.assertIn("services/api/build.sh", lint_checks[0].message)
+
+    def test_command_lint_warnings_do_not_fail_check_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                test=ManifestTestConfig(command="base-missing-tool-817 | cat"),
+            )
+            stdout = StringIO()
+
+            with redirect_stdout(stdout):
+                status = engine.check_manifest(
+                    fake_context(),
+                    default_manifest(project_root / "default.yaml"),
+                    manifest,
+                    output_format="json",
+                )
+
+        payload = json.loads(stdout.getvalue())
+        lint_checks = [check for check in payload["checks"] if check["id"] == "BASE-P160"]
+        self.assertEqual(status, 0)
+        self.assertEqual(payload["status"], "warn")
+        self.assertEqual(len(lint_checks), 1)
+        self.assertEqual(lint_checks[0]["status"], "warn")
+
+    def test_doctor_json_reports_command_lint_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                commands={
+                    "audit": CommandConfig(command="base-missing-tool-817"),
+                },
+            )
+            stdout = StringIO()
+
+            with redirect_stdout(stdout):
+                status = engine.doctor_manifest(
+                    default_manifest(project_root / "default.yaml"),
+                    manifest,
+                    output_format="json",
+                )
+
+        findings = json.loads(stdout.getvalue())
+        lint_findings = [finding for finding in findings if finding["id"] == "BASE-P160"]
+        self.assertEqual(status, 0)
+        self.assertEqual(len(lint_findings), 1)
+        self.assertEqual(lint_findings[0]["status"], "warn")
+
+    def test_complex_shell_expansion_in_first_token_is_not_warned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                test=ManifestTestConfig(command="$PROJECT_TEST_RUNNER tests"),
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        self.assertNotIn("BASE-P160", [check.finding_id for check in checks])
+        self.assertNotIn("BASE-P161", [check.finding_id for check in checks])
+
+    def test_compound_shell_command_is_not_warned_as_missing_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                test=ManifestTestConfig(command="if command -v pytest; then pytest; fi"),
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        self.assertNotIn("BASE-P160", [check.finding_id for check in checks])
+        self.assertNotIn("BASE-P161", [check.finding_id for check in checks])
+
+    def test_absolute_executable_path_outside_project_root_is_allowed_when_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            project_root = root / "project"
+            project_root.mkdir()
+            tool = root / "tools" / "audit"
+            tool.parent.mkdir()
+            tool.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            tool.chmod(0o755)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                commands={"audit": CommandConfig(command=f"{tool} --strict")},
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        self.assertNotIn("BASE-P160", [check.finding_id for check in checks])
+        self.assertNotIn("BASE-P161", [check.finding_id for check in checks])
+
+    def test_absolute_executable_path_warns_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            project_root = root / "project"
+            project_root.mkdir()
+            missing_tool = root / "missing" / "audit"
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                commands={"audit": CommandConfig(command=f"{missing_tool} --strict")},
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        lint_checks = [check for check in checks if check.finding_id == "BASE-P160"]
+        self.assertEqual(len(lint_checks), 1)
+        self.assertEqual(lint_checks[0].name, "commands.audit.command")
+
+    def test_uv_runner_uses_uv_diagnostic_without_command_executable_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                commands={
+                    "audit": CommandConfig(command="pytest tests/audit", runner="uv"),
+                },
+            )
+
+            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+                checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        self.assertIn("BASE-P150", [check.finding_id for check in checks])
+        self.assertNotIn("BASE-P160", [check.finding_id for check in checks])
+
+    def test_uv_runner_still_warns_for_missing_project_script(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                commands={
+                    "audit": CommandConfig(command="./scripts/audit.sh --strict", runner="uv"),
+                },
+            )
+
+            checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        findings = [check.finding_id for check in checks]
+        self.assertIn("BASE-P161", findings)
+        self.assertNotIn("BASE-P160", findings)
+
+    def test_project_venv_command_executable_does_not_warn_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            home = Path(tmpdir) / "home"
+            pytest_bin = home / ".base.d" / "demo" / ".venv" / "bin" / "pytest"
+            pytest_bin.parent.mkdir(parents=True)
+            pytest_bin.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            pytest_bin.chmod(0o755)
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                test=ManifestTestConfig(command="pytest tests"),
+            )
+
+            with mock.patch.dict("os.environ", {"HOME": str(home)}), mock.patch(
+                "base_setup.process.command_exists",
+                return_value=False,
+            ):
+                checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
+
+        self.assertNotIn("BASE-P160", [check.finding_id for check in checks])

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -134,6 +134,8 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P151` | uv-managed project `pyproject.toml` presence |
 | `BASE-P152` | uv-managed project `uv.lock` presence |
 | `BASE-P153` | Stale Base-managed project virtual environment ignored by a uv-managed project |
+| `BASE-P160` | Manifest command executable availability |
+| `BASE-P161` | Manifest command project script path readiness |
 
 `BASE-P050` is the stable project virtual-environment readiness finding. The
 Bash setup/check path reports detailed venv health messages when a project venv
@@ -154,6 +156,13 @@ when uv tooling or expected uv project files are missing, because check/doctor
 should explain readiness without performing dependency resolution. Command
 invocation still fails hard when a command declares `runner: uv` and the `uv`
 executable is unavailable.
+
+`BASE-P160` and `BASE-P161` are advisory manifest command-lint diagnostics for
+`test.command`, `commands.*.command`, and `build.targets.*.command`. They look
+for obvious missing executables or missing/non-executable project script paths
+without executing command strings or treating the manifest as safe. They should
+not reject complex shell syntax or replace human review of unfamiliar
+repositories.
 
 `BASE-P080` through `BASE-P083` are read-only project Git remote diagnostics.
 They report whether the project directory is inside a Git repository, whether

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -134,9 +134,15 @@ uv support adds these project diagnostics:
 - `BASE-P152`: uv-managed project `uv.lock` presence
 - `BASE-P153`: stale Base-managed project virtual environment ignored by a
   uv-managed project
+- `BASE-P160`: manifest command starts with an executable that is not available
+  on PATH or in the project virtual environment
+- `BASE-P161`: manifest command references a project script path that is
+  missing, outside the project root, not a file, or not executable
 
 These diagnostics are warning-oriented in `check` and `doctor`; they explain
-readiness without performing dependency resolution.
+readiness without performing dependency resolution or executing project command
+strings. Command linting is advisory and does not replace reviewing manifests
+from unfamiliar repositories before running their declared commands.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary
- Add advisory manifest command lint diagnostics for missing command executables and project script paths.
- Surface the warnings through existing `check` and `doctor` text/JSON flows with stable finding IDs `BASE-P160` and `BASE-P161`.
- Document the advisory trust boundary and update AI context for the new diagnostic behavior.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_command_lint.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_demo.py -q`
- `BASE_CACHE_DIR=/private/tmp/base-817-cache env -u BASE_HOME ./bin/base-test`
- `git diff --check`

## Demo Impact
- None. Diagnostic behavior only.

## AI Context
- Updated `.ai-context/STATUS.md` for advisory manifest command lint diagnostics.

Closes #817
