### PR TITLE
Detect missing Project intake token

### DIFF
--- a/.github/workflows/project-intake.yml
+++ b/.github/workflows/project-intake.yml
@@ -53,6 +53,9 @@ jobs:
           )"
           if [[ -z "$project_number" ]]; then
             echo "::error::GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'."
+            echo "::error::If this Project exists, set BASE_PROJECT_TOKEN with user Project read/write access."
+            echo "::error::The default GitHub Actions token cannot access user-level Projects."
+            echo "::error::Fix: gh auth token | gh secret set BASE_PROJECT_TOKEN --repo $GITHUB_REPOSITORY"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Made `basectl repo configure` report missing `BASE_PROJECT_TOKEN` Project
+  intake secrets and improved generated workflow diagnostics when the Actions
+  token cannot see repo Projects.
 - Made Homebrew-managed `basectl update` preflight tap trust before upgrading
   Base when Homebrew requires trust for the tap-owned `base-bash-libs`
   dependency.

--- a/README.md
+++ b/README.md
@@ -555,7 +555,9 @@ fallback for issues created outside `basectl gh issue create`. `repo configure`
 creates the workflow when it is missing from older Base-managed repositories.
 Set a `BASE_PROJECT_TOKEN` Actions secret with Project write access so that
 workflow can add issue items and apply the repo Project defaults on issue open,
-reopen, and close events.
+reopen, and close events. `repo configure` checks for that secret when Project
+support is enabled and prints a `gh secret set BASE_PROJECT_TOKEN` command when
+the workflow would otherwise fall back to the default Actions token.
 Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -98,8 +98,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   `Area` and `Initiative` options are added from that file and `issue_defaults`
   are applied to missing Project item field values. `repo init` also seeds a
   Project intake workflow that can add externally-created issues to the
-  repo-named Project when `BASE_PROJECT_TOKEN` has Project write access. Use
-  `--no-project` to skip Project setup, `--project <title>` to override the
+  repo-named Project when `BASE_PROJECT_TOKEN` has Project write access.
+  `repo configure` reports when that secret is missing so the workflow does not
+  silently fall back to the default Actions token. Use `--no-project` to skip
+  Project setup, `--project <title>` to override the
   Project title, or
   `--initiative-option <name>` to seed repository-specific Initiative values.
   Use `--copy-project-fields-from <title>` during migration to copy missing

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1186,6 +1186,9 @@ jobs:
           )"
           if [[ -z "$project_number" ]]; then
             echo "::error::GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'."
+            echo "::error::If this Project exists, set BASE_PROJECT_TOKEN with user Project read/write access."
+            echo "::error::The default GitHub Actions token cannot access user-level Projects."
+            echo "::error::Fix: gh auth token | gh secret set BASE_PROJECT_TOKEN --repo $GITHUB_REPOSITORY"
             exit 1
           fi
 
@@ -1546,6 +1549,47 @@ base_repo_project_config_path() {
     fi
 }
 
+base_repo_project_intake_secret_fix_command() {
+    local repo="$1"
+
+    printf 'gh auth token | gh secret set BASE_PROJECT_TOKEN --repo %s\n' "$repo"
+}
+
+base_repo_secret_list_has_project_token() {
+    awk '
+        $1 == "BASE_PROJECT_TOKEN" { found = 1 }
+        END { exit found ? 0 : 1 }
+    '
+}
+
+base_repo_check_project_intake_secret() {
+    local dry_run="$1"
+    local output=""
+    local repo="$2"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would verify GitHub Actions secret 'BASE_PROJECT_TOKEN' exists for '%s'.\n" "$repo"
+        return 0
+    fi
+
+    base_repo_require_gh || return 1
+    output="$(gh secret list --repo "$repo" 2>&1)" || {
+        log_warn "Unable to inspect GitHub Actions secrets for '$repo'."
+        [[ -z "$output" ]] || log_warn "$output"
+        log_warn "Project Intake may fail unless BASE_PROJECT_TOKEN is configured with user Project access."
+        log_warn "Fix: $(base_repo_project_intake_secret_fix_command "$repo")"
+        return 0
+    }
+
+    if printf '%s\n' "$output" | base_repo_secret_list_has_project_token; then
+        return 0
+    fi
+
+    log_warn "Project Intake secret 'BASE_PROJECT_TOKEN' is not configured for '$repo'."
+    log_warn "GitHub Actions default token cannot access user-level Projects."
+    log_warn "Fix: $(base_repo_project_intake_secret_fix_command "$repo")"
+}
+
 base_repo_configure_project_metadata() {
     local dry_run="$1"
     local config_path="$6"
@@ -1574,6 +1618,7 @@ base_repo_configure_project_metadata() {
                 "$copy_fields_from_project" \
                 "$project_title"
         fi
+        base_repo_check_project_intake_secret "$dry_run" "$repo"
         printf "[DRY-RUN] Would run: %s --project base base_github_projects project configure --project %s --owner %s --repo %s --schema %s" \
             "$wrapper" \
             "$(base_repo_pretty_arg "$project_title")" \
@@ -1598,6 +1643,7 @@ base_repo_configure_project_metadata() {
         log_error "Base Python wrapper '$wrapper' is missing or is not executable."
         return 1
     }
+    base_repo_check_project_intake_secret "$dry_run" "$repo" || return 1
 
     local command=(
         "$wrapper"

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -818,6 +818,7 @@ EOF
     grep -Fq "name: Project Intake" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "BASE_PROJECT_TOKEN" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "gh project item-add" "$repo_dir/.github/workflows/project-intake.yml"
+    grep -Fq "If this Project exists, set BASE_PROJECT_TOKEN" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "set_single_select_if_missing Priority priority" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "BASE_PROJECT_DEFAULT_AREA: Product" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "BASE_PROJECT_DEFAULT_INITIATIVE: Adoption Polish" "$repo_dir/.github/workflows/project-intake.yml"
@@ -1042,6 +1043,7 @@ EOF
     [[ "$output" == *"Would copy GitHub Project 'base-project-template' to 'base-demo' if missing."* ]]
     [[ "$output" == *"Would link GitHub Project 'base-demo' to repository 'codeforester/base-demo'."* ]]
     [[ "$output" == *"Would backfill issues from 'codeforester/base-demo' into GitHub Project 'base-demo'."* ]]
+    [[ "$output" == *"Would verify GitHub Actions secret 'BASE_PROJECT_TOKEN' exists for 'codeforester/base-demo'."* ]]
     [[ "$output" == *"--schema base-roadmap"* ]]
     [[ "$output" == *"Status, Priority, Area, Size, Initiative"* ]]
 }
@@ -1249,6 +1251,81 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"GitHub Project metadata skipped for 'codeforester/base-demo'."* ]]
     [[ "$output" == *"gh auth refresh -h github.com -s project"* ]]
