### PR TITLE
Clarify agent and contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Codex Guidance
+# AI Agent Guidance
 
 This file gives coding agents the repository-specific rules for Base. It is a
 navigation layer over the existing contributor docs, not a replacement for
@@ -24,7 +24,7 @@ them.
 - Use one primary category label: `bug`, `enhancement`, `documentation`, `ci`,
   or `security`.
 - Do not create or apply `type:*` issue labels.
-- Assign Codex-created Base repository issues to `codeforester` when GitHub
+- Assign agent-created Base repository issues to `codeforester` when GitHub
   allows it; `.github/base-project.yml` carries this repo-local default for
   `basectl gh issue create`.
 - For issues tracked in Base Roadmap, set Project `Status` to `In Progress`
@@ -75,7 +75,11 @@ milestones, GitHub Projects, and cleanup rules.
 
 ## AI Context Maintenance
 
-- Treat `.ai-context/` as the AI-facing orientation layer for Base.
+- Treat `.ai-context/` at the repository root as the AI-facing orientation layer
+  for Base.
+- Use `basectl export-context base --print` to view the current context pack, or
+  `ls .ai-context/` to inspect available context files. When
+  `.ai-context/INDEX.md` exists, it controls export ordering.
 - For every meaningful PR, decide whether `.ai-context/` needs an update and
   state the result in the PR body.
 - Update `.ai-context/` when a change affects Base's product shape,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,8 @@ Before opening a PR:
 - The PR body explains what changed and how it was validated.
 - Relevant BATS and Python tests pass.
 - Documentation is updated when behavior or user-facing commands change.
+- `.ai-context/` is updated when the change affects Base's product shape,
+  architecture, command surface, manifest model, workflows, or release status.
 - The PR includes `Fixes #<issue>` when it should close the issue.
 - `Demo Impact` is meaningful for `needs-demo` work, or explicitly says
   `None.` when no demo update is needed.

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -31,8 +31,10 @@ should use the labels above.
 
 ## Issue Assignment
 
-Issues created by Codex or other automation for the Base repository should be
-assigned to `codeforester`.
+Issues created by automation for the Base repository should be assigned to the
+current primary maintainer. Today that maintainer is `codeforester`, and
+`.github/base-project.yml` carries the same repo-local default for
+`basectl gh issue create`.
 
 If assignment fails, the automation should mention that in its summary instead
 of silently leaving the issue unassigned.

--- a/docs/ide-bootstrapping.md
+++ b/docs/ide-bootstrapping.md
@@ -10,6 +10,10 @@ IDE readiness for project work.
 
 ## Scope
 
+IDE bootstrapping is currently macOS-only. Linux IDE setup is not implemented
+yet; see [Linux Support](linux-support.md) for the current Linux runtime-support
+status and boundaries.
+
 Base owns:
 
 - installing supported IDEs through Homebrew casks when a project opts in


### PR DESCRIPTION
## Summary
- Retitle AGENTS.md for all AI coding agents and document .ai-context location/export usage.
- Add the .ai-context update responsibility to the contributor PR checklist.
- Clarify maintainer assignment guidance and macOS-only IDE bootstrapping scope.

## Validation
- `git diff --check`

Fixes #970
Fixes #975
Fixes #978
Fixes #982
Fixes #986