### PR TITLE
Document Base orientation maps

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -159,6 +159,11 @@ such command directories exist. Optional utility CLIs such as `caff` and
   Optional repositories are reported but skipped unless `--include-optional` is
   supplied, `--dry-run` previews the delegated clone work, and explicit
   `--manifest <path>` takes precedence over `workspace.manifest`.
+- `basectl workspace pull` explicitly fetches and validates a canonical
+  workspace manifest source from `workspace.manifest_source` in
+  `~/.base.d/config.yaml`, or from an explicit `--source <url-or-path>`, and
+  writes the result to `workspace.manifest` or `--manifest <path>` before the
+  next workspace status, check, doctor, or clone operation.
 - `basectl workspace configure` applies the existing `basectl repo configure`
   repair path across discovered Base-managed projects, or across present
   Base-managed repositories from a configured or explicit workspace manifest.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,14 @@ see [Release Process](release-process.md).
 For self-guided or live walkthrough material, see
 [Presentations](presentations/README.md).
 
+## Internal Planning Artifacts
+
+The `docs/superpowers/` directory contains agent-written planning artifacts
+such as implementation plans and feature specs. These files are useful for
+understanding how a change was shaped, but they are not the canonical product
+contract. Treat the mapped documents below, the top-level README, FAQ, and
+CHANGELOG as the normative documentation for shipped Base behavior.
+
 ## Naming Convention
 
 Use stable topic names for documentation files:

--- a/lib/README.md
+++ b/lib/README.md
@@ -4,9 +4,14 @@ Top-level library namespace for Base.
 
 ## Layout
 
+- `lib/base/`
+  Base-owned internal manifests such as the default manifest and built-in
+  prerequisite profiles.
 - `lib/bash/`
   Base Bash runtime libraries such as `std`, `git`, `file`, and runtime shell
   startup files.
+- `lib/python/`
+  Python package source for Base-owned Python libraries, including `base_cli`.
 - `lib/shell/`
   Base-managed Bash/Zsh startup files and optional shared interactive defaults.
 


### PR DESCRIPTION
## Summary
- Explain that docs/superpowers contains internal planning artifacts, not canonical docs.
- Add basectl workspace pull details to the basectl README.
- Add lib/base and lib/python to the lib layout map.

## Validation
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Fixes #963
Fixes #976
Fixes #977