### PR TITLE
Document optional shell defaults boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Documented the boundary for optional personal shell defaults such as color
+  aliases, navigation shortcuts, signing helpers, and strict shell modes.
 - Improved opt-in Bash and Zsh completion ergonomics for interactive shell
   defaults.
 - Added conservative pager and terminal usability behavior to opt-in shell

--- a/README.md
+++ b/README.md
@@ -1318,6 +1318,21 @@ Those defaults are intended to stay conservative:
 - history behavior, including duplicate suppression, timestamped history, and
   multi-line command preservation
 
+The defaults should not become a personal dotfile bundle. The following remain
+outside `basectl update-profile --defaults` unless Base adds a separate,
+explicit opt-in:
+
+- color or listing aliases for tools such as `ls`, `grep`, or `diff`
+- navigation shortcuts, `CDPATH`, auto-directory changes, or spelling
+  correction
+- signing and agent helpers such as `GPG_TTY`
+- strict shell modes such as global `errexit`, `nounset`, or `pipefail`
+- prompt features that run expensive checks, such as dirty Git status
+
+Those settings are platform-sensitive, workflow-specific, or more likely to
+change command behavior in surprising ways. Keep personal aliases and functions
+in normal shell dotfiles, and keep simple Base preferences in `~/.baserc`.
+
 ## Optional Utility Tools
 
 Base no longer owns general-purpose utility CLIs such as `caff` and

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -564,6 +564,13 @@ Base-managed shell startup files follow this separation of concerns:
 Startup files should stay thin and predictable. They must not source
 `base_init.sh`; Base runtime setup belongs to the `basectl` command path.
 
+Optional shell defaults must stay conservative. Platform-sensitive or highly
+personal behavior, such as color/listing aliases, navigation shortcuts, shell
+spelling correction, signing-agent setup, strict shell modes, or prompt features
+that run expensive checks, should remain in user dotfiles or move behind a
+separate explicit opt-in instead of being added to
+`basectl update-profile --defaults`.
+
 `~/.baserc` is user-managed input for simple Base preferences such as
 `BASE_DEBUG=1`. It must not set Base-owned runtime or profile state such as
 `BASE_HOME`, `BASE_BIN_DIR`, `BASE_LIB_DIR`, `BASE_OS`, `BASE_SHELL`,


### PR DESCRIPTION
## Summary
- Document why color/listing aliases, navigation shortcuts, signing helpers, strict shell modes, and expensive prompt checks stay out of update-profile --defaults.
- Point personal or platform-sensitive shell behavior toward user-managed dotfiles or future explicit opt-ins instead of the shared defaults bundle.

## Validation
- git diff --check

Fixes #870