### PR TITLE
Update Base references for Base Foundry

### DIFF
--- a/.ai-context/PROJECT.md
+++ b/.ai-context/PROJECT.md
@@ -3,7 +3,7 @@
 ## Identity
 
 - Name: Base
-- Repository: `github.com/codeforester/base`
+- Repository: `github.com/basefoundry/base`
 - Current release: `1.0.5`
 - Primary platform: macOS
 - Future platform direction: Linux support is a design target; Windows is not

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -92,7 +92,7 @@ Release-prep PRs update `VERSION`, README release text, and `CHANGELOG.md`.
 The `basectl release check|plan|notes` commands are read-only inspection
 commands. `basectl release publish` is guarded and creates the annotated tag and
 GitHub Release after checks pass. The Homebrew tap update happens in
-`codeforester/homebrew-base` after the Base tag and GitHub Release exist.
+`basefoundry/homebrew-base` after the Base tag and GitHub Release exist.
 Supported macOS tap releases should publish Homebrew bottles before the tap PR
 is merged: run the tap's `Build Base Bottles` workflow from the tap release
 branch, let it upload bottle assets to the tap release `base-vX.Y.Z`, and commit

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @codeforester
+* @basefoundry/maintainers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: codeforester/base-bash-libs
+          repository: basefoundry/base-bash-libs
           path: .dependencies/base-bash-libs
 
       - name: Install BATS
@@ -68,7 +68,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: codeforester/base-bash-libs
+          repository: basefoundry/base-bash-libs
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
@@ -118,7 +118,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: codeforester/base-bash-libs
+          repository: basefoundry/base-bash-libs
           path: .dependencies/base-bash-libs
 
       - name: Set up Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ On a fresh macOS machine, use `bootstrap.sh` in source mode so the repository is
 available for local edits:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
 ~/work/base/bin/basectl setup --profile dev
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l

--- a/FAQ.md
+++ b/FAQ.md
@@ -7,7 +7,7 @@
 Use `bootstrap.sh`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
 ```
 
 The bootstrapper verifies macOS, ensures Homebrew is available, installs Git and
@@ -40,7 +40,7 @@ Use Homebrew when you already have Homebrew and Bash and want Base managed like
 an ordinary installed tool:
 
 ```bash
-brew install codeforester/base/base
+brew install basefoundry/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
@@ -51,7 +51,7 @@ run the repository directly. This is also the preferred active install for a
 Base development machine:
 
 ```bash
-git clone https://github.com/codeforester/base.git ~/work/base
+git clone https://github.com/basefoundry/base.git ~/work/base
 ~/work/base/bin/basectl setup
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l
@@ -65,8 +65,8 @@ update Base and then run setup/profile commands as one script.
 Pass an explicit mode:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --source
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
 ```
 
 Without an explicit mode, bootstrap preserves an existing Homebrew Base install,
@@ -393,7 +393,7 @@ intended to run through `basectl`. Use the standalone `base-bash-libs` package:
 
 ```bash
 #!/usr/bin/env bash
-base_bash_libs_prefix="$(brew --prefix codeforester/base/base-bash-libs)"
+base_bash_libs_prefix="$(brew --prefix basefoundry/base/base-bash-libs)"
 source "$base_bash_libs_prefix/libexec/lib/bash/std/lib_std.sh"
 
 main() {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Base
 
-![Tests](https://github.com/codeforester/base/actions/workflows/tests.yml/badge.svg)
-![Lint](https://github.com/codeforester/base/actions/workflows/pylint.yml/badge.svg)
+![Tests](https://github.com/basefoundry/base/actions/workflows/tests.yml/badge.svg)
+![Lint](https://github.com/basefoundry/base/actions/workflows/pylint.yml/badge.svg)
 ![Platform: macOS](https://img.shields.io/badge/platform-macOS-lightgrey)
 ![Version](https://img.shields.io/badge/version-1.0.5-blue)
 
@@ -50,8 +50,8 @@ normal Base install paths:
 
 ```bash
 # Homebrew-managed install
-brew trust codeforester/base
-brew install codeforester/base/base
+brew trust basefoundry/base
+brew install basefoundry/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
@@ -59,7 +59,7 @@ exec "$SHELL" -l
 
 ```bash
 # Source checkout install
-git clone https://github.com/codeforester/base.git ~/work/base
+git clone https://github.com/basefoundry/base.git ~/work/base
 ~/work/base/bin/basectl setup
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l
@@ -71,7 +71,7 @@ On a new macOS machine, or any machine where Homebrew, Git, or a supported Bash
 may be missing, start with the first-mile bootstrap script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
 ```
 
 The bootstrapper installs Homebrew, Git, and a supported Bash when needed,
@@ -82,8 +82,8 @@ source checkout at `~/work/base`, and prints the exact `basectl setup` and
 Choose an install mode explicitly when needed:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --source
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
 ```
 
 For mode selection, dry-run behavior, and contributor setup details, see
@@ -136,11 +136,11 @@ basectl test base
 ```
 
 To inspect a small, real Base-managed project, clone
