### PR TITLE
Expose workspace root on base_cli context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Added `ctx.workspace_root` to `base_cli.Context` so workspace-aware commands
+  can use the configured workspace root without reaching through user config.
 - Documented the `base-bash-libs` Homebrew/core readiness path, including the
   formula-name audit command and future `basefoundry` dependency plan.
 - Documented the `basectl setup` parallelism evaluation and the decision to

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -14,7 +14,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 import base_cli
-from base_cli.config import read_user_config
 from base_cli.paths import base_cache_root, discover_manifest
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
@@ -816,12 +815,8 @@ def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int
 def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path:
     if workspace:
         return Path(workspace).expanduser().resolve()
-    try:
-        workspace_root = read_user_config().workspace.root
-    except (RuntimeError, ValueError) as exc:
-        raise ProjectDiscoveryError(str(exc)) from exc
-    if workspace_root is not None:
-        return workspace_root
+    if ctx.workspace_root is not None:
+        return ctx.workspace_root
     if ctx.base_home is None:
         raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
     return ctx.base_home.parent.resolve()

--- a/cli/python/base_projects/workspace_configure.py
+++ b/cli/python/base_projects/workspace_configure.py
@@ -192,8 +192,8 @@ def print_workspace_configure_header(
 def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path:
     if workspace:
         return Path(workspace).expanduser().resolve()
-    if ctx.user_config.workspace.root is not None:
-        return ctx.user_config.workspace.root
+    if ctx.workspace_root is not None:
+        return ctx.workspace_root
     if ctx.base_home is None:
         raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
     return ctx.base_home.parent.resolve()

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -209,6 +209,7 @@ Important fields include:
 - `ctx.run_id`: timestamp plus short random suffix for this invocation.
 - `ctx.base_home`: resolved `BASE_HOME`, when available.
 - `ctx.project_root`: directory containing the nearest `base_manifest.yaml`.
+- `ctx.workspace_root`: configured workspace root from `~/.base.d/config.yaml`.
 - `ctx.manifest_path`: nearest discovered Base manifest.
 - `ctx.state_dir`: per-CLI runtime directory under the Base cache root.
 - `ctx.log_dir`: persistent log directory.

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -170,6 +170,7 @@ class App:
             run_id=run_id,
             base_home=resolve_base_home(),
             project_root=project_root,
+            workspace_root=user_config.workspace.root,
             manifest_path=manifest_path,
             state_dir=state_dir,
             log_dir=log_dir,

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -40,6 +40,7 @@ class Context:
     manifest_path: Path | None = None
     user_config: UserConfig = field(default_factory=_default_user_config)
     cleanup_hooks: list[Callable[[], None]] = field(default_factory=list)
+    workspace_root: Path | None = None
 
     def on_cleanup(self, hook: Callable[[], None]) -> None:
         self.cleanup_hooks.append(hook)

--- a/lib/python/base_cli/tests/test_context_workspace.py
+++ b/lib/python/base_cli/tests/test_context_workspace.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import base_cli
+from base_cli.config import user_config_path
+
+
+@unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+class ContextWorkspaceRootTests(unittest.TestCase):
+    def test_context_exposes_workspace_root_when_configured(self) -> None:
+        app = base_cli.App(name="workspace-root-configured", log_to_file=False)
+        seen: dict[str, Path | None] = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["workspace_root"] = ctx.workspace_root
+            seen["user_config_workspace_root"] = ctx.user_config.workspace.root
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            workspace.mkdir()
+            path = user_config_path(home)
+            path.parent.mkdir(parents=True)
+            path.write_text(f"workspace:\n  root: {workspace}\n", encoding="utf-8")
+
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["workspace_root"], workspace.resolve())
+        self.assertEqual(seen["user_config_workspace_root"], workspace.resolve())
+
+    def test_context_workspace_root_is_none_without_configured_root(self) -> None:
+        app = base_cli.App(name="workspace-root-default", log_to_file=False)
+        seen: dict[str, Path | None] = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["workspace_root"] = ctx.workspace_root
+            seen["user_config_workspace_root"] = ctx.user_config.workspace.root
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            from base_cli.testing import invoke
+
+            result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIsNone(seen["workspace_root"])
+        self.assertIsNone(seen["user_config_workspace_root"])


### PR DESCRIPTION
## Summary
- Add `workspace_root` to `base_cli.Context` and populate it from typed user config.
- Update workspace command resolvers to use `ctx.workspace_root` for configured workspace defaults.
- Document the new context field alongside `ctx.project_root`.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_context_workspace.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/context.py lib/python/base_cli/app.py lib/python/base_cli/tests/test_context_workspace.py cli/python/base_projects/engine.py cli/python/base_projects/workspace_configure.py`
- `git diff --check`

## Planned Project Fields
- Priority: P1
- Size: S
- Area: Python
- Initiative: Workspace Handling

GraphQL project field writes are currently rate-limited; these values are queued for backfill.

Fixes #940
