### PR TITLE
Fix workspace broken venv detection

### DIFF
--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -29,8 +29,12 @@ def write_uv_manifest(project_root: Path, name: str) -> None:
         encoding="utf-8",
     )
     python_bin = project_root / ".venv" / "bin" / "python"
+    write_ready_python_bin(python_bin)
+
+
+def write_ready_python_bin(python_bin: Path) -> None:
     python_bin.parent.mkdir(parents=True)
-    python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+    python_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     python_bin.chmod(0o755)
 
 
@@ -293,8 +297,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             write_manifest(workspace / "base", "base")
             write_manifest(workspace / "demo", "demo")
             python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
-            python_bin.parent.mkdir(parents=True)
-            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_ready_python_bin(python_bin)
             write_last_check(home, "base", "2026-06-17T14:30:00Z")
 
             status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -32,8 +32,12 @@ def write_uv_manifest(project_root: Path, name: str) -> None:
     )
     (project_root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
     python_bin = project_root / ".venv" / "bin" / "python"
+    write_ready_python_bin(python_bin)
+
+
+def write_ready_python_bin(python_bin: Path) -> None:
     python_bin.parent.mkdir(parents=True)
-    python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+    python_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     python_bin.chmod(0o755)
 
 
@@ -104,8 +108,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_manifest(workspace / "extra", "extra")
             for project_name in ("base", "extra"):
                 python_bin = home / ".base.d" / project_name / ".venv" / "bin" / "python"
-                python_bin.parent.mkdir(parents=True)
-                python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+                write_ready_python_bin(python_bin)
 
             status, stdout, stderr = invoke_engine(
                 ["check", "--workspace", str(workspace), "--manifest", str(manifest_path)],
@@ -143,8 +146,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_manifest(workspace / "extra", "extra")
             for project_name in ("base", "extra"):
                 python_bin = home / ".base.d" / project_name / ".venv" / "bin" / "python"
-                python_bin.parent.mkdir(parents=True)
-                python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+                write_ready_python_bin(python_bin)
 
             status, stdout, stderr = invoke_engine(
                 [
@@ -220,8 +222,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_default_manifest(base_home)
             write_manifest(workspace / "demo", "demo")
             python_bin = home / ".base.d" / "demo" / ".venv" / "bin" / "python"
-            python_bin.parent.mkdir(parents=True)
-            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_ready_python_bin(python_bin)
             broken_root = workspace / "broken"
             broken_root.mkdir(parents=True)
             (broken_root / "base_manifest.yaml").write_text("project: [", encoding="utf-8")
@@ -312,6 +313,37 @@ class WorkspaceCheckTests(unittest.TestCase):
         self.assertEqual(payload["projects"][0]["checks"][0]["status"], "error")
         self.assertNotIn("ok", payload["projects"][0]["checks"][0])
 
+    def test_workspace_check_reports_unrunnable_project_venv_as_p050(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_manifest(workspace / "demo", "demo")
+            python_bin = home / ".base.d" / "demo" / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            python_bin.chmod(0o755)
+
+            status, stdout, stderr = invoke_engine(
+                ["check", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        checks = payload["projects"][0]["checks"]
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["projects"][0]["status"], "error")
+        self.assertEqual(checks[0]["id"], "BASE-P050")
+        self.assertEqual(checks[0]["status"], "error")
+        self.assertIn("basectl setup demo --recreate-venv", checks[0]["fix"])
+        self.assertNotIn("BASE-P040", {check["id"] for check in checks})
+
     def test_workspace_doctor_supports_json_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -351,8 +383,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_default_manifest(base_home)
             write_manifest(workspace / "demo", "demo")
             python_bin = home / ".base.d" / "demo" / ".venv" / "bin" / "python"
-            python_bin.parent.mkdir(parents=True)
-            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_ready_python_bin(python_bin)
 
             status, stdout, stderr = invoke_engine(["doctor", "--workspace", str(workspace)], base_home, home)
 

--- a/cli/python/base_projects/tests/test_workspace_status_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_status_manifest.py
@@ -37,6 +37,12 @@ def write_last_check(home: Path, project: str, checked_at: str, status: str = "o
     )
 
 
+def write_ready_python_bin(python_bin: Path) -> None:
+    python_bin.parent.mkdir(parents=True)
+    python_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    python_bin.chmod(0o755)
+
+
 def write_workspace_manifest(path: Path) -> None:
     path.write_text(
         "\n".join(
@@ -99,8 +105,7 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
             (workspace / "docs").mkdir(parents=True)
             write_manifest(workspace / "extra", "extra")
             python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
-            python_bin.parent.mkdir(parents=True)
-            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_ready_python_bin(python_bin)
             write_last_check(home, "base", "2026-06-17T14:30:00Z")
 
             status, stdout, stderr = invoke_engine(
@@ -133,8 +138,7 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
             write_manifest(workspace / "base", "base")
             (workspace / "docs").mkdir(parents=True)
             python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
-            python_bin.parent.mkdir(parents=True)
-            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            write_ready_python_bin(python_bin)
             write_last_check(home, "base", "2026-06-17T14:30:00Z")
 
             status, stdout, stderr = invoke_engine(

--- a/cli/python/base_projects/workspace_reports.py
+++ b/cli/python/base_projects/workspace_reports.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass
 from dataclasses import replace
 from pathlib import Path
@@ -233,7 +234,20 @@ def project_venv_dir(manifest: BaseManifest) -> Path:
 
 
 def project_venv_ready(venv_dir: Path) -> bool:
-    return (venv_dir / "bin" / "python").is_file()
+    python_bin = venv_dir / "bin" / "python"
+    if not python_bin.is_file():
+        return False
+    try:
+        completed = subprocess.run(
+            [str(python_bin), "-c", "import sys"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
 
 
 def project_last_check(project_name: str) -> ProjectLastCheck | None:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -142,9 +142,9 @@ Doctor commands use the same diagnostic item fields. The top-level
 `BASE-P050` is the stable project virtual-environment readiness finding. The
 Bash setup/check path reports detailed venv health messages when a project venv
 is missing, incomplete, or has a broken Python executable. Workspace-level
-project discovery currently verifies that the expected project venv Python path
-exists. The finding should be treated as the project-venv readiness contract,
-not as a guarantee that every project dependency import succeeds.
+project discovery verifies that the expected project venv Python executable can
+start. The finding should be treated as the project-venv readiness contract, not
+as a guarantee that every project dependency import succeeds.
 
 `BASE-P140` through `BASE-P143` are read-only `pyproject.toml` diagnostics.
 Base only inspects the `pyproject.toml` file beside the active


### PR DESCRIPTION
## Summary
- Verify workspace project venv Python executables can start before marking them ready.
- Keep broken project venvs on the BASE-P050 path so artifact checks do not mask the root failure.
- Update BASE-P050 docs for workspace-level readiness.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_projects.tests.test_workspace_checks.WorkspaceCheckTests.test_workspace_check_reports_unrunnable_project_venv_as_p050
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests -q
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test

Fixes #922