### PR TITLE
Clarify Homebrew tap trust install path

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -40,11 +40,16 @@ Use Homebrew when you already have Homebrew and Bash and want Base managed like
 an ordinary installed tool:
 
 ```bash
+brew trust basefoundry/base
 brew install basefoundry/base/base
 basectl setup
 basectl update-profile
 exec "$SHELL" -l
 ```
+
+Trusting the tap lets Homebrew load both the `base` formula and Base's
+tap-owned `base-bash-libs` dependency. The command is safe to rerun on machines
+that already trust `basefoundry/base`.
 
 Use a source checkout when you are contributing to Base or want to inspect and
 run the repository directly. This is also the preferred active install for a

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -214,9 +214,13 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | Method | Best for |
 |---|---|
 | `curl … bootstrap.sh \| bash` | Blank macOS machine; installs Homebrew, Git, Bash, then Base |
-| `brew install basefoundry/base/base` | Users wanting Base installed as a managed tool |
+| `brew trust basefoundry/base` + `brew install basefoundry/base/base` | Users wanting Base installed as a managed tool |
 | `git clone` + `basectl setup` | Contributors / Base developers |
 | `curl … install.sh \| bash` | Source-install shortcut |
+
+Homebrew installs should trust the `basefoundry/base` tap before installing
+Base. The tap owns both `base` and the `base-bash-libs` dependency, and the
+trust command is safe to rerun on machines that already trust the tap.
 
 All paths converge on the same daily command surface. After any install, finish
 with:


### PR DESCRIPTION
## Summary
- Add the `brew trust basefoundry/base` step to the FAQ Homebrew install path.
- Clarify in the technical overview that the Base tap owns both `base` and `base-bash-libs`, so whole-tap trust is the canonical Homebrew install path.

## Validation
- `git diff --check`
- `env -u BASE_HOME ./bin/base-test` (504 passed, 1 skipped; 430 BATS tests passed)

Closes #906