### PR TITLE
Record workspace project check timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,10 @@ Use `--workspace <path>` to inspect a different workspace root for one command.
 Project list output is tab-separated as `<project-name><TAB><path>`. Use
 `--format json` for machine-readable output. Workspace status, check, and
 doctor are read-only. Status reports each discovered project's manifest
-validity and whether the Base-managed project virtual environment is present.
+validity, whether the Base-managed project virtual environment is present, and
+the latest recorded `basectl check <project>` date when one exists. Check
+records live under `~/.base.d/<project>/checks/last.json`; status JSON includes
+the full timestamp and recorded check status.
 Check and doctor run project diagnostics across discovered projects and keep
 invalid project manifests visible as per-project findings.
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -139,7 +139,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   project names and paths.
 - `basectl workspace status` reports a read-only workspace summary across
   discovered projects, or across expected repositories when
-  `workspace.manifest` is configured or `--manifest <path>` is supplied.
+  `workspace.manifest` is configured or `--manifest <path>` is supplied. When
+  `basectl check <project>` has run, status reports the latest recorded project
+  check date from `~/.base.d/<project>/checks/last.json`.
 - `basectl workspace check` and `basectl workspace doctor` run read-only
   project checks and diagnostics across discovered projects. With a configured
   workspace manifest or `--manifest <path>`, they also report missing expected

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -41,6 +41,7 @@ Check does:
   4. Verify ~/.base.d/base/.venv is healthy.
   5. Verify prerequisite profiles when --profile is passed.
   6. Verify project manifest artifacts when a project name is passed.
+  7. Record the latest project check result under ~/.base.d/<project>/checks/last.json.
 EOF
 }
 

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -783,6 +783,47 @@ setup_project_venv_dir() {
     printf '%s\n' "$HOME/.base.d/$project/.venv"
 }
 
+setup_project_check_record_path() {
+    local project="$1"
+
+    printf '%s\n' "$HOME/.base.d/$project/checks/last.json"
+}
+
+setup_record_project_check_result() {
+    local checked_at path project="$1" status="$2" temp_file
+
+    [[ -n "$project" ]] || return 0
+    case "$status" in
+        ok|warn|error)
+            ;;
+        *)
+            status=error
+            ;;
+    esac
+
+    path="$(setup_project_check_record_path "$project")"
+    safe_mkdir -p "$(dirname "$path")" || return 0
+    temp_file="$path.$$"
+    checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 0
+
+    {
+        printf '{\n'
+        printf '  "schema_version": 1,\n'
+        printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
+        printf '  "command": "basectl check",\n'
+        printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
+        printf '  "checked_at": "%s"\n' "$(setup_json_escape "$checked_at")"
+        printf '}\n'
+    } >"$temp_file" || {
+        rm -f -- "$temp_file"
+        return 0
+    }
+    mv -- "$temp_file" "$path" || {
+        rm -f -- "$temp_file"
+        return 0
+    }
+}
+
 setup_user_config_path() {
     printf '%s\n' "$HOME/.base.d/config.yaml"
 }
