### PR TITLE
Correct Base documentation accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   formula-name audit command and future `basefoundry` dependency plan.
 - Documented the `basectl setup` parallelism evaluation and the decision to
   keep mutating setup serial until a setup-plan/preflight layer exists.
+- Corrected 1.1.0 documentation status, source-checkout `base-bash-libs`
+  prerequisites, future-design banners, and CI bootstrap package guidance.
 
 ## [1.1.0] - 2026-06-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ available for local edits:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
+git clone https://github.com/basefoundry/base-bash-libs.git ~/work/base-bash-libs
 ~/work/base/bin/basectl setup --profile dev
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l
@@ -78,6 +79,10 @@ exec "$SHELL" -l
 and Bash 4.2+ before handing off to `basectl`. `basectl setup --profile dev`
 installs developer prerequisites such as BATS, the GitHub CLI, and ShellCheck. See
 [First-Mile Bootstrap](docs/bootstrap.md) for install modes and boundaries.
+
+Base source development resolves reusable Bash libraries from the sibling
+`~/work/base-bash-libs` checkout. If that checkout already exists, update it
+instead of cloning a second copy.
 
 ## Running Tests
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -640,14 +640,16 @@ what happened on their own machine.
 
 ## Mac Bootstrap Sequence
 
-When `basectl setup` runs on a fresh Mac:
+On a fresh Mac, installation and first-run setup use this sequence:
 
 1. Check for Homebrew — install if missing
 2. Check for Xcode CLI tools — install if missing
 3. Install Python (target version) via Homebrew
 4. Create Base's own virtual environment at `~/.base.d/base/.venv`
 5. Install Base's Python bootstrap dependencies into `~/.base.d/base/.venv`
-6. Prepare the managed shell startup model with `basectl update-profile`
+6. After `basectl setup` finishes, explicitly run `basectl update-profile` as a
+   separate one-time shell-profile step; run it again only when updating
+   Base-managed shell dotfiles
 7. Scan the parent directory for peer repos with base manifests
 8. For each project setup target, seed the project venv with `bootstrap: true`
    default artifacts, then run project artifact reconciliation through

--- a/docs/artifact-adapter-registry.md
+++ b/docs/artifact-adapter-registry.md
@@ -1,5 +1,10 @@
 # Artifact Adapter Registry
 
