### PR TITLE
Implement declarative artifact registry

### DIFF
--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -18,6 +18,7 @@ The current command surface covers:
 - advisory check/doctor lint warnings for missing manifest command executables
   and project script paths
 - mise integration
+- bundled declarative artifact registry for Base-managed built-in artifacts
 - explicit uv-managed Python project setup through `python.manager: uv`
 - cleanup and logs
 - local config inspection
@@ -58,6 +59,7 @@ Recent released work includes:
 - Homebrew `basectl update` handoff and package-aware `basectl test base`
 - Base `1.0.1` AGPL license cleanup and release artifacts
 - explicit uv-managed Python setup and command runner support
+- bundled `lib/base/artifact-registry.yaml` support for built-in artifacts
 - workspace-aware repo clone, manifest-driven workspace clone, Project intake
   workflow generation, and resilient `basectl gh` command execution
 - external `base-bash-libs` consumption for reusable Bash libraries, with Base

--- a/README.md
+++ b/README.md
@@ -414,15 +414,18 @@ explicit, reviewable hook contract for when hooks run, where they run, whether
 they are interactive, and how dry-run/check/doctor report them. See
 [Setup Hooks Boundary](docs/setup-hooks.md).
 
-The curated tool artifact registry lives in `cli/python/base_setup/registry.py`.
-It should stay small and Base-aware. `python-package` artifacts are pass-through
-PyPI package names and install into the project virtual environment at
-`~/.base.d/<project>/.venv`. Homebrew-managed `tool` artifacts currently support
-`version: latest`; `basectl check` and `basectl doctor` treat an installed but
-outdated Homebrew package as unhealthy, and `basectl setup` upgrades it. Ordinary
-Homebrew tools should move toward Brewfile delegation. Pinned Homebrew versions
-fail clearly until Base grows explicit versioned tool support. The next registry
-shape is captured in [Artifact Adapter Registry](docs/artifact-adapter-registry.md).
+The curated built-in artifact registry lives in
+`lib/base/artifact-registry.yaml` using schema version `1`, and
+`cli/python/base_setup/registry.py` loads and validates that data before setup,
+check, or doctor use it. The registry should stay small and Base-aware.
+`python-package` artifacts are pass-through PyPI package names and install into
+the project virtual environment at `~/.base.d/<project>/.venv`.
+Homebrew-managed `tool` artifacts currently support `version: latest`;
+`basectl check` and `basectl doctor` treat an installed but outdated Homebrew
+package as unhealthy, and `basectl setup` upgrades it. Ordinary Homebrew tools
+should move toward Brewfile delegation. Pinned Homebrew versions fail clearly
+until Base grows explicit versioned tool support. The registry boundary is
+captured in [Artifact Adapter Registry](docs/artifact-adapter-registry.md).
 
 The optional structured `python:` manifest section supports uv-managed Python
 projects:

--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -99,7 +99,21 @@ def check_artifact(
         message=f"Artifact manager '{definition.manager}' is not implemented.",
         fix=f"basectl setup {project}",
         finding_id="BASE-P030",
+        details=artifact_details(definition),
     )
