### PR TITLE
Add base_cli app group help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and Base versions are tracked in the repo-root `VERSION` file.
   that need a fixture `base_manifest.yaml`.
 - Added optional stream and formatter overrides to `base_cli.configure_logger`
   for tests and CI wrappers that need to capture or reshape user-facing logs.
+- Added `base_cli.App(help=...)` support for subcommand group help text.
 - Documented the `base-bash-libs` Homebrew/core readiness path, including the
   formula-name audit command and future `basefoundry` dependency plan.
 - Documented the `basectl setup` parallelism evaluation and the decision to

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -103,7 +103,11 @@ Use `@app.subcommand()` when one CLI needs multiple verbs while keeping Base's
 standard context, logging, redaction, and cleanup lifecycle for each invocation:
 
 ```python
-app = base_cli.App(name="workspace-tools", version="0.1.0")
+app = base_cli.App(
+    name="workspace-tools",
+    version="0.1.0",
+    help="Inspect and sync workspace projects.",
+)
 
 
 @app.subcommand()
@@ -120,10 +124,11 @@ def sync_project(ctx: base_cli.Context, dry_run: bool) -> None:
 ```
 
 Subcommands use the same `base_cli.option()` and `base_cli.argument()` metadata
-as single commands. Standard Base options belong to the subcommand invocation,
-for example `workspace-tools status --debug demo`. Use either `@app.command()`
-for a single-command CLI or `@app.subcommand()` for a command group; do not mix
-the two registration styles on one `App`.
+as single commands. `App(help=...)` appears in the command group's `--help`
+output. Standard Base options belong to the subcommand invocation, for example
+`workspace-tools status --debug demo`. Use either `@app.command()` for a
+single-command CLI or `@app.subcommand()` for a command group; do not mix the
+two registration styles on one `App`.
 
 ## Options And Arguments
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -22,10 +22,12 @@ def _require_click():
 
 
 class App:
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
         name: str | None = None,
         version: str | None = None,
+        help: str | None = None,  # pylint: disable=redefined-builtin
         log_to_file: bool = True,
         max_log_files: int | None = None,
     ) -> None:
@@ -33,6 +35,7 @@ class App:
             raise ValueError("max_log_files must be greater than 0 when set.")
         self.name = normalize_cli_name(name or sys.argv[0])
         self.version = version
+        self.help = help
         self.log_to_file = log_to_file
         self.max_log_files = max_log_files
         self._click_command = None
@@ -88,12 +91,15 @@ class App:
         click = _require_click()
         if self._command_func is not None:
             wrapper = self._build_command_wrapper(click, self._command_func, include_version=True)
-            return click.command(*self._command_args, **self._command_kwargs)(wrapper)
+            command_kwargs = dict(self._command_kwargs)
+            if self.help is not None:
+                command_kwargs.setdefault("help", self.help)
+            return click.command(*self._command_args, **command_kwargs)(wrapper)
 
         group_wrapper = _build_group_wrapper()
         if self.version is not None:
             group_wrapper = click.version_option(self.version)(group_wrapper)
-        group = click.group(name=self.name)(group_wrapper)
+        group = click.group(name=self.name, help=self.help)(group_wrapper)
         for func, command_args, command_kwargs in self._subcommands:
             wrapper = self._build_command_wrapper(click, func, include_version=False)
             group.add_command(click.command(*command_args, **command_kwargs)(wrapper))

--- a/lib/python/base_cli/tests/test_app_subcommands.py
+++ b/lib/python/base_cli/tests/test_app_subcommands.py
@@ -13,6 +13,38 @@ from base_cli.testing import invoke
 
 @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
 class AppSubcommandTests(unittest.TestCase):
+    def test_subcommand_group_help_includes_app_help_text(self) -> None:
+        app = base_cli.App(name="multi-help", help="Manage workspace demo tasks.")
+
+        @app.subcommand()
+        def status(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            result = invoke(app, ["--help"], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Manage workspace demo tasks.", result.output)
+        self.assertIn("status", result.output)
+
+    def test_subcommand_group_help_without_app_help_keeps_command_listing(self) -> None:
+        app = base_cli.App(name="multi-help-default")
+
+        @app.subcommand()
+        def status(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            result = invoke(app, ["--help"], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Commands:", result.output)
+        self.assertIn("status", result.output)
+
     def test_runs_multiple_subcommands_with_base_lifecycle(self) -> None:
         app = base_cli.App(name="multi-tool", version="0.1.0")
         seen = {}


### PR DESCRIPTION
## Summary
- Add optional `help=` support to `base_cli.App`.
- Pass app help text into subcommand group help output while preserving default group help.
- Document `App(help=...)` for subcommand apps.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_app_subcommands.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/app.py lib/python/base_cli/tests/test_app_subcommands.py`
- `git diff --check`

## Project Fields
- Priority: P3
- Size: S
- Area: Python
- Initiative: Adoption Polish

GraphQL project field writes are currently rate-limited; these values are queued for backfill.

Fixes #943
