### PR TITLE
Enrich shell history defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Enriched opt-in shell history defaults for `basectl update-profile --defaults`.
 - Made Homebrew-managed `version: latest` profile and project artifacts report
   outdated installed packages during `check`/`doctor` and upgrade them during
   `setup`.

--- a/README.md
+++ b/README.md
@@ -1312,7 +1312,8 @@ Those defaults are intended to stay conservative:
 - vi-style command editing
 - editor defaults
 - prompt defaults
-- history behavior
+- history behavior, including duplicate suppression, timestamped history, and
+  multi-line command preservation
 
 ## Optional Utility Tools
 

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -497,26 +497,43 @@ EOF
     [[ "$(cat "$TEST_HOME/.zshrc")" != *"defaults.sh"* ]]
 
     run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u EDITOR -u VISUAL -u EXINIT \
+        -u HISTCONTROL -u HISTSIZE -u HISTFILESIZE \
         HOME="$TEST_HOME" \
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'alias cp; printf "EDITOR=%s\n" "$EDITOR"; printf "VISUAL=%s\n" "$VISUAL"; printf "EXINIT=%s\n" "$EXINIT"; printf "BASE_HOME=%s\n" "$BASE_HOME"; cd "$BASE_HOME"; printf "git=%s\n" "$(_base_bash_defaults_git_prompt)"; printf "PS1=%s\n" "$PS1"'
+        bash --rcfile "$TEST_HOME/.bashrc" -i -c 'alias cp; printf "EDITOR=%s\n" "$EDITOR"; printf "VISUAL=%s\n" "$VISUAL"; printf "EXINIT=%s\n" "$EXINIT"; printf "HISTCONTROL=%s\n" "$HISTCONTROL"; printf "HISTSIZE=%s\n" "$HISTSIZE"; printf "HISTFILESIZE=%s\n" "$HISTFILESIZE"; shopt -q cmdhist && printf "cmdhist=enabled\n"; shopt -q lithist && printf "lithist=enabled\n"; printf "BASE_HOME=%s\n" "$BASE_HOME"; cd "$BASE_HOME"; printf "git=%s\n" "$(_base_bash_defaults_git_prompt)"; printf "PS1=%s\n" "$PS1"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"alias cp='cp -i'"* ]]
     [[ "$output" == *"EDITOR=vi"* ]]
     [[ "$output" == *"VISUAL=vi"* ]]
     [[ "$output" == *"EXINIT=set ts=4 sw=4 ai nows nosm expandtab"* ]]
+    [[ "$output" == *"HISTCONTROL=ignoreboth:erasedups"* ]]
+    [[ "$output" == *"HISTSIZE=10000"* ]]
+    [[ "$output" == *"HISTFILESIZE=20000"* ]]
+    [[ "$output" == *"cmdhist=enabled"* ]]
+    [[ "$output" == *"lithist=enabled"* ]]
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
     [[ "$output" == *"git=("* ]]
     [[ "$output" == *'PS1=\[\033[0;35m\]\T \h\[\033[0;33m\] $(_base_bash_defaults_git_prompt)\w\[\033[00m\]: '* ]]
 
     if command -v zsh >/dev/null 2>&1; then
         run env -u BASE_HOME -u BASE_HOST -u BASE_OS -u EDITOR -u VISUAL -u EXINIT \
+            -u HISTFILE -u HISTSIZE -u SAVEHIST \
             HOME="$TEST_HOME" \
             PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-            zsh -f -i -c 'source "$HOME/.zshrc"; cd "$BASE_HOME"; printf "git=%s\n" "$(_base_zsh_defaults_git_prompt)"; printf "PROMPT=%s\n" "$PROMPT"; setopt | grep -q "^promptsubst$"; printf "prompt_subst=enabled\n"'
