### PR TITLE
Document base-bash-libs Homebrew core readiness

### DIFF
--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -62,6 +62,8 @@ Recent released work includes:
   workflow generation, and resilient `basectl gh` command execution
 - external `base-bash-libs` consumption for reusable Bash libraries, with Base
   retaining only Bash runtime and version helpers
+- documented `base-bash-libs` Homebrew/core readiness as the future standalone
+  dependency for a non-conflicting `basefoundry` core formula
 
 ## Recent Merged Changes
 
@@ -76,6 +78,7 @@ Recent commits on `main` include:
 - Homebrew bottle and upgrade-path release process hardening
 - external reusable Bash library resolution from `base-bash-libs`
 - documented `base-bash-libs` consumption and post-migration contract
+- formula-name Homebrew audit guidance for Base and `base-bash-libs`
 
 ## Useful Orientation Links
 

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -113,6 +113,11 @@ Supported macOS tap releases should publish Homebrew bottles before the tap PR
 is merged: run the tap's `Build Base Bottles` workflow from the tap release
 branch, let it upload bottle assets to the tap release `base-vX.Y.Z`, and commit
 the generated `bottle do` stanza back to `Formula/base.rb`.
+Homebrew formula audits should be run by formula name, for example
+`brew audit --new --formula basefoundry/base/base` and
+`brew audit --new --formula basefoundry/base/base-bash-libs`. Keep
+`base-bash-libs` core-ready as a standalone dependency so a future
+Homebrew/core `basefoundry` formula can declare `depends_on "base-bash-libs"`.
 
 ## AI Context Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Changed
+
+- Documented the `base-bash-libs` Homebrew/core readiness path, including the
+  formula-name audit command and future `basefoundry` dependency plan.
+
 ## [1.1.0] - 2026-06-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -998,6 +998,15 @@ Use the full formula name `basefoundry/base/base` for Homebrew installs and
 upgrades. `basefoundry/base` is the tap name, not the formula, and bare `base`
 can resolve to unrelated Homebrew formulae or casks.
 
+Base is not yet in Homebrew/core. Until that changes, use the tap commands
+above. The planned core path keeps the reusable Bash libraries as a separate
+`base-bash-libs` dependency so a future non-conflicting Base formula, expected
+to be named `basefoundry`, can install with:
+
+```bash
+brew install basefoundry
+```
+
 The trust step is required on Homebrew versions that block formulae from
 non-official taps until the tap is trusted. It is safe to run again on machines
 that already trust `basefoundry/base`. Existing installs that predate this

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ reference. The filename should answer "what is this about?"
   Base-managed environment variables, `~/.baserc`, and mutability rules.
 - [Base Bash Libraries](base-bash-libs.md) documents the standalone
   `base-bash-libs` package, Base's external reusable-library consumption path,
-  and the post-migration boundary.
+  Homebrew/core readiness path, and the post-migration boundary.
 - [Local Observability](observability.md) defines the future local command
   history, last-error explanation, and report model beyond raw runtime logs.
 - [Release Process](release-process.md) defines the Base release ceremony,

