### PR TITLE
Align basectl completions with current command surface

### DIFF
--- a/.ai-context/DECISIONS.md
+++ b/.ai-context/DECISIONS.md
@@ -57,9 +57,7 @@ architecture discussion.
 
 ## Repository Workflow
 
-- GitHub Issues are the durable product backlog.
-- `TODO.md`, when present, is scratch/private planning and not the public
-  backlog.
+- GitHub Issues are the durable product backlog and activity tracker.
 - Work should use issue-backed branches and dedicated worktrees.
 - Branch names include category, issue number, date, and slug.
 - Base dogfoods `basectl gh` when it supports the needed workflow.

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -102,7 +102,15 @@ EOF
             COMP_WORDS=(basectl workspace status --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
-            printf "workspace_options=%s\n" "${COMPREPLY[*]}"; \
+            printf "workspace_status_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace clone --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "workspace_clone_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace pull --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "workspace_pull_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl onboard --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -204,7 +212,9 @@ EOF
     [[ "$output" == *"export_context_options=--workspace --format --output --print --list-files"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"workspace_commands=status check doctor clone pull"* ]]
-    [[ "$output" == *"workspace_options=--workspace --manifest --source --format --include-optional --dry-run"* ]]
+    [[ "$output" == *"workspace_status_options=--workspace --manifest --format"* ]]
+    [[ "$output" == *"workspace_clone_options=--workspace --manifest --include-optional --dry-run"* ]]
+    [[ "$output" == *"workspace_pull_options=--source --manifest --dry-run"* ]]
     [[ "$output" == *"onboard_options=--profile --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"onboard_projects=base demo"* ]]
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
@@ -219,7 +229,7 @@ EOF
     [[ "$output" == *"repo_installer_template_options=--repo --pr --dry-run"* ]]
     [[ "$output" == *"ci_commands=setup check doctor"* ]]
     [[ "$output" == *"ci_check_options=--format --manifest --profile"* ]]
-    [[ "$output" == *"gh_areas=issue pr branch worktree todo project"* ]]
+    [[ "$output" == *"gh_areas=issue pr branch worktree project"* ]]
     [[ "$output" == *"gh_project_commands=doctor configure issue"* ]]
     [[ "$output" == *"gh_project_configure_options=--project --owner --schema --initiative-option --repo --replace-project --dry-run"* ]]
     [[ "$output" == *"gh_project_issue_set_fields_options=--repo --project --owner --status --priority --area --initiative --size --dry-run"* ]]

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -93,7 +93,17 @@ _base_basectl_completion() {
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "status check doctor clone pull" "$cur"
             else
-                _base_basectl_completion_compgen "--workspace --manifest --source --format --include-optional --dry-run -v -h --help" "$cur"
+                case "${COMP_WORDS[2]:-}" in
+                    status|check|doctor)
+                        _base_basectl_completion_compgen "--workspace --manifest --format -v -h --help" "$cur"
+                        ;;
+                    clone)
+                        _base_basectl_completion_compgen "--workspace --manifest --include-optional --dry-run -v -h --help" "$cur"
+                        ;;
+                    pull)
+                        _base_basectl_completion_compgen "--source --manifest --dry-run -v -h --help" "$cur"
+                        ;;
+                esac
             fi
             ;;
         setup)
@@ -181,7 +191,7 @@ _base_basectl_completion() {
         gh)
             case "${COMP_WORDS[2]:-}" in
                 "")
-                    _base_basectl_completion_compgen "issue pr branch worktree todo project" "$cur"
+                    _base_basectl_completion_compgen "issue pr branch worktree project" "$cur"
                     ;;
                 issue)
                     if ((COMP_CWORD == 3)); then
@@ -207,13 +217,6 @@ _base_basectl_completion() {
                         _base_basectl_completion_compgen "prune" "$cur"
                     else
                         _base_basectl_completion_compgen "--dry-run --yes -h --help" "$cur"
-                    fi
-                    ;;
-                todo)
-                    if ((COMP_CWORD == 3)); then
-                        _base_basectl_completion_compgen "import" "$cur"
-                    else
-                        _base_basectl_completion_compgen "--dry-run --file -h --help" "$cur"
                     fi
                     ;;
                 project)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -63,14 +63,33 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         workspace)
