### PR TITLE
Document Homebrew tap trust for Base installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Changed
+
+- Documented Homebrew tap trust for Base and standalone `base-bash-libs`
+  installs, and updated direct Base upgrade examples to use
+  `brew upgrade --no-ask codeforester/base/base`.
+
 ## [1.0.4] - 2026-06-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ normal Base install paths:
 
 ```bash
 # Homebrew-managed install
+brew trust codeforester/base
 brew install codeforester/base/base
 basectl setup
 basectl update-profile
@@ -171,6 +172,7 @@ scripts that want Base's Bash helper conventions without adopting the Base
 workspace control plane:
 
 ```bash
+brew trust codeforester/base
 brew install codeforester/base/base-bash-libs
 ```
 
@@ -961,11 +963,16 @@ See [First-Mile Bootstrap](docs/bootstrap.md) for the full bootstrap contract.
 Base can be installed through its Homebrew tap:
 
 ```bash
+brew trust codeforester/base
 brew install codeforester/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
 ```
+
+The trust step is required on Homebrew versions that block formulae from
+non-official taps until the tap is trusted. It is safe to run again on machines
+that already trust `codeforester/base`.
 
 Homebrew installs the Base files. `basectl setup` still prepares the local Base
 runtime under `~/.base.d/base/.venv`, and `basectl update-profile` adds Base to
@@ -973,7 +980,7 @@ your shell startup path. When installed through Homebrew, `basectl update` for
 Base hands off to Homebrew and runs setup afterward. This is equivalent to:
 
 ```bash
-brew upgrade codeforester/base/base
+brew upgrade --no-ask codeforester/base/base
 ```
 
 For a Base development machine, prefer the source checkout as the active
@@ -1145,6 +1152,9 @@ In a Homebrew-managed install, the Base update path remains Base-only:
 `brew upgrade codeforester/base/base`, and then runs `basectl setup base` with
 inherited Base environment variables cleared. `basectl update --dry-run` prints
 the Git or Homebrew handoff it would perform without changing files or packages.
+For manual Homebrew upgrades outside `basectl update`, prefer
+`brew upgrade --no-ask codeforester/base/base` so Homebrew skips the preview
+prompt path on already-current installs.
 
 Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
 is user-managed and may be hand-edited. It is intended for simple,

--- a/docs/base-bash-libs.md
+++ b/docs/base-bash-libs.md
@@ -34,8 +34,13 @@ Users who want only the Bash libraries can install them from the existing
 Homebrew tap:
 
 ```bash
+brew trust codeforester/base
 brew install codeforester/base/base-bash-libs
 ```
+
+The trust step is required on Homebrew versions that block formulae from
+non-official taps until the tap is trusted. It is safe to run again on machines
+that already trust `codeforester/base`.
 
 Standalone scripts can then source the stdlib from the installed prefix:
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -108,6 +108,7 @@ Use Homebrew directly when Homebrew is already installed and Base should be
 managed like a normal formula:
 
 ```bash
+brew trust codeforester/base
 brew install codeforester/base/base
 basectl setup
 basectl update-profile

--- a/docs/homebrew-upgrade-rehearsal.md
+++ b/docs/homebrew-upgrade-rehearsal.md
@@ -46,6 +46,7 @@ printf 'workspace:\n  root: %s/work\n' "$TEST_ROOT" > "$TEST_ROOT/home/.base.d/c
 Install the current released formula and prepare local state:
 
 ```bash
+brew trust codeforester/base
 brew install codeforester/base/base
 env -u BASE_HOME -u BASE_PROJECT -u BASE_PROJECT_ROOT \
   HOME="$TEST_ROOT/home" PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
@@ -70,7 +71,7 @@ Upgrade through the tap path:
 
 ```bash
 brew update
-brew upgrade codeforester/base/base
+brew upgrade --no-ask codeforester/base/base
 ```
 
 For a pre-1.0.0 release candidate, use the candidate formula or tap branch that
@@ -108,7 +109,7 @@ shasum -a 256 "$TEST_ROOT/home/.base.d/config.yaml"
 
 Accept the rehearsal only when:
 
-- `brew upgrade codeforester/base/base` exits zero.
+- `brew upgrade --no-ask codeforester/base/base` exits zero.
 - The upgrade uses a Homebrew bottle on supported macOS hosts, not a normal
   source build. If Homebrew falls back to source, record why before accepting
   the rehearsal.

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -85,6 +85,7 @@ Use this path when validating the consumer install experience.
 For a machine that already has Homebrew:
 
 ```bash
+brew trust codeforester/base
 brew install codeforester/base/base
 basectl setup
 basectl update-profile

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -147,9 +147,10 @@ Complete these steps in `codeforester/homebrew-base` after the Base tag exists:
 
    ```bash
    brew update
+   brew trust codeforester/base
    brew install --force-bottle codeforester/base/base
    brew test codeforester/base
-   brew upgrade codeforester/base/base
+   brew upgrade --no-ask codeforester/base/base
    ```
 
    Use `brew reinstall --force-bottle codeforester/base/base` when Base is
@@ -158,8 +159,9 @@ Complete these steps in `codeforester/homebrew-base` after the Base tag exists:
    [Homebrew Upgrade Rehearsal](homebrew-upgrade-rehearsal.md) against a
    release candidate or equivalent test formula. Record the exact commands,
    host facts, pre-upgrade state, post-upgrade checks, and any follow-up issues.
-   Do not close the rehearsal issue until `brew upgrade codeforester/base/base`
-   and the post-upgrade Base project checks pass on a qualified host.
+   Do not close the rehearsal issue until
+   `brew upgrade --no-ask codeforester/base/base` and the post-upgrade Base
+   project checks pass on a qualified host.
 
 ## Cleanup
 


### PR DESCRIPTION
## Summary

- Add `brew trust codeforester/base` to Homebrew install instructions for Base and standalone `base-bash-libs`.
- Prefer `brew upgrade --no-ask codeforester/base/base` in direct user-run upgrade and release rehearsal examples.
- Record the documentation change in the unreleased changelog.

## Issue

Closes #839

## Validation

- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`
  - Python: 486 passed, 1 skipped
  - BATS: ok 532
- `./tests/validate.sh` was attempted, but Base does not provide that script.

## Demo Impact

None. Documentation-only change.

## Notes

AI context was not updated because this PR changes install and upgrade guidance, not the current product architecture or status.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`