### PR TITLE
Detect outdated Homebrew artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Made Homebrew-managed `version: latest` profile and project artifacts report
+  outdated installed packages during `check`/`doctor` and upgrade them during
+  `setup`.
 - Made `basectl repo configure` report missing `BASE_PROJECT_TOKEN` Project
   intake secrets and improved generated workflow diagnostics when the Actions
   token cannot see repo Projects.

--- a/README.md
+++ b/README.md
@@ -419,10 +419,11 @@ The curated tool artifact registry lives in `cli/python/base_setup/registry.py`.
 It should stay small and Base-aware. `python-package` artifacts are pass-through
 PyPI package names and install into the project virtual environment at
 `~/.base.d/<project>/.venv`. Homebrew-managed `tool` artifacts currently support
-`version: latest`, but ordinary Homebrew tools should move toward Brewfile
-delegation. Pinned Homebrew versions fail clearly until Base grows explicit
-versioned tool support. The next registry shape is captured in
-[Artifact Adapter Registry](docs/artifact-adapter-registry.md).
+`version: latest`; `basectl check` and `basectl doctor` treat an installed but
+outdated Homebrew package as unhealthy, and `basectl setup` upgrades it. Ordinary
+Homebrew tools should move toward Brewfile delegation. Pinned Homebrew versions
+fail clearly until Base grows explicit versioned tool support. The next registry
+shape is captured in [Artifact Adapter Registry](docs/artifact-adapter-registry.md).
 
 The optional structured `python:` manifest section supports uv-managed Python
 projects:

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -47,7 +47,9 @@ artifacts:
   #   ~/.base.d/<project>/.venv
   #
   # tool artifacts are currently managed through Homebrew. For Homebrew-managed
-  # artifacts, Base currently supports version: latest only.
+  # artifacts, Base currently supports version: latest only. Base reports
+  # installed-but-outdated Homebrew packages during check/doctor and upgrades
+  # them during setup.
   #
   # Example:
   #   - type: tool

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import base_cli
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
-from base_setup.artifacts import reconcile_artifact, resolve_artifact_definitions
+from base_setup.artifacts import homebrew_package_outdated, reconcile_artifact, resolve_artifact_definitions
 from base_setup.errors import ArtifactError
 from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError, read_manifest
 from base_setup.process import command_exists, dry_run_command, run_check, run_command
@@ -543,12 +543,22 @@ def check_homebrew_artifact(
             finding_id="BASE-D103",
         )
 
-    ok = run_check(["brew", "list", definition.package])
-    if ok:
+    if run_check(["brew", "list", definition.package]):
+        if homebrew_package_outdated(definition.package):
+            return DevCheck(
+                name=artifact.name,
+                ok=False,
+                message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
+                fix=profile_setup_fix(profile),
+                finding_id="BASE-D104",
+            )
         return DevCheck(
             name=artifact.name,
             ok=True,
-            message=f"Artifact '{artifact.name}' is installed via Homebrew package '{definition.package}'.",
+            message=(
+                f"Artifact '{artifact.name}' is installed via Homebrew package "
+                f"'{definition.package}' and is current."
+            ),
             fix="",
             finding_id="BASE-D104",
         )

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -8,6 +8,7 @@ import importlib.util
 import json
 import os
 import runpy
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -116,7 +117,8 @@ class DevManifestTests(unittest.TestCase):
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_setup_profile_sre_uses_sre_manifest(self) -> None:
-        status, _stdout, stderr = run_engine(["setup", "--profile", "sre", "--dry-run"])
+        with mock.patch("base_setup.process.command_exists", return_value=False):
+            status, _stdout, stderr = run_engine(["setup", "--profile", "sre", "--dry-run"])
 
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: brew install kubernetes-cli", stderr)
@@ -172,7 +174,8 @@ class DevManifestTests(unittest.TestCase):
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_setup_default_dry_run_does_not_include_ai_remote_installers(self) -> None:
-        status, _stdout, stderr = run_engine(["setup", "--dry-run"])
+        with mock.patch("base_setup.process.command_exists", return_value=False):
+            status, _stdout, stderr = run_engine(["setup", "--dry-run"])
 
         self.assertEqual(status, 0)
         self.assertNotIn("chatgpt.com/codex/install.sh", stderr)