@@ -1708,6 +1749,7 @@ setup_run_check() {
     fi
 
     if ((missing == 0)); then
+        setup_record_project_check_result "$project" ok
         if [[ -n "$project" ]]; then
             log_info "Base CLI environment and project '$project' check passed."
         else
@@ -1716,6 +1758,7 @@ setup_run_check() {
         return 0
     fi
 
+    setup_record_project_check_result "$project" error
     if [[ -n "$project" ]]; then
         log_warn "Base CLI environment or project '$project' check found missing requirements."
         log_warn "Run 'basectl setup $project' to reconcile the missing requirements."
@@ -1925,6 +1968,8 @@ setup_run_check_json() {
         project_status="$(setup_json_payload_status "$project_json")"
         status="$(setup_merge_diagnostic_status "$status" "$project_status")"
     fi
+
+    setup_record_project_check_result "$project" "$status"
 
     printf '{\n'
     printf '  "schema_version": 1,\n'

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -229,6 +229,59 @@ load ./setup_helpers.bash
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format text demo)" ]
 }
 
+@test "basectl check project records last check status" {
+    local record_path="$TEST_HOME/.base.d/demo/checks/last.json"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$TEST_HOME/.base.d/demo/.venv"
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
+
+    [ "$status" -eq 0 ]
+    [ -f "$record_path" ]
+    grep -Fq '"schema_version": 1' "$record_path"
+    grep -Fq '"project": "demo"' "$record_path"
+    grep -Fq '"command": "basectl check"' "$record_path"
+    grep -Fq '"status": "ok"' "$record_path"
+    grep -Eq '"checked_at": "20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"' "$record_path"
+}
+
+@test "basectl check project records failed checks with error status" {
+    local record_path="$TEST_HOME/.base.d/demo/checks/last.json"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
+
+    [ "$status" -eq 1 ]
+    [ -f "$record_path" ]
+    grep -Fq '"project": "demo"' "$record_path"
+    grep -Fq '"command": "basectl check"' "$record_path"
+    grep -Fq '"status": "error"' "$record_path"
+    ! grep -Fq '"status": "ok"' "$record_path"
+    [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/demo/.venv'."* ]]
+}
+
 @test "basectl check project passes opt-in remote network diagnostics flag" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -22,6 +22,23 @@ def write_manifest(project_root: Path, name: str) -> None:
     )
 
 
+def write_last_check(home: Path, project: str, checked_at: str, status: str = "ok") -> None:
+    record_path = home / ".base.d" / project / "checks" / "last.json"
+    record_path.parent.mkdir(parents=True)
+    record_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "project": project,
+                "command": "basectl check",
+                "status": status,
+                "checked_at": checked_at,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def write_test_manifest(project_root: Path, name: str, command: str) -> None:
     project_root.mkdir(parents=True)
     (project_root / "base_manifest.yaml").write_text(
@@ -266,14 +283,15 @@ class ProjectDiscoveryTests(unittest.TestCase):
             python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
             python_bin.parent.mkdir(parents=True)
             python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_last_check(home, "base", "2026-06-17T14:30:00Z")
 
             status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertIn(f"Workspace: {workspace.resolve()} (2 projects)", stdout)
-        self.assertIn("base                 ok     ready    valid", stdout)
-        self.assertIn("demo                 warn   missing  valid", stdout)
+        self.assertIn("base                 ok     ready    valid    2026-06-17", stdout)
+        self.assertIn("demo                 warn   missing  valid    -", stdout)
         self.assertIn("1 project(s) need attention", stdout)
 
     def test_workspace_status_supports_json_format(self) -> None:
@@ -285,6 +303,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             home.mkdir()
             base_home.mkdir()
             write_manifest(workspace / "demo", "demo")
+            write_last_check(home, "demo", "2026-06-17T14:30:00Z", status="error")
 
             status, stdout, stderr = invoke_engine(
                 ["status", "--workspace", str(workspace), "--format", "json"],
@@ -303,6 +322,13 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(payload["projects"][0]["status"], "warn")
         self.assertEqual(payload["projects"][0]["venv"], "missing")
         self.assertEqual(payload["projects"][0]["manifest"], "valid")
+        self.assertEqual(
+            payload["projects"][0]["last_check"],
+            {
+                "checked_at": "2026-06-17T14:30:00Z",
+                "status": "error",
+            },
+        )
         self.assertIn("project virtual environment missing", payload["projects"][0]["issues"][0])
 
     def test_workspace_status_reports_invalid_manifest_without_stopping_scan(self) -> None:

--- a/cli/python/base_projects/tests/test_workspace_status_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_status_manifest.py
@@ -20,6 +20,23 @@ def write_manifest(project_root: Path, name: str) -> None:
     )
 
 
+def write_last_check(home: Path, project: str, checked_at: str, status: str = "ok") -> None:
+    record_path = home / ".base.d" / project / "checks" / "last.json"
+    record_path.parent.mkdir(parents=True)
+    record_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "project": project,
+                "command": "basectl check",
+                "status": status,
+                "checked_at": checked_at,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def write_workspace_manifest(path: Path) -> None:
     path.write_text(
         "\n".join(
@@ -84,6 +101,7 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
             python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
             python_bin.parent.mkdir(parents=True)
             python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_last_check(home, "base", "2026-06-17T14:30:00Z")
 
             status, stdout, stderr = invoke_engine(
                 ["status", "--workspace", str(workspace), "--manifest", str(manifest_path)],
@@ -95,7 +113,7 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn(f"Workspace: {workspace.resolve()} (5 repositories)", stdout)
         self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
-        self.assertIn("base                 ok", stdout)
+        self.assertIn("base                 ok     yes      present  ready          valid    2026-06-17", stdout)
         self.assertIn("docs                 ok", stdout)
         self.assertIn("api                  error", stdout)
         self.assertIn("optional-tool        warn", stdout)
@@ -117,6 +135,7 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
             python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
             python_bin.parent.mkdir(parents=True)
             python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_last_check(home, "base", "2026-06-17T14:30:00Z")
 
             status, stdout, stderr = invoke_engine(
                 [
@@ -146,6 +165,13 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
         self.assertEqual(projects_by_repo["base"]["required"], True)
         self.assertEqual(projects_by_repo["base"]["repo"], "present")
         self.assertEqual(projects_by_repo["base"]["url"], "git@github.com:codeforester/base.git")
+        self.assertEqual(
+            projects_by_repo["base"]["last_check"],
+            {
+                "checked_at": "2026-06-17T14:30:00Z",
+                "status": "ok",
+            },
+        )
         self.assertEqual(projects_by_repo["docs"]["manifest"], "missing")
         self.assertEqual(projects_by_repo["docs"]["venv"], "not_applicable")
         self.assertEqual(projects_by_repo["api"]["status"], "error")

--- a/cli/python/base_projects/workspace_reports.py
+++ b/cli/python/base_projects/workspace_reports.py
@@ -35,6 +35,12 @@ class ManifestEntry:
 
 
 @dataclass(frozen=True)
+class ProjectLastCheck:
+    checked_at: str
+    status: str
+
+
+@dataclass(frozen=True)
 class WorkspaceProjectStatus:
     name: str
     root: Path
@@ -43,6 +49,7 @@ class WorkspaceProjectStatus:
     venv: str
     manifest: str
     issues: tuple[str, ...]
+    last_check: ProjectLastCheck | None = None
     expected: bool = False
     required: bool = False
     repo: str = "present"
@@ -111,6 +118,7 @@ def workspace_expected_repo_status(
     if entry is not None:
         status = workspace_project_status(entry)
         return attach_status_repo_metadata(status, repo)
+    last_check = project_last_check(repo.name)
     if root.exists():
         return WorkspaceProjectStatus(
             name=repo.name,
@@ -120,6 +128,7 @@ def workspace_expected_repo_status(
             venv="not_applicable",
             manifest="missing",
             issues=(),
+            last_check=last_check,
             expected=True,
             required=repo.required,
             repo="present",
@@ -136,6 +145,7 @@ def workspace_expected_repo_status(
         venv="unknown",
         manifest="unknown",
         issues=(missing_repo_message(repo, root),),
+        last_check=last_check,
         expected=True,
         required=repo.required,
         repo="missing",
@@ -186,8 +196,10 @@ def workspace_project_status(entry: ManifestEntry) -> WorkspaceProjectStatus:
             venv="unknown",
             manifest="invalid",
             issues=(str(exc),),
+            last_check=project_last_check(root.name),
         )
 
+    last_check = project_last_check(manifest.project_name)
     venv_dir = project_venv_dir(manifest.project_name)
     if project_venv_ready(venv_dir):
         return WorkspaceProjectStatus(
@@ -198,6 +210,7 @@ def workspace_project_status(entry: ManifestEntry) -> WorkspaceProjectStatus:
             venv="ready",
             manifest="valid",
             issues=(),
+            last_check=last_check,
         )
 
     return WorkspaceProjectStatus(
@@ -208,6 +221,7 @@ def workspace_project_status(entry: ManifestEntry) -> WorkspaceProjectStatus:
         venv="missing",
         manifest="valid",
         issues=(f"project virtual environment missing at {venv_dir}",),
+        last_check=last_check,
     )
 
 
@@ -217,6 +231,25 @@ def project_venv_dir(project_name: str) -> Path:
 
 def project_venv_ready(venv_dir: Path) -> bool:
     return (venv_dir / "bin" / "python").is_file()
+
+
+def project_last_check(project_name: str) -> ProjectLastCheck | None:
+    record_path = base_state_root() / project_name / "checks" / "last.json"
+    try:
+        payload = json.loads(record_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if payload.get("schema_version") != 1:
+        return None
+    if payload.get("project") != project_name:
+        return None
+
+    checked_at = payload.get("checked_at")
+    status = payload.get("status")
+    if not isinstance(checked_at, str) or not isinstance(status, str):
+        return None
+    return ProjectLastCheck(checked_at=checked_at, status=status)
 
 
 def workspace_project_check_results(
@@ -524,6 +557,7 @@ def workspace_status_item_to_json(
         "manifest_path": str(status.manifest_path) if status.manifest_path is not None else None,
         "venv": status.venv,
         "manifest": status.manifest,
+        "last_check": last_check_to_json(status.last_check),
         "issues": list(status.issues),
     }
     if workspace_manifest is not None:
@@ -624,6 +658,23 @@ def workspace_check_item_to_json(check: ArtifactCheck) -> dict[str, Any]:
     return check_to_json(check)
 
 
+def last_check_to_json(last_check: ProjectLastCheck | None) -> dict[str, str] | None:
+    if last_check is None:
+        return None
+    return {
+        "checked_at": last_check.checked_at,
+        "status": last_check.status,
+    }
+
+
+def last_check_display(last_check: ProjectLastCheck | None) -> str:
+    if last_check is None:
+        return "-"
+    if len(last_check.checked_at) >= 10:
+        return last_check.checked_at[:10]
+    return last_check.checked_at
+
+
 def print_workspace_status(
     workspace_root: Path,
     statuses: tuple[WorkspaceProjectStatus, ...],
@@ -646,7 +697,7 @@ def print_workspace_status(
             f"{status.status:<6} "
             f"{status.venv:<8} "
             f"{status.manifest:<8} "
-            f"{'-':<10} "
+            f"{last_check_display(status.last_check):<10} "
             f"{status.root}"
         )
 
@@ -669,7 +720,10 @@ def print_manifest_workspace_status(
         print("No repositories reported by the workspace manifest.")
         return
 
-    print(f"{'REPOSITORY':<20} {'STATUS':<6} {'REQUIRED':<8} {'REPO':<8} {'VENV':<14} {'MANIFEST':<8} PATH")
+    print(
+        f"{'REPOSITORY':<20} {'STATUS':<6} {'REQUIRED':<8} {'REPO':<8} "
+        f"{'VENV':<14} {'MANIFEST':<8} {'LAST CHECK':<10} PATH"
+    )
     for status in statuses:
         print(
             f"{status.repository or status.root.name:<20} "
@@ -678,6 +732,7 @@ def print_manifest_workspace_status(
             f"{status.repo:<8} "
             f"{status.venv:<14} "
             f"{status.manifest:<8} "
+            f"{last_check_display(status.last_check):<10} "
             f"{status.root}"
         )
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -35,7 +35,7 @@ inspect the resolved command contract first.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl check [project]` | Verify Base and optional project readiness without making changes. | `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
+| `basectl check [project]` | Verify Base and optional project readiness without making changes. Project checks record the latest result under `~/.base.d/<project>/checks/last.json`. | `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
 | `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
 | `basectl ci setup <project>` | Run setup in non-interactive CI mode. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv` |
 | `basectl ci check <project>` | Run readiness checks in non-interactive CI mode. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>` |
@@ -53,7 +53,7 @@ inspect the resolved command contract first.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl workspace status` | Show read-only workspace project status. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
+| `basectl workspace status` | Show read-only workspace project status and latest recorded project check dates. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
 | `basectl workspace check` | Run read-only checks across workspace projects. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
 | `basectl workspace doctor` | Run read-only diagnostics across workspace projects. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|json>` |
 | `basectl workspace clone` | Clone or validate expected repositories from a workspace manifest. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--include-optional`, `--dry-run` |

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -227,6 +227,7 @@ exec "$SHELL" -l
 |---|---|
 | `~/.base.d/config.yaml` | Machine-local config (workspace root, workspace manifest, log level) |
 | `~/.base.d/<project>/.venv` | Per-project Python virtual environment |
+| `~/.base.d/<project>/checks/last.json` | Latest recorded `basectl check <project>` result used by workspace status |
 | `~/Library/Caches/base/` | Runtime logs, temp files, project discovery cache |
 | `~/.baserc` | User preferences (e.g., `BASE_DEBUG=1`) |
 | `~/.base.d/profile.conf` | Shell defaults opt-in state |

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -51,6 +51,12 @@ basectl workspace check
 basectl workspace doctor
 ```
 
+`basectl workspace status` reads the latest project check record from
+`~/.base.d/<project>/checks/last.json` when it exists. Text output shows the
+check date in the `LAST CHECK` column, while JSON output includes the full
+timestamp and check status. Projects without a recorded check show `-` in text
+output and `null` in JSON output.
+
 With `--manifest <path>`, the same commands also report expected repositories,
 missing required and optional repositories, and discovered Base-managed
 projects outside the manifest.


### PR DESCRIPTION
## Summary
- Record `basectl check <project>` results under `~/.base.d/<project>/checks/last.json`.
- Show the recorded date in `basectl workspace status` text output and expose the full record in status JSON.
- Document the state file and add regression coverage for successful and failed project checks.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_engine cli.python.base_projects.tests.test_workspace_status_manifest cli.python.base_projects.tests.test_workspace_checks cli.python.base_projects.tests.test_workspace_manifest cli.python.base_projects.tests.test_workspace_clone
- bats cli/bash/commands/basectl/tests/check.bats
- git diff --check
- BASE_CACHE_DIR=/private/tmp/base-cache-826 env -u BASE_HOME ./bin/base-test

## Demo Impact
- None.

## AI Context
- Not applicable.

Closes #826