### PR TITLE
Make Base workflow guidance main-ready

### DIFF
--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -66,7 +66,7 @@ Recent released work includes:
 
 ## Recent Merged Changes
 
-Recent commits on `master` include:
+Recent commits on `main` include:
 
 - public evaluator documentation through `docs/why-base.md`
 - AGPL license cleanup and generated-license correction for `basectl repo init`

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -42,7 +42,7 @@ The standard worktree location is:
 ~/work/base-worktrees/<slug>
 ```
 
-Start from current `origin/master`, keep the worktree while the PR is open, and
+Start from current `origin/main`, keep the worktree while the PR is open, and
 clean it up after merge.
 
 ## Pull Requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,14 +33,14 @@ them.
   operations.
 - Fall back to the GitHub connector, raw `gh`, or `git` when `basectl gh` does
   not support the needed operation or local tooling is unavailable.
-- Branch from `origin/master` with
+- Branch from `origin/main` with
   `<category>/<issue>-<YYYYMMDD>-<slug>`.
 - Use a dedicated worktree under `~/work/base-worktrees/<slug>` for PR work.
 - Before creating a worktree, check whether the current checkout is already a
   linked worktree for the intended issue.
 - Link PRs with `Fixes #<issue>` or `Closes #<issue>` when merge should close
   the issue.
-- After merge, sync `master`, remove the worktree, and delete local and remote
+- After merge, sync `main`, remove the worktree, and delete local and remote
   branches.
 
 See `docs/github-workflow.md` for the full policy, including PR body sections,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Made live workflow docs and installer examples main-ready, using default-branch
+  URLs for raw GitHub install scripts and `main` for contributor branch
+  examples.
 - Documented the boundary for optional personal shell defaults such as color
   aliases, navigation shortcuts, signing helpers, and strict shell modes.
 - Improved opt-in Bash and Zsh completion ergonomics for interactive shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,19 +41,19 @@ for issue-backed work, validation, and design-only sessions.
 5. Use an isolated Git worktree for each pull request:
 
    ```bash
-   git fetch origin master
-   git worktree add -b <branch> ~/work/base-worktrees/<slug> origin/master
+   git fetch origin main
+   git worktree add -b <branch> ~/work/base-worktrees/<slug> origin/main
    ```
 
 6. Keep the PR scoped to the issue. Avoid unrelated refactors.
 7. Link the PR back to the issue with `Fixes #<issue>` or `Closes #<issue>`.
 8. Use the standard PR body and fill in Summary, Issue, Validation, Demo
    Impact, and Notes.
-9. After merge, sync `master`, remove the worktree, and delete the local and
+9. After merge, sync `main`, remove the worktree, and delete the local and
    remote branches:
 
    ```bash
-   git -C ~/work/base pull --ff-only origin master
+   git -C ~/work/base pull --ff-only origin main
    git -C ~/work/base worktree remove ~/work/base-worktrees/<slug>
    git -C ~/work/base branch -d <branch>
    git -C ~/work/base push origin --delete <branch>
@@ -68,7 +68,7 @@ On a fresh macOS machine, use `bootstrap.sh` in source mode so the repository is
 available for local edits:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
 ~/work/base/bin/basectl setup --profile dev
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l

--- a/FAQ.md
+++ b/FAQ.md
@@ -7,7 +7,7 @@
 Use `bootstrap.sh`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
 ```
 
 The bootstrapper verifies macOS, ensures Homebrew is available, installs Git and
@@ -70,8 +70,8 @@ update Base and then run setup/profile commands as one script.
 Pass an explicit mode:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --brew
 ```
 
 Without an explicit mode, bootstrap preserves an existing Homebrew Base install,

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ On a new macOS machine, or any machine where Homebrew, Git, or a supported Bash
 may be missing, start with the first-mile bootstrap script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
 ```
 
 The bootstrapper installs Homebrew, Git, and a supported Bash when needed,
@@ -82,8 +82,8 @@ source checkout at `~/work/base`, and prints the exact `basectl setup` and
 Choose an install mode explicitly when needed:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --brew
 ```
 
 For mode selection, dry-run behavior, and contributor setup details, see
@@ -953,7 +953,7 @@ is requested on macOS, Base warns if `osascript` is not available.
 For a blank macOS machine, use `bootstrap.sh`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
 ```
 
 The bootstrapper is intentionally small. It verifies macOS, installs Homebrew