@@ -378,6 +381,13 @@ class DevManifestTests(unittest.TestCase):
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_check_json_reports_invalid_github_auth_when_gh_is_installed(self) -> None:
+        current = subprocess.CompletedProcess(
+            ["brew", "outdated", "gh"],
+            0,
+            stdout="",
+            stderr="",
+        )
+
         def fake_run_check(command: list[str]) -> bool:
             if command == ["brew", "list", "bats-core"]:
                 return True
@@ -392,6 +402,7 @@ class DevManifestTests(unittest.TestCase):
         with (
             mock.patch("base_dev.engine.command_exists", return_value=True),
             mock.patch("base_dev.engine.run_check", side_effect=fake_run_check),
+            mock.patch("base_setup.process.run_capture", return_value=current),
         ):
             status, stdout, stderr = run_engine(["check", "--format", "json"])
 
@@ -411,21 +422,70 @@ class DevManifestTests(unittest.TestCase):
         )
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_check_json_reports_outdated_homebrew_artifact(self) -> None:
+        def fake_run_capture(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            output = "gh\n" if command == ["brew", "outdated", "gh"] else ""
+            return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+        with (
+            mock.patch("base_dev.engine.command_exists", return_value=True),
+            mock.patch("base_dev.engine.run_check", return_value=True),
+            mock.patch("base_setup.process.run_capture", side_effect=fake_run_capture),
+        ):
+            status, stdout, stderr = run_engine(["check", "--format", "json"])
+
+        payload = json.loads(stdout)
+        findings = payload["checks"]
+        gh_finding = next(finding for finding in findings if finding["name"] == "gh")
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(gh_finding["id"], "BASE-D104")
+        self.assertEqual(gh_finding["status"], "error")
+        self.assertIn("outdated via Homebrew package 'gh'", gh_finding["message"])
+        self.assertEqual(gh_finding["fix"], "basectl setup --profile dev")
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_setup_dry_run_uses_homebrew_registry_definitions(self) -> None:
-        status, _stdout, stderr = run_engine(["setup", "--dry-run"])
+        with mock.patch("base_setup.process.command_exists", return_value=False):
+            status, _stdout, stderr = run_engine(["setup", "--dry-run"])
 
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: brew install bats-core", stderr)
         self.assertIn("[DRY-RUN] Would run: brew install gh", stderr)
         self.assertIn("[DRY-RUN] Would run: brew install shellcheck", stderr)
 
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_setup_dry_run_upgrades_outdated_homebrew_artifact(self) -> None:
+        def fake_run_capture(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            output = "gh\n" if command == ["brew", "outdated", "gh"] else ""
+            return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+        with (
+            mock.patch("base_setup.process.command_exists", return_value=True),
+            mock.patch("base_setup.process.run_check", return_value=True),
+            mock.patch("base_setup.process.run_capture", side_effect=fake_run_capture),
+        ):
+            status, _stdout, stderr = run_engine(["setup", "--dry-run"])
+
+        self.assertEqual(status, 0)
+        self.assertIn("[DRY-RUN] Would run: brew upgrade gh", stderr)
+        self.assertNotIn("[DRY-RUN] Would run: brew install gh", stderr)
+
     def test_check_homebrew_artifact_reports_installed_formula(self) -> None:
         artifact = engine.ArtifactRequest("tool", "gh", "latest")
         definition = engine.ArtifactDefinition("gh", "tool", "homebrew", "gh", "system")
+        current = subprocess.CompletedProcess(
+            ["brew", "outdated", "gh"],
+            0,
+            stdout="",
+            stderr="",
+        )
 
         with (
             mock.patch("base_dev.engine.command_exists", return_value=True),
             mock.patch("base_dev.engine.run_check", return_value=True) as run_check,
+            mock.patch("base_setup.process.run_capture", return_value=current),
         ):
             check = engine.check_homebrew_artifact(artifact, definition)
 
@@ -434,6 +494,29 @@ class DevManifestTests(unittest.TestCase):
         self.assertEqual(check.fix, "")
         self.assertIn("is installed via Homebrew package 'gh'", check.message)
         run_check.assert_called_once_with(["brew", "list", "gh"])
+
+    def test_check_homebrew_artifact_reports_outdated_formula(self) -> None:
+        artifact = engine.ArtifactRequest("tool", "gh", "latest")
+        definition = engine.ArtifactDefinition("gh", "tool", "homebrew", "gh", "system")
+        outdated = subprocess.CompletedProcess(
+            ["brew", "outdated", "gh"],
+            0,
+            stdout="gh\n",
+            stderr="",
+        )
+
+        with (
+            mock.patch("base_dev.engine.command_exists", return_value=True),
+            mock.patch("base_dev.engine.run_check", return_value=True),
+            mock.patch("base_setup.process.run_capture", return_value=outdated),
+        ):
+            check = engine.check_homebrew_artifact(artifact, definition)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.name, "gh")
+        self.assertEqual(check.finding_id, "BASE-D104")
+        self.assertEqual(check.fix, "basectl setup --profile dev")
+        self.assertIn("outdated via Homebrew package 'gh'", check.message)
 
     def test_check_homebrew_artifact_reports_missing_formula(self) -> None:
         artifact = engine.ArtifactRequest("tool", "bats-core", "latest")
@@ -578,6 +661,12 @@ class DevManifestTests(unittest.TestCase):
     def test_doctor_reports_invalid_github_auth(self) -> None:
         manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
         definitions = engine.resolve_artifact_definitions(manifest.artifacts)
+        current = subprocess.CompletedProcess(
+            ["brew", "outdated", "gh"],
+            0,
+            stdout="",
+            stderr="",
+        )
 
         def fake_run_check(command: list[str]) -> bool:
             if command == ["brew", "list", "bats-core"]:
@@ -593,6 +682,7 @@ class DevManifestTests(unittest.TestCase):
         with (
             mock.patch("base_dev.engine.command_exists", return_value=True),
             mock.patch("base_dev.engine.run_check", side_effect=fake_run_check),
+            mock.patch("base_setup.process.run_capture", return_value=current),
         ):
             stdout = io.StringIO()
             with redirect_stdout(stdout):

--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -14,6 +14,28 @@ from .manifest import ArtifactRequest
 from .registry import ArtifactDefinition, get_artifact_definition
 
 
+def homebrew_no_auto_update_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+    return env
+
+
+def homebrew_package_outdated(package: str) -> bool:
+    completed = process.run_capture(
+        ["brew", "outdated", package],
+        env=homebrew_no_auto_update_env(),
+    )
+    return homebrew_outdated_output_contains_package(completed.stdout, package)
+
+
+def homebrew_outdated_output_contains_package(output: str, package: str) -> bool:
+    for line in output.splitlines():
+        fields = line.split()
+        if fields and fields[0] == package:
+            return True
+    return False
+
+
 def resolve_artifact_definitions(artifacts: tuple[ArtifactRequest, ...]) -> tuple[ArtifactDefinition, ...]:
     definitions: list[ArtifactDefinition] = []
     for artifact in artifacts:
@@ -100,12 +122,22 @@ def check_homebrew_artifact(
             fix="basectl setup",
             finding_id="BASE-P032",
         )
-    ok = process.run_check(["brew", "list", definition.package])
-    if ok:
+    if process.run_check(["brew", "list", definition.package]):
+        if homebrew_package_outdated(definition.package):
+            return ArtifactCheck(
+                name=artifact.name,
+                ok=False,
+                message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
+                fix=f"basectl setup {project}",
+                finding_id="BASE-P033",
+            )
         return ArtifactCheck(
             name=artifact.name,
             ok=True,
-            message=f"Artifact '{artifact.name}' is installed via Homebrew package '{definition.package}'.",
+            message=(
+                f"Artifact '{artifact.name}' is installed via Homebrew package "
+                f"'{definition.package}' and is current."
+            ),
             fix="",
             finding_id="BASE-P033",
         )
@@ -196,17 +228,36 @@ def reconcile_homebrew_artifact(
             "Homebrew artifact version 'latest' right now."
         )
 
-    command = ["brew", "install", definition.package]
+    install_command = ["brew", "install", definition.package]
+    upgrade_command = ["brew", "upgrade", definition.package]
     if dry_run:
-        process.dry_run_command(ctx, command)
+        if process.command_exists("brew") and process.run_check(["brew", "list", definition.package]):
+            if homebrew_package_outdated(definition.package):
+                process.dry_run_command(ctx, upgrade_command)
+                return
+            ctx.log.info(
+                "Artifact '%s' is already installed via Homebrew package '%s' and is current.",
+                definition.name,
+                definition.package,
+            )
+            return
+        process.dry_run_command(ctx, install_command)
         return
 
     if not process.command_exists("brew"):
         raise ArtifactError(f"Homebrew is required to install artifact '{definition.name}'.")
 
     if process.run_check(["brew", "list", definition.package]):
+        if homebrew_package_outdated(definition.package):
+            ctx.log.info(
+                "Upgrading outdated artifact '%s' via Homebrew package '%s'.",
+                definition.name,
+                definition.package,
+            )
+            process.run_command(ctx, upgrade_command)
+            return
         ctx.log.info(
-            "Artifact '%s' is already installed via Homebrew package '%s'.",
+            "Artifact '%s' is already installed via Homebrew package '%s' and is current.",
             definition.name,
             definition.package,
         )
@@ -218,7 +269,7 @@ def reconcile_homebrew_artifact(
         definition.package,
         version,
     )
-    process.run_command(ctx, command)
+    process.run_command(ctx, install_command)
 
 
 def reconcile_python_artifact(

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -60,10 +60,15 @@ def run_check(command: list[str]) -> bool:
     return subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False).returncode == 0
 
 
-def run_capture(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+def run_capture(
+    command: list[str],
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         cwd=cwd,
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -285,6 +286,70 @@ class ArtifactReconcileTests(unittest.TestCase):
 
         run_command.assert_called_once_with(ctx, ["brew", "install", "terraform"])
 
+
+    def test_homebrew_artifact_latest_dry_run_upgrades_outdated_package(self) -> None:
+        definition = get_artifact_definition("tool", "terraform")
+        self.assertIsNotNone(definition)
+        ctx = fake_context()
+        outdated = subprocess.CompletedProcess(
+            ["brew", "outdated", "terraform"],
+            0,
+            stdout="terraform\n",
+            stderr="",
+        )
+
+        with (
+            mock.patch("base_setup.process.command_exists", return_value=True),
+            mock.patch("base_setup.process.run_check", return_value=True),
+            mock.patch("base_setup.process.run_capture", return_value=outdated),
+        ):
+            artifacts.reconcile_homebrew_artifact(ctx, definition, "latest", dry_run=True)
+
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertIn("[DRY-RUN] Would run: brew upgrade terraform", info_messages)
+
+    def test_homebrew_artifact_latest_upgrades_outdated_package(self) -> None:
+        definition = get_artifact_definition("tool", "terraform")
+        self.assertIsNotNone(definition)
+        ctx = fake_context()
+        outdated = subprocess.CompletedProcess(
+            ["brew", "outdated", "terraform"],
+            0,
+            stdout="terraform\n",
+            stderr="",
+        )
+
+        with (
+            mock.patch("base_setup.process.command_exists", return_value=True),
+            mock.patch("base_setup.process.run_check", return_value=True),
+            mock.patch("base_setup.process.run_capture", return_value=outdated),
+            mock.patch("base_setup.process.run_command") as run_command,
+        ):
+            artifacts.reconcile_homebrew_artifact(ctx, definition, "latest", dry_run=False)
+
+        run_command.assert_called_once_with(ctx, ["brew", "upgrade", "terraform"])
+
+    def test_homebrew_package_outdated_disables_homebrew_auto_update(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["brew", "outdated", "terraform"],
+            0,
+            stdout="terraform\n",
+            stderr="",
+        )
+
+        with (
+            mock.patch.dict(os.environ, {"HOMEBREW_NO_AUTO_UPDATE": "0"}),
+            mock.patch("base_setup.process.run_capture", return_value=completed) as run_capture,
+        ):
+            self.assertTrue(artifacts.homebrew_package_outdated("terraform"))
+            self.assertEqual(os.environ["HOMEBREW_NO_AUTO_UPDATE"], "0")
+
+        run_capture.assert_called_once()
+        self.assertEqual(
+            run_capture.call_args.args[0],
+            ["brew", "outdated", "terraform"],
+        )
+        self.assertEqual(run_capture.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
 
 
     def test_python_artifact_honors_project_venv_dir_override(self) -> None:

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import socket
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -73,6 +74,29 @@ class ProjectCheckTests(unittest.TestCase):
 
         self.assertFalse(check.ok)
         self.assertIn("not installed via Homebrew package 'terraform'", check.message)
+        self.assertEqual(check.fix, "basectl setup demo")
+
+    def test_check_homebrew_artifact_reports_outdated_package(self) -> None:
+        artifact = ArtifactRequest(artifact_type="tool", name="terraform", version="latest")
+        definition = get_artifact_definition("tool", "terraform")
+        self.assertIsNotNone(definition)
+
+        outdated = subprocess.CompletedProcess(
+            ["brew", "outdated", "terraform"],
+            0,
+            stdout="terraform\n",
+            stderr="",
+        )
+        with (
+            mock.patch("base_setup.process.command_exists", return_value=True),
+            mock.patch("base_setup.process.run_check", return_value=True),
+            mock.patch("base_setup.process.run_capture", return_value=outdated),
+        ):
+            check = artifacts.check_homebrew_artifact("demo", artifact, definition)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P033")
+        self.assertIn("outdated via Homebrew package 'terraform'", check.message)
         self.assertEqual(check.fix, "basectl setup demo")
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -471,9 +471,11 @@ design target and migration boundary.
 
 Homebrew-managed `tool` artifacts currently support `version: latest`. If a
 project requests a pinned Homebrew version, setup fails clearly instead of
-silently installing a different version. New ordinary Homebrew tools should
-prefer Brewfile delegation over registry growth. Richer version conflict
-handling across projects is a later iteration, not part of the initial build.
+silently installing a different version. For `version: latest`, check and doctor
+report installed-but-outdated Homebrew packages, and setup upgrades them. New
+ordinary Homebrew tools should prefer Brewfile delegation over registry growth.
+Richer version conflict handling across projects is a later iteration, not part
+of the initial build.
 
 Default artifacts can be marked with `bootstrap: true` when they are required to
 run Base's Python CLI layer inside a project virtual environment before the rest

--- a/docs/artifact-adapter-registry.md
+++ b/docs/artifact-adapter-registry.md
@@ -184,7 +184,8 @@ The initial adapter set is the current behavior:
 
 - `pip` installs into `target: project-venv`;
 - `homebrew` installs `target: system` artifacts with `version_policy:
-  latest-only`.
+  latest-only`, reports installed-but-outdated packages during check/doctor, and
+  upgrades outdated packages during setup.
 
 Adding a new manager should require a Python adapter and tests. Registry data
 alone should not be enough to execute new behavior.

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -84,7 +84,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-D101` | Unsupported prerequisite profile manager |
 | `BASE-D102` | Unsupported prerequisite profile version |
 | `BASE-D103` | Homebrew unavailable for prerequisite profile checks |
-| `BASE-D104` | Prerequisite profile Homebrew package status |
+| `BASE-D104` | Prerequisite profile Homebrew package presence and freshness |
 | `BASE-D105` | GitHub CLI availability |
 | `BASE-D106` | GitHub CLI authentication status |
 | `BASE-D107` | AI developer tool availability and version status |
@@ -104,7 +104,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P030` | Unsupported artifact manager |
 | `BASE-P031` | Unsupported Homebrew artifact version |
 | `BASE-P032` | Homebrew unavailable for artifact checks |
-| `BASE-P033` | Homebrew artifact package status |
+| `BASE-P033` | Homebrew artifact package presence and freshness |
 | `BASE-P040` | Python package artifact status in the project virtual environment |
 | `BASE-P050` | Project virtual environment readiness |
 | `BASE-P060` | Project demo declaration |


### PR DESCRIPTION
## Summary
- Treat installed-but-outdated Homebrew `version: latest` artifacts as unhealthy in profile and project checks.
- Upgrade outdated Homebrew artifacts during setup, including dry-run upgrade reporting.
- Document the presence/freshness semantics for Homebrew artifact findings.

## Validation
- `env -u BASE_HOME PYTHONPATH="$PWD/lib/python:$PWD/cli/python" "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_dev/tests/test_engine.py`
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. CLI diagnostics/setup behavior change only.

Closes #851