### PR TITLE
Preflight Homebrew tap trust before Base upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Changed
+
+- Made Homebrew-managed `basectl update` preflight tap trust before upgrading
+  Base when Homebrew requires trust for the tap-owned `base-bash-libs`
+  dependency.
+
 ## [1.0.5] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -972,7 +972,14 @@ exec "$SHELL" -l
 
 The trust step is required on Homebrew versions that block formulae from
 non-official taps until the tap is trusted. It is safe to run again on machines
-that already trust `codeforester/base`.
+that already trust `codeforester/base`. Existing installs that predate this
+trust step can fail during upgrade while Homebrew loads Base's tap-owned
+`base-bash-libs` dependency. If that happens, run:
+
+```bash
+brew trust codeforester/base
+brew upgrade --no-ask codeforester/base/base
+```
 
 Homebrew installs the Base files. `basectl setup` still prepares the local Base
 runtime under `~/.base.d/base/.venv`, and `basectl update-profile` adds Base to
@@ -1154,7 +1161,9 @@ inherited Base environment variables cleared. `basectl update --dry-run` prints
 the Git or Homebrew handoff it would perform without changing files or packages.
 For manual Homebrew upgrades outside `basectl update`, prefer
 `brew upgrade --no-ask codeforester/base/base` so Homebrew skips the preview
-prompt path on already-current installs.
+prompt path on already-current installs. If Homebrew refuses to load
+`codeforester/base/base-bash-libs` from an untrusted tap, run
+`brew trust codeforester/base` once and retry the upgrade.
 
 Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
 is user-managed and may be hand-edited. It is intended for simple,

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -29,6 +29,8 @@ Notes:
     pull-time overwrite protection.
   - Homebrew installs update only project 'base' through the Base formula:
     brew upgrade codeforester/base/base
+  - If Homebrew requires tap trust, trust codeforester/base before upgrading:
+    brew trust codeforester/base
 EOF
 }
 
