### PR TITLE
Expand operational documentation references

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -125,6 +125,35 @@ For example, Homebrew exposes both executables under the Homebrew prefix, but
 `basectl` or a project-owned launcher instead of invoking `base-wrapper`
 directly.
 
+### Why does Base require an external base-bash-libs checkout or package?
+
+Base's reusable Bash helpers live in the standalone
+`basefoundry/base-bash-libs` repository so other scripts can reuse the logging,
+command execution, filesystem, and Git conventions without depending on the
+full Base workspace control plane.
+
+That separation also keeps the Homebrew packaging path cleaner: `base-bash-libs`
+can mature as its own formula, and a future Homebrew/core Base formula can
+depend on it directly instead of bundling reusable library files inside Base.
+
+Base resolves the libraries in this order:
+
+1. `BASE_BASH_LIBS_DIR`, for tests and nonstandard source worktrees.
+2. A sibling checkout at `~/work/base-bash-libs/lib/bash`.
+3. The Homebrew `base-bash-libs` package when Base itself is Homebrew-managed.
+
+If the library source is missing, clone the sibling repository or install the
+tap formula:
+
+```bash
+git clone https://github.com/basefoundry/base-bash-libs.git ~/work/base-bash-libs
+brew install basefoundry/base/base-bash-libs
+```
+
+`basectl check` and `basectl doctor` report the resolved source through the
+`BASE-D007` finding. See [Base Bash Libraries](docs/base-bash-libs.md) for the
+full resolution contract.
+
 ### How do I know which basectl is active?
 
 Run:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -203,3 +203,8 @@ manifests do not require every repository to be Base-managed.
 | --- | --- |
 | `BASE-H001` | Required environment variable presence; each variable is keyed by `(id, name)`. |
 | `BASE-H002` | Required TCP port listening/free state |
+
+For `BASE-H001`, `id` is always `BASE-H001` and `name` is the environment
+variable name from `health.required_env`. A suppression targeting a specific
+missing-variable finding would match values such as `id: BASE-H001` and
+`name: DATABASE_URL`.

--- a/docs/homebrew-upgrade-rehearsal.md
+++ b/docs/homebrew-upgrade-rehearsal.md
@@ -107,6 +107,10 @@ env HOME="$TEST_ROOT/home" PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
 shasum -a 256 "$TEST_ROOT/home/.base.d/config.yaml"
 ```
 
+The command examples above use the Intel Homebrew prefix. On Apple Silicon,
+replace `/usr/local/bin/basectl` with `/opt/homebrew/bin/basectl` and include
+`/opt/homebrew/bin` instead of `/usr/local/bin` in the explicit `PATH` values.
+
 Accept the rehearsal only when:
 
 - `brew upgrade --no-ask basefoundry/base/base` exits zero.
@@ -124,6 +128,14 @@ Accept the rehearsal only when:
 If any Base-specific breakage appears, fix it or file a blocking follow-up
 before 1.0.0. If a host prerequisite blocks the run, record it and rerun on a
 qualified host; do not close the rehearsal issue.
+
+## Historical Run Record Notes
+
+The run records below are historical rehearsal notes. Treat the macOS, Xcode,
+and Command Line Tools strings as the host facts recorded by the operator at the
+time of the run, not as normative examples of current Apple release numbering.
+New run records should paste fresh output from `sw_vers`, `xcodebuild -version`,
+and Homebrew diagnostics so the version fields can be audited later.
 
 ## 2026-06-09 Run Record
 

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -30,6 +30,38 @@ environment. `show` prints the parsed config as JSON. `doctor` reports whether
 the file exists, whether it is valid YAML, whether it is a mapping, and whether
 the path is a symlink.
 
+## Complete Example
+
+A fully populated user config keeps each section as a top-level YAML key:
+
+```yaml
+workspace:
+  root: ~/work
+  manifest: ~/work/base-workspace/workspace.yaml
+  manifest_source: https://raw.githubusercontent.com/example/platform/main/workspace.yaml
+
+github:
+  default_owner: your-github-username
+  clone_protocol: ssh
+
+ide:
+  enabled: true
+
+  vscode:
+    enabled: true
+    install: false
+    extra_extensions:
+      - eamodio.gitlens
+    settings:
+      editor.fontSize: 14
+
+  cursor:
+    enabled: false
+```
+
+Omit sections or keys you do not use. Base treats omitted sections as empty
+defaults.
+
 ## Ownership Boundary
 
 Base owns the meaning of `~/.base.d/config.yaml`.
@@ -126,7 +158,7 @@ commands:
 
 ```yaml
 github:
-  default_owner: codeforester
+  default_owner: your-github-username
   clone_protocol: ssh
 ```
 


### PR DESCRIPTION
## Summary
- Add a complete local config example with generic GitHub placeholders.
- Add the base-bash-libs FAQ rationale and clarify BASE-H001 suppression keys.
- Document Apple Silicon Homebrew command equivalents and historical run-record version context.

## Validation
- `git diff --check`

Fixes #968
Fixes #969
Fixes #981
Fixes #987