### PR TITLE
Make Homebrew artifact dry-run tests hermetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
   Base when Homebrew requires trust for the tap-owned `base-bash-libs`
   dependency.
 
+### Fixed
+
+- Made Homebrew artifact dry-run tests independent of the developer machine's
+  installed or outdated Homebrew formulae.
+
 ## [1.0.5] - 2026-06-18
 
 ### Added

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -227,10 +227,15 @@ class ArtifactReconcileTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=False),
+                mock.patch("base_setup.process.run_check") as run_check,
+            ):
+                status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
 
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: brew install terraform", stderr)
+        run_check.assert_not_called()
 
 
 
@@ -256,11 +261,16 @@ class ArtifactReconcileTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=False),
+                mock.patch("base_setup.process.run_check") as run_check,
+            ):
+                status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
 
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: brew install docker", stderr)
         self.assertIn("[DRY-RUN] Would run: brew install colima", stderr)
+        run_check.assert_not_called()
 
 
 


### PR DESCRIPTION
## Summary
- Mock Homebrew availability in the engine-level Homebrew artifact dry-run tests.
- Keep the #862 product behavior intact while avoiding local Cellar/outdated-state leaks into the test expectations.
- Add a changelog note for the test hermeticity fix.

## Validation
- git diff --check
- env -u BASE_HOME PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py -q
- env -u BASE_HOME ./bin/base-test

## Demo Impact
- None. Test-only fix.

Fixes #866