### PR TITLE
Rename Project schema to base-project

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -44,7 +44,7 @@ the canonical current command list.
   - `basectl gh pr create` auto-injects `Fixes #<issue>` from Base branch
     names; pass `--no-fixes` to suppress that body injection.
   - `basectl gh project doctor --project <title>` - inspect Project metadata
-    fields against the Base roadmap schema.
+    fields against the Base Project schema.
   - `basectl gh project configure --project <title>` - create or repair the
     standard Project metadata schema.
   - `basectl gh project issue set-fields <number>` - add an issue to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Made Homebrew-managed `version: latest` profile and project artifacts report
   outdated installed packages during `check`/`doctor` and upgrade them during
   `setup`.
+- Renamed the Base-managed GitHub Project metadata schema from `base-roadmap`
+  to `base-project`.
 - Made `basectl repo configure` report missing `BASE_PROJECT_TOKEN` Project
   intake secrets and improved generated workflow diagnostics when the Actions
   token cannot see repo Projects.

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -15,8 +15,8 @@ Usage:
   basectl gh pr checks [gh options...]
   basectl gh pr ready [gh options...]
   basectl gh pr merge [gh options...]
-  basectl gh project doctor --project <title> [--owner <login>] [--schema base-roadmap]
-  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-roadmap] [--initiative-option <name>] [--dry-run]
+  basectl gh project doctor --project <title> [--owner <login>] [--schema base-project]
+  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-project] [--initiative-option <name>] [--dry-run]
   basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [field options...]
   basectl gh branch stale [--days <days>]
   basectl gh branch prune [--dry-run] [--yes] [--remote]
@@ -101,8 +101,8 @@ EOF
 base_gh_project_usage() {
     cat <<'EOF'
 Usage:
-  basectl gh project doctor --project <title> [--owner <login>] [--schema base-roadmap]
-  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-roadmap] [--initiative-option <name>] [--dry-run]
+  basectl gh project doctor --project <title> [--owner <login>] [--schema base-project]
+  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-project] [--initiative-option <name>] [--dry-run]
   basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [field options...]
 
 Purpose:

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -64,7 +64,7 @@ Options:
   --no-protect-default-branch   Skip Base-managed default branch protection during repo configure.
   --project <title>             GitHub Project title to configure. Defaults to the repository name.
   --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
-  --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
+  --project-schema <schema>     Project metadata schema. Defaults to base-project.
   --initiative-option <name>    Initiative option to seed. May be repeated.
   --copy-project-fields-from <title>
                                 Copy missing Project item field values from another Project.
@@ -147,7 +147,7 @@ Options:
   --no-protect-default-branch   Skip Base-managed default branch protection.
   --project <title>             GitHub Project title to configure. Defaults to the repository name.
   --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
-  --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
+  --project-schema <schema>     Project metadata schema. Defaults to base-project.
   --initiative-option <name>    Initiative option to seed. May be repeated.
   --copy-project-fields-from <title>
                                 Copy missing Project item field values from another Project.