@@ -1024,7 +1024,7 @@ workspace:
 The standalone installer is also available:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/install.sh | bash
 exec "$SHELL" -l
 ```
 
@@ -1032,7 +1032,7 @@ This runs a shell script from GitHub, so review the script first if you do not
 already trust this repository:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/install.sh
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/install.sh
 ```
 
 By default, the installer clones or updates Base at `~/work/base`, runs
@@ -1042,7 +1042,7 @@ By default, the installer clones or updates Base at `~/work/base`, runs
 installer options with `bash -s --`, for example:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/install.sh | bash -s -- --dir ~/work/base --no-profile
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/install.sh | bash -s -- --dir ~/work/base --no-profile
 ```
 
 Use `--no-profile` to skip shell startup integration and `--dry-run` to print

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -238,7 +238,7 @@ base_gh_default_branch() {
         return 0
     fi
 
-    printf '%s\n' master
+    printf '%s\n' main
 }
 
 base_gh_validate_category() {

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -383,6 +383,26 @@ EOF
     [[ "$output" == "enhancement/117-"*"-prune-merged-branches" ]]
 }
 
+@test "basectl gh branch prune falls back to main when default branch is unknown" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    git init "$repo" >/dev/null 2>&1
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Branch prune preview for default branch main."* ]]
+}
+
 @test "basectl gh branch prune defaults to dry-run" {
     local repo
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -10,7 +10,7 @@ installation of Base.
 Run the bootstrapper from GitHub:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
 ```
 
 The bootstrapper verifies macOS, installs missing first-mile prerequisites, and
@@ -32,8 +32,8 @@ see what was installed before Base changes future interactive shells.
 Choose a mode explicitly when the default should not infer one:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --brew
 ```
 
 Without an explicit mode, bootstrap uses this order:
@@ -67,7 +67,7 @@ route without changing the machine.
 Contributors should prefer source mode:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
 ~/work/base/bin/basectl setup --profile dev
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -177,14 +177,14 @@ non-empty `--show-superproject-working-tree` result means the checkout is a
 submodule and should be treated as a normal repository for worktree detection.
 Continue in an existing issue worktree instead of creating a nested or
 duplicate worktree. If the checkout is a normal repository, create the issue
-worktree from current `origin/master`.
+worktree from current `origin/main`.
 
-Create a worktree from current `origin/master`:
+Create a worktree from current `origin/main`:
 
 ```bash
-git fetch origin master
+git fetch origin main
 git worktree add -b documentation/241-20260529-document-github-workflow \
-  ~/work/base-worktrees/documentation-241-github-workflow origin/master
+  ~/work/base-worktrees/documentation-241-github-workflow origin/main
 ```
 
 Keep the worktree while the pull request is open so review feedback can be
@@ -194,7 +194,7 @@ discard decision.
 After a pull request is merged:
 
 ```bash
-git -C ~/work/base pull --ff-only origin master
+git -C ~/work/base pull --ff-only origin main
 git -C ~/work/base worktree remove ~/work/base-worktrees/<slug>
 git -C ~/work/base branch -d <branch>
 git -C ~/work/base push origin --delete <branch>

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -95,7 +95,7 @@ exec "$SHELL" -l
 For a first-mile bootstrap run that should choose the Homebrew route:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --brew
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --brew
 ```
 
 Then run the handoff commands printed by `bootstrap.sh`. They should include
@@ -205,7 +205,7 @@ Use this path when validating the contributor and dogfood experience.
 For bootstrap source mode:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash -s -- --source
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
 ```
 
 Then run the handoff commands printed by `bootstrap.sh`. They should point at

