### PR TITLE
Align workspace command contract docs

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -21,12 +21,15 @@ the canonical current command list.
   Zip bundle for manual upload or copy/paste into AI tools.
 - `basectl projects list` - list Base-managed projects discovered in the
   workspace.
-- `basectl workspace <status|check|doctor|clone|pull>` - show read-only
-  workspace project status, checks, diagnostics, clone expected repositories
-  from a manifest, or explicitly sync a local manifest from a configured
-  canonical source.
+- `basectl workspace <status|check|doctor|clone|pull>` - inspect workspace
+  status, checks, and diagnostics; explicitly clone expected repositories from
+  a manifest; or explicitly sync a local manifest from a configured canonical
+  source.
   - `workspace status`, `workspace check`, and `workspace doctor` support
     `--format json`; `workspace clone` and `workspace pull` use text output.
+  - `workspace clone` mutates repository checkouts only when invoked directly;
+    `workspace pull` mutates only the local workspace manifest after validating
+    the source.
 - `basectl repo <init|clone|check|configure|agent-guidance|installer-template>` -
   create repository baselines, clone GitHub repositories into the configured
   workspace, configure GitHub repository settings and default branch protection,

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -44,7 +44,8 @@ source builds treated as fallback validation rather than the normal user path.
 Recent released work includes:
 
 - local observability model for future command history and report surfaces
-- read-only workspace manifest support
+- workspace manifest status/check/doctor reporting plus explicit clone and pull
+  support
 - guarded `basectl release publish`
 - release check, plan, and notes commands
 - local `.ai-context/` export bundles through `basectl export-context`

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -66,7 +66,8 @@ load ./basectl_helpers.bash
 @test "AI command context includes current clone and update surfaces" {
     local commands_file="$BASE_REPO_ROOT/.ai-context/COMMANDS.md"
 
-    grep -Fqx -- "- \`basectl workspace <status|check|doctor|clone|pull>\` - show read-only" "$commands_file"
+    grep -Fqx -- "- \`basectl workspace <status|check|doctor|clone|pull>\` - inspect workspace" "$commands_file"
+    grep -Fqx -- "  - \`workspace clone\` mutates repository checkouts only when invoked directly;" "$commands_file"
     grep -Fqx -- "- \`basectl repo <init|clone|check|configure|agent-guidance|installer-template>\` -" "$commands_file"
     grep -Fqx -- "- \`basectl update [project]\` - update Base or a named project using the" "$commands_file"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -587,23 +587,29 @@ basectl projects list
 basectl workspace status
 basectl workspace check
 basectl workspace doctor
+basectl workspace clone
+basectl workspace pull
 ```
 
-Workspace commands are intentionally read-only. `basectl workspace status`
-reports project manifest state, virtual environment state, and Git state across
-discovered projects, including invalid manifests without stopping the whole
-scan. With `workspace.manifest` or `--manifest <path>`, workspace commands also
-report missing required repositories, missing optional repositories, and
-discovered Base-managed projects outside the expected repo set. `basectl
-workspace check` and
-`basectl workspace doctor` run project checks and diagnostics across discovered
-projects. JSON output is part of the contract so automation and future CI smoke
-checks can use the same data.
+Workspace commands are read-first and mutate only through explicit clone or
+pull commands. `basectl workspace status` reports project manifest state,
+virtual environment state, and Git state across discovered projects, including
+invalid manifests without stopping the whole scan. With `workspace.manifest` or
+`--manifest <path>`, workspace commands also report missing required
+repositories, missing optional repositories, and discovered Base-managed
+projects outside the expected repo set. `basectl workspace check` and `basectl
+workspace doctor` run project checks and diagnostics across discovered
+projects. `basectl workspace clone` materializes missing expected repositories
+only when invoked directly, and `basectl workspace pull` updates only the local
+workspace manifest after validating an explicit or configured source. JSON
+output is part of the status/check/doctor contract so automation and future CI
+smoke checks can use the same data.
 
 Future workspace commands should follow the same principles:
 
 - start with read-only status, check, and doctor behavior
-- require explicit flags before mutating many repositories
+- require explicit commands and dry-run paths before mutating many repositories
+  or local workspace metadata
 - treat partial failure as normal in multi-repo workspaces
 - keep sibling repositories under a shared workspace root as the default
   discovery model

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -179,7 +179,9 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 
 | Command | What it does |
 |---|---|
-| `basectl workspace status/check/doctor/clone/pull [--manifest]` | Cross-project manifest, venv state, cloning, and explicit manifest sync |
+| `basectl workspace status/check/doctor [--manifest] [--format json]` | Read-only cross-project manifest, venv, Git, check, and diagnostic state |
+| `basectl workspace clone [--manifest] [--dry-run]` | Explicitly clone or validate expected repositories from a workspace manifest |
+| `basectl workspace pull [--source] [--manifest] [--dry-run]` | Explicitly refresh the local workspace manifest from a validated source |
 | `basectl workspace check [--manifest]` | Cross-project readiness check |
 | `basectl workspace doctor [--manifest]` | Cross-project diagnostic findings |
 

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -142,7 +142,7 @@ them.
 `repos[].required` defaults to `true`. Optional repositories should appear in
 status reports without failing the whole workspace when they are absent.
 
-## Location
+## Location And Sources
 
 The v1 implementation supports an explicit local file:
 
@@ -154,15 +154,24 @@ The manifest should live outside individual project repositories unless a team
 intentionally keeps it in a dedicated workspace-config repository. A local file
 keeps the trust model simple: Base reads only a path the user named.
 
-URL support should be deferred. Fetching remote manifests creates questions
-about caching, trust, authentication, redirects, and offline behavior. A
-project-owned or team-owned installer can fetch a manifest and then hand Base a
-local path when that workflow is needed.
+Teams can also configure a canonical manifest source in
+`workspace.manifest_source` and refresh the local manifest with the explicit
+`basectl workspace pull` command. Pull supports local paths, `file://` URLs,
+and raw `https://` file URLs; cleartext `http://` sources are rejected by
+default. Remote source fetching is therefore an explicit manifest-file update,
+not passive workspace discovery, and it does not clone, pull, reset, or rewrite
+project repositories.
 
 ## Trust And Authentication
 
 Base should delegate repository authentication to Git, SSH, and the GitHub CLI.
 It should not store, read, print, or manage credentials.
+
+Remote workspace manifest sources should use HTTPS. Cleartext HTTP is rejected
+by default because a workspace manifest controls expected repositories and
+clone plans. If a future internal workflow proves that insecure transport is
+needed, it should use an explicit opt-in rather than making HTTP ordinary
+configuration.
 
 Workspace manifest validation may check that clone URLs are syntactically
 present. Network reachability, SSH key readiness, and GitHub authentication


### PR DESCRIPTION
## Summary
- Reframe workspace architecture docs around read-first behavior and explicit clone/pull mutation.
- Remove stale deferred URL-source language and document the HTTPS/local manifest-source trust boundary.
- Update technical overview and AI context so workspace status/check/doctor, clone, and pull have distinct contracts.

## Validation
- `bats cli/bash/commands/basectl/tests/help.bats`
- `bats cli/bash/commands/basectl/tests/workspace.bats`
- stale-phrase scan for old workspace read-only/deferred URL wording
- `git diff --check`

Fixes #859