@@ -2139,7 +2139,7 @@ base_repo_init_pr_rerun_command() {
     [[ "$configure_project" == "1" ]] || command+=(--no-project)
     [[ -z "$project_title" ]] || command+=(--project "$project_title")
     [[ -z "$project_owner" ]] || command+=(--project-owner "$project_owner")
-    [[ "$project_schema" == "base-roadmap" ]] || command+=(--project-schema "$project_schema")
+    [[ "$project_schema" == "base-project" ]] || command+=(--project-schema "$project_schema")
     [[ -z "$copy_project_fields_from" ]] || command+=(--copy-project-fields-from "$copy_project_fields_from")
     for option in "$@"; do
         command+=(--initiative-option "$option")
@@ -2410,7 +2410,7 @@ base_repo_init() {
     local name=""
     local path=""
     local project_owner=""
-    local project_schema="base-roadmap"
+    local project_schema="base-project"
     local project_title=""
     local copy_project_fields_from=""
     local protect_default_branch=1
@@ -3076,7 +3076,7 @@ base_repo_configure() {
     local initiative_options=()
     local path="."
     local project_owner=""
-    local project_schema="base-roadmap"
+    local project_schema="base-project"
     local project_title=""
     local protect_default_branch=1
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -1044,7 +1044,7 @@ EOF
     [[ "$output" == *"Would link GitHub Project 'base-demo' to repository 'codeforester/base-demo'."* ]]
     [[ "$output" == *"Would backfill issues from 'codeforester/base-demo' into GitHub Project 'base-demo'."* ]]
     [[ "$output" == *"Would verify GitHub Actions secret 'BASE_PROJECT_TOKEN' exists for 'codeforester/base-demo'."* ]]
-    [[ "$output" == *"--schema base-roadmap"* ]]
+    [[ "$output" == *"--schema base-project"* ]]
     [[ "$output" == *"Status, Priority, Area, Size, Initiative"* ]]
 }
 
@@ -1213,10 +1213,10 @@ EOF
     grep -Fq "BASE_PROJECT_TOKEN" "$repo_dir/.github/workflows/project-intake.yml"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     [[ "$output" == *"Configuring GitHub Project 'base-demo' for 'codeforester/base-demo'."* ]]
-    [[ "$output" == *"Running: $TEST_MOCKBIN/project-wrapper --project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from \"Base Roadmap\""* ]]
+    [[ "$output" == *"Running: $TEST_MOCKBIN/project-wrapper --project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-project --config $repo_dir/.github/base-project.yml --copy-fields-from \"Base Roadmap\""* ]]
     [[ "$output" == *"  GitHub Project 'base-demo': Status, Priority, Area, Size, Initiative fields configured."* ]]
     [[ "$output" == *"Configuration complete."* ]]
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-project --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
 }
 
 @test "basectl repo configure warns when project metadata needs GitHub project scope" {
@@ -1497,7 +1497,7 @@ EOF
     [ -f "$repo_dir/base_manifest.yaml" ]
     grep -Fq "repo create codeforester/base-demo --private --description Base-managed project base-demo." "$TEST_STATE_DIR/gh-args"
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml" ]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-project --config $repo_dir/.github/base-project.yml" ]
     ! grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"
 }
 
@@ -1618,7 +1618,7 @@ EOF
     [[ "$output" == *"No repository baseline changes to commit; continuing with GitHub repository configuration."* ]]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
     ! grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"