-[`codeforester/base-demo`](https://github.com/codeforester/base-demo) next to
+[`basefoundry/base-demo`](https://github.com/basefoundry/base-demo) next to
 Base and run its walkthrough:
 
 ```bash
-git clone https://github.com/codeforester/base-demo.git
+git clone https://github.com/basefoundry/base-demo.git
 basectl setup base-demo
 basectl demo base-demo
 ```
@@ -172,8 +172,8 @@ scripts that want Base's Bash helper conventions without adopting the Base
 workspace control plane:
 
 ```bash
-brew trust codeforester/base
-brew install codeforester/base/base-bash-libs
+brew trust basefoundry/base
+brew install basefoundry/base/base-bash-libs
 ```
 
 Base consumes reusable Bash libraries from an external `base-bash-libs` checkout
@@ -514,8 +514,8 @@ private by default; pass `--public` when a public repository is intentional. Use
 Clone an existing GitHub repository into the configured workspace with:
 
 ```bash
-basectl repo clone codeforester/example
-basectl repo clone example --owner codeforester
+basectl repo clone basefoundry/example
+basectl repo clone example --owner basefoundry
 ```
 
 Short names can use `github.default_owner` from `~/.base.d/config.yaml`.
@@ -528,7 +528,7 @@ Check and repair the repo baseline with:
 
 ```bash
 basectl repo check ~/work/example
-basectl repo configure ~/work/example --repo codeforester/example
+basectl repo configure ~/work/example --repo basefoundry/example
 ```
 
 Seed optional repo-local agent guidance with:
@@ -879,7 +879,7 @@ should be treated as implementation details unless a project-owned launcher
 exposes them from `bin/`.
 
 Optional utility commands live in
-[`codeforester/base-platform-tools`](https://github.com/codeforester/base-platform-tools).
+[`basefoundry/base-platform-tools`](https://github.com/basefoundry/base-platform-tools).
 When that repository is checked out next to Base as `base-platform-tools`, Base
 adds its `bin/` directory to `PATH` in new Bash/Zsh shells and Base runtime
 shells. This is detected dynamically by the sourced shell snippets; users do not
@@ -945,7 +945,7 @@ is requested on macOS, Base warns if `osascript` is not available.
 For a blank macOS machine, use `bootstrap.sh`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
 ```
 
 The bootstrapper is intentionally small. It verifies macOS, installs Homebrew
@@ -967,8 +967,8 @@ See [First-Mile Bootstrap](docs/bootstrap.md) for the full bootstrap contract.
 Base can be installed through its Homebrew tap:
 
 ```bash
-brew trust codeforester/base
-brew install codeforester/base/base
+brew trust basefoundry/base
+brew install basefoundry/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
@@ -976,13 +976,13 @@ exec "$SHELL" -l
 
 The trust step is required on Homebrew versions that block formulae from
 non-official taps until the tap is trusted. It is safe to run again on machines
-that already trust `codeforester/base`. Existing installs that predate this
+that already trust `basefoundry/base`. Existing installs that predate this
 trust step can fail during upgrade while Homebrew loads Base's tap-owned
 `base-bash-libs` dependency. If that happens, run:
 
 ```bash
-brew trust codeforester/base
-brew upgrade --no-ask codeforester/base/base
+brew trust basefoundry/base
+brew upgrade --no-ask basefoundry/base/base
 ```
 
 Homebrew installs the Base files. `basectl setup` still prepares the local Base
@@ -991,7 +991,7 @@ your shell startup path. When installed through Homebrew, `basectl update` for
 Base hands off to Homebrew and runs setup afterward. This is equivalent to:
 
 ```bash
-brew upgrade --no-ask codeforester/base/base
+brew upgrade --no-ask basefoundry/base/base
 ```
 
 For a Base development machine, prefer the source checkout as the active
@@ -1016,7 +1016,7 @@ workspace:
 The standalone installer is also available:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/install.sh | bash
 exec "$SHELL" -l
 ```
 
@@ -1024,7 +1024,7 @@ This runs a shell script from GitHub, so review the script first if you do not
 already trust this repository:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/install.sh
 ```
 
 By default, the installer clones or updates Base at `~/work/base`, runs
@@ -1034,7 +1034,7 @@ By default, the installer clones or updates Base at `~/work/base`, runs
 installer options with `bash -s --`, for example:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/install.sh | bash -s -- --dir ~/work/base --no-profile
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/install.sh | bash -s -- --dir ~/work/base --no-profile
 ```
 
 Use `--no-profile` to skip shell startup integration and `--dry-run` to print
@@ -1043,7 +1043,7 @@ planned actions.
 The explicit manual bootstrap path is:
 
 ```bash
-git clone https://github.com/codeforester/base.git ~/work/base
+git clone https://github.com/basefoundry/base.git ~/work/base
 ~/work/base/bin/basectl setup
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l
@@ -1160,14 +1160,14 @@ tracked file would overwrite them.
 
 In a Homebrew-managed install, the Base update path remains Base-only:
 `basectl update` runs the Base package upgrade,
-`brew upgrade codeforester/base/base`, and then runs `basectl setup base` with
+`brew upgrade basefoundry/base/base`, and then runs `basectl setup base` with
 inherited Base environment variables cleared. `basectl update --dry-run` prints
 the Git or Homebrew handoff it would perform without changing files or packages.
 For manual Homebrew upgrades outside `basectl update`, prefer
-`brew upgrade --no-ask codeforester/base/base` so Homebrew skips the preview
+`brew upgrade --no-ask basefoundry/base/base` so Homebrew skips the preview
 prompt path on already-current installs. If Homebrew refuses to load
-`codeforester/base/base-bash-libs` from an untrusted tap, run
-`brew trust codeforester/base` once and retry the upgrade.
+`basefoundry/base/base-bash-libs` from an untrusted tap, run
+`brew trust basefoundry/base` once and retry the upgrade.
 
 Base also reads `~/.baserc` when it exists. Unlike `profile.conf`, `~/.baserc`
 is user-managed and may be hand-edited. It is intended for simple,
@@ -1337,13 +1337,13 @@ in normal shell dotfiles, and keep simple Base preferences in `~/.baserc`.
 
 Base no longer owns general-purpose utility CLIs such as `caff` and
 `sort-in-place`. Those tools live in
-[`codeforester/base-platform-tools`](https://github.com/codeforester/base-platform-tools),
+[`basefoundry/base-platform-tools`](https://github.com/basefoundry/base-platform-tools),
 which is the optional platform/SRE utility layer for Base-managed workspaces.
 Check it out next to Base to make its launchers available automatically in new
 shells:
 
 ```bash
-git clone https://github.com/codeforester/base-platform-tools.git ~/work/base-platform-tools
+git clone https://github.com/basefoundry/base-platform-tools.git ~/work/base-platform-tools
 exec "$SHELL" -l
 ```
 

--- a/base_init.sh
+++ b/base_init.sh
@@ -125,7 +125,7 @@ base_init_report_missing_bash_libs() {
         base_init_error "Tried Homebrew base-bash-libs package at '$candidate'."
     fi
 
-    base_init_error "Clone codeforester/base-bash-libs next to Base, install it with 'brew install codeforester/base/base-bash-libs', or set BASE_BASH_LIBS_DIR to a compatible lib/bash directory."
+    base_init_error "Clone basefoundry/base-bash-libs next to Base, install it with 'brew install basefoundry/base/base-bash-libs', or set BASE_BASH_LIBS_DIR to a compatible lib/bash directory."
 }
 
 base_init_set_bash_libs_contract() {

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -17,13 +17,13 @@ release:
   changelog: CHANGELOG.md
   tag_prefix: v
   github:
-    repository: codeforester/base
+    repository: basefoundry/base
     release_title: "Base v{version}"
   homebrew:
     required: true
-    tap_repository: codeforester/homebrew-base
+    tap_repository: basefoundry/homebrew-base
     formula_path: Formula/base.rb
-    package: codeforester/base/base
+    package: basefoundry/base/base
 
 # Optional relative path to a Homebrew Brewfile for ordinary macOS tools.
 # Base runs `brew bundle --file=<path>` during setup when this is set.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -399,10 +399,10 @@ bootstrap_print_next_steps() {
 bootstrap_main() {
     local allow_homebrew_install="${BASE_BOOTSTRAP_HOMEBREW_INSTALL:-true}"
     local branch="${BASE_BOOTSTRAP_BRANCH:-}"
-    local formula="${BASE_BOOTSTRAP_BREW_FORMULA:-codeforester/base/base}"
+    local formula="${BASE_BOOTSTRAP_BREW_FORMULA:-basefoundry/base/base}"
     local install_dir="${BASE_BOOTSTRAP_INSTALL_DIR:-${BASE_HOME:-$HOME/work/base}}"
     local mode="${BASE_BOOTSTRAP_MODE:-}"
-    local repo_url="${BASE_BOOTSTRAP_REPO_URL:-https://github.com/codeforester/base.git}"
+    local repo_url="${BASE_BOOTSTRAP_REPO_URL:-https://github.com/basefoundry/base.git}"
 
     BASE_BOOTSTRAP_DRY_RUN="${BASE_BOOTSTRAP_DRY_RUN:-false}"
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -18,7 +18,7 @@ for command implementations, then sources this command implementation and calls
 
 `basectl` also dispatches direct Base-owned command names by convention when
 such command directories exist. Optional utility CLIs such as `caff` and
-`sort-in-place` live in `codeforester/base-platform-tools` instead of Base core.
+`sort-in-place` live in `basefoundry/base-platform-tools` instead of Base core.
 
 ## Current subcommands
 
@@ -135,7 +135,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl update [project]` updates the selected project checkout through Git
   and then runs `basectl setup <project>`. Omitting the project selects `base`;
   Homebrew-managed Base installs still hand off only the Base package to
-  `brew upgrade codeforester/base/base`.
+  `brew upgrade basefoundry/base/base`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`
   when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
   project names and paths.

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -75,7 +75,7 @@ Options:
 
 Examples:
   # Create a new public GitHub repo and open a baseline PR.
-  basectl repo init base-demo --repo codeforester/base-demo --public --pr
+  basectl repo init base-demo --repo basefoundry/base-demo --public --pr
 
   # Add or refresh the Base baseline in an existing checkout.
   basectl repo init bankbuddy --path . --repo codeforester/bankbuddy --pr
@@ -112,9 +112,9 @@ Options:
 
 Examples:
   basectl repo clone base
-  basectl repo clone banyanlabs --owner codeforester
+  basectl repo clone banyanlabs --owner basefoundry
   basectl repo clone codeforester/bankbuddy
-  basectl repo clone codeforester/base --path ~/work/base
+  basectl repo clone basefoundry/base --path ~/work/base
 
 Short repository names require --owner <owner> or github.default_owner in
 ~/.base.d/config.yaml. The optional github.clone_protocol value controls the
@@ -640,7 +640,7 @@ $description
 
 ## Base
 
-This repository is managed by [Base](https://github.com/codeforester/base).
+This repository is managed by [Base](https://github.com/basefoundry/base).
 
 Common commands:
 

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -376,7 +376,7 @@ setup_recovery_base_python_package() {
 }
 
 setup_recovery_base_bash_libraries() {
-    printf "%s\n" "Clone codeforester/base-bash-libs next to Base, install it with 'brew install codeforester/base/base-bash-libs', or set BASE_BASH_LIBS_DIR."
+    printf "%s\n" "Clone basefoundry/base-bash-libs next to Base, install it with 'brew install basefoundry/base/base-bash-libs', or set BASE_BASH_LIBS_DIR."
 }
 
 setup_recovery_ci_python() {

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -28,9 +28,9 @@ Notes:
   - Tracked project files must be clean; untracked files are left to Git's normal
     pull-time overwrite protection.
   - Homebrew installs update only project 'base' through the Base formula:
-    brew upgrade codeforester/base/base
-  - If Homebrew requires tap trust, trust codeforester/base before upgrading:
-    brew trust codeforester/base
+    brew upgrade basefoundry/base/base
+  - If Homebrew requires tap trust, trust basefoundry/base before upgrading:
+    brew trust basefoundry/base
 EOF
 }
 
@@ -39,15 +39,15 @@ base_update_source_git_library() {
 }
 
 base_update_homebrew_package() {
-    printf '%s\n' "codeforester/base/base"
+    printf '%s\n' "basefoundry/base/base"
 }
 
 base_update_homebrew_tap() {
-    printf '%s\n' "codeforester/base"
+    printf '%s\n' "basefoundry/base"
 }
 
 base_update_homebrew_bash_libs_package() {
-    printf '%s\n' "codeforester/base/base-bash-libs"
+    printf '%s\n' "basefoundry/base/base-bash-libs"
 }
 
 base_update_is_homebrew_install() {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -37,7 +37,7 @@ line_at() {
     [[ "$output" == *"--pr"* ]]
     [[ "$output" == *"--copy-project-fields-from <title>"* ]]
     [[ "$output" == *"Create a new public GitHub repo and open a baseline PR."* ]]
-    [[ "$output" == *"basectl repo init base-demo --repo codeforester/base-demo --public --pr"* ]]
+    [[ "$output" == *"basectl repo init base-demo --repo basefoundry/base-demo --public --pr"* ]]
     [[ "$output" == *"Add or refresh the Base baseline in an existing checkout."* ]]
     [[ "$output" == *"basectl repo init bankbuddy --path . --repo codeforester/bankbuddy --pr"* ]]
     [[ "$output" == *"Safe to run against an existing repository"* ]]
@@ -57,7 +57,7 @@ line_at() {
     [[ "$output" == *"--owner <owner>"* ]]
     [[ "$output" == *"--path <path>"* ]]
     [[ "$output" == *"--dry-run"* ]]
-    [[ "$output" == *"basectl repo clone codeforester/base --path ~/work/base"* ]]
+    [[ "$output" == *"basectl repo clone basefoundry/base --path ~/work/base"* ]]
     [[ "$output" != *"--copy-project-fields-from <title>"* ]]
 }
 

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -12,7 +12,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Update a Base-managed project from Git, or update Base through Homebrew"* ]]
     [[ "$output" == *"When project is omitted, Base updates project 'base'."* ]]
     [[ "$output" == *"Tracked project files must be clean"* ]]
-    [[ "$output" == *"brew upgrade codeforester/base/base"* ]]
+    [[ "$output" == *"brew upgrade basefoundry/base/base"* ]]
 }
 
 @test "basectl update dry-run reports planned update and setup" {
@@ -98,7 +98,7 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Detected Homebrew-managed Base install at '$fake_base'."* ]]
-    [[ "$output" == *"[DRY-RUN] Would run: brew upgrade codeforester/base/base"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: brew upgrade basefoundry/base/base"* ]]
     [[ "$output" == *"[DRY-RUN] Would run 'basectl setup' after the Homebrew upgrade with inherited Base environment cleared."* ]]
     [[ "$output" != *"brew should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
@@ -119,7 +119,7 @@ case "\$1" in
         ;;
     trust)
         if [[ "\$2" == "--json" && "\$3" == "v1" ]]; then
-            printf '%s\n' '{"taps":[],"formulae":["codeforester/base/base"],"casks":[],"commands":[]}'
+            printf '%s\n' '{"taps":[],"formulae":["basefoundry/base/base"],"casks":[],"commands":[]}'
             exit 0
         fi
         ;;
@@ -147,9 +147,9 @@ EOF
         '
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Homebrew requires trust for 'codeforester/base' before upgrading Base's tap-owned Bash library dependency."* ]]
-    [[ "$output" == *"Run 'brew trust codeforester/base', then rerun 'basectl update'."* ]]
-    [[ "$output" == *"brew trust --formula codeforester/base/base-bash-libs"* ]]
+    [[ "$output" == *"Homebrew requires trust for 'basefoundry/base' before upgrading Base's tap-owned Bash library dependency."* ]]
+    [[ "$output" == *"Run 'brew trust basefoundry/base', then rerun 'basectl update'."* ]]
+    [[ "$output" == *"brew trust --formula basefoundry/base/base-bash-libs"* ]]
     [[ ! -e "$brew_log" ]]
 }
 
@@ -194,12 +194,12 @@ EOF
         '
 
     [ "$status" -eq 0 ]
-    [ "$(cat "$brew_log")" = "upgrade codeforester/base/base" ]
+    [ "$(cat "$brew_log")" = "upgrade basefoundry/base/base" ]
     [[ "$(cat "$setup_log")" == *"args=setup"* ]]
     [[ "$(cat "$setup_log")" == *"BASE_HOME=unset"* ]]
     [[ "$(cat "$setup_log")" == *"BASE_PROJECT=unset"* ]]
     [[ "$output" == *"Detected Homebrew-managed Base install at '$fake_base'."* ]]
-    [[ "$output" == *"Running Homebrew upgrade for codeforester/base/base."* ]]
+    [[ "$output" == *"Running Homebrew upgrade for basefoundry/base/base."* ]]
     [[ "$output" == *"Running basectl setup after Homebrew upgrade."* ]]
     [[ "$output" == *"Base update is complete."* ]]
 }
@@ -284,6 +284,7 @@ EOF
     cp "$BASE_REPO_ROOT/base_init.sh" "$repo/base_init.sh"
     cp -R "$BASE_REPO_ROOT/cli" "$repo/cli"
     cp -R "$BASE_REPO_ROOT/lib" "$repo/lib"
+    copy_base_bash_libs_fixture "$TEST_TMPDIR/base-bash-libs/lib/bash"
     mkdir -p "$repo/bin"
     printf 'notes\n' > "$repo/local-notes.md"
 

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -345,13 +345,13 @@ class ManifestParsingTests(unittest.TestCase):
                         "  changelog: CHANGELOG.md",
                         "  tag_prefix: v",
                         "  github:",
-                        "    repository: codeforester/base",
+                        "    repository: basefoundry/base",
                         "    release_title: \"Base v{version}\"",
                         "  homebrew:",
                         "    required: true",
-                        "    tap_repository: codeforester/homebrew-base",
+                        "    tap_repository: basefoundry/homebrew-base",
                         "    formula_path: Formula/base.rb",
-                        "    package: codeforester/base/base",
+                        "    package: basefoundry/base/base",
                         "",
                         "artifacts: []",
                     ]
@@ -366,15 +366,15 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.release.version_file, "VERSION")
         self.assertEqual(manifest.release.changelog, "CHANGELOG.md")
         self.assertEqual(manifest.release.tag_prefix, "v")
-        self.assertEqual(manifest.release.github.repository, "codeforester/base")
+        self.assertEqual(manifest.release.github.repository, "basefoundry/base")
         self.assertEqual(manifest.release.github.release_title, "Base v{version}")
         self.assertIsNone(manifest.release.runner)
         self.assertIsNotNone(manifest.release.homebrew)
         assert manifest.release.homebrew is not None
         self.assertTrue(manifest.release.homebrew.required)
-        self.assertEqual(manifest.release.homebrew.tap_repository, "codeforester/homebrew-base")
+        self.assertEqual(manifest.release.homebrew.tap_repository, "basefoundry/homebrew-base")
         self.assertEqual(manifest.release.homebrew.formula_path, "Formula/base.rb")
-        self.assertEqual(manifest.release.homebrew.package, "codeforester/base/base")
+        self.assertEqual(manifest.release.homebrew.package, "basefoundry/base/base")
 
     def test_reads_manifest_release_runner(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -471,45 +471,45 @@ class ManifestParsingTests(unittest.TestCase):
     def test_rejects_invalid_manifest_release_config(self) -> None:
         invalid_values = {
             "scalar": "release: true",
-            "unknown_key": "release:\n  github:\n    repository: codeforester/base\n  package: base",
+            "unknown_key": "release:\n  github:\n    repository: basefoundry/base\n  package: base",
             "missing_github": "release:\n  version_file: VERSION",
-            "github_scalar": "release:\n  github: codeforester/base",
+            "github_scalar": "release:\n  github: basefoundry/base",
             "missing_repository": "release:\n  github:\n    release_title: Base",
             "invalid_repository": "release:\n  github:\n    repository: codeforester",
             "absolute_version_file": (
-                "release:\n  version_file: /tmp/VERSION\n  github:\n    repository: codeforester/base"
+                "release:\n  version_file: /tmp/VERSION\n  github:\n    repository: basefoundry/base"
             ),
             "absolute_changelog": (
-                "release:\n  changelog: /tmp/CHANGELOG.md\n  github:\n    repository: codeforester/base"
+                "release:\n  changelog: /tmp/CHANGELOG.md\n  github:\n    repository: basefoundry/base"
             ),
-            "empty_tag_prefix": "release:\n  tag_prefix: ''\n  github:\n    repository: codeforester/base",
-            "homebrew_scalar": "release:\n  github:\n    repository: codeforester/base\n  homebrew: true",
+            "empty_tag_prefix": "release:\n  tag_prefix: ''\n  github:\n    repository: basefoundry/base",
+            "homebrew_scalar": "release:\n  github:\n    repository: basefoundry/base\n  homebrew: true",
             "homebrew_required_missing_tap": (
                 "release:\n"
                 "  github:\n"
-                "    repository: codeforester/base\n"
+                "    repository: basefoundry/base\n"
                 "  homebrew:\n"
                 "    required: true\n"
                 "    formula_path: Formula/base.rb\n"
-                "    package: codeforester/base/base"
+                "    package: basefoundry/base/base"
             ),
             "homebrew_absolute_formula": (
                 "release:\n"
                 "  github:\n"
-                "    repository: codeforester/base\n"
+                "    repository: basefoundry/base\n"
                 "  homebrew:\n"
                 "    required: true\n"
-                "    tap_repository: codeforester/homebrew-base\n"
+                "    tap_repository: basefoundry/homebrew-base\n"
                 "    formula_path: /tmp/base.rb\n"
-                "    package: codeforester/base/base"
+                "    package: basefoundry/base/base"
             ),
             "homebrew_invalid_package": (
                 "release:\n"
                 "  github:\n"
-                "    repository: codeforester/base\n"
+                "    repository: basefoundry/base\n"
                 "  homebrew:\n"
                 "    required: true\n"
-                "    tap_repository: codeforester/homebrew-base\n"
+                "    tap_repository: basefoundry/homebrew-base\n"
                 "    formula_path: Formula/base.rb\n"
                 "    package: base"
             ),
@@ -517,7 +517,7 @@ class ManifestParsingTests(unittest.TestCase):
                 "release:\n"
                 "  runner: npm\n"
                 "  github:\n"
-                "    repository: codeforester/base"
+                "    repository: basefoundry/base"
             ),
         }
         for name, release_yaml in invalid_values.items():

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -665,12 +665,12 @@ through managed workstation provisioning before invoking `basectl setup`.
 
 ## GitHub and Repository Conventions
 
-- Base uses a public GitHub repository at `codeforester/base`.
+- Base uses a public GitHub repository at `basefoundry/base`.
 - GitHub Issues are the official product backlog for bugs, feature requests,
   release work, maintenance, and documentation follow-up.
 - `basectl release` manages annotated tags and GitHub Releases for Base using
   the manifest-owned release metadata in `base_manifest.yaml`.
-- The Homebrew tap at `codeforester/homebrew-base` owns the formula that installs
+- The Homebrew tap at `basefoundry/homebrew-base` owns the formula that installs
   published Base releases.
 - Homebrew tap updates happen after each GitHub Release and remain a manual
   handoff. `basectl release` prints the required tap follow-up when the project

--- a/docs/base-bash-libs.md
+++ b/docs/base-bash-libs.md
@@ -1,7 +1,7 @@
 # Base Bash Libraries
 
 Base's reusable Bash libraries live in the standalone
-[`codeforester/base-bash-libs`](https://github.com/codeforester/base-bash-libs)
+[`basefoundry/base-bash-libs`](https://github.com/basefoundry/base-bash-libs)
 repository. That repository lets scripts use Base's Bash logging, command
 execution, filesystem, and Git helper conventions without adopting the full
 Base workspace control plane.
@@ -34,18 +34,18 @@ Users who want only the Bash libraries can install them from the existing
 Homebrew tap:
 
 ```bash
-brew trust codeforester/base
-brew install codeforester/base/base-bash-libs
+brew trust basefoundry/base
+brew install basefoundry/base/base-bash-libs
 ```
 
 The trust step is required on Homebrew versions that block formulae from
 non-official taps until the tap is trusted. It is safe to run again on machines
-that already trust `codeforester/base`.
+that already trust `basefoundry/base`.
 
 Standalone scripts can then source the stdlib from the installed prefix:
 
 ```bash
-base_bash_libs_prefix="$(brew --prefix codeforester/base/base-bash-libs)"
+base_bash_libs_prefix="$(brew --prefix basefoundry/base/base-bash-libs)"
 source "$base_bash_libs_prefix/libexec/lib/bash/std/lib_std.sh"
 ```
 
@@ -61,7 +61,7 @@ For source checkout development, clone the repository next to Base or source it
 directly from the checkout path:
 
 ```bash
-git clone https://github.com/codeforester/base-bash-libs.git ~/work/base-bash-libs
+git clone https://github.com/basefoundry/base-bash-libs.git ~/work/base-bash-libs
 source "$HOME/work/base-bash-libs/lib/bash/std/lib_std.sh"
 ```
 
@@ -95,7 +95,7 @@ import_base_lib git/lib_git.sh
 ```
 
 `import_base_lib` checks only the resolved reusable library root. Base-specific
-runtime and version helpers remain in `codeforester/base` under `lib/bash`, but
+runtime and version helpers remain in `basefoundry/base` under `lib/bash`, but
 the reusable libraries come from `base-bash-libs`.
 
 ## Post-Migration Contract

--- a/docs/base-managed-demo-project.md
+++ b/docs/base-managed-demo-project.md
@@ -7,7 +7,7 @@ Base repo.
 
 ## Current Reference Project
 
-Use [`codeforester/base-demo`](https://github.com/codeforester/base-demo) as
+Use [`basefoundry/base-demo`](https://github.com/basefoundry/base-demo) as
 the public reference project.
 
 `base-demo` should be small, inspectable, and safe to run on a fresh supported

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -10,7 +10,7 @@ installation of Base.
 Run the bootstrapper from GitHub:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
 ```
 
 The bootstrapper verifies macOS, installs missing first-mile prerequisites, and
@@ -32,8 +32,8 @@ see what was installed before Base changes future interactive shells.
 Choose a mode explicitly when the default should not infer one:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --source
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
 ```
 
 Without an explicit mode, bootstrap uses this order:
@@ -53,7 +53,7 @@ is whichever executable the shell finds first on `PATH`.
 bootstrap.sh --source
 bootstrap.sh --brew
 bootstrap.sh --install-dir ~/work/base
-bootstrap.sh --repo-url https://github.com/codeforester/base.git
+bootstrap.sh --repo-url https://github.com/basefoundry/base.git
 bootstrap.sh --branch <name>
 bootstrap.sh --no-homebrew-install
 bootstrap.sh --dry-run
@@ -67,7 +67,7 @@ route without changing the machine.
 Contributors should prefer source mode:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
 ~/work/base/bin/basectl setup --profile dev
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l
@@ -108,8 +108,8 @@ Use Homebrew directly when Homebrew is already installed and Base should be
 managed like a normal formula:
 
 ```bash
-brew trust codeforester/base
-brew install codeforester/base/base
+brew trust basefoundry/base
+brew install basefoundry/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l

--- a/docs/demo-maintenance.md
+++ b/docs/demo-maintenance.md
@@ -40,7 +40,7 @@ edits.
 
 ## `base-demo` Repository
 
-`codeforester/base-demo` should use the same `needs-demo` label with the same
+`basefoundry/base-demo` should use the same `needs-demo` label with the same
 color and description as this repository:
 
 - color: `fbca04`

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -120,7 +120,7 @@ standalone `base-bash-libs` package:
 
 ```bash
 #!/usr/bin/env bash
-base_bash_libs_prefix="$(brew --prefix codeforester/base/base-bash-libs)"
+base_bash_libs_prefix="$(brew --prefix basefoundry/base/base-bash-libs)"
 source "$base_bash_libs_prefix/libexec/lib/bash/std/lib_std.sh"
 
 main() {
@@ -208,7 +208,7 @@ The implementation still lives under `cli/bash/commands/<command>/` with its
 local README and tests.
 
 Optional utility CLIs such as `caff` and `sort-in-place` live in
-[`codeforester/base-platform-tools`](https://github.com/codeforester/base-platform-tools)
+[`basefoundry/base-platform-tools`](https://github.com/basefoundry/base-platform-tools)
 instead of Base core.
 
 When `base-platform-tools` is checked out next to Base and contains both

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -94,10 +94,10 @@ When migrating from an existing shared Project, pass
 overwriting values already set there.
 
 ```bash
-basectl gh project doctor --project "Base Roadmap" --owner codeforester
-basectl gh project configure --project "Base Roadmap" --owner codeforester --schema base-project
-basectl repo configure ~/work/base --repo codeforester/base --copy-project-fields-from "Base Roadmap"
-basectl gh project issue set-fields 604 --repo codeforester/base --project "Base Roadmap" --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
+basectl gh project doctor --project base --owner basefoundry
+basectl gh project configure --project base --owner basefoundry --schema base-project
+basectl repo configure ~/work/base --repo basefoundry/base --copy-project-fields-from "Base Roadmap"
+basectl gh project issue set-fields 604 --repo basefoundry/base --project base --owner basefoundry --status Backlog --priority P2 --area CLI --initiative "v1.0 Readiness" --size M
 ```
 
 ## Preferred GitHub Interface
@@ -402,7 +402,7 @@ Every issue does not need a milestone. Use milestones when the issue contributes
 to a concrete release goal.
 
 For the release checklist itself, including `VERSION`, changelog, tags, GitHub
-Releases, and the follow-up `codeforester/homebrew-base` tap update, see
+Releases, and the follow-up `basefoundry/homebrew-base` tap update, see
 [Release Process](release-process.md).
 
 ## Projects

--- a/docs/homebrew-upgrade-rehearsal.md
+++ b/docs/homebrew-upgrade-rehearsal.md
@@ -22,10 +22,10 @@ upgrade without losing local Base state.
   ```bash
   brew update
   brew doctor
-  brew info codeforester/base/base
+  brew info basefoundry/base/base
   ```
 - Confirm the target formula has bottles for the host or that
-  `brew install --force-bottle codeforester/base/base` succeeds on an equivalent
+  `brew install --force-bottle basefoundry/base/base` succeeds on an equivalent
   clean install. The release checklist owns bottle creation; this rehearsal
   should prove an existing user can upgrade through that bottled formula path.
 
@@ -39,15 +39,15 @@ Create an isolated test account shape:
 ```bash
 TEST_ROOT="$(mktemp -d /private/tmp/base-homebrew-upgrade.XXXXXX)"
 mkdir -p "$TEST_ROOT/home/.base.d" "$TEST_ROOT/work"
-git clone https://github.com/codeforester/base-demo.git "$TEST_ROOT/work/base-demo"
+git clone https://github.com/basefoundry/base-demo.git "$TEST_ROOT/work/base-demo"
 printf 'workspace:\n  root: %s/work\n' "$TEST_ROOT" > "$TEST_ROOT/home/.base.d/config.yaml"
 ```
 
 Install the current released formula and prepare local state:
 
 ```bash
-brew trust codeforester/base
-brew install codeforester/base/base
+brew trust basefoundry/base
+brew install basefoundry/base/base
 env -u BASE_HOME -u BASE_PROJECT -u BASE_PROJECT_ROOT \
   HOME="$TEST_ROOT/home" PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
   /usr/local/bin/basectl setup
@@ -71,7 +71,7 @@ Upgrade through the tap path:
 
 ```bash
 brew update
-brew upgrade --no-ask codeforester/base/base
+brew upgrade --no-ask basefoundry/base/base
 ```
 
 For a pre-1.0.0 release candidate, use the candidate formula or tap branch that
@@ -109,7 +109,7 @@ shasum -a 256 "$TEST_ROOT/home/.base.d/config.yaml"
 
 Accept the rehearsal only when:
 
-- `brew upgrade --no-ask codeforester/base/base` exits zero.
+- `brew upgrade --no-ask basefoundry/base/base` exits zero.
 - The upgrade uses a Homebrew bottle on supported macOS hosts, not a normal
   source build. If Homebrew falls back to source, record why before accepting
   the rehearsal.
@@ -139,7 +139,7 @@ Host facts:
 - Xcode: 26.5
 - CLT reported by Homebrew: 11.3.1
 - Existing `basectl` on `PATH`: source checkout at `<workspace>/base/bin/basectl`
-- Homebrew formula state before rehearsal: `codeforester/base/base` stable
+- Homebrew formula state before rehearsal: `basefoundry/base/base` stable
   `0.3.0`, not installed
 
 Commands attempted:
@@ -151,16 +151,16 @@ TEST_ROOT="$(mktemp -d /private/tmp/base-526-homebrew-upgrade.XXXXXX)"
 mkdir -p "$TEST_ROOT/work" "$TEST_ROOT/home/.base.d"
 printf 'workspace:\n  root: %s/work\n' "$TEST_ROOT" > "$TEST_ROOT/home/.base.d/config.yaml"
 git clone <local-base-demo-checkout> "$TEST_ROOT/work/base-demo"
-brew install codeforester/base/base
-brew install --ignore-dependencies codeforester/base/base
+brew install basefoundry/base/base
+brew install --ignore-dependencies basefoundry/base/base
 brew config
 brew doctor
 ```
 
 Observed result:
 
-- `brew install codeforester/base/base` exited 1 before installing Base.
-- `brew install --ignore-dependencies codeforester/base/base` also exited 1
+- `brew install basefoundry/base/base` exited 1 before installing Base.
+- `brew install --ignore-dependencies basefoundry/base/base` also exited 1
   with the same host prerequisite failure.
 - Homebrew reported: `Your Command Line Tools are too outdated` and instructed
   the operator to install Command Line Tools for Xcode 26.3.
@@ -170,7 +170,7 @@ Commands not reached:
 
 - `basectl setup`
 - `basectl update-profile`
-- `brew upgrade codeforester/base/base`
+- `brew upgrade basefoundry/base/base`
 - post-upgrade Base and `base-demo` checks
 
 Next action:
@@ -188,7 +188,7 @@ Result: upgrade succeeded, but shell startup exposed a stale Cellar path problem
 
 Observed result:
 
-- `brew upgrade codeforester/base/base` exited zero and upgraded Base from
+- `brew upgrade basefoundry/base/base` exited zero and upgraded Base from
   `0.3.0` to `0.4.0`.
 - Homebrew cleanup removed `/usr/local/Cellar/base/0.3.0`.
 - The active shell still attempted to run the removed
@@ -235,7 +235,7 @@ sandbox.
 
 Observed result:
 
-- `brew upgrade codeforester/base/base` attempted to upgrade Base from `0.4.3`
+- `brew upgrade basefoundry/base/base` attempted to upgrade Base from `0.4.3`
   to `0.4.4`.
 - Homebrew fetched and verified the `0.4.4` formula archive.
 - Homebrew then failed in `Sandbox#path_filter` while denying reads under the

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -85,8 +85,8 @@ Use this path when validating the consumer install experience.
 For a machine that already has Homebrew:
 
 ```bash
-brew trust codeforester/base
-brew install codeforester/base/base
+brew trust basefoundry/base
+brew install basefoundry/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
@@ -95,7 +95,7 @@ exec "$SHELL" -l
 For a first-mile bootstrap run that should choose the Homebrew route:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
 ```
 
 Then run the handoff commands printed by `bootstrap.sh`. They should include
@@ -172,7 +172,7 @@ install:
 
 ```bash
 cd <scratch-workspace>
-git clone https://github.com/codeforester/base-demo.git
+git clone https://github.com/basefoundry/base-demo.git
 basectl projects list
 basectl setup base-demo
 basectl check base-demo
@@ -205,7 +205,7 @@ Use this path when validating the contributor and dogfood experience.
 For bootstrap source mode:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
 ```
 
 Then run the handoff commands printed by `bootstrap.sh`. They should point at
@@ -220,7 +220,7 @@ exec "$SHELL" -l
 For a manual source clone:
 
 ```bash
-git clone https://github.com/codeforester/base.git <source-checkout>
+git clone https://github.com/basefoundry/base.git <source-checkout>
 <source-checkout>/bin/basectl setup --profile dev
 <source-checkout>/bin/basectl update-profile
 exec "$SHELL" -l

--- a/docs/presentations/base-newcomer-orientation.md
+++ b/docs/presentations/base-newcomer-orientation.md
@@ -84,7 +84,7 @@ Base starts before the developer has a working Base environment.
 On macOS, `bootstrap.sh` handles the first mile:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/codeforester/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
 ```
 
 It installs or checks the prerequisites needed to hand off to `basectl setup`.
@@ -211,12 +211,12 @@ Read more: [Project Demo Workflow](../project-demo-workflow.md)
 There are two demo layers:
 
 - `basectl demo base -- --non-interactive` demonstrates Base itself
-- `codeforester/base-demo` demonstrates a normal Base-managed project
+- `basefoundry/base-demo` demonstrates a normal Base-managed project
 
 Clone `base-demo` beside Base to inspect a small reference project:
 
 ```bash
-git clone https://github.com/codeforester/base-demo.git
+git clone https://github.com/basefoundry/base-demo.git
 basectl setup base-demo
 basectl demo base-demo
 ```

--- a/docs/project-demo-workflow.md
+++ b/docs/project-demo-workflow.md
@@ -15,7 +15,7 @@ for CI.
 There are two demo layers:
 
 - Base's self-demo lives in this repository and demonstrates Base itself.
-- `codeforester/base-demo` is a separate peer repository that demonstrates how a
+- `basefoundry/base-demo` is a separate peer repository that demonstrates how a
   normal Base-managed project participates in the workflow.
 
 Those layers should stay separate. `basectl demo base` must not depend on the
@@ -130,7 +130,7 @@ external reference repository.
 ## Reference Project
 
 The public reference repository is
-[`codeforester/base-demo`](https://github.com/codeforester/base-demo).
+[`basefoundry/base-demo`](https://github.com/basefoundry/base-demo).
 
 `base-demo` serves two roles:
 
@@ -145,8 +145,8 @@ executable, but its product role is onboarding and inspection.
 Clone it next to Base:
 
 ```bash
-git clone https://github.com/codeforester/base.git
-git clone https://github.com/codeforester/base-demo.git
+git clone https://github.com/basefoundry/base.git
+git clone https://github.com/basefoundry/base-demo.git
 ```
 
 Then run:

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -73,7 +73,7 @@ project-owned values at the top:
 
 ```bash
 PROJECT_NAME="${PROJECT_NAME:-banyanlabs}"
-PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/codeforester/banyanlabs.git}"
+PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/basefoundry/banyanlabs.git}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/work}"
 BASE_DIR="${BASE_DIR:-$WORKSPACE_DIR/base}"
 PROJECT_DIR="${PROJECT_DIR:-$WORKSPACE_DIR/$PROJECT_NAME}"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,9 +10,9 @@ Use this checklist when preparing and publishing a new Base release such as
 
 The release spans two repositories:
 
-- `codeforester/base` owns Base source, release notes, `VERSION`, Git tags, and
+- `basefoundry/base` owns Base source, release notes, `VERSION`, Git tags, and
   GitHub Releases.
-- `codeforester/homebrew-base` owns the Homebrew formula that installs published
+- `basefoundry/homebrew-base` owns the Homebrew formula that installs published
   Base releases, plus the Homebrew bottle artifacts for supported macOS hosts.
 
 The Homebrew tap update happens after the Base tag and GitHub Release exist.
@@ -71,7 +71,7 @@ handoff checklist when `release.homebrew` is declared.
 
 ## Base Release Checklist
 
-Complete these steps in `codeforester/base`:
+Complete these steps in `basefoundry/base`:
 
 1. Choose the release version and create or use a GitHub issue for the release
    artifact work.
@@ -110,7 +110,7 @@ Complete these steps in `codeforester/base`:
 
 ## Homebrew Tap And Bottle Checklist
 
-Complete these steps in `codeforester/homebrew-base` after the Base tag exists:
+Complete these steps in `basefoundry/homebrew-base` after the Base tag exists:
 
 1. Create a Homebrew tap update issue or PR for the new Base version.
 2. Create a tap release branch. Do not run the bottle workflow from `master`;
@@ -122,7 +122,7 @@ Complete these steps in `codeforester/homebrew-base` after the Base tag exists:
 4. Compute the archive checksum from the published tag:
 
    ```bash
-   curl -fsSL https://github.com/codeforester/base/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+   curl -fsSL https://github.com/basefoundry/base/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
    ```
 
 5. Validate the formula source-build path from the tap repository when the host
@@ -130,7 +130,7 @@ Complete these steps in `codeforester/homebrew-base` after the Base tag exists:
 
    ```bash
    brew install --build-from-source Formula/base.rb
-   brew test codeforester/base
+   brew test basefoundry/base/base
    brew audit --new --formula Formula/base.rb
    ```
 
@@ -147,20 +147,20 @@ Complete these steps in `codeforester/homebrew-base` after the Base tag exists:
 
    ```bash
    brew update
-   brew trust codeforester/base
-   brew install --force-bottle codeforester/base/base
-   brew test codeforester/base
-   brew upgrade --no-ask codeforester/base/base
+   brew trust basefoundry/base
+   brew install --force-bottle basefoundry/base/base
+   brew test basefoundry/base/base
+   brew upgrade --no-ask basefoundry/base/base
    ```
 
-   Use `brew reinstall --force-bottle codeforester/base/base` when Base is
+   Use `brew reinstall --force-bottle basefoundry/base/base` when Base is
    already installed on the validation host.
 10. Before 1.0.0, complete the
    [Homebrew Upgrade Rehearsal](homebrew-upgrade-rehearsal.md) against a
    release candidate or equivalent test formula. Record the exact commands,
    host facts, pre-upgrade state, post-upgrade checks, and any follow-up issues.
    Do not close the rehearsal issue until
-   `brew upgrade --no-ask codeforester/base/base` and the post-upgrade Base
+   `brew upgrade --no-ask basefoundry/base/base` and the post-upgrade Base
    project checks pass on a qualified host.
 
 ## Cleanup

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -11,8 +11,8 @@ product-specific setup.
 Clone an existing GitHub repository into the configured workspace:
 
 ```bash
-basectl repo clone codeforester/base-demo
-basectl repo clone base-demo --owner codeforester
+basectl repo clone basefoundry/base-demo
+basectl repo clone base-demo --owner basefoundry
 ```
 
 `repo clone` is for repositories that already exist on GitHub. Without
@@ -23,7 +23,7 @@ basectl repo clone base-demo --owner codeforester
 
 ```yaml
 github:
-  default_owner: codeforester
+  default_owner: basefoundry
   clone_protocol: ssh
 ```
 
@@ -38,7 +38,7 @@ with an actionable conflict.
 Create a new repo baseline:
 
 ```bash
-basectl repo init base-demo --repo codeforester/base-demo
+basectl repo init base-demo --repo basefoundry/base-demo
 ```
 
 `repo init` creates the local files, creates the GitHub repository if it does
@@ -65,7 +65,7 @@ already exists:
 ```bash
 basectl repo init base-demo \
   --path ~/work/base-demo \
-  --repo codeforester/base-demo \
+  --repo basefoundry/base-demo \
   --pr
 ```
 
@@ -96,7 +96,7 @@ basectl repo agent-guidance ~/work/base-demo --repo-name base-demo --pr --dry-ru
 Reapply GitHub-side repository settings and labels:
 
 ```bash
-basectl repo configure ~/work/base-demo --repo codeforester/base-demo
+basectl repo configure ~/work/base-demo --repo basefoundry/base-demo
 ```
 
 `repo configure` is idempotent and safe to rerun when repository settings drift.

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -126,7 +126,7 @@ as read-only contract values even when the operating shell cannot enforce that.
 ## Optional Companion Repository Variables
 
 Base can integrate with the optional
-[`base-platform-tools`](https://github.com/codeforester/base-platform-tools)
+[`base-platform-tools`](https://github.com/basefoundry/base-platform-tools)
 repository when it is checked out next to Base. Detection is intentionally local
 and conservative: the sibling directory must be named `base-platform-tools` and
 must contain both `base_manifest.yaml` and `bin/`.

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -214,7 +214,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | Method | Best for |
 |---|---|
 | `curl … bootstrap.sh \| bash` | Blank macOS machine; installs Homebrew, Git, Bash, then Base |
-| `brew install codeforester/base/base` | Users wanting Base installed as a managed tool |
+| `brew install basefoundry/base/base` | Users wanting Base installed as a managed tool |
 | `git clone` + `basectl setup` | Contributors / Base developers |
 | `curl … install.sh \| bash` | Source-install shortcut |
 

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -105,7 +105,7 @@ workspace:
 
 repos:
   - name: base
-    url: git@github.com:codeforester/base.git
+    url: git@github.com:basefoundry/base.git
     default_branch: master
     required: true
 
@@ -115,7 +115,7 @@ repos:
     required: false
 
   - name: banyanlabs
-    url: git@github.com:codeforester/banyanlabs.git
+    url: git@github.com:basefoundry/banyanlabs.git
     default_branch: main
     required: true
 ```

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ Usage:
 
 Options:
   --dir <path>       Install or update Base at this path. Defaults to ~/work/base.
-  --repo-url <url>   Git repository URL to clone. Defaults to https://github.com/codeforester/base.git.
+  --repo-url <url>   Git repository URL to clone. Defaults to https://github.com/basefoundry/base.git.
   --branch <name>    Clone a specific branch when installing into a new directory.
   --no-profile       Skip basectl update-profile after setup.
   --dry-run          Print planned actions without making changes.
@@ -200,7 +200,7 @@ install_run_update_profile() {
 }
 
 install_main() {
-    local repo_url="${BASE_INSTALL_REPO_URL:-https://github.com/codeforester/base.git}"
+    local repo_url="${BASE_INSTALL_REPO_URL:-https://github.com/basefoundry/base.git}"
     local install_dir="${BASE_INSTALL_DIR:-${BASE_HOME:-$HOME/work/base}}"
     local branch="${BASE_INSTALL_BRANCH:-}"
     local update_profile="${BASE_INSTALL_UPDATE_PROFILE:-true}"

--- a/skills.md
+++ b/skills.md
@@ -197,9 +197,9 @@ behavior.
 
 - Standalone installer: `install.sh`
 - User-facing install test coverage: `tests/install.bats`
-- Homebrew tap repository: `https://github.com/codeforester/homebrew-base`
-- User-facing Homebrew install command: `brew install codeforester/base/base`
-- Keep Homebrew users on `brew upgrade codeforester/base/base` rather than
+- Homebrew tap repository: `https://github.com/basefoundry/homebrew-base`
+- User-facing Homebrew install command: `brew install basefoundry/base/base`
+- Keep Homebrew users on `brew upgrade basefoundry/base/base` rather than
   `basectl update`.
 - Validate with:
 

--- a/templates/project-install.sh
+++ b/templates/project-install.sh
@@ -9,7 +9,7 @@ PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/example/example-project
 WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/work}"
 BASE_DIR="${BASE_DIR:-$WORKSPACE_DIR/base}"
 PROJECT_DIR="${PROJECT_DIR:-$WORKSPACE_DIR/$PROJECT_NAME}"
-BASE_INSTALL_URL="${BASE_INSTALL_URL:-https://raw.githubusercontent.com/codeforester/base/master/install.sh}"
+BASE_INSTALL_URL="${BASE_INSTALL_URL:-https://raw.githubusercontent.com/basefoundry/base/master/install.sh}"
 RUN_UPDATE_PROFILE="${RUN_UPDATE_PROFILE:-true}"
 
 INSTALLER_TMP=""

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -394,7 +394,7 @@ run_base_init_script() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"Base reusable Bash libraries were not found."* ]]
     [[ "$output" == *"Tried sibling base-bash-libs checkout at '$TEST_BASE_HOME/../base-bash-libs/lib/bash'."* ]]
-    [[ "$output" == *"Clone codeforester/base-bash-libs next to Base"* ]]
+    [[ "$output" == *"Clone basefoundry/base-bash-libs next to Base"* ]]
 }
 
 @test "base_init resolves Homebrew base-bash-libs next to Homebrew Base" {

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -169,8 +169,8 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Install mode: brew"* ]]
-    [[ "$output" == *"Formula: codeforester/base/base"* ]]
-    [[ "$output" == *"[DRY-RUN] Would run: brew install codeforester/base/base"* ]]
+    [[ "$output" == *"Formula: basefoundry/base/base"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: brew install basefoundry/base/base"* ]]
     [[ "$output" == *"  basectl setup"* ]]
     [[ "$output" == *"  basectl update-profile"* ]]
 }
@@ -204,12 +204,12 @@ EOF
     [[ "$output" == *"Git is available."* ]]
     [[ "$output" == *"Bash 4.2+ is available for Base."* ]]
     [[ "$output" == *"Install mode: brew"* ]]
-    [[ "$output" == *"Base Homebrew formula 'codeforester/base/base' is already installed."* ]]
+    [[ "$output" == *"Base Homebrew formula 'basefoundry/base/base' is already installed."* ]]
     [[ "$output" == *"Homebrew basectl: $brew_prefix/bin/basectl"* ]]
     [[ "$output" == *"active basectl: $TEST_MOCKBIN/basectl"* ]]
     [[ "$output" == *"$brew_prefix/bin/basectl setup"* ]]
     [[ "$output" == *"$brew_prefix/bin/basectl update-profile"* ]]
-    ! grep -Fqx "brew install codeforester/base/base" "$TEST_COMMAND_LOG"
+    ! grep -Fqx "brew install basefoundry/base/base" "$TEST_COMMAND_LOG"
 }
 
 @test "bootstrap command-line mode overrides BASE_BOOTSTRAP_MODE" {
@@ -227,7 +227,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Install mode: source"* ]]
-    [[ "$output" != *"Formula: codeforester/base/base"* ]]
+    [[ "$output" != *"Formula: basefoundry/base/base"* ]]
 }
 
 @test "bootstrap can refuse to install missing Homebrew" {

--- a/tests/test_helper.sh
+++ b/tests/test_helper.sh
@@ -67,7 +67,7 @@ base_bash_libs_fixture_dir() {
         fi
     done
 
-    printf 'ERROR: Base Bash library fixtures were not found. Clone codeforester/base-bash-libs next to Base or set BASE_BASH_LIBS_DIR.\n' >&2
+    printf 'ERROR: Base Bash library fixtures were not found. Clone basefoundry/base-bash-libs next to Base or set BASE_BASH_LIBS_DIR.\n' >&2
     return 1
 }
 


### PR DESCRIPTION
## Summary
- Update current Base docs, `.ai-context`, workflow checkout repos, CODEOWNERS, and related repo links for the Base Foundry org migration.
- Switch live install/bootstrap/release metadata and Homebrew update defaults to `basefoundry` coordinates.
- Refresh related tests and fix the update BATS fixture so fake Base checkouts include the external `base-bash-libs` fixture required by `base_init.sh`.

## Validation
- `rg -n "codeforester/base|github.com/codeforester|@codeforester|codeforester/homebrew-base|codeforester/base-bash-libs|codeforester/base-demo|codeforester/banyanlabs|--owner codeforester" README.md .github .ai-context docs`
  - Remaining hits are historical `docs/superpowers/plans` artifacts and are intentionally unchanged.
- `git diff --check`
- `bats --filter "basectl update allows untracked files before pulling" cli/bash/commands/basectl/tests/update.bats`
- `bats cli/bash/commands/basectl/tests/update.bats`
- `bats tests/bootstrap.bats tests/base_init.bats`
- `PYTHONPATH="$PWD/lib/python:$PWD/cli/python" $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py`
- `env -u BASE_HOME ./bin/base-test`

Closes #880