--- a/docs/presentations/base-newcomer-orientation.md
+++ b/docs/presentations/base-newcomer-orientation.md
@@ -84,7 +84,7 @@ Base starts before the developer has a working Base environment.
 On macOS, `bootstrap.sh` handles the first mile:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basefoundry/base/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
 ```
 
 It installs or checks the prerequisites needed to hand off to `basectl setup`.
@@ -261,7 +261,7 @@ Read more: [Release Process](../release-process.md)
 Base work normally follows an issue-backed PR train:
 
 1. pick or create the GitHub issue
-2. create a branch/worktree from `origin/master`
+2. create a branch/worktree from `origin/main`
 3. make the narrow change
 4. run the relevant validation
 5. open the PR with issue closure text and validation evidence

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -75,7 +75,7 @@ Complete these steps in `basefoundry/base`:
 
 1. Choose the release version and create or use a GitHub issue for the release
    artifact work.
-2. Create a release-prep branch and worktree from `origin/master`.
+2. Create a release-prep branch and worktree from `origin/main`.
 3. Update release metadata:
    - `VERSION`
    - README version badge
@@ -90,8 +90,8 @@ Complete these steps in `basefoundry/base`:
    bin/base-test
    ```
 
-5. Merge the release-prep PR into `master`.
-6. Sync local `master`.
+5. Merge the release-prep PR into `main`.
+6. Sync local `main`.
 7. Dry-run the guarded publish command:
 
    ```bash
@@ -113,7 +113,7 @@ Complete these steps in `basefoundry/base`:
 Complete these steps in `basefoundry/homebrew-base` after the Base tag exists:
 
 1. Create a Homebrew tap update issue or PR for the new Base version.
-2. Create a tap release branch. Do not run the bottle workflow from `master`;
+2. Create a tap release branch. Do not run the bottle workflow from `main`;
    it pushes the generated bottle stanza back to the branch that triggered it.
 3. Update `Formula/base.rb`:
    - `url` to the new Base tag archive

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -106,7 +106,7 @@ workspace:
 repos:
   - name: base
     url: git@github.com:basefoundry/base.git
-    default_branch: master
+    default_branch: main
     required: true
 
   - name: bankbuddy

--- a/skills.md
+++ b/skills.md
@@ -28,7 +28,7 @@ requests for Base.
 - Before creating a worktree, check whether the current checkout is already a
   linked worktree for the issue. Do not create nested or duplicate worktrees.
 - Keep the PR worktree available while review feedback is pending. After merge,
-  sync `master`, remove the worktree, and delete local and remote branches.
+  sync `main`, remove the worktree, and delete local and remote branches.
 - Link PRs to issues with `Fixes #<issue>` or `Closes #<issue>`.
 - See `docs/github-workflow.md` for the full policy, including milestones and
   GitHub Projects.
@@ -93,7 +93,7 @@ guidance such as this `skills.md` file, `AGENTS.md`, or workflow documentation.
   should make it clear when the workflow applies.
 - Keep entries concise and Base-specific. Link to focused docs for longer
   policy instead of duplicating it.
-- Align examples with Base conventions: `basectl gh`, `origin/master`,
+- Align examples with Base conventions: `basectl gh`, `origin/main`,
   `<category>/<issue>-<YYYYMMDD>-<slug>`, and
   `~/work/base-worktrees/<slug>`.
 - Review the workflow against likely pressure cases: time pressure, ambiguous

--- a/templates/project-install.sh
+++ b/templates/project-install.sh
@@ -9,7 +9,7 @@ PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/example/example-project
 WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/work}"
 BASE_DIR="${BASE_DIR:-$WORKSPACE_DIR/base}"
 PROJECT_DIR="${PROJECT_DIR:-$WORKSPACE_DIR/$PROJECT_NAME}"
-BASE_INSTALL_URL="${BASE_INSTALL_URL:-https://raw.githubusercontent.com/basefoundry/base/master/install.sh}"
+BASE_INSTALL_URL="${BASE_INSTALL_URL:-https://raw.githubusercontent.com/basefoundry/base/HEAD/install.sh}"
 RUN_UPDATE_PROFILE="${RUN_UPDATE_PROFILE:-true}"
 
 INSTALLER_TMP=""


### PR DESCRIPTION
## Summary
- Make `basectl gh` fall back to `main` when no default branch can be detected, while preserving explicit `master` branch compatibility.
- Update live contributor/workflow docs, `.ai-context`, and presentation guidance from `master` to `main`.
- Use raw GitHub `HEAD` URLs for bootstrap/install examples and templates so installer commands follow the default branch through the rename.

## Validation
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test
- git diff --check

Fixes #904