-    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-roadmap --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
+    [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-project --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
 }
 
 @test "basectl repo init --pr requires a clean target worktree" {

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -10,7 +10,7 @@ from . import graphql_queries as queries
 from .project_item_fields import FieldCopySummary
 from .project_item_fields import apply_missing_project_item_defaults as _apply_missing_project_item_defaults
 from .project_item_fields import copy_missing_project_item_fields as _copy_missing_project_item_fields
-from .project_model import BASE_ROADMAP_SCHEMA, DEFAULT_TEMPLATE_PROJECT, FIELD_OPTION_TO_PROJECT_FIELD
+from .project_model import BASE_PROJECT_SCHEMA, DEFAULT_TEMPLATE_PROJECT, FIELD_OPTION_TO_PROJECT_FIELD
 from .project_model import STANDARD_TEMPLATE_VIEWS, ConfigureAction, FieldUpdate, Finding, OwnerInfo
 from .project_model import ProjectArguments, ProjectField, ProjectInfo, ProjectSchema, ProjectView
 from .project_model import SelectFieldSpec, SelectOption
@@ -68,9 +68,9 @@ def print_usage(file=sys.stdout) -> None:
             (
                 "Usage:",
                 "  base_github_projects project doctor --project <title> "
-                "[--owner <login>] [--schema base-roadmap]",
+                "[--owner <login>] [--schema base-project]",
                 "  base_github_projects project configure --project <title> "
-                "[--owner <login>] [--repo <owner/name>] [--schema base-roadmap] [--config <path>] "
+                "[--owner <login>] [--repo <owner/name>] [--schema base-project] [--config <path>] "
                 "[--copy-fields-from <title>] [--initiative-option <name>] [--dry-run]",
                 "  base_github_projects project issue set-fields <number> "
                 "--repo <owner/name> --project <title> [--config <path>] [field options...]",
@@ -121,7 +121,7 @@ class OptionState:
     project_title: str | None = None
     owner: str | None = None
     repo: str | None = None
-    schema: str = "base-roadmap"
+    schema: str = "base-project"
     config_path: str | None = None
     copy_fields_from_project: str | None = None
     initiative_options: list[str] | None = None
@@ -151,8 +151,8 @@ def parse_project_options(remaining: list[str], *, allow_fields: bool, allow_iss
         if allow_issue:
             raise ProjectUsageError(f"Unknown issue field option '{arg}'.")
         raise ProjectUsageError(f"Unknown option '{arg}'.")
-    if state.schema != "base-roadmap":
-        raise ProjectUsageError("Only project schema 'base-roadmap' is supported.")
+    if state.schema != "base-project":
+        raise ProjectUsageError("Only project schema 'base-project' is supported.")
     if not state.owner and state.repo:
         state.owner = state.repo.split("/", 1)[0]
     if not state.owner:
@@ -241,15 +241,15 @@ def run_command(args: ProjectArguments) -> int:
 
 
 def schema_for_args(args: ProjectArguments) -> ProjectSchema:
-    if args.schema != "base-roadmap":
-        raise ProjectUsageError("Only project schema 'base-roadmap' is supported.")
+    if args.schema != "base-project":
+        raise ProjectUsageError("Only project schema 'base-project' is supported.")
     config = project_config_for_args(args)
     if args.initiative_options:
         return schema_with_project_config(
-            schema_with_initiatives(BASE_ROADMAP_SCHEMA, args.initiative_options),
+            schema_with_initiatives(BASE_PROJECT_SCHEMA, args.initiative_options),
             config,
         )
-    return schema_with_project_config(BASE_ROADMAP_SCHEMA, config)
+    return schema_with_project_config(BASE_PROJECT_SCHEMA, config)
 
 
 def project_config_for_args(args: ProjectArguments) -> ProjectConfig:

--- a/cli/python/base_github_projects/project_model.py
+++ b/cli/python/base_github_projects/project_model.py
@@ -84,7 +84,7 @@ class ProjectArguments:
     project_title: str | None = None
     owner: str | None = None
     repo: str | None = None
-    schema: str = "base-roadmap"
+    schema: str = "base-project"
     config_path: str | None = None
     copy_fields_from_project: str | None = None
     initiative_options: tuple[str, ...] = ()
@@ -93,7 +93,7 @@ class ProjectArguments:
     field_values: dict[str, str] | None = None
 
 
-BASE_ROADMAP_SCHEMA = ProjectSchema(
+BASE_PROJECT_SCHEMA = ProjectSchema(
     fields=(
         SelectFieldSpec(
             "Status",

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -19,7 +19,7 @@ def test_parse_project_configure_arguments() -> None:
             "--repo",
             "codeforester/bankbuddy",
             "--schema",
-            "base-roadmap",
+            "base-project",
             "--initiative-option",
             "MVP",
             "--initiative-option",
@@ -33,7 +33,7 @@ def test_parse_project_configure_arguments() -> None:
     assert args.project_title == "BankBuddy Roadmap"
     assert args.owner == "codeforester"
     assert args.repo == "codeforester/bankbuddy"
-    assert args.schema == "base-roadmap"
+    assert args.schema == "base-project"
     assert args.initiative_options == ("MVP", "Imports")
     assert args.dry_run is True
 
@@ -220,7 +220,7 @@ def test_compare_schema_reports_missing_fields_wrong_types_and_missing_options()
         ),
     )
 
-    findings = engine.compare_schema(fields, engine.BASE_ROADMAP_SCHEMA)
+    findings = engine.compare_schema(fields, engine.BASE_PROJECT_SCHEMA)
 
     assert engine.Finding("error", "Status", "Status exists with type TEXT; expected SINGLE_SELECT.") in findings
     assert engine.Finding("missing", "Area", "Area field is missing.") in findings
@@ -241,13 +241,13 @@ def test_configuration_plan_preserves_extra_options_and_adds_required_options() 
     actions = engine.configuration_plan(
         project_exists=True,
         fields=(field,),
-        schema=engine.ProjectSchema(fields=(engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority"),)),
+        schema=engine.ProjectSchema(fields=(engine.BASE_PROJECT_SCHEMA.field_by_name("Priority"),)),
     )
 
     assert actions == (
         engine.ConfigureAction("update-field", "Priority", "Add missing options: P0, P2, P3."),
     )
-    updated = engine.merged_options(field, engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority"))
+    updated = engine.merged_options(field, engine.BASE_PROJECT_SCHEMA.field_by_name("Priority"))
     assert [option.name for option in updated] == ["P1", "Later", "P0", "P2", "P3"]
     assert updated[0].option_id == "priority-p1"
     assert updated[1].option_id == "manual-later"
@@ -409,31 +409,31 @@ def test_configure_command_copies_template_for_repo_project_and_backfills_issues
         field_id="status-field",
         name="Status",
         data_type="SINGLE_SELECT",
-        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Status").options,
+        options=engine.BASE_PROJECT_SCHEMA.field_by_name("Status").options,
     )
     priority_field = engine.ProjectField(
         field_id="priority-field",
         name="Priority",
         data_type="SINGLE_SELECT",
-        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority").options,
+        options=engine.BASE_PROJECT_SCHEMA.field_by_name("Priority").options,
     )
     area_field = engine.ProjectField(
         field_id="area-field",
         name="Area",
         data_type="SINGLE_SELECT",
-        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Area").options,
+        options=engine.BASE_PROJECT_SCHEMA.field_by_name("Area").options,
     )
     size_field = engine.ProjectField(
         field_id="size-field",
         name="Size",
         data_type="SINGLE_SELECT",
-        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Size").options,
+        options=engine.BASE_PROJECT_SCHEMA.field_by_name("Size").options,
     )
     initiative_field = engine.ProjectField(
         field_id="initiative-field",
         name="Initiative",
         data_type="SINGLE_SELECT",
-        options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Initiative").options,
+        options=engine.BASE_PROJECT_SCHEMA.field_by_name("Initiative").options,
     )
     calls: list[tuple[str, str]] = []
     linked: list[tuple[str, str]] = []
@@ -567,31 +567,31 @@ def test_configure_command_applies_issue_defaults_from_project_config(
             field_id="status-field",
             name="Status",
             data_type="SINGLE_SELECT",
-            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Status").options,
+            options=engine.BASE_PROJECT_SCHEMA.field_by_name("Status").options,
         ),
         engine.ProjectField(
             field_id="priority-field",
             name="Priority",
             data_type="SINGLE_SELECT",
-            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Priority").options,
+            options=engine.BASE_PROJECT_SCHEMA.field_by_name("Priority").options,
         ),
         engine.ProjectField(
             field_id="area-field",
             name="Area",
             data_type="SINGLE_SELECT",
-            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Area").options,
+            options=engine.BASE_PROJECT_SCHEMA.field_by_name("Area").options,
         ),
         engine.ProjectField(
             field_id="initiative-field",
             name="Initiative",
             data_type="SINGLE_SELECT",
-            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Initiative").options,
+            options=engine.BASE_PROJECT_SCHEMA.field_by_name("Initiative").options,
         ),
         engine.ProjectField(
             field_id="size-field",
             name="Size",
             data_type="SINGLE_SELECT",
-            options=engine.BASE_ROADMAP_SCHEMA.field_by_name("Size").options,
+            options=engine.BASE_PROJECT_SCHEMA.field_by_name("Size").options,
         ),
     )
     applied: list[tuple[str, dict[str, str]]] = []

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -76,7 +76,7 @@ inspect the resolved command contract first.
 | `basectl gh branch stale` | Report stale local branches. | `--days <days>` |
 | `basectl gh branch prune` | Prune safe merged branches. | `--dry-run`, `--yes`, `--remote` |
 | `basectl gh worktree prune` | Prune stale merged worktrees. | `--dry-run`, `--yes` |
-| `basectl gh project doctor` | Inspect GitHub Project metadata against the Base roadmap schema. | `--project <title>`, `--owner <login>`, `--schema base-roadmap` |
+| `basectl gh project doctor` | Inspect GitHub Project metadata against the Base Project schema. | `--project <title>`, `--owner <login>`, `--schema base-project` |
 | `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--config <path>`, `--copy-fields-from <title>`, `--dry-run` |
 | `basectl gh project issue set-fields <number>` | Add an issue to the Project if needed and update metadata fields. | `--project <title>`, `--repo <owner/name>`, `--config <path>`, field options |
 | `basectl gh todo plan` | Preview migration of `TODO.md` items into GitHub Issues. Creation is not enabled yet. | `--file <path>` |

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -95,7 +95,7 @@ overwriting values already set there.
 
 ```bash
 basectl gh project doctor --project "Base Roadmap" --owner codeforester
-basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap
+basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-project
 basectl repo configure ~/work/base --repo codeforester/base --copy-project-fields-from "Base Roadmap"
 basectl gh project issue set-fields 604 --repo codeforester/base --project "Base Roadmap" --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
 ```

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -110,7 +110,7 @@ default when a GitHub repository is known. If the Project is missing, Base copie
 `base-project-template`, links the new Project to the repository, and backfills
 the repository's existing issues into it. Pass `--no-project` to skip Project V2
 metadata, `--project <title>` to override the Project title, `--project-owner
-<login>` to override the owner, `--project-schema base-roadmap` to select the
+<login>` to override the owner, `--project-schema base-project` to select the
 schema, and repeat `--initiative-option <name>` to seed repository-specific
 Initiative values. If `.github/base-project.yml` exists, Base reads repo-owned
 `Area` and `Initiative` options from that file and adds missing Project options

--- a/docs/superpowers/plans/2026-06-11-github-project-roadmap-metadata.md
+++ b/docs/superpowers/plans/2026-06-11-github-project-roadmap-metadata.md
@@ -60,7 +60,7 @@ Zsh syntax checks, and Markdown docs.
 
 ## Canonical Schema
 
-Use this schema for `--schema base-roadmap`. Project-specific `Initiative`
+Use this schema for `--schema base-project`. Project-specific `Initiative`
 options are allowed, but the field itself is always required.
 
 ```text
@@ -111,8 +111,8 @@ basectl repo configure ~/work/bankbuddy --repo codeforester/bankbuddy
 basectl repo configure ~/work/bankbuddy --repo codeforester/bankbuddy --project "BankBuddy Roadmap" --initiative-option MVP --initiative-option Imports
 basectl repo configure ~/work/bankbuddy --repo codeforester/bankbuddy --no-project
 basectl gh project doctor --project "Base Roadmap" --owner codeforester
-basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap
-basectl gh project configure --project "BankBuddy Roadmap" --owner codeforester --schema base-roadmap --initiative-option MVP --initiative-option Imports
+basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-project
+basectl gh project configure --project "BankBuddy Roadmap" --owner codeforester --schema base-project --initiative-option MVP --initiative-option Imports
 basectl gh project issue set-fields 600 --repo codeforester/base --project "Base Roadmap" --owner codeforester --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
 ```
 
@@ -125,7 +125,7 @@ Rules:
   `<RepositoryName> Roadmap`, except the Base repository uses `Base Roadmap`.
 - `--project-owner <login>` overrides the GitHub Project owner. The default is
   the owner from `--repo <owner/name>` or the inferred `origin` repository.
-- `--project-schema base-roadmap` is the only schema in the first release.
+- `--project-schema base-project` is the only schema in the first release.
 - `--initiative-option <name>` can be passed more than once and seeds
   project-specific Initiative options.
 - If Project V2 access is missing during `repo init` or `repo configure`, log a
@@ -200,7 +200,7 @@ Expected: exit 0.
 - [ ] Add an apply-mode test that mocks `bin/base-wrapper` and expects:
 
 ```text
---project base base_github_projects project configure --project Base Demo Roadmap --owner codeforester --schema base-roadmap --repo codeforester/base-demo
+--project base base_github_projects project configure --project Base Demo Roadmap --owner codeforester --schema base-project --repo codeforester/base-demo
 ```
 
 - [ ] Add a Project-scope failure test where the Project engine returns exit 3
@@ -281,8 +281,8 @@ Expected: failure because `gh project` dispatch and completions do not exist.
 - [ ] Update `base_gh_usage()` with:
 
 ```text
-  basectl gh project doctor --project <title> [--owner <login>] [--schema base-roadmap]
-  basectl gh project configure --project <title> [--owner <login>] [--schema base-roadmap] [--initiative-option <name>] [--dry-run]
+  basectl gh project doctor --project <title> [--owner <login>] [--schema base-project]
+  basectl gh project configure --project <title> [--owner <login>] [--schema base-project] [--initiative-option <name>] [--dry-run]
   basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [field options...]
 ```
 
@@ -326,7 +326,7 @@ exist until Task 4.
 - [ ] Create the package files with a minimal `main()` that returns 0 for help.
 - [ ] Add tests for `parse_args()`:
   - `project doctor --project "Base Roadmap" --owner codeforester`
-  - `project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap --dry-run`
+  - `project configure --project "Base Roadmap" --owner codeforester --schema base-project --dry-run`
   - `project issue set-fields 600 --repo codeforester/base --project "Base Roadmap" --owner codeforester --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M`
 - [ ] Add tests for `compare_schema(project, schema)`:
   - missing fields produce missing-field findings
@@ -384,7 +384,7 @@ class ProjectField:
     options: tuple[SelectOption, ...] = ()
 ```
 
-- [ ] Encode the canonical schema from this plan as `BASE_ROADMAP_SCHEMA`.
+- [ ] Encode the canonical schema from this plan as `BASE_PROJECT_SCHEMA`.
 - [ ] Add `run_gh_graphql(query: str, variables: dict[str, str]) -> dict`.
   It should run:
 
@@ -567,7 +567,7 @@ Expected: pass.
 ```text
   --project <title>             GitHub Project title to configure. Defaults to <repo-name> Roadmap.
   --project-owner <login>       GitHub Project owner. Defaults to the repository owner.
-  --project-schema <schema>     Project metadata schema. Defaults to base-roadmap.
+  --project-schema <schema>     Project metadata schema. Defaults to base-project.
   --initiative-option <name>    Initiative option to seed; may be repeated.
   --no-project                  Skip GitHub Project metadata configuration.
 ```
@@ -615,7 +615,7 @@ Expected: pass.
 
 ```bash
 basectl gh project doctor --project "Base Roadmap" --owner codeforester
-basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-roadmap
+basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-project
 basectl gh project issue set-fields 600 --repo codeforester/base --project "Base Roadmap" --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
 ```
 

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -161,7 +161,7 @@ _base_basectl_completion() {
                         '--no-protect-default-branch[Skip Base-managed default branch protection]' \
                         '--project[GitHub Project title]:title:' \
                         '--project-owner[GitHub Project owner]:owner:' \
-                        '--project-schema[Project metadata schema]:schema:(base-roadmap)' \
+                        '--project-schema[Project metadata schema]:schema:(base-project)' \
                         '--initiative-option[Initiative option to seed]:name:' \
                         '--no-project[Skip GitHub Project metadata configuration]' \
                         '--dry-run[Print planned changes]' \
@@ -182,7 +182,7 @@ _base_basectl_completion() {
                         '--no-protect-default-branch[Skip Base-managed default branch protection]' \
                         '--project[GitHub Project title]:title:' \
                         '--project-owner[GitHub Project owner]:owner:' \
-                        '--project-schema[Project metadata schema]:schema:(base-roadmap)' \
+                        '--project-schema[Project metadata schema]:schema:(base-project)' \
                         '--initiative-option[Initiative option to seed]:name:' \
                         '--no-project[Skip GitHub Project metadata configuration]' \
                         '--dry-run[Print planned changes]' \
@@ -326,7 +326,7 @@ _base_basectl_completion() {
                                 '2:project command:(doctor configure issue)' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
-                                '--schema[Project metadata schema]:schema:(base-roadmap)' \
+                                '--schema[Project metadata schema]:schema:(base-project)' \
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         configure)
@@ -334,7 +334,7 @@ _base_basectl_completion() {
                                 '2:project command:(doctor configure issue)' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
-                                '--schema[Project metadata schema]:schema:(base-roadmap)' \
+                                '--schema[Project metadata schema]:schema:(base-project)' \
                                 '--initiative-option[Initiative option to seed]:name:' \
                                 '--repo[GitHub repository]:repo:' \
                                 '--dry-run[Print planned changes]' \


### PR DESCRIPTION
## Summary
- Rename the supported GitHub Project metadata schema from `base-roadmap` to `base-project`.
- Update Bash/Python defaults, help text, completions, docs, `.ai-context`, changelog, and tests.
- Keep `.github/base-project.yml` as the repo-local Project config file.

## Validation
- `env -u BASE_HOME -u BASE_PROJECT -u BASE_PROJECT_ROOT -u BASE_PROJECT_MANIFEST -u BASE_PROJECT_VENV_DIR PYTHONPATH=/Users/rameshhp/work/base-worktrees/enhancement-856-base-project-schema/lib/python:/Users/rameshhp/work/base-worktrees/enhancement-856-base-project-schema/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests/test_engine.py`
- `env -u BASE_HOME -u BASE_PROJECT -u BASE_PROJECT_ROOT -u BASE_PROJECT_MANIFEST -u BASE_PROJECT_VENV_DIR bats cli/bash/commands/basectl/tests/repo.bats`
- `git diff --check`
- `env -u BASE_HOME -u BASE_PROJECT -u BASE_PROJECT_ROOT -u BASE_PROJECT_MANIFEST -u BASE_PROJECT_VENV_DIR ./bin/base-test`

Fixes #856