### PR TITLE
Clarify workspace clone and pull help

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -25,6 +25,8 @@ the canonical current command list.
   workspace project status, checks, diagnostics, clone expected repositories
   from a manifest, or explicitly sync a local manifest from a configured
   canonical source.
+  - `workspace status`, `workspace check`, and `workspace doctor` support
+    `--format json`; `workspace clone` and `workspace pull` use text output.
 - `basectl repo <init|clone|check|configure|agent-guidance|installer-template>` -
   create repository baselines, clone GitHub repositories into the configured
   workspace, configure GitHub repository settings and default branch protection,

--- a/README.md
+++ b/README.md
@@ -459,9 +459,11 @@ By default this scans `workspace.root` from `~/.base.d/config.yaml` when that
 value is configured. If it is not configured, Base falls back to the parent
 directory of `BASE_HOME`, which matches the source-checkout sibling-repo layout.
 Use `--workspace <path>` to inspect a different workspace root for one command.
-Project list output is tab-separated as `<project-name><TAB><path>`. Use
-`--format json` for machine-readable output. Workspace status, check, and
-doctor are read-only. Status reports each discovered project's manifest
+Project list output is tab-separated as `<project-name><TAB><path>`.
+`basectl projects list` and the read-only workspace status, check, and doctor
+commands support `--format json` for machine-readable output. Workspace clone
+and pull use text output only. Workspace status, check, and doctor are
+read-only. Status reports each discovered project's manifest
 validity, whether the Base-managed project virtual environment is present, and
 the latest recorded `basectl check <project>` date when one exists. Check
 records live under `~/.base.d/<project>/checks/last.json`; status JSON includes

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -3,26 +3,87 @@
 _base_workspace_subcommand_sourced=1
 readonly _base_workspace_subcommand_sourced
 
-base_workspace_subcommand_usage() {
+base_workspace_report_usage() {
     cat <<'EOF'
 Usage:
-  basectl workspace <status|check|doctor|clone|pull> [options]
+  basectl workspace <status|check|doctor> [options]
 
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
-  --source <url-or-path>
-                      Canonical workspace manifest source for workspace pull.
-                      Overrides workspace.manifest_source from ~/.base.d/config.yaml.
   --format <format>   Output format for the workspace command: text or json.
-  --include-optional  Include optional workspace manifest repositories when cloning.
-  --dry-run           Show planned workspace clone or pull work without writing.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
-Show status, check, doctor, clone, or pull output for repositories in the workspace.
+Show status, check, or doctor output for repositories in the workspace.
 EOF
+}
+
+base_workspace_clone_usage() {
+    cat <<'EOF'
+Usage:
+  basectl workspace clone [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --manifest <path>   Local workspace manifest describing expected repositories.
+                      Overrides workspace.manifest from ~/.base.d/config.yaml.
+  --include-optional  Include optional workspace manifest repositories when cloning.
+  --dry-run           Show planned workspace clone work without writing.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Clone or validate expected repositories from a workspace manifest.
+EOF
+}
+
+base_workspace_pull_usage() {
+    cat <<'EOF'
+Usage:
+  basectl workspace pull [options]
+
+Options:
+  --source <url-or-path>
+                      Canonical workspace manifest source for workspace pull.
+                      Overrides workspace.manifest_source from ~/.base.d/config.yaml.
+  --manifest <path>   Local workspace manifest describing expected repositories.
+                      Overrides workspace.manifest from ~/.base.d/config.yaml.
+  --dry-run           Show planned workspace pull work without writing.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Fetch and validate a canonical workspace manifest before updating the local manifest.
+EOF
+}
+
+base_workspace_subcommand_usage() {
+    case "${1:-}" in
+        status|check|doctor)
+            base_workspace_report_usage
+            ;;
+        clone)
+            base_workspace_clone_usage
+            ;;
+        pull)
+            base_workspace_pull_usage
+            ;;
+        *)
+            cat <<'EOF'
+Usage:
+  basectl workspace <status|check|doctor|clone|pull> [options]
+
+Commands:
+  status   Show workspace status. Supports --format text|json.
+  check    Run workspace checks. Supports --format text|json.
+  doctor   Run workspace diagnostics. Supports --format text|json.
+  clone    Clone or validate expected repositories from a workspace manifest.
+  pull     Fetch and validate a canonical workspace manifest source.
+
+Run `basectl workspace <command> --help` for command-specific options.
+EOF
+            ;;
+    esac
 }
 
 base_workspace_usage_error() {
@@ -57,7 +118,7 @@ base_workspace_subcommand_main() {
                 shift
                 ;;
             -h|--help)
-                base_workspace_subcommand_usage
+                base_workspace_subcommand_usage "$workspace_command"
                 return 0
                 ;;
             *)

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -146,33 +146,41 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull> [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
-    [[ "$output" == *"--source <url-or-path>"* ]]
     [[ "$output" == *"--format <format>"* ]]
-    [[ "$output" == *"--include-optional"* ]]
-    [[ "$output" == *"--dry-run"* ]]
 
     run_basectl workspace check --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull> [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
+    [[ "$output" == *"--format <format>"* ]]
 
     run_basectl workspace doctor --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull> [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
+    [[ "$output" == *"--format <format>"* ]]
 
     run_basectl workspace clone --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull> [options]"* ]]
+    [[ "$output" == *"basectl workspace clone [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--manifest <path>"* ]]
+    [[ "$output" == *"--include-optional"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" != *"--format <format>"* ]]
 
     run_basectl workspace pull --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull> [options]"* ]]
+    [[ "$output" == *"basectl workspace pull [options]"* ]]
+    [[ "$output" == *"--source <url-or-path>"* ]]
+    [[ "$output" == *"--manifest <path>"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" != *"--format <format>"* ]]
 }
 
 @test "basectl workspace rejects unknown subcommands" {


### PR DESCRIPTION
## Summary
- Split workspace help into reporting, clone, and pull command-specific usage.
- Stop advertising `--format json` for `workspace clone` and `workspace pull` while keeping it for status/check/doctor.
- Clarify README and AI command context around workspace JSON support.

## Validation
- `bats cli/bash/commands/basectl/tests/workspace.bats`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

Fixes #857