@@ -38,6 +40,14 @@ base_update_source_git_library() {
 
 base_update_homebrew_package() {
     printf '%s\n' "codeforester/base/base"
+}
+
+base_update_homebrew_tap() {
+    printf '%s\n' "codeforester/base"
+}
+
+base_update_homebrew_bash_libs_package() {
+    printf '%s\n' "codeforester/base/base-bash-libs"
 }
 
 base_update_is_homebrew_install() {
@@ -117,6 +127,52 @@ base_update_run_homebrew_upgrade() {
     brew upgrade "$package"
 }
 
+base_update_homebrew_requires_tap_trust() {
+    local config_output
+
+    [[ -n "${HOMEBREW_NO_REQUIRE_TAP_TRUST:-}" ]] && return 1
+    [[ -n "${HOMEBREW_REQUIRE_TAP_TRUST:-}" ]] && return 0
+
+    config_output="$(brew config 2>/dev/null)" || return 1
+    [[ "$config_output" == *"HOMEBREW_REQUIRE_TAP_TRUST: set"* ]]
+}
+
+base_update_homebrew_trust_contains() {
+    local trust_json="$1"
+    local target="$2"
+
+    [[ "$trust_json" == *"\"$target\""* ]]
+}
+
+base_update_homebrew_trust_satisfied() {
+    local bash_libs_package
+    local tap
+    local trust_json
+
+    base_update_homebrew_requires_tap_trust || return 0
+
+    trust_json="$(brew trust --json v1 2>/dev/null)" || return 0
+    tap="$(base_update_homebrew_tap)"
+    bash_libs_package="$(base_update_homebrew_bash_libs_package)"
+
+    base_update_homebrew_trust_contains "$trust_json" "$tap" && return 0
+    base_update_homebrew_trust_contains "$trust_json" "$bash_libs_package" && return 0
+
+    return 1
+}
+
+base_update_report_homebrew_trust_required() {
+    local bash_libs_package
+    local tap
+
+    tap="$(base_update_homebrew_tap)"
+    bash_libs_package="$(base_update_homebrew_bash_libs_package)"
+
+    log_error "Homebrew requires trust for '$tap' before upgrading Base's tap-owned Bash library dependency."
+    log_error "Run 'brew trust $tap', then rerun 'basectl update'."
+    log_error "To trust only the dependency formula instead, run 'brew trust --formula $bash_libs_package'."
+}
+
 base_update_run_homebrew_setup() {
     local base_home="$1"
     local package="$2"
@@ -151,6 +207,7 @@ base_update_run_homebrew_setup() {
 base_update_homebrew_install() {
     local base_home="$1"
     local dry_run="$2"
+    local exit_code
     local package
 
     package="$(base_update_homebrew_package)"
@@ -167,8 +224,18 @@ base_update_homebrew_install() {
         return 1
     fi
 
+    if ! base_update_homebrew_trust_satisfied; then
+        base_update_report_homebrew_trust_required
+        return 1
+    fi
+
     log_info "Running Homebrew upgrade for $package."
-    base_update_run_homebrew_upgrade "$package" || return $?
+    base_update_run_homebrew_upgrade "$package"
+    exit_code=$?
+    if ((exit_code != 0)); then
+        log_error "Homebrew upgrade failed. If Homebrew refused to load '$package' or '$(base_update_homebrew_bash_libs_package)' from an untrusted tap, run 'brew trust $(base_update_homebrew_tap)' and retry."
+        return "$exit_code"
+    fi
 
     log_info "Running basectl setup after Homebrew upgrade."
     base_update_run_homebrew_setup "$base_home" "$package" || return $?

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -104,6 +104,55 @@ load ./basectl_helpers.bash
     [[ "$output" != *"setup should not run"* ]]
 }
 
+@test "basectl update reports Homebrew tap trust recovery before upgrade" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local fake_base="$TEST_TMPDIR/homebrew/opt/base/libexec"
+    local brew_log="$TEST_TMPDIR/brew.log"
+
+    mkdir -p "$fake_bin" "$fake_base/bin"
+    cat > "$fake_bin/brew" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+    config)
+        printf '%s\n' 'HOMEBREW_REQUIRE_TAP_TRUST: set'
+        exit 0
+        ;;
+    trust)
+        if [[ "\$2" == "--json" && "\$3" == "v1" ]]; then
+            printf '%s\n' '{"taps":[],"formulae":["codeforester/base/base"],"casks":[],"commands":[]}'
+            exit 0
+        fi
+        ;;
+esac
+printf '%s\n' "\$*" >> "$brew_log"
+exit 0
+EOF
+    chmod +x "$fake_bin/brew"
+    touch "$fake_base/bin/basectl"
+    chmod +x "$fake_base/bin/basectl"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$fake_base" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -c '
+            log_debug() { :; }
+            log_error() { printf "ERROR: %s\n" "$*"; }
+            log_info() { printf "INFO: %s\n" "$*"; }
+            log_warn() { printf "WARN: %s\n" "$*"; }
+            print_error() { printf "ERROR: %s\n" "$*"; }
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Homebrew requires trust for 'codeforester/base' before upgrading Base's tap-owned Bash library dependency."* ]]
+    [[ "$output" == *"Run 'brew trust codeforester/base', then rerun 'basectl update'."* ]]
+    [[ "$output" == *"brew trust --formula codeforester/base/base-bash-libs"* ]]
+    [[ ! -e "$brew_log" ]]
+}
+
 @test "basectl update runs exact Homebrew package upgrade and clears Base env for setup" {
     local fake_bin="$TEST_TMPDIR/bin"
     local fake_base="$TEST_TMPDIR/homebrew/opt/base/libexec"
@@ -113,6 +162,9 @@ load ./basectl_helpers.bash
     mkdir -p "$fake_bin" "$fake_base/bin"
     cat > "$fake_bin/brew" <<EOF
 #!/usr/bin/env bash
+if [[ "\$1" == "config" ]]; then
+    exit 0
+fi
 printf '%s\n' "\$*" >> "$brew_log"
 exit 0
 EOF


### PR DESCRIPTION
## Summary
- Add a Homebrew tap-trust preflight before `basectl update` runs `brew upgrade codeforester/base/base`.
- Stop early with a targeted `brew trust codeforester/base` recovery when Homebrew requires trust and `base-bash-libs` is not trusted.
- Document the manual upgrade recovery for existing Homebrew installs that predate the trust step.

## Validation
- git diff --check
- bats cli/bash/commands/basectl/tests/update.bats
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. Upgrade-path behavior and docs only.

Fixes #852