### PR TITLE
Prove external Bash libs without bundled dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `BASE_BASH_LIBS_SOURCE` and `BASE-D007` diagnostics so `basectl check`
   and `basectl doctor` report whether Base is using external reusable Bash
   libraries or the bundled fallback.
+- Added BATS coverage proving Base can bootstrap from external
+  `base-bash-libs` when bundled reusable Bash library directories are absent.
 
 ### Changed
 

--- a/docs/base-bash-libs.md
+++ b/docs/base-bash-libs.md
@@ -123,7 +123,10 @@ source checkout contributors. The practical removal gate is:
 4. Base setup, check, or doctor paths report missing external Bash libraries
    clearly where that state can affect users. `BASE-D007` now covers the
    check and doctor side of this gate.
-5. CI validates Base without relying on the bundled reusable directories.
+5. CI validates Base without relying on the bundled reusable directories. The
+   `base_init` BATS suite now includes a temporary Base home with bundled
+   reusable `std`, `file`, and `git` directories removed and external
+   `base-bash-libs` provided through the sibling checkout path.
 6. A Base release cycle has passed with the external package as the normal path
    and without needing the fallback for ordinary installs.
 

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -309,6 +309,52 @@ run_base_init_script() {
     [[ "$output" == *"BASE_BASH_LIBS_SOURCE=sibling"* ]]
 }
 
+@test "base_init runs from external reusable libraries when bundled reusable dirs are absent" {
+    local external_dir="$TEST_TMPDIR/base-bash-libs/lib/bash"
+    local expected_dir
+
+    create_external_bash_libs "$external_dir"
+    printf '\nexternal_only_file_marker() { :; }\n' >>"$external_dir/file/lib_file.sh"
+    printf '\nexternal_only_git_marker() { :; }\n' >>"$external_dir/git/lib_git.sh"
+    rm -rf \
+        "$TEST_BASE_HOME/lib/bash/file" \
+        "$TEST_BASE_HOME/lib/bash/git" \
+        "$TEST_BASE_HOME/lib/bash/std"
+    expected_dir="$(cd "$external_dir" && pwd -P)"
+
+    run env \
+        -u BASE_HOME \
+        -u BASE_BIN_DIR \
+        -u BASE_CLI_DIR \
+        -u BASE_BASH_DIR \
+        -u BASE_BASH_COMMANDS_DIR \
+        -u BASE_LIB_DIR \
+        -u BASE_BASH_LIB_DIR \
+        -u BASE_BASH_LIBS_DIR \
+        -u BASE_BASH_LIBS_SOURCE \
+        -u BASE_SHELL_DIR \
+        -u BASE_OS \
+        -u BASE_HOST \
+        -u BASE_SHELL \
+        bash -c '
+            base_home="$1"
+            source "$base_home/base_init.sh"
+            printf "BASE_BASH_LIBS_DIR=%s\n" "$BASE_BASH_LIBS_DIR"
+            printf "BASE_BASH_LIBS_SOURCE=%s\n" "$BASE_BASH_LIBS_SOURCE"
+            import_base_lib file/lib_file.sh
+            import_base_lib git/lib_git.sh
+            declare -F external_only_file_marker >/dev/null
+            declare -F external_only_git_marker >/dev/null
+            [[ ! -d "$BASE_BASH_LIB_DIR/std" ]]
+            [[ ! -d "$BASE_BASH_LIB_DIR/file" ]]
+            [[ ! -d "$BASE_BASH_LIB_DIR/git" ]]
+        ' bash "$TEST_BASE_HOME"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_BASH_LIBS_DIR=$expected_dir"* ]]
+    [[ "$output" == *"BASE_BASH_LIBS_SOURCE=sibling"* ]]
+}
+
 @test "base_init import_base_lib falls back to bundled Base libraries" {
     local external_dir="$TEST_TMPDIR/partial-base-bash-libs/lib/bash"
 


### PR DESCRIPTION
## Summary
- Add a `base_init` BATS proof that removes bundled reusable `std`, `file`, and `git` directories from a temporary Base home.
- Verify runtime bootstrap and `import_base_lib` succeed through an external sibling `base-bash-libs` root.
- Mark the CI proof gate in the Base Bash libraries migration contract.

## Validation
- `bats --print-output-on-failure tests/base_init.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

Closes #842