+}
+
+@test "basectl repo configure warns when project intake token secret is missing" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
+    exit 0
+fi
+if [[ "$1" == "secret" && "$2" == "list" ]]; then
+    printf 'OTHER_TOKEN\t2026-06-18T00:00:00Z\n'
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/project-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Project Intake secret 'BASE_PROJECT_TOKEN' is not configured for 'codeforester/base-demo'."* ]]
+    [[ "$output" == *"GitHub Actions default token cannot access user-level Projects."* ]]
+    [[ "$output" == *"gh auth token | gh secret set BASE_PROJECT_TOKEN --repo codeforester/base-demo"* ]]
+}
+
+@test "basectl repo configure accepts existing project intake token secret" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
+    exit 0
+fi
+if [[ "$1" == "secret" && "$2" == "list" ]]; then
+    printf 'BASE_PROJECT_TOKEN\t2026-06-18T00:00:00Z\n'
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/project-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Project Intake secret 'BASE_PROJECT_TOKEN' is not configured"* ]]
+    [[ "$output" == *"Configuration complete."* ]]
 }
 
 @test "basectl repo configure updates an existing Base ruleset" {

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -83,7 +83,10 @@ Base-managed repositories. Set a `BASE_PROJECT_TOKEN` Actions secret with
 Project write access so the workflow can idempotently add the issue to the
 repo-named Project and set `Status`, `Priority`, `Size`, `Area`, and
 `Initiative` from the generated defaults on issue open, reopen, and close
-events. Use `basectl gh project` directly for lower-level Project inspection,
+events. `basectl repo configure` verifies that the secret exists when Project
+support is enabled and prints a `gh secret set BASE_PROJECT_TOKEN` command when
+the workflow would otherwise fall back to the default Actions token.
+Use `basectl gh project` directly for lower-level Project inspection,
 schema repair, or issue field updates.
 When migrating from an existing shared Project, pass
 `--copy-project-fields-from <title>` to copy missing `Status`, `Priority`,

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -195,7 +195,9 @@ created outside `basectl gh issue create`: the workflow idempotently adds the
 issue to the repo-named Project and sets `Status`, `Priority`, `Size`, `Area`,
 and `Initiative` from the generated defaults. Set a `BASE_PROJECT_TOKEN`
 Actions secret with Project write access when `GITHUB_TOKEN` cannot update the
-user or organization Project.
+user or organization Project. `basectl repo configure` checks for
+`BASE_PROJECT_TOKEN` when Project support is enabled and reports the
+`gh secret set BASE_PROJECT_TOKEN` command if the secret is missing.
 
 For older repositories that predate this workflow, rerun
 `basectl repo configure <path> --repo <owner/name>` to create the missing


### PR DESCRIPTION
## Summary
- Warn during repo Project configuration when BASE_PROJECT_TOKEN is missing, with the exact gh secret set recovery command.
- Improve generated and checked-in Project Intake workflow diagnostics when Actions cannot see repo Projects.
- Document Project token verification and add Bats coverage for missing and present token paths.

## Validation
- `bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. CLI diagnostics and workflow-generation change only.

Closes #846