### PR TITLE
Add quiet mode to base_cli standard options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added optional stream and formatter overrides to `base_cli.configure_logger`
   for tests and CI wrappers that need to capture or reshape user-facing logs.
 - Added `base_cli.App(help=...)` support for subcommand group help text.
+- Added standard `--quiet` / `-q` support to `base_cli.App` to suppress INFO
+  output on the user-facing stream while preserving warnings, errors, and
+  persistent DEBUG log detail.
 - Documented the `base-bash-libs` Homebrew/core readiness path, including the
   formula-name audit command and future `basefoundry` dependency plan.
 - Documented the `basectl setup` parallelism evaluation and the decision to

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -7,8 +7,8 @@ It is intentionally thin. Click still owns argument parsing and command
 execution, while `base_cli` adds the Base-specific behavior every project CLI
 should get by default:
 
-- standard command options such as `--debug`, `--environment`, `--config`,
-  `--keep-temp`, and `--log-file`
+- standard command options such as `--debug`, `--quiet`, `--environment`,
+  `--config`, `--keep-temp`, and `--log-file`
 - structured logging to stderr and, by default, to a persistent per-run log file
 - Base project discovery through `base_manifest.yaml`
 - config loading with predictable precedence
@@ -63,6 +63,7 @@ Running this command automatically adds the standard Base options:
 ```bash
 hello --name Ada
 hello --debug --name Ada
+hello --quiet --name Ada
 hello --environment prod --name Ada
 hello --keep-temp --name Ada
 hello --log-file /tmp/hello.log --name Ada
@@ -176,6 +177,7 @@ option that is ignored by `ctx.dry_run`.
 Every `base_cli.App` command gets these options:
 
 - `--debug`: enable DEBUG logging on the user-facing stderr stream.
+- `--quiet`, `-q`: suppress INFO logs on the user-facing stderr stream.
 - `--environment <name>`: set `ctx.environment` for the run.
 - `--config <path>`: merge an additional YAML config file.
 - `--keep-temp`: preserve the run's temp directory after command completion.
@@ -228,6 +230,7 @@ Important fields include:
 - `ctx.user_config`: typed user configuration from `~/.base.d/config.yaml`.
 - `ctx.environment`: active environment, defaulting to `dev`.
 - `ctx.debug`: whether debug logging is enabled for the stderr stream.
+- `ctx.quiet`: whether INFO logs are suppressed on the stderr stream.
 - `ctx.dry_run`: whether the command is running in a no-durable-write mode.
 - `ctx.keep_temp`: whether `ctx.temp_dir` should survive cleanup.
 - `ctx.log`: standard Python logger configured by Base.
@@ -249,9 +252,15 @@ def helper() -> None:
 
 `base_cli` configures two handlers:
 
-- a user-facing stderr handler at INFO by default, DEBUG with `--debug`
+- a user-facing stderr handler at INFO by default, DEBUG with `--debug`, or
+  WARNING with `--quiet` / `-q`
 - a persistent file handler that records DEBUG logs when persistent logging is
   enabled
+
+`--quiet` suppresses INFO output on the user-facing stream but still shows
+warnings and errors. `--debug` and `--quiet` cannot be used together. Persistent
+log files still receive DEBUG-level detail, including INFO messages suppressed
+from stderr.
 
 Advanced tests and CI wrappers can call `base_cli.configure_logger(...,
 stream=..., formatter=...)` to capture user-facing logs or apply a custom
@@ -259,10 +268,10 @@ formatter without replacing Base's logger setup. Leave those arguments as
 `None` to keep the default stderr stream and `BaseCliFormatter`.
 
 Commands that inspect runtime artifacts can use `base_cli.App(log_to_file=False)`
-to keep the standard context and `--debug` behavior without creating default
-`logs/`, `cache/`, or `tmp/<run-id>/` directories. `base_logs` uses this mode so
-`basectl logs` does not appear in its own output. An explicit `--log-file <path>`
-still enables file logging for that invocation.
+to keep the standard context, `--debug`, and `--quiet` behavior without creating
+default `logs/`, `cache/`, or `tmp/<run-id>/` directories. `base_logs` uses this
+mode so `basectl logs` does not appear in its own output. An explicit
+`--log-file <path>` still enables file logging for that invocation.
 
 Commands running with `ctx.dry_run` also skip default `logs/`, `cache/`, and
 `tmp/<run-id>/` creation. Passing `--log-file <path>` still writes to that

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -12,7 +12,7 @@ from .logging import configure_logger, log_invocation
 from .paths import base_cache_root, discover_manifest, make_run_id, normalize_cli_name, resolve_base_home
 from .redaction import parameter_name_from_decls
 
-_STANDARD_OPTION_KEYS = ("debug", "environment", "config", "keep_temp", "log_file")
+_STANDARD_OPTION_KEYS = ("debug", "quiet", "environment", "config", "keep_temp", "log_file")
 _GROUP_STANDARD_OPTIONS_KEY = "base_cli_standard_options"
 
 
@@ -116,6 +116,7 @@ class App:
                 _group_standard_options(click),
                 _pop_standard_options(kwargs),
             )
+            _validate_standard_options(click, standard)
             try:
                 context = self._create_context(standard, sensitive_options, dry_run=bool(kwargs.get(dry_run_parameter)))
             except (RuntimeError, ValueError) as exc:
@@ -151,6 +152,7 @@ class App:
 
         environment = standard.get("environment") or config.get("environment") or "dev"
         debug = bool(standard.get("debug") or str(config.get("log_level", "")).lower() == "debug")
+        quiet = bool(standard.get("quiet"))
         keep_temp = bool(standard.get("keep_temp") or config.get("keep_temp"))
 
         cache_root = base_cache_root()
@@ -170,7 +172,7 @@ class App:
             if log_file is None:
                 log_file = log_dir / f"{run_id}.log"
             _create_runtime_directory(log_file.parent, cache_root)
-        logger = configure_logger(self.name, log_file, debug)
+        logger = configure_logger(self.name, log_file, debug, quiet=quiet)
         logger.debug("cli=%s run_id=%s environment=%s", self.name, run_id, environment)
         if self.max_log_files is not None and uses_default_log_file and log_file is not None:
             _prune_log_files(log_dir, log_file, self.max_log_files, logger)
@@ -190,6 +192,7 @@ class App:
             config=config,
             environment=environment,
             debug=debug,
+            quiet=quiet,
             keep_temp=keep_temp,
             log=logger,
             user_config=user_config,
@@ -275,6 +278,13 @@ def _decorate_standard_options(click: Any, func: Callable[..., Any], version: st
         default=None,
         help="Enable DEBUG logging on the user-facing stream.",
     )(func)
+    func = click.option(
+        "--quiet",
+        "-q",
+        is_flag=True,
+        default=None,
+        help="Suppress INFO logs on the user-facing stream.",
+    )(func)
     if version is not None:
         func = click.version_option(version)(func)
     return func
@@ -293,6 +303,11 @@ def _merge_standard_options(group_standard: dict[str, Any], command_standard: di
         value = command_standard.get(key)
         merged[key] = group_standard.get(key) if value is None else value
     return merged
+
+
+def _validate_standard_options(click: Any, standard: dict[str, Any]) -> None:
+    if standard.get("debug") and standard.get("quiet"):
+        raise click.UsageError("--debug and --quiet cannot be used together.")
 
 
 def _group_standard_options(click: Any) -> dict[str, Any]:

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -41,6 +41,7 @@ class Context:
     user_config: UserConfig = field(default_factory=_default_user_config)
     cleanup_hooks: list[Callable[[], None]] = field(default_factory=list)
     workspace_root: Path | None = None
+    quiet: bool = False
 
     def on_cleanup(self, hook: Callable[[], None]) -> None:
         self.cleanup_hooks.append(hook)

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -11,11 +11,13 @@ from .context import get_current_context
 from .redaction import redact_argv
 
 
+# pylint: disable=too-many-arguments
 def configure_logger(
     cli_name: str,
     log_file: Path | None,
     debug: bool,
     *,
+    quiet: bool = False,
     stream: TextIO | None = None,
     formatter: logging.Formatter | None = None,
 ) -> logging.Logger:
@@ -27,7 +29,7 @@ def configure_logger(
         logger.removeHandler(handler)
 
     user_handler = logging.StreamHandler(stream)
-    user_handler.setLevel(logging.DEBUG if debug else logging.INFO)
+    user_handler.setLevel(_user_stream_level(debug, quiet))
     user_handler.setFormatter(_handler_formatter(formatter))
     logger.addHandler(user_handler)
 
@@ -38,6 +40,14 @@ def configure_logger(
         file_handler.setFormatter(_handler_formatter(formatter))
         logger.addHandler(file_handler)
     return logger
+
+
+def _user_stream_level(debug: bool, quiet: bool) -> int:
+    if quiet:
+        return logging.WARNING
+    if debug:
+        return logging.DEBUG
+    return logging.INFO
 
 
 def _handler_formatter(formatter: logging.Formatter | None) -> logging.Formatter:

--- a/lib/python/base_cli/tests/test_app_quiet.py
+++ b/lib/python/base_cli/tests/test_app_quiet.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import base_cli
+from base_cli.testing import invoke
+
+
+@unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+class AppQuietTests(unittest.TestCase):
+    def test_quiet_suppresses_info_but_keeps_warning_and_error_output(self) -> None:
+        app = base_cli.App(name="quiet-demo", log_to_file=False)
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            ctx.log.info("info hidden")
+            ctx.log.warning("warning visible")
+            ctx.log.error("error visible")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            result = invoke(app, ["--quiet"], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("info hidden", result.stderr)
+        self.assertIn("warning visible", result.stderr)
+        self.assertIn("error visible", result.stderr)
+
+    def test_quiet_keeps_debug_detail_in_persistent_log_file(self) -> None:
+        app = base_cli.App(name="quiet-file-demo")
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            ctx.log.debug("debug in file")
+            ctx.log.info("info in file")
+            ctx.log.warning("warning visible")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            log_file = home / "logs" / "quiet.log"
+
+            result = invoke(app, ["--quiet", "--log-file", str(log_file)], home=home)
+
+            log_text = log_file.read_text(encoding="utf-8")
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("debug in file", result.stderr)
+        self.assertNotIn("info in file", result.stderr)
+        self.assertIn("warning visible", result.stderr)
+        self.assertIn("debug in file", log_text)
+        self.assertIn("info in file", log_text)
+        self.assertIn("warning visible", log_text)
+
+    def test_debug_and_quiet_conflict(self) -> None:
+        app = base_cli.App(name="quiet-conflict", log_to_file=False)
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            result = invoke(app, ["--debug", "--quiet"], home=home)
+
+        self.assertEqual(result.exit_code, 2, result.output)
+        self.assertIn("--debug and --quiet cannot be used together", result.output)
+
+    def test_quiet_before_subcommand_uses_warning_user_stream(self) -> None:
+        app = base_cli.App(name="quiet-subcommand", log_to_file=False)
+
+        @app.subcommand()
+        def status(ctx: base_cli.Context) -> None:
+            ctx.log.info("info hidden")
+            ctx.log.warning("warning visible")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            result = invoke(app, ["--quiet", "status"], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("info hidden", result.stderr)
+        self.assertIn("warning visible", result.stderr)


### PR DESCRIPTION
## Summary
- Add standard `--quiet` / `-q` support for base_cli single-command and subcommand apps.
- Set the user-facing logger stream to WARNING in quiet mode while keeping persistent file logs at DEBUG.
- Reject `--debug` and `--quiet` together with a Click usage error.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `git ls-files -z '*.py' | PYTHONPATH=lib/python:cli/python xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`
- `git diff --check`

## Project Fields
- Priority: P1
- Size: M
- Area: Python
- Initiative: Adoption Polish

Fixes #939