### PR TITLE
Tolerate external Bash libs in readiness BATS tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
   installs, and updated direct Base upgrade examples to use
   `brew upgrade --no-ask codeforester/base/base`.
 
+### Fixed
+
+- Fixed Bash library readiness BATS assertions so they pass both with a sibling
+  `base-bash-libs` checkout and with bundled fallback.
+
 ## [1.0.4] - 2026-06-17
 
 ### Changed

--- a/cli/bash/commands/basectl/tests/basectl_helpers.bash
+++ b/cli/bash/commands/basectl/tests/basectl_helpers.bash
@@ -1,6 +1,7 @@
 # Shared helpers for basectl command BATS suites.
 
 load ../../../../../lib/bash/tests/test_helper.sh
+load ./bash_lib_readiness_helpers.bash
 bats_require_minimum_version 1.5.0
 
 setup() {

--- a/cli/bash/commands/basectl/tests/bash_lib_readiness_helpers.bash
+++ b/cli/bash/commands/basectl/tests/bash_lib_readiness_helpers.bash
@@ -1,0 +1,61 @@
+# Shared assertions for Base Bash library readiness diagnostics.
+
+base_bash_libraries_json_status() {
+    local payload="$1"
+
+    case "$payload" in
+        *'"id":"BASE-D007","status":"ok","name":"base_bash_libraries"'*)
+            printf '%s\n' "ok"
+            ;;
+        *'"id":"BASE-D007","status":"warn","name":"base_bash_libraries"'*)
+            printf '%s\n' "warn"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+assert_base_bash_libraries_json_finding() {
+    local payload="$1"
+    local status
+
+    if ! status="$(base_bash_libraries_json_status "$payload")"; then
+        printf 'BASE-D007 finding was not present in diagnostic JSON.\n' >&2
+        return 1
+    fi
+
+    case "$status" in
+        ok)
+            [[ "$payload" == *"Base is using reusable Bash libraries from"* ]]
+            ;;
+        warn)
+            [[ "$payload" == *"Base is using bundled reusable Bash libraries"* ]]
+            [[ "$payload" == *"Clone codeforester/base-bash-libs next to Base"* ]]
+            ;;
+        *)
+            printf 'Unexpected BASE-D007 status: %s\n' "$status" >&2
+            return 1
+            ;;
+    esac
+}
+
+assert_base_check_json_status_for_readiness() {
+    local payload="$1"
+    local readiness_status
+
+    readiness_status="$(base_bash_libraries_json_status "$payload")" || return 1
+    if [[ "$readiness_status" == warn ]]; then
+        [[ "$payload" == *'"status": "warn"'* ]]
+    else
+        [[ "$payload" == *'"status": "ok"'* ]]
+    fi
+}
+
+base_bash_libraries_json_line() {
+    local payload="$1"
+
+    printf '%s\n' "$payload" |
+        grep -n '"id":"BASE-D007","status":"[a-z]*","name":"base_bash_libraries"' |
+        cut -d: -f1
+}

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -332,11 +332,9 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *'"schema_version": 1'* ]]
-    [[ "$output" == *'"status": "warn"'* ]]
+    assert_base_check_json_status_for_readiness "$output"
     [[ "$output" == *'"id":"BASE-D001","status":"ok","name":"homebrew"'* ]]
-    [[ "$output" == *'"id":"BASE-D007","status":"warn","name":"base_bash_libraries"'* ]]
-    [[ "$output" == *"Base is using bundled reusable Bash libraries"* ]]
-    [[ "$output" == *"Clone codeforester/base-bash-libs next to Base"* ]]
+    assert_base_bash_libraries_json_finding "$output"
     [[ "$output" != *'"name":"bats"'* ]]
     [[ "$output" == *'"id":"BASE-D005","status":"ok","name":"pyyaml"'* ]]
     [[ "$output" == *'"id":"BASE-D006","status":"ok","name":"click"'* ]]
