### PR TITLE
Redact authorization command output

### DIFF
--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -19,7 +19,7 @@ from .errors import ArtifactError
 
 COMMAND_OUTPUT_TAIL_CHARS = 4000
 SECRET_VALUE_RE = re.compile(
-    r"(?i)(?P<name>[A-Za-z0-9_.:-]*(?:token|password|secret|api[-_]?key)[A-Za-z0-9_.:-]*)=\S+"
+    r"(?i)(?P<name>[A-Za-z0-9_.:-]*(?:token|password|secret|api[-_]?key|authorization)[A-Za-z0-9_.:-]*)=\S+"
 )
 URL_CREDENTIALS_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s:@]+:[^@\s/]+@")
 HOMEBREW_LINK_FAILURE = "The `brew link` step did not complete successfully"

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -691,6 +691,8 @@ class ProcessTests(unittest.TestCase):
                 "SOME_SECRET=value-secret",
                 "API_KEY=api-secret",
                 "AWS_SECRET_ACCESS_KEY=aws-secret",
+                "authorization=auth-secret",
+                "AUTHORIZATION=auth-token",
             ]
         )
 
@@ -703,6 +705,8 @@ class ProcessTests(unittest.TestCase):
         self.assertNotIn("value-secret", redacted)
         self.assertNotIn("api-secret", redacted)
         self.assertNotIn("aws-secret", redacted)
+        self.assertNotIn("auth-secret", redacted)
+        self.assertNotIn("auth-token", redacted)
         self.assertIn("token=[REDACTED]", redacted)
         self.assertIn("--github-token=[REDACTED]", redacted)
         self.assertIn("GITHUB_TOKEN=[REDACTED]", redacted)
@@ -710,6 +714,8 @@ class ProcessTests(unittest.TestCase):
         self.assertIn("SOME_SECRET=[REDACTED]", redacted)
         self.assertIn("API_KEY=[REDACTED]", redacted)
         self.assertIn("AWS_SECRET_ACCESS_KEY=[REDACTED]", redacted)
+        self.assertIn("authorization=[REDACTED]", redacted)
+        self.assertIn("AUTHORIZATION=[REDACTED]", redacted)
 
     def test_run_command_failure_truncates_large_single_chunk_tail(self) -> None:
         ctx = fake_context()


### PR DESCRIPTION
## Summary
- Redact Authorization-style key assignments in setup command output.
- Extend the existing command-output redaction regression test to cover lowercase and uppercase authorization keys.

## Validation
- PYTHONPATH=lib/python:cli/python uv run python -m unittest cli.python.base_setup.tests.test_artifacts.ProcessTests.test_redact_command_output_redacts_compound_secret_assignments
- git diff --check

## Notes
- A broader cli.python.base_setup.tests.test_artifacts run still hits the pre-existing BaseSetupMainTests.test_main_reports_unknown_option_without_traceback failure that also reproduces on master.

Fixes #892