### PR TITLE
Prune base_cli logs by filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Made `base_cli.option(..., dry_run=True)` reject duplicate dry-run markers on
   the same command function.
+- Made default `base_cli.App(max_log_files=...)` log retention prune by
+  timestamp-prefixed run-id filename instead of filesystem modification time.
 
 ## [1.1.0] - 2026-06-21
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -258,7 +258,9 @@ explicit file so tests and diagnostics can inspect dry-run logs when needed.
 High-frequency tools can set `base_cli.App(max_log_files=<count>)` to keep at
 most that many default persistent log files for the CLI. Retention runs during
 startup after the current run's default log file is resolved, and the current
-run's log file is never pruned. The policy is skipped for `ctx.dry_run`,
+run's log file is never pruned. Default log pruning uses the timestamp-prefixed
+run ID in each log filename rather than filesystem modification time. The
+policy is skipped for `ctx.dry_run`,
 `log_to_file=False`, and explicit `--log-file` paths so no-durable-write modes
 and caller-selected log locations stay under caller control. Use this as a
 small guardrail for busy local tools; `basectl clean` remains the broader

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -284,22 +284,17 @@ def _prune_log_files(
     max_log_files: int,
     logger: logging.Logger,
 ) -> None:
-    candidates: list[tuple[float, str, Path]] = []
+    candidates: list[tuple[str, Path]] = []
     for path in log_dir.glob("*.log"):
         if _same_path(path, current_log_file):
             continue
-        try:
-            stat = path.stat()
-        except OSError as exc:
-            logger.warning("Could not inspect log file '%s' for pruning: %s", path, exc)
-            continue
-        candidates.append((stat.st_mtime, path.name, path))
+        candidates.append((path.name, path))
 
     excess_count = len(candidates) + 1 - max_log_files
     if excess_count <= 0:
         return
 
-    for _, _, path in sorted(candidates)[:excess_count]:
+    for _, path in sorted(candidates)[:excess_count]:
         try:
             path.unlink()
         except OSError as exc:

--- a/lib/python/base_cli/tests/test_app_log_retention.py
+++ b/lib/python/base_cli/tests/test_app_log_retention.py
@@ -30,8 +30,8 @@ class AppLogRetentionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
             log_dir = home / ".cache" / "base" / "cli" / "retention-demo" / "logs"
-            oldest = log_dir / "oldest.log"
-            newest = log_dir / "newest.log"
+            oldest = log_dir / "20260620T120000_oldest.log"
+            newest = log_dir / "20260621T120000_newest.log"
             write_log_file(oldest, 1)
             write_log_file(newest, 2)
 
@@ -40,6 +40,33 @@ class AppLogRetentionTests(unittest.TestCase):
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertFalse(oldest.exists())
             self.assertTrue(newest.exists())
+            self.assertIsNotNone(seen["log_file"])
+            self.assertTrue(seen["log_file"].exists())
+            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 2)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_prunes_by_filename_when_mtimes_disagree(self) -> None:
+        app = base_cli.App(name="retention-filename", max_log_files=2)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("filename retention")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_dir = home / ".cache" / "base" / "cli" / "retention-filename" / "logs"
+            older_by_name = log_dir / "20260620T120000_old.log"
+            newer_by_name = log_dir / "20260621T120000_new.log"
+            write_log_file(older_by_name, 2)
+            write_log_file(newer_by_name, 1)
+
+            result = invoke(app, home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertFalse(older_by_name.exists())
+            self.assertTrue(newer_by_name.exists())
             self.assertIsNotNone(seen["log_file"])
             self.assertTrue(seen["log_file"].exists())
             self.assertEqual(len(tuple(log_dir.glob("*.log"))), 2)
@@ -70,6 +97,33 @@ class AppLogRetentionTests(unittest.TestCase):
             self.assertIsNotNone(seen["log_file"])
             self.assertTrue(seen["log_file"].exists())
             self.assertEqual(tuple(log_dir.glob("*.log")), (seen["log_file"],))
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_keeps_logs_when_count_is_within_limit(self) -> None:
+        app = base_cli.App(name="retention-within-limit", max_log_files=3)
+        seen = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("within retention limit")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_dir = home / ".cache" / "base" / "cli" / "retention-within-limit" / "logs"
+            old_a = log_dir / "20260620T120000_a.log"
+            old_b = log_dir / "20260621T120000_b.log"
+            write_log_file(old_a, 1)
+            write_log_file(old_b, 2)
+
+            result = invoke(app, home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(old_a.exists())
+            self.assertTrue(old_b.exists())
+            self.assertIsNotNone(seen["log_file"])
+            self.assertTrue(seen["log_file"].exists())
+            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 3)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_is_disabled_by_default(self) -> None:


### PR DESCRIPTION
## Summary

- Change default `base_cli.App(max_log_files=...)` pruning to sort by timestamp-prefixed log filename instead of filesystem mtime.
- Add regression coverage for filename ordering when mtimes disagree.
- Add coverage that retention leaves logs alone when the count is within the configured limit.
- Document the filename-based retention contract in the `base_cli` README and changelog.

## Issue

Fixes #946

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_app_log_retention.py::AppLogRetentionTests::test_prunes_by_filename_when_mtimes_disagree -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_app_log_retention.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/app.py lib/python/base_cli/tests/test_app_log_retention.py`
- `git diff --check`

## Demo Impact

None.

## Notes

- `.ai-context/` is unchanged because this narrows internal log-retention determinism without changing the public command surface or user workflow.
- Planned Project fields: Priority `P2`, Size `S`, Area `Python`, Initiative `Adoption Polish`.
