### PR TITLE
Document base-bash-libs migration contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Made Base resolve reusable Bash libraries from an external `base-bash-libs`
   checkout or Homebrew package when available, while keeping the bundled
   `lib/bash` tree as a fallback.
+- Documented the standalone `base-bash-libs` install path, Base's consumption
+  contract, and the migration gate for eventually removing bundled reusable
+  Bash libraries.
 
 ## [1.0.3] - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,22 @@ Base orchestrates tools that already own their domains:
 
 See [Tool Boundaries](docs/tool-boundaries.md) for the detailed boundary model.
 
+### Reusable Bash Libraries
+
+Base's reusable Bash libraries are also available as a standalone package for
+scripts that want Base's Bash helper conventions without adopting the Base
+workspace control plane:
+
+```bash
+brew install codeforester/base/base-bash-libs
+```
+
+Base currently prefers an external `base-bash-libs` checkout or Homebrew package
+when available and keeps its bundled reusable libraries as a compatibility
+fallback during the migration window. The resolution order, standalone usage
+path, and bundled-library removal gate are documented in
+[Base Bash Libraries](docs/base-bash-libs.md).
+
 ## Top Goals
 
 Base is organized around three primary goals.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,9 @@ reference. The filename should answer "what is this about?"
   support plan and bootstrap boundaries.
 - [Runtime Environment](runtime-environment.md) is the canonical reference for
   Base-managed environment variables, `~/.baserc`, and mutability rules.
+- [Base Bash Libraries](base-bash-libs.md) documents the standalone
+  `base-bash-libs` package, Base's external-first consumption path, fallback
+  behavior, and bundled-library removal gate.
 - [Local Observability](observability.md) defines the future local command
   history, last-error explanation, and report model beyond raw runtime logs.
 - [Release Process](release-process.md) defines the Base release ceremony,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,7 +209,9 @@ Contains:
 
 This layer is established by `base_init.sh`, which is sourced only through the
 `basectl` command path. The canonical variable reference and mutability policy
-live in [Runtime Environment](runtime-environment.md).
+live in [Runtime Environment](runtime-environment.md). The standalone
+`base-bash-libs` install path and migration contract live in
+[Base Bash Libraries](base-bash-libs.md).
 
 ### Layer 3 — Project-Specific Environment
 