-            _arguments '1:workspace command:(status check doctor clone pull)' \
-                '--workspace[Workspace directory to scan]:path:_files' \
-                '--manifest[Local workspace manifest]:path:_files' \
-                '--source[Canonical workspace manifest source]:url-or-path:' \
-                '--format[Output format]:format:(text json)' \
-                '--include-optional[Include optional manifest repositories when cloning]' \
-                '--dry-run[Show planned clone or pull work without changing files]' \
-                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            case "${words[3]:-}" in
+                status|check|doctor)
+                    _arguments '1:workspace command:(status check doctor clone pull)' \
+                        '--workspace[Workspace directory to scan]:path:_files' \
+                        '--manifest[Local workspace manifest]:path:_files' \
+                        '--format[Output format]:format:(text json)' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                clone)
+                    _arguments '1:workspace command:(status check doctor clone pull)' \
+                        '--workspace[Workspace directory to scan]:path:_files' \
+                        '--manifest[Local workspace manifest]:path:_files' \
+                        '--include-optional[Include optional manifest repositories when cloning]' \
+                        '--dry-run[Show planned workspace clone work without writing]' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                pull)
+                    _arguments '1:workspace command:(status check doctor clone pull)' \
+                        '--source[Canonical workspace manifest source]:url-or-path:' \
+                        '--manifest[Local workspace manifest]:path:_files' \
+                        '--dry-run[Show planned workspace pull work without writing]' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                *)
+                    _arguments '1:workspace command:(status check doctor clone pull)'
+                    ;;
+            esac
             ;;
         setup)
             _arguments '--profile[Install prerequisite profiles]:profile:(dev sre ai dev,sre dev,ai sre,ai dev,sre,ai)' \
@@ -285,7 +304,7 @@ _base_basectl_completion() {
         gh)
             case "${words[3]:-}" in
                 issue)
-                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                    _arguments '1:gh area:(issue pr branch worktree project)' \
                         '2:issue command:(list create start)' \
                         '--category[Issue category]:category:(bug enhancement documentation ci security)' \
                         '--title[Issue title]:title:' \
@@ -293,11 +312,11 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 pr)
-                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                    _arguments '1:gh area:(issue pr branch worktree project)' \
                         '2:pr command:(create status checks ready merge)'
                     ;;
                 branch)
-                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                    _arguments '1:gh area:(issue pr branch worktree project)' \
                         '2:branch command:(stale prune)' \
                         '--days[Stale threshold in days]:days:' \
                         '--dry-run[Show planned deletions]' \
@@ -306,23 +325,16 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 worktree)
-                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                    _arguments '1:gh area:(issue pr branch worktree project)' \
                         '2:worktree command:(prune)' \
                         '--dry-run[Show planned removals]' \
                         '--yes[Apply worktree pruning]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
-                todo)
-                    _arguments '1:gh area:(issue pr branch worktree todo project)' \
-                        '2:todo command:(import)' \
-                        '--dry-run[Show planned issues]' \
-                        '--file[TODO file]:path:_files' \
-                        '(-h --help)'{-h,--help}'[Show help text]'
-                    ;;
                 project)
                     case "${words[4]:-}" in
                         doctor)
-                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                            _arguments '1:gh area:(issue pr branch worktree project)' \
                                 '2:project command:(doctor configure issue)' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
@@ -330,7 +342,7 @@ _base_basectl_completion() {
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         configure)
-                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                            _arguments '1:gh area:(issue pr branch worktree project)' \
                                 '2:project command:(doctor configure issue)' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
@@ -341,7 +353,7 @@ _base_basectl_completion() {
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         issue)
-                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                            _arguments '1:gh area:(issue pr branch worktree project)' \
                                 '2:project command:(doctor configure issue)' \
                                 '3:issue command:(set-fields)' \
                                 '4:issue number:' \
@@ -357,13 +369,13 @@ _base_basectl_completion() {
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         *)
-                            _arguments '1:gh area:(issue pr branch worktree todo project)' \
+                            _arguments '1:gh area:(issue pr branch worktree project)' \
                                 '2:project command:(doctor configure issue)'
                             ;;
                     esac
                     ;;
                 *)
-                    _arguments '1:gh area:(issue pr branch worktree todo project)'
+                    _arguments '1:gh area:(issue pr branch worktree project)'
                     ;;
             esac
             ;;


### PR DESCRIPTION
## Summary
- Make bash and zsh workspace completions expose subcommand-specific flags.
- Remove stale gh todo completion entries now that GitHub Issues are the backlog source of truth.
- Update AI context decisions to state the GitHub Issues backlog convention directly.

## Validation
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/completions.bats
- bash -n lib/shell/completions/basectl_completion.sh
- zsh -n lib/shell/completions/basectl_completion.zsh
- git diff --check

Fixes #893