### PR TITLE
Handle missing project manifest errors

### DIFF
--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -159,6 +159,8 @@ def read_manifest(path: Path) -> BaseManifest:
 
     try:
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ManifestError(f"{path}: unable to read manifest: {exc}") from exc
     except yaml.YAMLError as exc:
         raise ManifestError(f"{path}: invalid YAML: {exc}") from exc
 

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -28,6 +28,17 @@ class BaseSetupMainTests(unittest.TestCase):
         self.assertIn("No such option", stderr)
         self.assertNotIn("Traceback", stderr)
 
+    def test_main_reports_missing_manifest_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+
+            status, stdout, stderr = run_engine(["--manifest", str(manifest_path)])
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("unable to read manifest", stderr)
+        self.assertNotIn("Traceback", stderr)
+
 
 class ArtifactMergeTests(unittest.TestCase):
 

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -40,6 +40,13 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.activate.source, ())
         self.assertIsNone(manifest.python.manager)
 
+    def test_rejects_missing_manifest_path_with_manifest_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+
+            with self.assertRaisesRegex(ManifestError, "unable to read manifest"):
+                read_manifest(manifest_path)
+
     def test_reads_manifest_python_uv_manager(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"


### PR DESCRIPTION
## Summary
- Convert missing or unreadable project manifest paths into ManifestError diagnostics.
- Add parser and CLI regression coverage for missing manifest files.
- Verify basectl check and setup now report concise Base errors instead of tracebacks.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_manifest.ManifestParsingTests.test_rejects_missing_manifest_path_with_manifest_error
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_artifacts.BaseSetupMainTests.test_main_reports_missing_manifest_without_traceback
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_manifest
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl check base --manifest /tmp/base-does-not-exist.yaml --format json
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl setup base --manifest /tmp/base-does-not-exist.yaml --dry-run
- git diff --check

Fixes #891