--- a/docs/base-bash-libs.md
+++ b/docs/base-bash-libs.md
@@ -1,0 +1,125 @@
+# Base Bash Libraries
+
+Base's reusable Bash libraries are being extracted into the standalone
+[`codeforester/base-bash-libs`](https://github.com/codeforester/base-bash-libs)
+repository. That repository lets scripts use Base's Bash logging, command
+execution, filesystem, and Git helper conventions without adopting the full
+Base workspace control plane.
+
+This page documents the Base-side consumption and migration contract. Library
+APIs and standalone examples live in the `base-bash-libs` repository.
+
+## Current Boundary
+
+The standalone reusable library package owns:
+
+- `lib/bash/std`
+- `lib/bash/file`
+- `lib/bash/git`
+- shared BATS helpers needed by those library test suites
+
+Base still owns Base-specific runtime files, including:
+
+- `lib/bash/runtime`
+- Base runtime bootstrap through `base_init.sh`
+- Base command dispatch and project activation
+
+During the migration window, Base also keeps bundled copies of the reusable
+library directories. Those copies are a compatibility fallback, not the
+long-term source of truth.
+
+## Standalone Installation
+
+Users who want only the Bash libraries can install them from the existing
+Homebrew tap:
+
+```bash
+brew install codeforester/base/base-bash-libs
+```
+
+Standalone scripts can then source the stdlib from the installed prefix:
+
+```bash
+base_bash_libs_prefix="$(brew --prefix codeforester/base/base-bash-libs)"
+source "$base_bash_libs_prefix/libexec/lib/bash/std/lib_std.sh"
+```
+
+Companion libraries should be loaded through the stdlib's absolute import
+helper:
+
+```bash
+import "$base_bash_libs_prefix/libexec/lib/bash/file/lib_file.sh"
+import "$base_bash_libs_prefix/libexec/lib/bash/git/lib_git.sh"
+```
+
+For source checkout development, clone the repository next to Base or source it
+directly from the checkout path:
+
+```bash
+git clone https://github.com/codeforester/base-bash-libs.git ~/work/base-bash-libs
+source "$HOME/work/base-bash-libs/lib/bash/std/lib_std.sh"
+```
+
+## How Base Resolves Libraries
+
+When `basectl` loads `base_init.sh`, Base resolves `BASE_BASH_LIBS_DIR` before
+it sources the Bash stdlib. The resolution order is:
+
+1. An explicit `BASE_BASH_LIBS_DIR` provided before runtime bootstrap.
+2. A sibling source checkout at `$BASE_HOME/../base-bash-libs/lib/bash`.
+3. A Homebrew package at
+   `<homebrew-prefix>/opt/base-bash-libs/libexec/lib/bash` when `BASE_HOME`
+   looks like a Homebrew Base install.
+4. Base's bundled fallback at `$BASE_HOME/lib/bash`.
+
+An explicit `BASE_BASH_LIBS_DIR` must contain `std/lib_std.sh`; otherwise Base
+fails early with a direct error. The variable is intended for tests, source
+checkout development, and controlled migration checks. Users should not set it
+in `~/.baserc`, shell dotfiles, or project activation scripts.
+
+Base command implementations should not source these files by absolute path.
+They should rely on `basectl` to establish the runtime and then import reusable
+libraries by convention:
+
+```bash
+import_base_lib file/lib_file.sh
+import_base_lib git/lib_git.sh
+```
+
+`import_base_lib` checks the resolved reusable library root first. If a
+requested companion library is not present there and the resolved reusable root
+is not the bundled Base root, it falls back to `$BASE_BASH_LIB_DIR`. That keeps
+Base working while the external package and Base-owned runtime files are still
+being separated.
+
+## Migration Contract
+
+The current Base contract is external-first, bundled-fallback:
+
+- Base can consume `base-bash-libs` from a sibling checkout.
+- Base can consume `base-bash-libs` from Homebrew when the formula is installed.
+- Base still works without the external package because the bundled reusable
+  libraries remain in `codeforester/base`.
+
+The bundled reusable libraries should not be removed from Base until the
+external path is normal, validated, and diagnosable for both Homebrew users and
+source checkout contributors. The practical removal gate is:
+
+1. `base-bash-libs` has a released version and installable Homebrew formula.
+2. Homebrew Base declares `base-bash-libs` as a dependency, or an equivalent
+   install path makes the external package present by default.
+3. Source checkout setup documents or installs the sibling `base-bash-libs`
+   checkout clearly enough that raw `git clone` development is not fragile.
+4. Base setup, check, or doctor paths report missing external Bash libraries
+   clearly where that state can affect users.
+5. CI validates Base without relying on the bundled reusable directories.
+6. A Base release cycle has passed with the external package as the normal path
+   and without needing the fallback for ordinary installs.
+
+Only after those gates are satisfied should Base remove the bundled reusable
+directories. If Base intentionally keeps the fallback long term, that decision
+should be recorded explicitly and the extraction tracker should close only
+after that policy is clear.
+
+The Python `base_cli` extraction is a separate effort and is not part of this
+Bash library migration.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -115,12 +115,14 @@ This makes Base stdlib helpers such as `log_info`, `print_error`,
 `fatal_error`, `run`, `assert_command_exists`, and `import_base_lib` available
 without the script sourcing `lib_std.sh` directly.
 
-Standalone Bash scripts that are not intended to run through Base can still
-source the standard library directly:
+Standalone Bash scripts that are not intended to run through Base should use the
+standalone `base-bash-libs` package instead of depending on Base's bundled
+fallback:
 
 ```bash
 #!/usr/bin/env bash
-source "/path/to/base/lib/bash/std/lib_std.sh"
+base_bash_libs_prefix="$(brew --prefix codeforester/base/base-bash-libs)"
+source "$base_bash_libs_prefix/libexec/lib/bash/std/lib_std.sh"
 
 main() {
     run echo "hello"
@@ -245,6 +247,9 @@ import_base_lib file/lib_file.sh
 bundled `lib/bash` root. It fails through Base standard error handling when the
 requested library cannot be found, so callers do not need to duplicate that
 check.
+
+The standalone install path, Base resolution order, and bundled-library removal
+gate are documented in [Base Bash Libraries](base-bash-libs.md).
 
 ## Runtime Shell
 

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -49,8 +49,8 @@ boundary.
 
 `~/.baserc` may set user knobs such as `BASE_DEBUG`. It must not set Base-owned
 runtime or profile variables such as `BASE_HOME`, `BASE_BIN_DIR`, `BASE_LIB_DIR`,
-`BASE_OS`, `BASE_HOST`, `BASE_SHELL`, `BASE_PLATFORM_TOOLS_HOME`,
-`BASE_PLATFORM_TOOLS_BIN_DIR`, `BASE_PROFILE_VERSION`,
+`BASE_OS`, `BASE_HOST`, `BASE_SHELL`, `BASE_BASH_LIBS_DIR`,
+`BASE_PLATFORM_TOOLS_HOME`, `BASE_PLATFORM_TOOLS_BIN_DIR`, `BASE_PROFILE_VERSION`,
 `BASE_ENABLE_BASH_DEFAULTS`, or `BASE_ENABLE_ZSH_DEFAULTS`. It must also not
 set command or project metadata such as `BASE_BASH_COMMAND_SCRIPT`,
 `BASE_PROJECT`, `BASE_PROJECT_ROOT`, or `BASE_PROJECT_VENV_DIR`.
@@ -74,6 +74,10 @@ explicit Bash script, or starts a Base runtime Bash shell.
 | `BASE_OS` | Base | Normalized host OS metadata such as `macos` or `linux`. Used by runtime decisions and diagnostics. | Do not set. Readonly after `base_init.sh`. |
 | `BASE_HOST` | Base | Short host name from `hostname -s`. Used by runtime metadata and prompts. | Do not set. Readonly after `base_init.sh`. |
 | `BASE_SHELL` | Base | Legacy runtime marker. Plain `base_init.sh` defaults it to `bash`; Base runtime shells seed it as `1` before `base_init.sh`. New code should avoid adding new meanings to it. | Do not set in user config. Readonly after `base_init.sh`. |
+
+`BASE_BASH_LIBS_DIR` is part of the Bash library extraction bridge. For the full
+resolution order, standalone install path, fallback behavior, and bundled
+library removal gate, see [Base Bash Libraries](base-bash-libs.md).
 
 ## CI Runtime Variables
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -73,6 +73,8 @@ Exports `BASE_HOME`, `BASE_BIN_DIR`, `BASE_BASH_LIB_DIR`,
 `BASE_BASH_LIBS_DIR`, `BASE_OS`, `BASE_HOST`, and `BASE_SHELL`. Loads the Bash
 standard library from the resolved reusable library root. Sets up
 `import_base_lib` for convention-based library imports with a bundled fallback.
+The standalone install path and migration contract for those reusable libraries
+are documented in [Base Bash Libraries](base-bash-libs.md).
 
 **Layer 3 — Project environment** (`basectl activate <project>`)
 


### PR DESCRIPTION
## Summary
- Add `docs/base-bash-libs.md` with the standalone Homebrew install path, Base resolution order, external-first/bundled-fallback contract, and bundled-library removal gate.
- Link the contract from the README, docs map, runtime reference, execution model, architecture, and technical overview.
- Note the documentation update in the changelog.

## Validation
- `git diff --check`
- `git diff --check --cached`

## Demo Impact
- None. Documentation-only change.

Parent tracker: #829
Fixes #835