### PR TITLE
Document single-file shell library standard

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -157,6 +157,20 @@ readonly _base_example_lib_sourced
 Prefer module-specific guard names to generic names that could collide across
 sourced files.
 
+#### Single-File Library Boundary
+
+Sourceable Bash libraries should stay single-file at their library boundary.
+For example, `lib_std.sh` is the stdlib library, and its implementation should
+remain in one sourceable file instead of being split into internal logging,
+path, string, prompt, or command-runner fragments.
+
+A new shell library file is appropriate when Base is introducing a distinct
+library boundary or ownership surface, not when one existing library grows large
+enough to have multiple internal concerns. Keep large libraries navigable with
+clear section ordering, consistent function prefixes, focused README coverage,
+and targeted tests rather than adding a shell module loader or chained
+source-fragment graph.
+
 ### 3.3 Error Handling
 
 1. Do not use `set -e`, `set -u`, or `set -o pipefail` in Base shell scripts


### PR DESCRIPTION
## Summary
- Document the single-file boundary for sourceable Bash libraries in Base standards.
- Clarify that large shell libraries should stay navigable through ordering, naming, README coverage, and tests instead of source-fragment splitting.
- Pair with basefoundry/base-bash-libs#39 so the extracted library repo inherits the same standard.

## Validation
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Closes #873