### PR TITLE
Resolve reusable Bash libs from base-bash-libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Changed
+
+- Made Base resolve reusable Bash libraries from an external `base-bash-libs`
+  checkout or Homebrew package when available, while keeping the bundled
+  `lib/bash` tree as a fallback.
+
 ## [1.0.3] - 2026-06-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1138,7 +1138,8 @@ a second `.bashrc` with arbitrary setup logic. See
 contract and mutability policy.
 
 `~/.baserc` must not set Base-owned runtime or profile variables such as
-`BASE_HOME`, `BASE_BIN_DIR`, `BASE_LIB_DIR`, `BASE_OS`, `BASE_SHELL`,
+`BASE_HOME`, `BASE_BIN_DIR`, `BASE_LIB_DIR`, `BASE_BASH_LIBS_DIR`, `BASE_OS`,
+`BASE_SHELL`,
 `BASE_PLATFORM_TOOLS_HOME`, `BASE_PLATFORM_TOOLS_BIN_DIR`,
 `BASE_PROFILE_VERSION`, `BASE_ENABLE_BASH_DEFAULTS`, or
 `BASE_ENABLE_ZSH_DEFAULTS`. Base startup snippets reject and restore those

--- a/base_init.sh
+++ b/base_init.sh
@@ -17,7 +17,7 @@
 #     - derive or validate BASE_HOME
 #     - export the BASE_* paths that downstream scripts may rely on
 #     - export BASE_OS and BASE_HOST runtime metadata
-#     - source Base's Bash standard library
+#     - resolve and source the reusable Bash standard library
 #     - add BASE_BIN_DIR to PATH
 #     - provide import_base_lib for convention-based Base Bash library imports
 #
@@ -26,8 +26,11 @@
 #
 #     import_base_lib file/lib_file.sh
 #
-# import_base_lib reports missing or invalid libraries through Base stdlib error
-# handling and fails immediately, so callers do not need duplicate checks.
+# import_base_lib prefers reusable libraries from base-bash-libs when available
+# and falls back to Base's bundled lib/bash tree for compatibility and
+# Base-specific runtime/version helpers. It reports missing or invalid libraries
+# through Base stdlib error handling and fails immediately, so callers do not
+# need duplicate checks.
 #
 
 [[ -n "${__base_init_sourced__:-}" ]] && return 0
@@ -91,6 +94,56 @@ base_init_resolve_home() {
     printf '%s\n' "$source_dir"
 }
 