+
+
+def artifact_details(definition: ArtifactDefinition) -> dict[str, str]:
+    return {
+        "artifact_type": definition.artifact_type,
+        "artifact": definition.name,
+        "manager": definition.manager,
+        "package": definition.package,
+        "target": definition.target,
+        "version_policy": definition.version_policy,
+        "check_kind": definition.check_kind,
+        "registry_source": definition.registry_source,
+    }
 
 
 def check_homebrew_artifact(
@@ -117,6 +131,7 @@ def check_homebrew_artifact(
             ),
             fix=f"Update '{artifact.name}' in the project manifest to use version 'latest'.",
             finding_id="BASE-P031",
+            details=artifact_details(definition),
         )
     if not process.command_exists("brew"):
         return ArtifactCheck(
@@ -125,6 +140,7 @@ def check_homebrew_artifact(
             message=f"Homebrew is required to check artifact '{artifact.name}'.",
             fix="basectl setup",
             finding_id="BASE-P032",
+            details=artifact_details(definition),
         )
     if process.run_check(["brew", "list", definition.package]):
         if homebrew_package_outdated(definition.package):
@@ -134,6 +150,7 @@ def check_homebrew_artifact(
                 message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
                 fix=f"basectl setup {project}",
                 finding_id="BASE-P033",
+                details=artifact_details(definition),
             )
         return ArtifactCheck(
             name=artifact.name,
@@ -144,6 +161,7 @@ def check_homebrew_artifact(
             ),
             fix="",
             finding_id="BASE-P033",
+            details=artifact_details(definition),
         )
     return ArtifactCheck(
         name=artifact.name,
@@ -151,6 +169,7 @@ def check_homebrew_artifact(
         message=f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'.",
         fix=f"basectl setup {project}",
         finding_id="BASE-P033",
+        details=artifact_details(definition),
     )
 
 
@@ -168,6 +187,7 @@ def check_python_artifact(
             message=f"Python artifact '{artifact.name}' is installed in the project virtual environment.",
             fix="",
             finding_id="BASE-P040",
+            details=artifact_details(definition),
         )
     return ArtifactCheck(
         name=artifact.name,
@@ -175,6 +195,7 @@ def check_python_artifact(
         message=f"Python artifact '{artifact.name}' is not installed in the project virtual environment.",
         fix=f"basectl setup {project}",
         finding_id="BASE-P040",
+        details=artifact_details(definition),
     )
 
 

--- a/cli/python/base_setup/registry.py
+++ b/cli/python/base_setup/registry.py
@@ -1,6 +1,37 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import ArtifactError
+from .manifest import yaml
+
+BUILTIN_REGISTRY_PATH = Path(__file__).resolve().parents[3] / "lib" / "base" / "artifact-registry.yaml"
+SUPPORTED_MANAGERS = {"homebrew", "pip"}
+SUPPORTED_TARGETS = {"project-venv", "system"}
+SUPPORTED_VERSION_POLICIES = {"latest-only", "requested"}
+SUPPORTED_CHECK_KINDS = {"homebrew_package", "python_import"}
+ARTIFACT_ENTRY_KEYS = {
+    "type",
+    "name",
+    "manager",
+    "package",
+    "target",
+    "version_policy",
+    "check",
+    "metadata",
+}
+CHECK_ENTRY_KEYS = {"kind"}
+REQUIRED_ARTIFACT_ENTRY_KEYS = {
+    "type",
+    "name",
+    "manager",
+    "package",
+    "target",
+    "version_policy",
+    "check",
+}
 
 
 @dataclass(frozen=True)
@@ -10,168 +41,135 @@ class ArtifactDefinition:
     manager: str
     package: str
     target: str
+    version_policy: str = ""
+    check_kind: str = ""
+    registry_source: str = ""
 
 
-_ARTIFACTS = {
-    ("python-package", "click"): ArtifactDefinition(
-        name="click",
-        artifact_type="python-package",
-        manager="pip",
-        package="click",
-        target="project-venv",
-    ),
-    ("python-package", "PyYAML"): ArtifactDefinition(
-        name="PyYAML",
-        artifact_type="python-package",
-        manager="pip",
-        package="PyYAML",
-        target="project-venv",
-    ),
-    ("python-package", "pylint"): ArtifactDefinition(
-        name="pylint",
-        artifact_type="python-package",
-        manager="pip",
-        package="pylint",
-        target="project-venv",
-    ),
-    ("python-package", "pytest"): ArtifactDefinition(
-        name="pytest",
-        artifact_type="python-package",
-        manager="pip",
-        package="pytest",
-        target="project-venv",
-    ),
-    ("tool", "terraform"): ArtifactDefinition(
-        name="terraform",
-        artifact_type="tool",
-        manager="homebrew",
-        package="terraform",
-        target="system",
-    ),
-    ("tool", "bats-core"): ArtifactDefinition(
-        name="bats-core",
-        artifact_type="tool",
-        manager="homebrew",
-        package="bats-core",
-        target="system",
-    ),
-    ("tool", "gh"): ArtifactDefinition(
-        name="gh",
-        artifact_type="tool",
-        manager="homebrew",
-        package="gh",
-        target="system",
-    ),
-    ("tool", "shellcheck"): ArtifactDefinition(
-        name="shellcheck",
-        artifact_type="tool",
-        manager="homebrew",
-        package="shellcheck",
-        target="system",
-    ),
-    ("tool", "docker"): ArtifactDefinition(
-        name="docker",
-        artifact_type="tool",
-        manager="homebrew",
-        package="docker",
-        target="system",
-    ),
-    ("tool", "colima"): ArtifactDefinition(
-        name="colima",
-        artifact_type="tool",
-        manager="homebrew",
-        package="colima",
-        target="system",
-    ),
-    ("tool", "kubectl"): ArtifactDefinition(
-        name="kubectl",
-        artifact_type="tool",
-        manager="homebrew",
-        package="kubernetes-cli",
-        target="system",
-    ),
-    ("tool", "helm"): ArtifactDefinition(
-        name="helm",
-        artifact_type="tool",
-        manager="homebrew",
-        package="helm",
-        target="system",
-    ),
-    ("tool", "k9s"): ArtifactDefinition(
-        name="k9s",
-        artifact_type="tool",
-        manager="homebrew",
-        package="k9s",
-        target="system",
-    ),
-    ("tool", "httpie"): ArtifactDefinition(
-        name="httpie",
-        artifact_type="tool",
-        manager="homebrew",
-        package="httpie",
-        target="system",
-    ),
-    ("tool", "grpcurl"): ArtifactDefinition(
-        name="grpcurl",
-        artifact_type="tool",
-        manager="homebrew",
-        package="grpcurl",
-        target="system",
-    ),
-    ("tool", "jq"): ArtifactDefinition(
-        name="jq",
-        artifact_type="tool",
-        manager="homebrew",
-        package="jq",
-        target="system",
-    ),
-    ("tool", "yq"): ArtifactDefinition(
-        name="yq",
-        artifact_type="tool",
-        manager="homebrew",
-        package="yq",
-        target="system",
-    ),
-    ("tool", "nmap"): ArtifactDefinition(
-        name="nmap",
-        artifact_type="tool",
-        manager="homebrew",
-        package="nmap",
-        target="system",
-    ),
-    ("tool", "mtr"): ArtifactDefinition(
-        name="mtr",
-        artifact_type="tool",
-        manager="homebrew",
-        package="mtr",
-        target="system",
-    ),
-    ("tool", "node"): ArtifactDefinition(
-        name="node",
-        artifact_type="tool",
-        manager="homebrew",
-        package="node",
-        target="system",
-    ),
-    ("tool", "nodejs"): ArtifactDefinition(
-        name="nodejs",
-        artifact_type="tool",
-        manager="homebrew",
-        package="node",
-        target="system",
-    ),
-    ("python-package", "requests"): ArtifactDefinition(
-        name="requests",
-        artifact_type="python-package",
-        manager="pip",
-        package="requests",
-        target="project-venv",
-    ),
-}
+@lru_cache(maxsize=None)
+def load_builtin_artifact_definitions() -> dict[tuple[str, str], ArtifactDefinition]:
+    return load_artifact_definitions(BUILTIN_REGISTRY_PATH)
+
+
+def load_artifact_definitions(path: Path) -> dict[tuple[str, str], ArtifactDefinition]:
+    data = _read_registry(path)
+    artifact_data = _registry_artifact_data(path, data)
+
+    definitions: dict[tuple[str, str], ArtifactDefinition] = {}
+    for index, entry in enumerate(artifact_data, start=1):
+        definition = _parse_artifact_entry(path, index, entry)
+        key = (definition.artifact_type, definition.name)
+        if key in definitions:
+            raise ArtifactError(
+                f"Artifact registry '{path}' artifacts[{index}] declares "
+                f"duplicate artifact definition: {definition.artifact_type}/{definition.name}."
+            )
+        definitions[key] = definition
+    return definitions
+
+
+def _read_registry(path: Path) -> dict[object, object]:
+    if yaml is None:
+        raise ArtifactError("PyYAML is required to read Base's built-in artifact registry.")
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ArtifactError(f"Unable to read artifact registry '{path}': {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ArtifactError(f"Artifact registry '{path}' is invalid YAML: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ArtifactError(f"Artifact registry '{path}' must be a YAML mapping.")
+    return data
+
+
+def _registry_artifact_data(path: Path, data: dict[object, object]) -> list[object]:
+    if data.get("version") != 1:
+        raise ArtifactError(f"Artifact registry '{path}' must declare version: 1.")
+
+    artifact_data = data.get("artifacts")
+    if not isinstance(artifact_data, list):
+        raise ArtifactError(f"Artifact registry '{path}' must declare artifacts as a list.")
+    return artifact_data
+
+
+def _parse_artifact_entry(path: Path, index: int, entry: object) -> ArtifactDefinition:
+    if not isinstance(entry, dict):
+        raise ArtifactError(f"Artifact registry '{path}' artifacts[{index}] must be a mapping.")
+
+    entry_path = f"Artifact registry '{path}' artifacts[{index}]"
+    _validate_artifact_keys(entry_path, entry)
+    check = _validate_check_entry(entry_path, entry["check"])
+
+    artifact_type = _required_string(entry_path, entry, "type")
+    name = _required_string(entry_path, entry, "name")
+    manager = _required_string(entry_path, entry, "manager")
+    package = _required_string(entry_path, entry, "package")
+    target = _required_string(entry_path, entry, "target")
+    version_policy = _required_string(entry_path, entry, "version_policy")
+    check_kind = _required_string(f"{entry_path}.check", check, "kind")
+    _validate_supported_values(entry_path, manager, target, version_policy, check_kind)
+
+    return ArtifactDefinition(
+        name=name,
+        artifact_type=artifact_type,
+        manager=manager,
+        package=package,
+        target=target,
+        version_policy=version_policy,
+        check_kind=check_kind,
+        registry_source=str(path),
+    )
+
+
+def _validate_artifact_keys(context: str, entry: dict[object, object]) -> None:
+    unknown_keys = sorted(set(entry) - ARTIFACT_ENTRY_KEYS)
+    if unknown_keys:
+        raise ArtifactError(f"{context} has unsupported keys: {', '.join(unknown_keys)}.")
+    missing_keys = sorted(REQUIRED_ARTIFACT_ENTRY_KEYS - set(entry))
+    if missing_keys:
+        raise ArtifactError(f"{context} is missing required keys: {', '.join(missing_keys)}.")
+
+
+def _validate_check_entry(context: str, check: object) -> dict[object, object]:
+    check_path = f"{context}.check"
+    if not isinstance(check, dict):
+        raise ArtifactError(f"{check_path} must be a mapping.")
+    unknown_keys = sorted(set(check) - CHECK_ENTRY_KEYS)
+    if unknown_keys:
+        raise ArtifactError(f"{check_path} has unsupported keys: {', '.join(unknown_keys)}.")
+    if "kind" not in check:
+        raise ArtifactError(f"{check_path} is missing required keys: kind.")
+    return check
+
+
+def _validate_supported_values(
+    context: str,
+    manager: str,
+    target: str,
+    version_policy: str,
+    check_kind: str,
+) -> None:
+    if manager not in SUPPORTED_MANAGERS:
+        raise ArtifactError(f"{context} has unsupported manager '{manager}'.")
+    if target not in SUPPORTED_TARGETS:
+        raise ArtifactError(f"{context} has unsupported target '{target}'.")
+    if version_policy not in SUPPORTED_VERSION_POLICIES:
+        raise ArtifactError(f"{context} has unsupported version_policy '{version_policy}'.")
+    if check_kind not in SUPPORTED_CHECK_KINDS:
+        raise ArtifactError(f"{context}.check has unsupported check kind '{check_kind}'.")
+
+
+def _required_string(context: str, data: dict[object, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ArtifactError(f"{context}.{key} must be a non-empty string.")
+    return value.strip()
 
 
 def get_artifact_definition(artifact_type: str, name: str) -> ArtifactDefinition | None:
-    definition = _ARTIFACTS.get((artifact_type, name))
+    definition = load_builtin_artifact_definitions().get((artifact_type, name))
     if definition is not None:
         return definition
 
@@ -182,6 +180,9 @@ def get_artifact_definition(artifact_type: str, name: str) -> ArtifactDefinition
             manager="pip",
             package=name,
             target="project-venv",
+            version_policy="requested",
+            check_kind="python_import",
+            registry_source="<python-package fallback>",
         )
 
     return None

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -16,7 +16,7 @@ from base_setup.artifacts import merge_artifacts
 from base_setup.errors import ArtifactError
 from base_setup.manifest import ArtifactRequest, read_manifest
 from base_setup.process import format_command
-from base_setup.registry import get_artifact_definition
+from base_setup.registry import get_artifact_definition, load_artifact_definitions
 from base_setup.tests.helpers import fake_context, run_engine
 
 
@@ -77,6 +77,11 @@ class ArtifactMergeTests(unittest.TestCase):
 
 class ArtifactRegistryTests(unittest.TestCase):
 
+    def write_registry(self, root: Path, body: str) -> Path:
+        path = root / "artifact-registry.yaml"
+        path.write_text(body, encoding="utf-8")
+        return path
+
     def test_base_manifest_declares_python_dev_tools(self) -> None:
         manifest = read_manifest(Path(__file__).resolve().parents[4] / "base_manifest.yaml")
         tools = {(artifact.artifact_type, artifact.name) for artifact in manifest.artifacts}
@@ -128,6 +133,122 @@ class ArtifactRegistryTests(unittest.TestCase):
         self.assertIsNotNone(colima)
         self.assertEqual(colima.package, "colima")
         self.assertEqual(colima.manager, "homebrew")
+
+    def test_builtin_artifact_definition_reports_registry_metadata(self) -> None:
+        definition = get_artifact_definition("tool", "kubectl")
+
+        self.assertIsNotNone(definition)
+        self.assertEqual(definition.package, "kubernetes-cli")
+        self.assertEqual(definition.version_policy, "latest-only")
+        self.assertEqual(definition.check_kind, "homebrew_package")
+        self.assertTrue(definition.registry_source.endswith("lib/base/artifact-registry.yaml"))
+
+    def test_registry_validation_rejects_bad_entries(self) -> None:
+        cases = {
+            "unknown_field": (
+                "version: 1\n"
+                "artifacts:\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: homebrew\n"
+                "    package: terraform\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    unexpected: true\n"
+                "    check:\n"
+                "      kind: homebrew_package\n",
+                "unsupported keys: unexpected",
+            ),
+            "missing_required": (
+                "version: 1\n"
+                "artifacts:\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: homebrew\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    check:\n"
+                "      kind: homebrew_package\n",
+                "missing required keys: package",
+            ),
+            "duplicate": (
+                "version: 1\n"
+                "artifacts:\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: homebrew\n"
+                "    package: terraform\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    check:\n"
+                "      kind: homebrew_package\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: homebrew\n"
+                "    package: terraform\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    check:\n"
+                "      kind: homebrew_package\n",
+                "duplicate artifact definition: tool/terraform",
+            ),
+            "unsupported_manager": (
+                "version: 1\n"
+                "artifacts:\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: apt\n"
+                "    package: terraform\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    check:\n"
+                "      kind: homebrew_package\n",
+                "unsupported manager 'apt'",
+            ),
+            "unsupported_check_kind": (
+                "version: 1\n"
+                "artifacts:\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: homebrew\n"
+                "    package: terraform\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    check:\n"
+                "      kind: shell_command\n",
+                "unsupported check kind 'shell_command'",
+            ),
+            "malformed_check": (
+                "version: 1\n"
+                "artifacts:\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: homebrew\n"
+                "    package: terraform\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    check: []\n",
+                "check must be a mapping",
+            ),
+            "missing_check_kind": (
+                "version: 1\n"
+                "artifacts:\n"
+                "  - type: tool\n"
+                "    name: terraform\n"
+                "    manager: homebrew\n"
+                "    package: terraform\n"
+                "    target: system\n"
+                "    version_policy: latest-only\n"
+                "    check: {}\n",
+                "check is missing required keys: kind",
+            ),
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for name, (body, message) in cases.items():
+                with self.subTest(name=name):
+                    with self.assertRaisesRegex(ArtifactError, message):
+                        load_artifact_definitions(self.write_registry(root, body))
 
 
 

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -58,6 +58,12 @@ class ProjectCheckTests(unittest.TestCase):
         self.assertEqual(request_checks[0]["status"], "error")
         self.assertNotIn("ok", request_checks[0])
         self.assertEqual(request_checks[0]["fix"], "basectl setup demo")
+        self.assertEqual(request_checks[0]["details"]["artifact_type"], "python-package")
+        self.assertEqual(request_checks[0]["details"]["manager"], "pip")
+        self.assertEqual(request_checks[0]["details"]["package"], "requests")
+        self.assertEqual(request_checks[0]["details"]["target"], "project-venv")
+        self.assertEqual(request_checks[0]["details"]["version_policy"], "requested")
+        self.assertTrue(request_checks[0]["details"]["registry_source"].endswith("lib/base/artifact-registry.yaml"))
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,8 +91,8 @@ reference. The filename should answer "what is this about?"
   sync guidance, and the user/project boundary.
 - [Project Installers](project-installers.md) defines how project-owned
   installers should use Base without moving product-specific logic into Base.
-- [Artifact Adapter Registry](artifact-adapter-registry.md) designs the
-  declarative registry and adapter boundary for Base-managed artifacts.
+- [Artifact Adapter Registry](artifact-adapter-registry.md) documents the
+  bundled declarative registry and adapter boundary for Base-managed artifacts.
 - [Python Manifest Section](python-manifest.md) records the structured Python
   manifest shape, uv adoption paths, and its relationship to `python-package`
   artifacts.

--- a/docs/artifact-adapter-registry.md
+++ b/docs/artifact-adapter-registry.md
@@ -1,15 +1,15 @@
 # Artifact Adapter Registry
 
-> **DESIGN DOC** — As of Base 1.1.0, Base still uses
-> `cli/python/base_setup/registry.py` for built-in artifact mappings. This
-> document describes the planned future declarative registry; implementation is
-> tracked in [#925](https://github.com/basefoundry/base/issues/925).
+> **IMPLEMENTATION STATUS** — Base ships Phase 1 of this design: built-in
+> artifact definitions live in `lib/base/artifact-registry.yaml` with schema
+> version `1`, and `cli/python/base_setup/registry.py` loads and validates that
+> bundled registry. Workspace overlays and repo-local registries remain future
+> work.
 
-This design records how Base should evolve the current built-in artifact
-mapping in `cli/python/base_setup/registry.py` without turning project setup
-into arbitrary plugin execution.
+This document records how Base evolves its built-in artifact mapping without
+turning project setup into arbitrary plugin execution.
 
-Today, Base has two artifact behaviors:
+Today, Base has two artifact behaviors backed by the bundled registry:
 
 - `python-package` artifacts resolve to pip packages installed in the
   Base-managed project virtual environment.
@@ -258,7 +258,7 @@ Unsupported artifact errors should distinguish:
 
 ## First Shippable Slice
 
-The smallest implementation that improves the product is Phase 1:
+The shipped Phase 1 implementation is:
 
 - built-in YAML registry;
 - no overlay support;

--- a/lib/base/README.md
+++ b/lib/base/README.md
@@ -15,6 +15,10 @@ They are not examples of project-local `base_manifest.yaml` files.
 - `sre_manifest.yaml`
   Defines the optional `sre` prerequisite profile for local operations and
   diagnostics tooling.
+- `artifact-registry.yaml`
+  Defines Base's bundled artifact registry using schema version `1`. The
+  Python setup layer loads and validates this file before resolving built-in
+  artifact definitions for setup, check, and doctor.
 
 ## Ownership
 
@@ -28,5 +32,5 @@ duplicating them here:
 
 - [Project manifest architecture](../../docs/architecture.md#project-manifest)
 - [Python manifest section](../../docs/python-manifest.md)
-- [Artifact adapter registry design](../../docs/artifact-adapter-registry.md)
+- [Artifact adapter registry](../../docs/artifact-adapter-registry.md)
 - [Base README setup notes](../../README.md)

--- a/lib/base/artifact-registry.yaml
+++ b/lib/base/artifact-registry.yaml
@@ -1,0 +1,199 @@
+version: 1
+artifacts:
+  - type: python-package
+    name: click
+    manager: pip
+    package: click
+    target: project-venv
+    version_policy: requested
+    check:
+      kind: python_import
+
+  - type: python-package
+    name: PyYAML
+    manager: pip
+    package: PyYAML
+    target: project-venv
+    version_policy: requested
+    check:
+      kind: python_import
+
+  - type: python-package
+    name: pylint
+    manager: pip
+    package: pylint
+    target: project-venv
+    version_policy: requested
+    check:
+      kind: python_import
+
+  - type: python-package
+    name: pytest
+    manager: pip
+    package: pytest
+    target: project-venv
+    version_policy: requested
+    check:
+      kind: python_import
+
+  - type: python-package
+    name: requests
+    manager: pip
+    package: requests
+    target: project-venv
+    version_policy: requested
+    check:
+      kind: python_import
+
+  - type: tool
+    name: terraform
+    manager: homebrew
+    package: terraform
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: bats-core
+    manager: homebrew
+    package: bats-core
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: gh
+    manager: homebrew
+    package: gh
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: shellcheck
+    manager: homebrew
+    package: shellcheck
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: docker
+    manager: homebrew
+    package: docker
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: colima
+    manager: homebrew
+    package: colima
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: kubectl
+    manager: homebrew
+    package: kubernetes-cli
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: helm
+    manager: homebrew
+    package: helm
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: k9s
+    manager: homebrew
+    package: k9s
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: httpie
+    manager: homebrew
+    package: httpie
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: grpcurl
+    manager: homebrew
+    package: grpcurl
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: jq
+    manager: homebrew
+    package: jq
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: yq
+    manager: homebrew
+    package: yq
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: nmap
+    manager: homebrew
+    package: nmap
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: mtr
+    manager: homebrew
+    package: mtr
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: node
+    manager: homebrew
+    package: node
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package
+
+  - type: tool
+    name: nodejs
+    manager: homebrew
+    package: node
+    target: system
+    version_policy: latest-only
+    check:
+      kind: homebrew_package


### PR DESCRIPTION
## Summary
- Move Base built-in artifact definitions into `lib/base/artifact-registry.yaml`.
- Load and validate schema version 1 registry entries before resolving artifacts.
- Surface registry metadata in artifact check details and update docs plus `.ai-context`.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_setup/tests/test_artifacts.py`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

## Demo Impact
- None.

Fixes #925