+            zsh -f -i -c 'source "$HOME/.zshrc"; printf "HISTFILE=%s\n" "$HISTFILE"; printf "HISTSIZE=%s\n" "$HISTSIZE"; printf "SAVEHIST=%s\n" "$SAVEHIST"; setopt | grep -q "^extendedhistory$" && printf "extended_history=enabled\n"; setopt | grep -q "^histignorespace$" && printf "hist_ignore_space=enabled\n"; setopt | grep -q "^histreduceblanks$" && printf "hist_reduce_blanks=enabled\n"; setopt | grep -q "^histexpiredupsfirst$" && printf "hist_expire_dups_first=enabled\n"; setopt | grep -q "^histsavenodups$" && printf "hist_save_no_dups=enabled\n"; setopt | grep -q "^histfindnodups$" && printf "hist_find_no_dups=enabled\n"; setopt | grep -q "^histverify$" && printf "hist_verify=enabled\n"; cd "$BASE_HOME"; printf "git=%s\n" "$(_base_zsh_defaults_git_prompt)"; printf "PROMPT=%s\n" "$PROMPT"; setopt | grep -q "^promptsubst$"; printf "prompt_subst=enabled\n"'
 
         [ "$status" -eq 0 ]
+        [[ "$output" == *"HISTFILE=$TEST_HOME/.zsh_history"* ]]
+        [[ "$output" == *"HISTSIZE=10000"* ]]
+        [[ "$output" == *"SAVEHIST=10000"* ]]
+        [[ "$output" == *"extended_history=enabled"* ]]
+        [[ "$output" == *"hist_ignore_space=enabled"* ]]
+        [[ "$output" == *"hist_reduce_blanks=enabled"* ]]
+        [[ "$output" == *"hist_expire_dups_first=enabled"* ]]
+        [[ "$output" == *"hist_save_no_dups=enabled"* ]]
+        [[ "$output" == *"hist_find_no_dups=enabled"* ]]
+        [[ "$output" == *"hist_verify=enabled"* ]]
         [[ "$output" == *"git=("* ]]
         [[ "$output" == *'PROMPT=%* %m $(_base_zsh_defaults_git_prompt)%1~: '* ]]
         [[ "$output" == *"prompt_subst=enabled"* ]]

--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -58,6 +58,18 @@ _base_bash_defaults_git_prompt() {
 
 export PS1='\[\033[0;35m\]\T \h\[\033[0;33m\] $(_base_bash_defaults_git_prompt)\w\[\033[00m\]: '
 
-export HISTCONTROL=ignoredups:erasedups
+export HISTCONTROL="${HISTCONTROL:-ignoreboth:erasedups}"
+if [[ "${HISTSIZE:-500}" == 500 ]]; then
+    export HISTSIZE=10000
+else
+    export HISTSIZE
+fi
+if [[ "${HISTFILESIZE:-500}" == 500 ]]; then
+    export HISTFILESIZE=20000
+else
+    export HISTFILESIZE
+fi
 export HISTTIMEFORMAT="[%F %T] "
 shopt -s histappend
+shopt -s cmdhist
+shopt -s lithist

--- a/lib/shell/zsh_defaults.sh
+++ b/lib/shell/zsh_defaults.sh
@@ -56,11 +56,27 @@ _base_zsh_defaults_git_prompt() {
     printf '(%s) ' "$branch"
 }
 
-export HISTSIZE="${HISTSIZE:-5000}"
-export SAVEHIST="${SAVEHIST:-5000}"
+export HISTFILE="${HISTFILE:-$HOME/.zsh_history}"
+if [[ "${HISTSIZE:-30}" == 30 ]]; then
+    export HISTSIZE=10000
+else
+    export HISTSIZE
+fi
+if [[ "${SAVEHIST:-0}" == 0 ]]; then
+    export SAVEHIST=10000
+else
+    export SAVEHIST
+fi
 setopt appendhistory
+setopt extended_history
+setopt hist_expire_dups_first
+setopt hist_find_no_dups
 setopt hist_ignore_dups
 setopt hist_ignore_all_dups
+setopt hist_ignore_space
+setopt hist_reduce_blanks
+setopt hist_save_no_dups
+setopt hist_verify
 setopt prompt_subst
 setopt share_history
 


### PR DESCRIPTION
## Summary
- Add richer Bash history defaults for opt-in `update-profile --defaults` shells.
- Add richer Zsh history persistence and duplicate-management defaults.
- Update README and CHANGELOG for the user-facing shell defaults change.

## Validation
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "basectl update-profile --defaults enables defaults through profile config" cli/bash/commands/basectl/tests/update-profile.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/update-profile.bats`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`
- `git diff --check`

Fixes #867