+base_init_homebrew_prefix() {
+    case "$BASE_HOME" in
+        */opt/base/libexec)
+            printf '%s\n' "${BASE_HOME%/opt/base/libexec}"
+            ;;
+        */Cellar/base/*/libexec)
+            printf '%s\n' "${BASE_HOME%%/Cellar/base/*}"
+            ;;
+    esac
+}
+
+base_init_bash_libs_dir_is_usable() {
+    local candidate="${1:-}"
+
+    [[ -n "$candidate" ]] || return 1
+    [[ -f "$candidate/std/lib_std.sh" ]]
+}
+
+base_init_resolve_bash_libs_dir() {
+    local candidate
+    local homebrew_prefix
+    local explicit_dir="${BASE_BASH_LIBS_DIR:-}"
+
+    if [[ -n "$explicit_dir" ]]; then
+        base_init_bash_libs_dir_is_usable "$explicit_dir" || {
+            base_init_error "BASE_BASH_LIBS_DIR '$explicit_dir' does not contain std/lib_std.sh."
+            return 1
+        }
+        (cd -L -- "$explicit_dir" && pwd -L)
+        return $?
+    fi
+
+    candidate="$BASE_HOME/../base-bash-libs/lib/bash"
+    if base_init_bash_libs_dir_is_usable "$candidate"; then
+        (cd -L -- "$candidate" && pwd -L)
+        return $?
+    fi
+
+    homebrew_prefix="$(base_init_homebrew_prefix || true)"
+    if [[ -n "$homebrew_prefix" ]]; then
+        candidate="$homebrew_prefix/opt/base-bash-libs/libexec/lib/bash"
+        if base_init_bash_libs_dir_is_usable "$candidate"; then
+            (cd -L -- "$candidate" && pwd -L)
+            return $?
+        fi
+    fi
+
+    printf '%s\n' "$BASE_BASH_LIB_DIR"
+}
+
 base_init_export_contract() {
     local base_home base_os base_host uname_os
 
@@ -130,18 +183,19 @@ base_init_export_contract() {
     BASE_BASH_COMMANDS_DIR="$BASE_BASH_DIR/commands"
     BASE_LIB_DIR="$BASE_HOME/lib"
     BASE_BASH_LIB_DIR="$BASE_LIB_DIR/bash"
+    BASE_BASH_LIBS_DIR="$(base_init_resolve_bash_libs_dir)" || return 1
     BASE_SHELL_DIR="$BASE_LIB_DIR/shell"
     BASE_OS="$base_os"
     BASE_HOST="$base_host"
     BASE_SHELL="${BASE_SHELL:-bash}"
     export BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_BASH_DIR BASE_BASH_COMMANDS_DIR
-    export BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_HOST BASE_SHELL
+    export BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_BASH_LIBS_DIR BASE_SHELL_DIR BASE_OS BASE_HOST BASE_SHELL
     readonly BASE_HOME BASE_BIN_DIR BASE_CLI_DIR BASE_BASH_DIR BASE_BASH_COMMANDS_DIR
-    readonly BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_SHELL_DIR BASE_OS BASE_HOST BASE_SHELL
+    readonly BASE_LIB_DIR BASE_BASH_LIB_DIR BASE_BASH_LIBS_DIR BASE_SHELL_DIR BASE_OS BASE_HOST BASE_SHELL
 }
 
 base_init_source_stdlib() {
-    local stdlib_path="$BASE_BASH_LIB_DIR/std/lib_std.sh"
+    local stdlib_path="$BASE_BASH_LIBS_DIR/std/lib_std.sh"
 
     [[ -f "$stdlib_path" ]] || {
         base_init_error "Base Bash stdlib '$stdlib_path' was not found."
@@ -157,7 +211,7 @@ import_base_lib() {
     local lib_path
 
     [[ -n "$relative_path" ]] || fatal_error "import_base_lib: no library path provided."
-    [[ "$relative_path" != /* ]] || fatal_error "import_base_lib: expected a path relative to '$BASE_BASH_LIB_DIR', got '$relative_path'."
+    [[ "$relative_path" != /* ]] || fatal_error "import_base_lib: expected a path relative to '$BASE_BASH_LIBS_DIR', got '$relative_path'."
 
     case "$relative_path" in
         ..|../*|*/..|*/../*)
@@ -165,8 +219,11 @@ import_base_lib() {
             ;;
     esac
 
-    lib_path="$BASE_BASH_LIB_DIR/$relative_path"
-    [[ -f "$lib_path" ]] || fatal_error "Base library '$relative_path' was not found at '$lib_path'."
+    lib_path="$BASE_BASH_LIBS_DIR/$relative_path"
+    if [[ ! -f "$lib_path" && "$BASE_BASH_LIBS_DIR" != "$BASE_BASH_LIB_DIR" ]]; then
+        lib_path="$BASE_BASH_LIB_DIR/$relative_path"
+    fi
+    [[ -f "$lib_path" ]] || fatal_error "Base library '$relative_path' was not found at '$BASE_BASH_LIBS_DIR/$relative_path' or '$BASE_BASH_LIB_DIR/$relative_path'."
 
     # shellcheck source=/dev/null
     source "$lib_path" || fatal_error "Failed to import Base library '$lib_path'."

--- a/bin/base-test
+++ b/bin/base-test
@@ -12,6 +12,7 @@ base_test_unset_env=(
     -u BASE_BASH_COMMANDS_DIR
     -u BASE_LIB_DIR
     -u BASE_BASH_LIB_DIR
+    -u BASE_BASH_LIBS_DIR
     -u BASE_SHELL_DIR
     -u BASE_OS
     -u BASE_HOST

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,10 +197,13 @@ starts the Base project runtime while preserving the caller's current
 directory.
 
 Contains:
-- exported Base path contract such as `BASE_HOME`, `BASE_BIN_DIR`, and `BASE_BASH_LIB_DIR`
+- exported Base path contract such as `BASE_HOME`, `BASE_BIN_DIR`,
+  `BASE_BASH_LIB_DIR`, and `BASE_BASH_LIBS_DIR`
 - OS and host metadata such as `BASE_OS` and `BASE_HOST`
 - Base's Bash standard library
-- `import_base_lib` for convention-based Base Bash library imports
+- `import_base_lib` for convention-based Base Bash library imports, preferring
+  the resolved reusable Bash library root and falling back to Base's bundled
+  library root
 - PATH additions for Base's own executable entrypoints
 - optional PATH additions for the local Base Platform Tools companion repo
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -223,11 +223,13 @@ has decided what should run.
 `base_init.sh` establishes the Base runtime contract, including:
 
 - exported Base environment variables such as `BASE_HOME`, `BASE_BIN_DIR`,
-  `BASE_BASH_COMMANDS_DIR`, and `BASE_BASH_LIB_DIR`
+  `BASE_BASH_COMMANDS_DIR`, `BASE_BASH_LIB_DIR`, and `BASE_BASH_LIBS_DIR`
 - OS and host metadata such as `BASE_OS` and `BASE_HOST`
-- Base's Bash standard library
+- the reusable Bash standard library, resolved from `base-bash-libs` when
+  available and from Base's bundled fallback otherwise
 - `import_base_lib`, the convention-based helper for sourcing Base Bash
-  libraries
+  libraries from the resolved reusable root with Base's bundled root as a
+  fallback
 - PATH additions needed by Base runtime execution
 
 The full variable list, ownership rules, readonly policy, and `~/.baserc`
@@ -239,8 +241,10 @@ Downstream Bash scripts should import Base Bash libraries with:
 import_base_lib file/lib_file.sh
 ```
 
-`import_base_lib` fails through Base standard error handling when the requested
-library cannot be found, so callers do not need to duplicate that check.
+`import_base_lib` checks the resolved reusable library root first, then Base's
+bundled `lib/bash` root. It fails through Base standard error handling when the
+requested library cannot be found, so callers do not need to duplicate that
+check.
 
 ## Runtime Shell
 

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -68,7 +68,8 @@ explicit Bash script, or starts a Base runtime Bash shell.
 | `BASE_BASH_DIR` | Base | `$BASE_HOME/cli/bash`. Root for Bash command implementations. | Do not set. Readonly after `base_init.sh`. |
 | `BASE_BASH_COMMANDS_DIR` | Base | `$BASE_BASH_DIR/commands`. Directory used by command dispatch. | Do not set. Readonly after `base_init.sh`. |
 | `BASE_LIB_DIR` | Base | `$BASE_HOME/lib`. Root for shared Base libraries. | Do not set. Readonly after `base_init.sh`. |
-| `BASE_BASH_LIB_DIR` | Base | `$BASE_HOME/lib/bash`. Root used by `import_base_lib`. | Do not set. Readonly after `base_init.sh`. |
+| `BASE_BASH_LIB_DIR` | Base | `$BASE_HOME/lib/bash`. Base's bundled Bash library root, including Base-specific runtime and version helpers. | Do not set. Readonly after `base_init.sh`. |
+| `BASE_BASH_LIBS_DIR` | Base | Resolved reusable Bash library root used for stdlib loading and preferred by `import_base_lib`. It can point at an explicit `BASE_BASH_LIBS_DIR`, a sibling `base-bash-libs` checkout, a Homebrew `base-bash-libs` package next to Homebrew Base, or the bundled `$BASE_BASH_LIB_DIR` fallback. | May be provided only before runtime bootstrap to force a compatible reusable library root. Readonly after `base_init.sh`. |
 | `BASE_SHELL_DIR` | Base | `$BASE_HOME/lib/shell`. Root for managed shell startup snippets and completions. | Do not set. Readonly after `base_init.sh`. |
 | `BASE_OS` | Base | Normalized host OS metadata such as `macos` or `linux`. Used by runtime decisions and diagnostics. | Do not set. Readonly after `base_init.sh`. |
 | `BASE_HOST` | Base | Short host name from `hostname -s`. Used by runtime metadata and prompts. | Do not set. Readonly after `base_init.sh`. |

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -69,9 +69,10 @@ Markers look like:
 
 **Layer 2 — Base runtime** (`base_init.sh`, sourced on every `basectl` invocation)
 
-Exports `BASE_HOME`, `BASE_BIN_DIR`, `BASE_BASH_LIB_DIR`, `BASE_OS`, `BASE_HOST`,
-and `BASE_SHELL`. Loads the Bash standard library. Sets up `import_base_lib` for
-convention-based library imports.
+Exports `BASE_HOME`, `BASE_BIN_DIR`, `BASE_BASH_LIB_DIR`,
+`BASE_BASH_LIBS_DIR`, `BASE_OS`, `BASE_HOST`, and `BASE_SHELL`. Loads the Bash
+standard library from the resolved reusable library root. Sets up
+`import_base_lib` for convention-based library imports with a bundled fallback.
 
 **Layer 3 — Project environment** (`basectl activate <project>`)
 

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -26,6 +26,19 @@ create_minimal_base_home() {
     cp "$BASE_REPO_ROOT/lib/bash/file/lib_file.sh" "$base_home/lib/bash/file/lib_file.sh"
 }
 
+create_external_bash_libs() {
+    local target_dir="$1"
+
+    mkdir -p \
+        "$target_dir/file" \
+        "$target_dir/git" \
+        "$target_dir/std"
+
+    cp "$BASE_REPO_ROOT/lib/bash/std/lib_std.sh" "$target_dir/std/lib_std.sh"
+    cp "$BASE_REPO_ROOT/lib/bash/file/lib_file.sh" "$target_dir/file/lib_file.sh"
+    cp "$BASE_REPO_ROOT/lib/bash/git/lib_git.sh" "$target_dir/git/lib_git.sh"
+}
+
 run_base_init_script() {
     local script="$1"
 
@@ -37,6 +50,7 @@ run_base_init_script() {
         -u BASE_BASH_COMMANDS_DIR \
         -u BASE_LIB_DIR \
         -u BASE_BASH_LIB_DIR \
+        -u BASE_BASH_LIBS_DIR \
         -u BASE_SHELL_DIR \
         -u BASE_OS \
         -u BASE_HOST \
@@ -55,6 +69,7 @@ run_base_init_script() {
         printf "BASE_BASH_COMMANDS_DIR=%s\n" "$BASE_BASH_COMMANDS_DIR"
         printf "BASE_LIB_DIR=%s\n" "$BASE_LIB_DIR"
         printf "BASE_BASH_LIB_DIR=%s\n" "$BASE_BASH_LIB_DIR"
+        printf "BASE_BASH_LIBS_DIR=%s\n" "$BASE_BASH_LIBS_DIR"
         printf "BASE_SHELL_DIR=%s\n" "$BASE_SHELL_DIR"
     '
 
@@ -66,6 +81,7 @@ run_base_init_script() {
     [[ "$output" == *"BASE_BASH_COMMANDS_DIR=$TEST_BASE_HOME/cli/bash/commands"* ]]
     [[ "$output" == *"BASE_LIB_DIR=$TEST_BASE_HOME/lib"* ]]
     [[ "$output" == *"BASE_BASH_LIB_DIR=$TEST_BASE_HOME/lib/bash"* ]]
+    [[ "$output" == *"BASE_BASH_LIBS_DIR=$TEST_BASE_HOME/lib/bash"* ]]
     [[ "$output" == *"BASE_SHELL_DIR=$TEST_BASE_HOME/lib/shell"* ]]
 }
 
@@ -85,6 +101,7 @@ run_base_init_script() {
         -u BASE_BASH_COMMANDS_DIR \
         -u BASE_LIB_DIR \
         -u BASE_BASH_LIB_DIR \
+        -u BASE_BASH_LIBS_DIR \
         -u BASE_SHELL_DIR \
         -u BASE_OS \
         -u BASE_HOST \
@@ -130,6 +147,7 @@ run_base_init_script() {
             BASE_BASH_COMMANDS_DIR \
             BASE_LIB_DIR \
             BASE_BASH_LIB_DIR \
+            BASE_BASH_LIBS_DIR \
             BASE_SHELL_DIR \
             BASE_OS \
             BASE_HOST \
@@ -147,6 +165,7 @@ run_base_init_script() {
         BASE_BASH_COMMANDS_DIR \
         BASE_LIB_DIR \
         BASE_BASH_LIB_DIR \
+        BASE_BASH_LIBS_DIR \
         BASE_SHELL_DIR \
         BASE_OS \
         BASE_HOST \
@@ -181,6 +200,7 @@ run_base_init_script() {
         BASE_BASH_COMMANDS_DIR \
         BASE_LIB_DIR \
         BASE_BASH_LIB_DIR \
+        BASE_BASH_LIBS_DIR \
         BASE_SHELL_DIR \
         BASE_OS \
         BASE_HOST \
@@ -201,7 +221,7 @@ run_base_init_script() {
     [ "$output" = "1" ]
 }
 
-@test "base_init import_base_lib resolves libraries relative to BASE_HOME" {
+@test "base_init import_base_lib resolves libraries relative to bundled Base fallback" {
     run_base_init_script '
         base_home="$1"
         source "$base_home/base_init.sh"
@@ -210,4 +230,100 @@ run_base_init_script() {
     '
 
     [ "$status" -eq 0 ]
+}
+
+@test "base_init can resolve reusable Bash libraries from explicit external dir" {
+    local external_dir="$TEST_TMPDIR/base-bash-libs/lib/bash"
+
+    create_external_bash_libs "$external_dir"
+    printf '\nexternal_file_marker() { :; }\n' >>"$external_dir/file/lib_file.sh"
+
+    run env \
+        -u BASE_HOME \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        BASE_BASH_LIBS_DIR="$external_dir" \
+        bash -c '
+            base_home="$1"
+            source "$base_home/base_init.sh"
+            printf "BASE_BASH_LIBS_DIR=%s\n" "$BASE_BASH_LIBS_DIR"
+            import_base_lib file/lib_file.sh
+            declare -F external_file_marker >/dev/null
+        ' bash "$TEST_BASE_HOME"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_BASH_LIBS_DIR=$external_dir"* ]]
+}
+
+@test "base_init import_base_lib falls back to bundled Base libraries" {
+    local external_dir="$TEST_TMPDIR/partial-base-bash-libs/lib/bash"
+
+    mkdir -p "$external_dir/std"
+    cp "$BASE_REPO_ROOT/lib/bash/std/lib_std.sh" "$external_dir/std/lib_std.sh"
+
+    run env \
+        -u BASE_HOME \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        BASE_BASH_LIBS_DIR="$external_dir" \
+        bash -c '
+            base_home="$1"
+            source "$base_home/base_init.sh"
+            import_base_lib file/lib_file.sh
+            declare -F update_file_section >/dev/null
+        ' bash "$TEST_BASE_HOME"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "base_init resolves Homebrew base-bash-libs next to Homebrew Base" {
+    local cellar_base="$TEST_TMPDIR/homebrew/Cellar/base/1.0.3/libexec"
+    local opt_dir="$TEST_TMPDIR/homebrew/opt"
+    local opt_base="$opt_dir/base/libexec"
+    local external_dir="$opt_dir/base-bash-libs/libexec/lib/bash"
+
+    mkdir -p "$opt_dir"
+    create_minimal_base_home "$cellar_base"
+    create_external_bash_libs "$external_dir"
+    printf '\nhomebrew_file_marker() { :; }\n' >>"$external_dir/file/lib_file.sh"
+    ln -s "../Cellar/base/1.0.3" "$opt_dir/base"
+
+    run env \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_BASH_LIBS_DIR \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        BASE_HOME="$opt_base" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            printf "BASE_BASH_LIBS_DIR=%s\n" "$BASE_BASH_LIBS_DIR"
+            import_base_lib file/lib_file.sh
+            declare -F homebrew_file_marker >/dev/null
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_BASH_LIBS_DIR=$external_dir"* ]]
 }


### PR DESCRIPTION
## Summary
- Add `BASE_BASH_LIBS_DIR` as the resolved reusable Bash library root.
- Prefer explicit, sibling, or Homebrew `base-bash-libs` libraries for stdlib/imports while keeping Base's bundled `lib/bash` as fallback.
- Update runtime docs and changelog for the new resolution contract.

## Validation
- shellcheck --severity=error base_init.sh bin/base-test
- bats tests/base_init.bats tests/install.bats lib/bash/runtime/tests/runtime_bashrc.bats
- git diff --check
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. Runtime resolution change only.

Fixes #833