+> **DESIGN DOC** — As of Base 1.1.0, Base still uses
+> `cli/python/base_setup/registry.py` for built-in artifact mappings. This
+> document describes the planned future declarative registry; implementation is
+> tracked in [#925](https://github.com/basefoundry/base/issues/925).
+
 This design records how Base should evolve the current built-in artifact
 mapping in `cli/python/base_setup/registry.py` without turning project setup
 into arbitrary plugin execution.

--- a/docs/basectl-ci.md
+++ b/docs/basectl-ci.md
@@ -97,8 +97,14 @@ Full Linux bootstrap can come later through the Linux support plan.
     mkdir -p "$HOME/.base.d/base"
     python -m venv "$HOME/.base.d/base/.venv"
     "$HOME/.base.d/base/.venv/bin/python" -m pip install --upgrade pip
-    "$HOME/.base.d/base/.venv/bin/python" -m pip install -r requirements-dev.txt
+    "$HOME/.base.d/base/.venv/bin/python" -m pip install PyYAML click
 
 - name: Check Base project
   run: ./bin/basectl ci check base --format json
 ```
+
+The Homebrew formula bundles Base's Python runtime environment. A source
+checkout CI job that prepares `~/.base.d/base/.venv` manually must install the
+same bootstrap packages that Base uses to read manifests and run Python command
+entry points. Add project-specific packages separately when the target project's
+manifest requires them.

--- a/docs/check-parallelism.md
+++ b/docs/check-parallelism.md
@@ -1,5 +1,9 @@
 # basectl check parallelism
 
+> **NOT YET IMPLEMENTED** as of Base 1.1.0. This document records the design for
+> a future `basectl check` performance PR; current check behavior remains
+> sequential and deterministic.
+
 `basectl check` is called frequently enough that reducing wall time matters, but
 the command also has to stay easy to reason about. The output order is part of
 the user experience and the JSON order is useful to automation, so the command

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -288,12 +288,14 @@ The full Base runtime is loaded only through the `basectl` command path.
 
 ## Current Non-Goals
 
-The current execution model does not yet define:
+The current execution model intentionally does not define:
 
-- Python command dispatch
-- project discovery
-- project activation
-- release automation around version numbers
-- Linux support beyond the current macOS implementation
+- Windows support.
+- Fish, tcsh, ksh, or other non-Bash/non-Zsh interactive shell support.
+- Automatic directory-triggered activation when a user runs `cd`.
+- Arbitrary project-provided setup hooks outside the manifest contract.
+- Full Linux bootstrap or installer support beyond the current runtime-oriented
+  CI path.
 
-Those features should build on this execution contract rather than bypass it.
+Future work in those areas should build on this execution contract rather than
+bypass it.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,5 +1,8 @@
 # Local Observability Model
 
+> **DESIGN DOC** — These commands are not yet implemented as of Base 1.1.0.
+> Use `basectl logs` for current log access.
+
 Issue: #396
 
 Base currently exposes raw runtime logs through `basectl logs`. This document

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -257,12 +257,14 @@ Run everything locally with `basectl test base` or `bin/base-test`.
 
 ## Current Status
 
-Base **1.0.5** (June 2026) covers: setup, check, doctor, project discovery,
-workspace status, project activation (subshell), test execution, build targets,
-named commands, demo scripts, repository baseline creation, guarded GitHub release
-publishing, AI context export, `basectl ci` for non-interactive CI, IDE
-bootstrapping (VS Code/Cursor), release readiness inspection, and external
-reusable Bash library consumption.
+Base **1.1.0** (June 2026) covers: first-mile `bootstrap.sh`
+installation, setup, check, doctor, project discovery, workspace
+status/check/doctor/clone/pull/configure, `basectl onboard`, project activation
+(subshell), test execution, build targets, named commands, demo scripts,
+explicit `python.manager: uv` project support, standalone and source-checkout
+`base-bash-libs` consumption, repository baseline creation, guarded GitHub
+release publishing, AI context export, `basectl ci` for non-interactive CI, IDE
+bootstrapping (VS Code/Cursor), and release readiness inspection.
 
 Linux support is a design target but not yet an implemented or tested contract.
 Windows is out of scope.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -72,6 +72,13 @@ dispatch, small command contracts, and failure messages. Keep these focused on
 one command or helper at a time. Reusable Bash library tests live in the
 standalone `base-bash-libs` repository.
 
+Before running source-checkout BATS tests for the first time, clone the reusable
+Bash library checkout next to Base:
+
+```bash
+git clone https://github.com/basefoundry/base-bash-libs.git ~/work/base-bash-libs
+```
+
 From a source checkout, run the full command/library suite through:
 
 ```bash
@@ -80,7 +87,7 @@ env -u BASE_HOME ./bin/base-test
 
 The full suite expects Base to resolve external reusable Bash libraries. A
 normal `~/work/base` checkout uses sibling `~/work/base-bash-libs`
-automatically. For a nonstandard worktree, set
+automatically. For a nonstandard worktree layout, set
 `BASE_BASH_LIBS_DIR=/path/to/base-bash-libs/lib/bash` before running
 `bin/base-test`.
 


### PR DESCRIPTION
## Summary

- Update the technical overview to Base 1.1.0 and the current shipped command surface.
- Add the source-checkout `base-bash-libs` prerequisite to contributor and testing docs.
- Mark future-design docs clearly and link the artifact registry implementation tracker.
- Clarify that `basectl update-profile` is a separate explicit step after setup.
- Replace the CI example's unexplained `requirements-dev.txt` with the Base bootstrap Python packages.

## Issue

Fixes #949
Fixes #950
Fixes #951
Fixes #952
Fixes #953
Fixes #954
Fixes #955
Fixes #956
Fixes #957

## Validation

- `git diff --check`

## Demo Impact

None. Documentation-only change.

## Notes

- Applied the `documentation` label to #949 through #957.
- `.ai-context/` is unchanged because this corrects public documentation accuracy and status markers without changing product behavior, architecture, command surface, workflows, or durable design decisions.
- GitHub Project V2 status updates were not attempted because the account GraphQL quota is exhausted; REST API calls remain healthy.