--- a/docs/base-bash-libs.md
+++ b/docs/base-bash-libs.md
@@ -65,6 +65,47 @@ git clone https://github.com/basefoundry/base-bash-libs.git ~/work/base-bash-lib
 source "$HOME/work/base-bash-libs/lib/bash/std/lib_std.sh"
 ```
 
+## Homebrew/Core Readiness
+
+The current public package lives in the `basefoundry/homebrew-base` tap as
+`Formula/base-bash-libs.rb`. That formula is intentionally shaped so it can be
+prepared for Homebrew/core without changing the Base runtime contract:
+
+- it installs from the stable `basefoundry/base-bash-libs` release archive;
+- it declares SPDX license metadata with `license "Apache-2.0"`;
+- it keeps the Homebrew package name `base-bash-libs`;
+- it depends only on Homebrew `bash`;
+- it installs reusable libraries under `libexec/lib/bash`;
+- it includes README, changelog, license, notice, and examples under
+  `pkgshare`; and
+- its formula test sources `lib_std.sh`, imports the companion `file` and `git`
+  libraries, and verifies the expected public functions through Homebrew Bash.
+
+Before submitting or refreshing a Homebrew/core proposal, validate the tap
+formula by name, not by local formula path:
+
+```bash
+brew test basefoundry/base/base-bash-libs
+brew audit --new --formula basefoundry/base/base-bash-libs
+```
+
+The future Homebrew/core path should keep `base-bash-libs` available as its own
+formula so the eventual Base formula can depend on it directly:
+
+```ruby
+depends_on "base-bash-libs"
+```
+
+That lets the intended user-facing Base install remain:
+
+```bash
+brew install basefoundry
+```
+
+Until Homebrew/core accepts those formulae, users should continue installing
+Base and the standalone libraries from the existing tap with the explicit
+`basefoundry/base/...` formula names documented above.
+
 ## How Base Resolves Libraries
 
 When `basectl` loads `base_init.sh`, Base resolves `BASE_BASH_LIBS_DIR` before

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -131,19 +131,29 @@ Complete these steps in `basefoundry/homebrew-base` after the Base tag exists:
    ```bash
    brew install --build-from-source Formula/base.rb
    brew test basefoundry/base/base
-   brew audit --new --formula Formula/base.rb
+   brew audit --new --formula basefoundry/base/base
    ```
 
-6. Run the `Build Base Bottles` GitHub Actions workflow from the tap release
+6. Confirm the tap-owned `base-bash-libs` formula remains Homebrew/core-ready.
+   The formula should keep its stable release archive, SPDX license metadata,
+   `bash` dependency, test block, and `base-bash-libs` package name so a future
+   `basefoundry` Homebrew/core formula can depend on it directly:
+
+   ```bash
+   brew test basefoundry/base/base-bash-libs
+   brew audit --new --formula basefoundry/base/base-bash-libs
+   ```
+
+7. Run the `Build Base Bottles` GitHub Actions workflow from the tap release
    branch. The workflow builds bottles on supported macOS runners, uploads
    bottle tarballs to the tap GitHub Release named `base-vX.Y.Z`, merges the
    generated bottle JSON into `Formula/base.rb`, and pushes the bottle stanza
    back to the branch.
-7. Confirm the tap PR includes a `bottle do` block for supported macOS targets
+8. Confirm the tap PR includes a `bottle do` block for supported macOS targets
    before merging. The bottle `root_url` should point at the tap release created
    by the workflow.
-8. Open or update the tap PR, wait for checks, and merge it.
-9. Smoke-test the consumer bottle and upgrade paths:
+9. Open or update the tap PR, wait for checks, and merge it.
+10. Smoke-test the consumer bottle and upgrade paths:
 
    ```bash
    brew update
@@ -155,7 +165,7 @@ Complete these steps in `basefoundry/homebrew-base` after the Base tag exists:
 
    Use `brew reinstall --force-bottle basefoundry/base/base` when Base is
    already installed on the validation host.
-10. Before 1.0.0, complete the
+11. Before 1.0.0, complete the
    [Homebrew Upgrade Rehearsal](homebrew-upgrade-rehearsal.md) against a
    release candidate or equivalent test formula. Record the exact commands,
    host facts, pre-upgrade state, post-upgrade checks, and any follow-up issues.


### PR DESCRIPTION
## Summary
- Document the current tap formula shape that makes `base-bash-libs` ready to prepare for Homebrew/core.
- Clarify the future `basefoundry` core formula dependency path and current tap install boundary.
- Update release workflow guidance to audit Homebrew formulae by formula name and include the `base-bash-libs` readiness gate.

## Validation
- `git diff --check`
- `brew audit --new --formula basefoundry/base/base`
- `brew audit --new --formula basefoundry/base/base-bash-libs`
- `brew test basefoundry/base/base-bash-libs`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Fixes #909