@@ -378,9 +376,9 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *'"schema_version": 1'* ]]
-    [[ "$output" == *'"status": "warn"'* ]]
+    assert_base_check_json_status_for_readiness "$output"
     homebrew_line="$(printf '%s\n' "$output" | grep -n '"id":"BASE-D001","status":"ok","name":"homebrew"' | cut -d: -f1)"
-    bash_libs_line="$(printf '%s\n' "$output" | grep -n '"id":"BASE-D007","status":"warn","name":"base_bash_libraries"' | cut -d: -f1)"
+    bash_libs_line="$(base_bash_libraries_json_line "$output")"
     xcode_line="$(printf '%s\n' "$output" | grep -n '"id":"BASE-D002","status":"ok","name":"xcode_command_line_tools"' | cut -d: -f1)"
     python_line="$(printf '%s\n' "$output" | grep -n '"id":"BASE-D003","status":"ok","name":"python"' | cut -d: -f1)"
     venv_line="$(printf '%s\n' "$output" | grep -n '"id":"BASE-D004","status":"ok","name":"base_virtualenv"' | cut -d: -f1)"
@@ -493,7 +491,7 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *'"schema_version": 1'* ]]
-    [[ "$output" == *'"status": "warn"'* ]]
+    assert_base_check_json_status_for_readiness "$output"
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
     [[ "$output" == *'"schema_version":1,"status":"ok","project":"demo","checks"'* ]]

--- a/cli/bash/commands/basectl/tests/ci.bats
+++ b/cli/bash/commands/basectl/tests/ci.bats
@@ -67,8 +67,8 @@ prepare_ci_runtime() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *'"schema_version": 1'* ]]
-    [[ "$output" == *'"status": "warn"'* ]]
-    [[ "$output" == *'"id":"BASE-D007","status":"warn","name":"base_bash_libraries"'* ]]
+    assert_base_check_json_status_for_readiness "$output"
+    assert_base_bash_libraries_json_finding "$output"
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format json demo)" ]

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -501,9 +501,7 @@ EOF
     [[ "$output" == *'"findings":'* ]]
     [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *'"id":"BASE-D001","status":"error","name":"homebrew","message":"Homebrew is not installed.","fix":"Run '\''basectl setup'\'' to install Homebrew, or install it manually from https://brew.sh/."'* ]]
-    [[ "$output" == *'"id":"BASE-D007","status":"warn","name":"base_bash_libraries"'* ]]
-    [[ "$output" == *"Base is using bundled reusable Bash libraries"* ]]
-    [[ "$output" == *"Clone codeforester/base-bash-libs next to Base"* ]]
+    assert_base_bash_libraries_json_finding "$output"
     [[ "$output" == *'"id":"BASE-D002","status":"error","name":"xcode_command_line_tools"'* ]]
     [[ "$output" == *'"id":"BASE-D003","status":"error","name":"python"'* ]]
     [[ "$output" == *'"id":"BASE-D004","status":"error","name":"base_virtualenv"'* ]]

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -1,6 +1,7 @@
 # Shared helpers for basectl setup/check/profile BATS suites.
 
 load ../../../../../lib/bash/tests/test_helper.sh
+load ./bash_lib_readiness_helpers.bash
 bats_require_minimum_version 1.5.0
 
 setup() {


### PR DESCRIPTION
## Summary
- Add shared BATS assertions for `BASE-D007` readiness JSON.
- Allow check/ci/doctor tests to pass when readiness is `ok` from an external sibling checkout or `warn` from bundled fallback.
- Document the test-suite fix in the changelog.

## Validation
- Reproduced the reported failures from `/Users/rameshhp/work/base`.
- `bats --print-output-on-failure cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/ci.bats cli/bash/commands/basectl/tests/doctor.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure --filter 'basectl check --format json writes successful|basectl check --format json preserves|basectl check project --format json includes|basectl ci check delegates|basectl doctor --format json reports structured' cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/ci.bats cli/bash/commands/basectl/tests/doctor.bats`\n- `git diff --check`\n- `env -u BASE_HOME ./bin/base-test`\n\nCloses #847