### PR TITLE
Reject duplicate base_cli dry-run markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Corrected 1.1.0 documentation status, source-checkout `base-bash-libs`
   prerequisites, future-design banners, and CI bootstrap package guidance.
 
+### Fixed
+
+- Made `base_cli.option(..., dry_run=True)` reject duplicate dry-run markers on
+  the same command function.
+
 ## [1.1.0] - 2026-06-21
 
 ### Changed

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -160,6 +160,9 @@ def main(ctx: base_cli.Context, preview: bool) -> None:
 
 The conventional `dry_run` parameter is recognized automatically, so commands
 using `@base_cli.option("--dry-run", is_flag=True)` do not need the marker.
+Only one option on a command may be marked `dry_run=True`; duplicate dry-run
+markers fail during command registration so authors do not accidentally ship an
+option that is ignored by `ctx.dry_run`.
 
 ## Standard Options
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -230,7 +230,14 @@ def option(*param_decls: str, sensitive: bool = False, dry_run: bool = False, **
             options.add(parameter_name_from_decls(param_decls))
             func.__base_cli_sensitive_options__ = options
         if dry_run:
-            func.__base_cli_dry_run_parameter__ = parameter_name_from_decls(param_decls)
+            dry_run_parameter = parameter_name_from_decls(param_decls)
+            existing_dry_run_parameter = getattr(func, "__base_cli_dry_run_parameter__", None)
+            if existing_dry_run_parameter is not None:
+                raise RuntimeError(
+                    f"{func.__name__} already designates '{existing_dry_run_parameter}' as dry-run. "
+                    "only one option can be designated dry_run=True."
+                )
+            func.__base_cli_dry_run_parameter__ = dry_run_parameter
         return func
 
     return decorator

--- a/lib/python/base_cli/tests/test_app_dry_run.py
+++ b/lib/python/base_cli/tests/test_app_dry_run.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import unittest
+
+import base_cli
+
+
+class AppDryRunTests(unittest.TestCase):
+    def test_rejects_duplicate_custom_dry_run_options(self) -> None:
+        app = base_cli.App(name="duplicate-dry-run")
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "main.*only one option can be designated dry_run=True",
+        ):
+
+            @app.command()
+            @base_cli.option("--preview", is_flag=True, dry_run=True)
+            @base_cli.option("--plan", is_flag=True, dry_run=True)
+            def main(ctx: base_cli.Context, preview: bool, plan: bool) -> None:
+                del ctx, preview, plan
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a registration-time guard for duplicate `base_cli.option(..., dry_run=True)` markers.
- Cover the duplicate marker failure with a focused unit test while preserving the existing custom dry-run option behavior.
- Document the one-dry-run-marker rule in the `base_cli` README and changelog.

## Issue

Fixes #941

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py::BaseCliTests::test_rejects_duplicate_custom_dry_run_options -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_app_dry_run.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/app.py lib/python/base_cli/tests/test_app_dry_run.py lib/python/base_cli/tests/test_base_cli.py`
- `git diff --check`

## Demo Impact

None.

## Notes

- `.ai-context/` is unchanged because this is a narrow `base_cli` authoring guard, not a product workflow or command-surface change.
- Planned Project fields: Priority `P2`, Size `S`, Area `Python`, Initiative `Adoption Polish`.
