### PR TITLE
Reject cleartext workspace manifest sources

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_pull.py
+++ b/cli/python/base_projects/tests/test_workspace_pull.py
@@ -173,6 +173,55 @@ class WorkspacePullTests(unittest.TestCase):
         self.assertIn(f"Source: {source.as_uri()}", stdout)
         self.assertIn("Status: created", stdout)
 
+    def test_workspace_pull_rejects_cleartext_http_source_before_fetching(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            target = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+
+            with mock.patch("base_projects.workspace_pull.urlopen") as urlopen:
+                status, stdout, stderr = invoke_engine(
+                    ["pull", "--source", "http://example.test/workspace.yaml", "--manifest", str(target)],
+                    base_home,
+                    home,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertFalse(target.exists())
+        urlopen.assert_not_called()
+        self.assertIn("Insecure workspace manifest source", stderr)
+        self.assertIn("Use https://, file://, or a local path", stderr)
+
+    def test_workspace_pull_accepts_https_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            target = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+
+            response = mock.MagicMock()
+            response.read.return_value = WORKSPACE_MANIFEST.encode("utf-8")
+            response.__enter__.return_value = response
+            with mock.patch("base_projects.workspace_pull.urlopen", return_value=response) as urlopen:
+                status, stdout, stderr = invoke_engine(
+                    ["pull", "--source", "https://example.test/workspace.yaml", "--manifest", str(target)],
+                    base_home,
+                    home,
+                )
+            target_content = target.read_text(encoding="utf-8") if target.exists() else ""
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(target_content, WORKSPACE_MANIFEST)
+        urlopen.assert_called_once_with("https://example.test/workspace.yaml", timeout=30)
+        self.assertIn("Status: created", stdout)
+
     def test_workspace_pull_rejects_invalid_manifest_without_overwriting_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/workspace_pull.py
+++ b/cli/python/base_projects/workspace_pull.py
@@ -62,7 +62,12 @@ def workspace_manifest_change_status(existing_content: bytes | None, content: by
 
 def fetch_workspace_manifest_source(source: str) -> bytes:
     parsed = urlparse(source)
-    if parsed.scheme in {"http", "https"}:
+    if parsed.scheme == "http":
+        raise WorkspaceManifestError(
+            f"Insecure workspace manifest source '{source}'. Use https://, file://, or a local path."
+        )
+
+    if parsed.scheme == "https":
         try:
             # This command fetches an explicit user-configured manifest source.
             with urlopen(source, timeout=30) as response:  # nosec B310
@@ -79,7 +84,7 @@ def fetch_workspace_manifest_source(source: str) -> bytes:
 
     if parsed.scheme and parsed.scheme not in {"", "file"}:
         raise WorkspaceManifestError(
-            f"Unsupported workspace manifest source '{source}'. Expected a local path, file:// URL, or http(s) URL."
+            f"Unsupported workspace manifest source '{source}'. Expected a local path, file:// URL, or https:// URL."
         )
 
     return read_workspace_manifest_source_file(source, Path(source).expanduser())

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -110,8 +110,9 @@ edit that value to make commands such as
 `workspace.manifest_source` is optional. When set, `basectl workspace pull`
 uses it as the canonical manifest source unless the command supplies
 `--source <url-or-path>`. Supported sources are local paths, `file://` URLs, and
-`http://` or `https://` raw file URLs. Pull validates fetched content as a
-workspace manifest before updating `workspace.manifest`.
+`https://` raw file URLs. Cleartext `http://` sources are rejected by default.
+Pull validates fetched content as a workspace manifest before updating
+`workspace.manifest`.
 
 `workspace.root` and `workspace.manifest` must be absolute paths or start with
 `~`. `workspace.manifest_source` must be a non-empty string when provided.

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -13,8 +13,9 @@ manifest is required.
 
 Teams can also configure `workspace.manifest_source` and refresh the local
 manifest explicitly with `basectl workspace pull`. Pull supports local paths,
-`file://` URLs, and raw `http://` or `https://` file URLs. It validates fetched
-content before writing and does not mutate project repositories.
+`file://` URLs, and raw `https://` file URLs. It rejects cleartext `http://`
+sources by default, validates fetched content before writing, and does not
+mutate project repositories.
 
 ## Vocabulary
 


### PR DESCRIPTION
## Summary
- Reject `http://` workspace manifest sources before any network fetch.
- Keep HTTPS, file URLs, and local path manifest pulls working.
- Update workspace manifest and local config docs to describe the HTTPS/local trust boundary.

## Validation
- `env -u BASE_HOME PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_workspace_pull.py -q`
- `env -u BASE_HOME ./bin/base-test`
- `git diff --check`

Fixes #858