### PR TITLE
Add local command history index

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -66,6 +66,8 @@ the canonical current command list.
     Project if needed and update its metadata fields.
 - `basectl clean` - remove old Base runtime logs, temp files, and cache entries.
 - `basectl logs` - list, print, open, or tail recent Base CLI runtime logs.
+- `basectl history` - list recent structured Base command runs from the local
+  history index, with `--format json` for scripts.
 - `basectl config <path|show|doctor>` - inspect Base's machine-local user
   config.
 - `basectl onboard` - guide a user through the first Base setup checklist.

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -20,7 +20,7 @@ The current command surface covers:
 - mise integration
 - bundled declarative artifact registry for Base-managed built-in artifacts
 - explicit uv-managed Python project setup through `python.manager: uv`
-- cleanup and logs
+- cleanup, logs, and local command history
 - local config inspection
 - onboarding
 - repository baseline creation and checks
@@ -43,7 +43,7 @@ source builds treated as fallback validation rather than the normal user path.
 
 Recent released work includes:
 
-- local observability model for future command history and report surfaces
+- local command-history index with future report surfaces still deferred
 - workspace manifest status/check/doctor reporting plus explicit clone and pull
   support
 - guarded `basectl release publish`

--- a/README.md
+++ b/README.md
@@ -767,7 +767,21 @@ basectl logs -v
 cache root so failed Python-layer runs can be inspected without rerunning with
 debug output enabled. It supports `-v`/`--debug` for its own diagnostics without
 creating a new default log entry for the inspection run.
-The future local command history and diagnostic report model is described in
+
+Show recent structured Base command history with:
+
+```bash
+basectl history
+basectl history --project base
+basectl history --command check --status error
+basectl history --format json
+```
+
+`basectl history` reads the local history index at
+`<base-cache-root>/history/runs.jsonl`. History records are best-effort
+metadata for Python-backed Base commands with persistent logs; they point to raw
+logs instead of replacing them, and malformed history lines are ignored while
+listing recent runs. The broader local diagnostic report model is described in
 [docs/observability.md](docs/observability.md).
 
 Inspect machine-local Base config with:

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -66,6 +66,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
 - `basectl logs` lists recent Base CLI runtime logs and can print, open, or tail
   the newest matching log file.
+- `basectl history` lists recent structured Base command runs from the local
+  history index and supports JSON output for scripts.
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -35,6 +35,8 @@ Commands:
     Remove old Base CLI runtime logs, temp files, and cache entries.
   logs [options]
     List and open recent Base CLI runtime logs.
+  history [options]
+    List recent Base command history records.
   config <path|show|doctor>
     Inspect Base's machine-local user config.
   doctor [project] [options]
@@ -228,6 +230,11 @@ basectl_do_logs() {
     base_logs_subcommand_main "$@"
 }
 
+basectl_do_history() {
+    basectl_source_subcommand_module history || return 1
+    base_history_subcommand_main "$@"
+}
+
 basectl_do_config() {
     basectl_source_subcommand_module config || return 1
     base_config_subcommand_main "$@"
@@ -376,6 +383,7 @@ basectl_main() {
         release)          basectl_do_release "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         logs)             basectl_do_logs "$@" ;;
+        history)          basectl_do_history "$@" ;;
         config)           basectl_do_config "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;
         gh)               basectl_do_gh "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/history.sh
+++ b/cli/bash/commands/basectl/subcommands/history.sh
@@ -1,0 +1,61 @@
+# shellcheck shell=bash
+[[ -n "${_base_history_subcommand_sourced:-}" ]] && return
+_base_history_subcommand_sourced=1
+readonly _base_history_subcommand_sourced
+
+base_history_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl history [options]
+
+Options:
+  --project <name>      Filter by Base project name.
+  --command <name>      Filter by basectl command name.
+  --status <ok|warn|error>
+                        Filter by command status.
+  --limit <count>       Number of recent history records to list. Defaults to 10.
+  --format <text|json>  Output format. Defaults to text.
+  -v                    Enable DEBUG logging for this subcommand.
+  -h, --help            Show this help text.
+
+List recent Base command runs from the local command history index.
+EOF
+}
+
+base_history_subcommand_main() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    while (($# > 0)); do
+        case "$1" in
+            -h|--help)
+                base_history_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --project|--command|--status|--limit|--format)
+                [[ -n "${2:-}" ]] || {
+                    base_history_subcommand_usage >&2
+                    print_error "Option '$1' requires an argument."
+                    return 2
+                }
+                args+=("$1" "$2")
+                shift 2
+                ;;
+            --project=*|--command=*|--status=*|--limit=*|--format=*)
+                args+=("$1")
+                shift
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_history "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -135,6 +135,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "logs_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl history --); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "history_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl repo ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -225,6 +229,7 @@ EOF
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
+    [[ "$output" == *"history_options=--project --command --status --limit --format"* ]]
     [[ "$output" == *"repo_commands=init clone check configure agent-guidance installer-template"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --no-project --dry-run"* ]]
     [[ "$output" == *"repo_clone_options=--owner --path --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -19,6 +19,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"release <check|plan|notes|publish> --version <version> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"logs [options]"* ]]
+    [[ "$output" == *"history [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"gh <area> <command> [options]"* ]]
@@ -57,6 +58,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
+    grep -Fqx '  history [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor|clone|pull|configure> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl history delegates to the Python history layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_history" ]]; then
+    printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected history python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl history --project demo --command check --status error --limit 3 --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=base"* ]]
+    [[ "$output" == *"ARGS=--project demo --command check --status error --limit 3 --format json"* ]]
+}
+
+@test "basectl history forwards verbose flag to the Python history layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_history" ]]; then
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected history python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl history -v --limit 2
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ARGS=--debug --limit 2"* ]]
+}
+
+@test "basectl history prints help without requiring the Base Python venv" {
+    run_basectl history --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl history [options]"* ]]
+    [[ "$output" == *"--project <name>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
+}
+
+@test "basectl history reports missing option arguments as usage errors" {
+    run_basectl history --project
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--project' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl history --limit
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--limit' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+}

--- a/cli/python/base_history/__init__.py
+++ b/cli/python/base_history/__init__.py
@@ -1,0 +1,1 @@
+"""List local Base command history records."""

--- a/cli/python/base_history/__main__.py
+++ b/cli/python/base_history/__main__.py
@@ -1,0 +1,5 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import base_cli
+from base_cli.history import HISTORY_PATH
+from base_cli.paths import base_cache_root
+
+
+app = base_cli.App(name="base_history", log_to_file=False)
+
+
+@dataclass(frozen=True)
+class HistoryRecord:
+    payload: dict[str, Any]
+    run_id: str
+    command: str
+    project: str
+    status: str
+    exit_code: int | None
+    ended_at: str
+    sort_time: datetime
+    log_path: str | None
+
+    @property
+    def log_exists(self) -> bool:
+        if not self.log_path:
+            return False
+        return Path(self.log_path).expanduser().is_file()
+
+    def to_json(self) -> dict[str, Any]:
+        payload = dict(self.payload)
+        payload["log_exists"] = self.log_exists
+        return payload
+
+
+@dataclass(frozen=True)
+class HistoryOptions:
+    project: str | None
+    command: str | None
+    status: str | None
+    limit: int
+    output_format: str
+
+
+def main(argv: list[str] | None = None) -> int:
+    return base_cli.run_app(app, argv)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.option("--project", "project_filter", help="Filter by Base project name.")
+@base_cli.option("--command", "command_filter", help="Filter by basectl command name.")
+@base_cli.option("--status", "status_filter", help="Filter by status: ok, warn, or error.")
+@base_cli.option("--limit", default="10", help="Maximum history records to list.")
+@base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def run(
+    ctx: base_cli.Context,
+    project_filter: str | None,
+    command_filter: str | None,
+    status_filter: str | None,
+    limit: str,
+    output_format: str,
+) -> int:
+    try:
+        options = HistoryOptions(
+            project=project_filter,
+            command=command_filter,
+            status=normalize_optional_filter(status_filter),
+            limit=parse_positive_int("--limit", limit),
+            output_format=normalize_format(output_format),
+        )
+    except ValueError as exc:
+        ctx.log.error(str(exc))
+        return 2
+
+    records = recent_history(base_cache_root(), options=options, logger=ctx.log)
+    if options.output_format == "json":
+        print(json.dumps([record.to_json() for record in records], indent=2))
+        return 0
+    if not records:
+        print(f"No Base command history found under {base_cache_root() / HISTORY_PATH}.")
+        return 0
+    print_history_table(records)
+    return 0
+
+
+def normalize_optional_filter(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value.strip().lower()
+
+
+def normalize_format(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"text", "json"}:
+        raise ValueError(f"Unsupported output format '{value}'. Expected one of: text, json.")
+    return normalized
+
+
+def parse_positive_int(option: str, value: str) -> int:
+    if not value.isdigit():
+        raise ValueError(f"Option '{option}' must be a positive integer.")
+    amount = int(value)
+    if amount <= 0:
+        raise ValueError(f"Option '{option}' must be greater than zero.")
+    return amount
+
+
+def recent_history(
+    cache_root: Path,
+    options: HistoryOptions | None = None,
+    logger: Any | None = None,
+) -> list[HistoryRecord]:
+    records = list(read_history_records(cache_root, logger=logger))
+    if options is not None:
+        records = filter_history(records, options)
+    sorted_records = sorted(records, key=lambda record: (record.sort_time, record.run_id), reverse=True)
+    if options is None:
+        return sorted_records
+    return sorted_records[: options.limit]
+
+
+def read_history_records(cache_root: Path, logger: Any | None = None) -> list[HistoryRecord]:
+    path = cache_root / HISTORY_PATH
+    if not path.is_file():
+        return []
+
+    records: list[HistoryRecord] = []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            record = parse_history_line(line)
+            if record is None:
+                if logger is not None:
+                    logger.debug("Ignoring malformed history line %s in '%s'.", line_number, path)
+                continue
+            records.append(record)
+    return records
+
+
+def parse_history_line(line: str) -> HistoryRecord | None:
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        return None
+    if payload.get("event") != "finished":
+        return None
+
+    run_id = optional_string(payload.get("run_id"))
+    command = optional_string(payload.get("command"))
+    status = optional_string(payload.get("status"))
+    if not run_id or not command or not status:
+        return None
+
+    ended_at = optional_string(payload.get("ended_at")) or optional_string(payload.get("started_at")) or ""
+    return HistoryRecord(
+        payload=payload,
+        run_id=run_id,
+        command=command,
+        project=optional_string(payload.get("project")) or "",
+        status=status,
+        exit_code=optional_int(payload.get("exit_code")),
+        ended_at=ended_at,
+        sort_time=parse_timestamp(ended_at),
+        log_path=optional_string(payload.get("log_path")),
+    )
+
+
+def optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def optional_int(value: Any) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def parse_timestamp(value: str) -> datetime:
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def filter_history(records: list[HistoryRecord], options: HistoryOptions) -> list[HistoryRecord]:
+    filtered = records
+    if options.project:
+        filtered = [record for record in filtered if record.project == options.project]
+    if options.command:
+        filtered = [record for record in filtered if record.command == options.command]
+    if options.status:
+        filtered = [record for record in filtered if record.status == options.status]
+    return filtered
+
+
+def print_history_table(records: list[HistoryRecord]) -> None:
+    print(f"{'TIME':<19}  {'COMMAND':<12}  {'PROJECT':<12}  {'STATUS':<6}  {'EXIT':<4}  LOG")
+    for record in records:
+        print(
+            f"{display_time(record):<19}  "
+            f"{record.command:<12}  "
+            f"{display_project(record):<12}  "
+            f"{record.status:<6}  "
+            f"{display_exit_code(record):<4}  "
+            f"{display_log_path(record)}"
+        )
+
+
+def display_time(record: HistoryRecord) -> str:
+    if record.sort_time == datetime.min.replace(tzinfo=timezone.utc):
+        return "?"
+    return f"{record.sort_time:%Y-%m-%d %H:%M:%S}"
+
+
+def display_project(record: HistoryRecord) -> str:
+    return record.project or "-"
+
+
+def display_exit_code(record: HistoryRecord) -> str:
+    return str(record.exit_code) if record.exit_code is not None else "-"
+
+
+def display_log_path(record: HistoryRecord) -> str:
+    if not record.log_path:
+        return "-"
+    suffix = "" if record.log_exists else " (missing)"
+    return f"{record.log_path}{suffix}"

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_history import engine
+
+
+def write_history_line(cache_root: Path, payload: dict | str) -> None:
+    path = cache_root / "history" / "runs.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{text}\n")
+
+
+# pylint: disable=too-many-arguments
+def history_record(
+    run_id: str,
+    command: str,
+    *,
+    project: str = "demo",
+    status: str = "ok",
+    exit_code: int = 0,
+    ended_at: str = "2026-06-10T10:15:00Z",
+    log_path: str = "~/logs/run.log",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": run_id,
+        "event": "finished",
+        "command": command,
+        "raw_command": f"base_{command}",
+        "argv": ["basectl", command],
+        "project": project,
+        "ended_at": ended_at,
+        "exit_code": exit_code,
+        "status": status,
+        "log_path": log_path,
+    }
+
+
+def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class BaseHistoryTests(unittest.TestCase):
+    def test_recent_history_ignores_malformed_lines_and_sorts_newest_first(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(
+                cache_root,
+                history_record(
+                    "older",
+                    "check",
+                    ended_at="2026-06-10T10:10:00Z",
+                ),
+            )
+            write_history_line(cache_root, "{not json")
+            write_history_line(
+                cache_root,
+                history_record(
+                    "newer",
+                    "setup",
+                    ended_at="2026-06-10T10:15:00Z",
+                    status="error",
+                    exit_code=1,
+                ),
+            )
+
+            records = engine.recent_history(cache_root)
+
+        self.assertEqual([record.run_id for record in records], ["newer", "older"])
+        self.assertEqual([record.command for record in records], ["setup", "check"])
+
+    def test_text_output_lists_recent_history_and_missing_log_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-1",
+                    "check",
+                    status="error",
+                    exit_code=2,
+                    log_path=str(cache_root / "cli" / "base_setup" / "logs" / "missing.log"),
+                ),
+            )
+
+            status, stdout, stderr = invoke([], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("TIME", stdout)
+        self.assertIn("COMMAND", stdout)
+        self.assertIn("PROJECT", stdout)
+        self.assertIn("check", stdout)
+        self.assertIn("error", stdout)
+        self.assertIn("missing", stdout)
+
+    def test_json_output_filters_history_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-1",
+                    "check",
+                    project="demo",
+                    status="error",
+                    exit_code=1,
+                    ended_at="2026-06-10T10:10:00Z",
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-2",
+                    "setup",
+                    project="base",
+                    status="ok",
+                    exit_code=0,
+                    ended_at="2026-06-10T10:15:00Z",
+                ),
+            )
+
+            status, stdout, stderr = invoke(
+                ["--project", "demo", "--command", "check", "--status", "error", "--format", "json"],
+                cache_root,
+            )
+            payload = json.loads(stdout)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["run_id"], "run-1")
+        self.assertEqual(payload[0]["project"], "demo")
+        self.assertEqual(payload[0]["status"], "error")
+        self.assertFalse(payload[0]["log_exists"])
+
+    def test_empty_history_set_is_not_an_error_for_table_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = invoke([], Path(tmpdir))
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("No Base command history found", stdout)
+
+    def test_invalid_options_report_usage_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = invoke(["--limit", "0"], Path(tmpdir))
+            format_status, _format_stdout, format_stderr = invoke(["--format", "yaml"], Path(tmpdir))
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("Option '--limit' must be greater than zero", stderr)
+        self.assertEqual(format_status, 2)
+        self.assertIn("Unsupported output format 'yaml'", format_stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,8 +65,9 @@ reference. The filename should answer "what is this about?"
 - [Base Bash Libraries](base-bash-libs.md) documents the standalone
   `base-bash-libs` package, Base's external reusable-library consumption path,
   Homebrew/core readiness path, and the post-migration boundary.
-- [Local Observability](observability.md) defines the future local command
-  history, last-error explanation, and report model beyond raw runtime logs.
+- [Local Observability](observability.md) defines the shipped local command
+  history index plus the future last-error explanation and report model beyond
+  raw runtime logs.
 - [Release Process](release-process.md) defines the Base release ceremony,
   version-file policy, GitHub Release flow, and Homebrew tap follow-up.
 - [Homebrew Upgrade Rehearsal](homebrew-upgrade-rehearsal.md) defines the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -628,7 +628,8 @@ Doctor findings use stable identifiers documented in
 on those IDs instead of human-readable messages.
 
 Base should also remain locally observable. `basectl logs` exposes recent Base
-CLI runtime logs from the Base cache root without sending telemetry anywhere.
+CLI runtime logs from the Base cache root, and `basectl history` lists the
+structured local command-history index without sending telemetry anywhere.
 Useful command metadata includes the command, target project or workspace,
 start and end time, exit code, manifest version where relevant, external tools
 invoked, and log file paths.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -44,6 +44,7 @@ inspect the resolved command contract first.
 | `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |
 | `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name>` |
 | `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name>`, `--lines <count>` |
+| `basectl history` | List recent structured Base command runs. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--format <text\|json>` |
 | `basectl clean` | Remove old Base runtime logs, temp files, and cache entries. | `--older-than <age>`, `--keep-last <count>`, `--dry-run` |
 | `basectl config path` | Print the local Base config path. | none |
 | `basectl config show` | Show local Base config. | none |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,14 +1,15 @@
 # Local Observability Model
 
-> **DESIGN DOC** — These commands are not yet implemented as of Base 1.1.0.
-> Use `basectl logs` for current log access.
+> **STATUS** — `basectl history` and the local history index are implemented as
+> the first slice. `basectl explain last-error`, `basectl report`, and history
+> cleanup integration remain future work.
 
 Issue: #396
 
-Base currently exposes raw runtime logs through `basectl logs`. This document
-defines the next local observability layer: structured command history,
-last-error explanation, and report generation. It is a design contract for
-future implementation, not a statement that these commands exist today.
+Base currently exposes raw runtime logs through `basectl logs` and structured
+local command metadata through `basectl history`. This document defines the
+local observability layer: shipped command history, future last-error
+explanation, and future report generation.
 
 ## Goals
 
@@ -48,7 +49,7 @@ Those questions need a structured index in addition to raw log discovery.
 
 ## History Index
 
-Base should add a structured command history index under the Base cache root:
+Base writes a structured command history index under the Base cache root:
 
 ```text
 <base-cache-root>/history/runs.jsonl
@@ -57,17 +58,16 @@ Base should add a structured command history index under the Base cache root:
 Each line is one JSON object. JSON Lines keeps writes append-only, easy to
 inspect with ordinary tools, and easy to recover when one line is malformed.
 
-History writes should be best-effort:
+History writes are best-effort:
 
-- write a start record when a command begins
-- write a completion record when the command exits
-- tolerate missing completion records
+- write a final completion record when a Python-backed command with a
+  persistent log exits
 - never fail the user command because the history file cannot be written
 - ignore malformed history lines while warning in debug output
 
-The first implementation can either emit one final record per run or pair
-`started` and `finished` events. If paired events are used, readers should
-collapse them by `run_id` and prefer the latest completion event.
+The first implementation emits one `finished` record per recorded run. Shell-only
+commands and no-durable-write modes such as `ctx.dry_run` or
+`App(log_to_file=False)` do not create history records in this slice.
 
 ## Record Shape
 
@@ -148,7 +148,7 @@ The retention contract should be:
 
 ### `basectl history`
 
-`basectl history` should read the structured index and print a compact table of
+`basectl history` reads the structured index and prints a compact table of
 recent Base command runs:
 
 ```text
@@ -205,7 +205,7 @@ should never upload the report.
 
 The commands should ship in separate, reviewable slices:
 
-1. Add history recording and `basectl history`.
+1. Add history recording and `basectl history`. **Shipped.**
 2. Add `basectl explain last-error` after history records exist.
 3. Add `basectl report` after history and explanation have stable local data.
 4. Extend `basectl clean` to compact or prune history records once the history
@@ -214,16 +214,13 @@ The commands should ship in separate, reviewable slices:
 This order keeps the data model and privacy boundary reviewable before Base
 starts producing summaries or shareable diagnostic artifacts.
 
-## Open Questions For Implementation
+## First Slice Decisions
 
-- Should shell-only commands record history before the Python layer starts, or
-  should the first slice cover only Python-backed commands?
-- Should the history writer live in `base_cli.App`, the Bash dispatcher, or a
-  small shared module used by both?
-- Should report generation include raw log excerpts by default, or require an
-  explicit `--include-log-excerpts` option?
-- Should missing logs be a warning row in `history`, or only visible with a
-  verbose flag?
-
-These questions should be answered in the first implementation issue before
-writing the history recorder.
+- The history writer lives in `base_cli.App`, so Python-backed commands share
+  the same local metadata lifecycle as persistent logs.
+- Shell-only commands are deferred until Base has a shell-side writer with the
+  same redaction and best-effort guarantees.
+- `basectl history` marks missing log files directly in text output and exposes
+  `log_exists` in JSON output.
+- Future report generation should require an explicit option before embedding
+  raw log excerpts.

--- a/docs/setup-parallelism.md
+++ b/docs/setup-parallelism.md
@@ -111,8 +111,8 @@ The first slice should:
 2. Preserve current text output and command behavior while allowing tests to
    inspect the plan.
 3. Keep all mutating actions serial.
-4. Add timing around each action in the persistent log or local history once
-   the command-history surface exists.
+4. Add timing around each action in the persistent log or local command-history
+   records when setup needs action-level observability.
 5. Mark only read-only plan/preflight actions as candidates for future
    concurrency.
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -172,6 +172,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | `basectl check [project] [--profile]` | Quick pass/fail readiness check |
 | `basectl doctor [project] [--profile]` | Human-readable findings + fix commands |
 | `basectl logs [--tail\|--command\|--path\|--open]` | Inspect runtime logs |
+| `basectl history [--format json]` | Inspect structured local command history |
 | `basectl config path\|show\|doctor` | Machine-local config |
 | `basectl clean [--older-than\|--keep-last]` | Prune cache/logs |
 

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -270,12 +270,19 @@ formatter without replacing Base's logger setup. Leave those arguments as
 Commands that inspect runtime artifacts can use `base_cli.App(log_to_file=False)`
 to keep the standard context, `--debug`, and `--quiet` behavior without creating
 default `logs/`, `cache/`, or `tmp/<run-id>/` directories. `base_logs` uses this
-mode so `basectl logs` does not appear in its own output. An explicit
-`--log-file <path>` still enables file logging for that invocation.
+mode so `basectl logs` does not appear in its own output; `base_history` does
+the same for `basectl history`. An explicit `--log-file <path>` still enables
+file logging for that invocation.
 
 Commands running with `ctx.dry_run` also skip default `logs/`, `cache/`, and
 `tmp/<run-id>/` creation. Passing `--log-file <path>` still writes to that
 explicit file so tests and diagnostics can inspect dry-run logs when needed.
+
+For Python-backed commands with persistent logs, `base_cli.App` also writes a
+best-effort final history record to `<base-cache-root>/history/runs.jsonl`.
+History records contain redacted command metadata, timing, exit status, project
+context when known, and a pointer to the raw log file. History writes are local
+only and do not fail the user command when the index cannot be updated.
 
 High-frequency tools can set `base_cli.App(max_log_files=<count>)` to keep at
 most that many default persistent log files for the CLI. Retention runs during

--- a/lib/python/base_cli/__init__.py
+++ b/lib/python/base_cli/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from . import history
 from .app import App, argument, command, option, run_app
 from .context import Context, get_current_context
 from .exit_codes import ExitCode
@@ -9,6 +10,7 @@ __all__ = [
     "App",
     "Context",
     "ExitCode",
+    "history",
     "argument",
     "command",
     "configure_logger",

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 from .config import load_config, read_user_config
 from .context import Context, reset_current_context, set_current_context
+from .history import utc_now, write_finished_record
 from .logging import configure_logger, log_invocation
 from .paths import base_cache_root, discover_manifest, make_run_id, normalize_cli_name, resolve_base_home
 from .redaction import parameter_name_from_decls
@@ -122,14 +123,22 @@ class App:
             except (RuntimeError, ValueError) as exc:
                 raise click.ClickException(str(exc)) from exc
             token = set_current_context(context)
+            started_at = utc_now()
+            exit_code = 0
             try:
                 log_invocation(context.log, sys.argv, sensitive_options)
                 if context.project_root is not None:
                     context.log.debug("project_root=%s", context.project_root)
                 if context.manifest_path is not None:
                     context.log.debug("manifest_path=%s", context.manifest_path)
-                return func(context, **kwargs)
+                result = func(context, **kwargs)
+                exit_code = int(result or 0)
+                return result
+            except Exception:
+                exit_code = 1
+                raise
             finally:
+                write_finished_record(context, sys.argv, sensitive_options, started_at, exit_code)
                 reset_current_context(token)
                 context.cleanup()
 

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import load_yaml_file
+from .context import Context
+from .paths import base_cache_root
+from .redaction import REDACTED, option_name_to_parameter, redact_argv
+
+
+SCHEMA_VERSION = 1
+HISTORY_PATH = Path("history") / "runs.jsonl"
+SECRET_KEY_RE = re.compile(r"(token|password|secret|api[-_]?key|authorization)", re.IGNORECASE)
+URL_CREDENTIALS_RE = re.compile(r"://[^/@\s]+@")
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def write_finished_record(
+    context: Context,
+    argv: list[str],
+    sensitive_options: set[str],
+    started_at: datetime,
+    exit_code: int,
+) -> None:
+    if context.dry_run or context.log_file is None:
+        return
+    try:
+        record = build_finished_record(context, argv, sensitive_options, started_at, exit_code)
+        write_history_record(record)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        context.log.debug("Unable to write command history record: %s", exc)
+
+
+def build_finished_record(
+    context: Context,
+    argv: list[str],
+    sensitive_options: set[str],
+    started_at: datetime,
+    exit_code: int,
+) -> dict[str, Any]:
+    ended_at = utc_now()
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": context.run_id,
+        "event": "finished",
+        "command": display_command(context.cli_name, argv),
+        "raw_command": context.cli_name,
+        "argv": redact_history_argv(argv, sensitive_options),
+        "started_at": format_timestamp(started_at),
+        "ended_at": format_timestamp(ended_at),
+        "duration_ms": duration_ms(started_at, ended_at),
+        "exit_code": exit_code,
+        "status": "ok" if exit_code == 0 else "error",
+        "log_path": compact_path(context.log_file),
+        "os": normalized_os(),
+    }
+    optional_fields = {
+        "project": project_name(context),
+        "project_root": compact_optional_path(context.project_root),
+        "manifest": compact_optional_path(context.manifest_path),
+        "workspace_root": compact_optional_path(context.workspace_root),
+        "base_version": base_version(context.base_home),
+        "shell": os.environ.get("SHELL"),
+    }
+    record.update({key: value for key, value in optional_fields.items() if value})
+    return record
+
+
+def write_history_record(record: dict[str, Any]) -> None:
+    path = base_cache_root() / HISTORY_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True))
+        handle.write("\n")
+    path.chmod(0o600)
+
+
+def format_timestamp(value: datetime) -> str:
+    normalized = value.astimezone(timezone.utc)
+    return normalized.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def duration_ms(started_at: datetime, ended_at: datetime) -> int:
+    return max(0, round((ended_at - started_at).total_seconds() * 1000))
+
+
+def display_command(cli_name: str, argv: list[str]) -> str:
+    if cli_name == "base_setup":
+        return base_setup_action(argv) or "setup"
+    if cli_name.startswith("base_"):
+        return cli_name.removeprefix("base_").replace("_", "-")
+    return cli_name.replace("_", "-")
+
+
+def base_setup_action(argv: list[str]) -> str | None:
+    for index, arg in enumerate(argv):
+        if arg == "--action" and index + 1 < len(argv):
+            return argv[index + 1]
+        if arg.startswith("--action="):
+            return arg.partition("=")[2]
+    return None
+
+
+def project_name(context: Context) -> str | None:
+    if context.manifest_path is None:
+        return None
+    try:
+        data = load_yaml_file(context.manifest_path)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    project_data = data.get("project")
+    if not isinstance(project_data, dict):
+        return None
+    value = project_data.get("name")
+    return value if isinstance(value, str) and value else None
+
+
+def base_version(base_home: Path | None) -> str | None:
+    if base_home is None:
+        return None
+    try:
+        version = (base_home / "VERSION").read_text(encoding="utf-8").splitlines()[0].strip()
+    except (IndexError, OSError):
+        return None
+    return version or None
+
+
+def normalized_os() -> str:
+    system = platform.system().lower()
+    if system == "darwin":
+        return "macos"
+    return system or platform.platform()
+
+
+def redact_history_argv(argv: list[str], sensitive_options: set[str]) -> list[str]:
+    redacted = redact_argv(argv, sensitive_options)
+    result: list[str] = []
+    redact_next = False
+    for arg in redacted:
+        if redact_next:
+            result.append(REDACTED)
+            redact_next = False
+            continue
+
+        option, separator, _value = arg.partition("=")
+        normalized = option_name_to_parameter(option) if option.startswith("--") else option
+        if option.startswith("--") and is_secret_key(normalized):
+            if separator:
+                result.append(f"{option}={REDACTED}")
+            else:
+                result.append(option)
+                redact_next = True
+            continue
+        result.append(redact_history_text(arg))
+    return result
+
+
+def redact_history_text(value: str) -> str:
+    key, separator, _value = value.partition("=")
+    if separator and is_secret_key(key):
+        return f"{key}={REDACTED}"
+    redacted = URL_CREDENTIALS_RE.sub(f"://{REDACTED}@", value)
+    return compact_home_text(redacted)
+
+
+def is_secret_key(value: str) -> bool:
+    return SECRET_KEY_RE.search(value) is not None
+
+
+def compact_optional_path(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    return compact_path(path)
+
+
+def compact_path(path: Path) -> str:
+    return compact_home_text(str(path.expanduser().resolve(strict=False)))
+
+
+def compact_home_text(value: str) -> str:
+    home = str(Path.home().expanduser().resolve(strict=False))
+    if value == home:
+        return "~"
+    if value.startswith(f"{home}/"):
+        return f"~/{value[len(home) + 1:]}"
+    return value

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+import base_cli
+
+
+def read_history_records(cache_root: Path) -> list[dict]:
+    history_path = cache_root / "history" / "runs.jsonl"
+    return [json.loads(line) for line in history_path.read_text(encoding="utf-8").splitlines()]
+
+
+class BaseCliHistoryTests(unittest.TestCase):
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_records_successful_command_history_with_redacted_metadata(self) -> None:
+        app = base_cli.App(name="history-demo", version="0.1.0")
+        seen = {}
+
+        @app.command()
+        @base_cli.option("--endpoint", required=True)
+        @base_cli.option("--token", sensitive=True, required=True)
+        def main(ctx: base_cli.Context, endpoint: str, token: str) -> None:
+            seen["endpoint"] = endpoint
+            seen["token"] = token
+            seen["run_id"] = ctx.run_id
+            ctx.log.info("processed request")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            project = home / "work" / "demo"
+            home.mkdir()
+            project.mkdir(parents=True)
+
+            from base_cli.testing import invoke
+
+            with mock.patch.object(
+                os.sys,
+                "argv",
+                [
+                    "history-demo",
+                    "--endpoint",
+                    "https://user:super-secret@example.invalid/path",
+                    "--token",
+                    "super-secret",
+                ],
+            ):
+                result = invoke(
+                    app,
+                    [
+                        "--endpoint",
+                        "https://user:super-secret@example.invalid/path",
+                        "--token",
+                        "super-secret",
+                    ],
+                    home=home,
+                    cwd=project,
+                    manifest={"project": {"name": "demo"}},
+                )
+
+            records = read_history_records(home / ".cache" / "base")
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record["schema_version"], 1)
+        self.assertEqual(record["event"], "finished")
+        self.assertEqual(record["run_id"], seen["run_id"])
+        self.assertEqual(record["command"], "history-demo")
+        self.assertEqual(record["raw_command"], "history-demo")
+        self.assertEqual(record["project"], "demo")
+        self.assertEqual(record["project_root"], "~/work/demo")
+        self.assertEqual(record["manifest"], "~/work/demo/base_manifest.yaml")
+        self.assertEqual(record["exit_code"], 0)
+        self.assertEqual(record["status"], "ok")
+        self.assertTrue(record["duration_ms"] >= 0)
+        self.assertTrue(record["log_path"].startswith("~/.cache/base/cli/history-demo/logs/"))
+        self.assertIn("[REDACTED]", record["argv"])
+        self.assertIn("https://[REDACTED]@example.invalid/path", record["argv"])
+        self.assertNotIn("super-secret", json.dumps(record))
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_records_failed_command_history(self) -> None:
+        app = base_cli.App(name="failing-history")
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> int:
+            ctx.log.error("planned failure")
+            return 7
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": str(home), "BASE_CACHE_DIR": str(home / ".cache" / "base")},
+            ):
+                with redirect_stderr(stderr):
+                    status = base_cli.run_app(app, [])
+            records = read_history_records(home / ".cache" / "base")
+
+        self.assertEqual(status, 7, stderr.getvalue())
+        self.assertEqual(records[0]["command"], "failing-history")
+        self.assertEqual(records[0]["exit_code"], 7)
+        self.assertEqual(records[0]["status"], "error")
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_app_history_write_failures_do_not_fail_command(self) -> None:
+        app = base_cli.App(name="history-best-effort")
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            ctx.log.info("still succeeds")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            from base_cli.testing import invoke
+
+            with mock.patch("base_cli.history.write_history_record", side_effect=OSError("permission denied")):
+                result = invoke(app, [], home=home)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -63,7 +63,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test export-context build demo run repo ci release clean logs config doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test export-context build demo run repo ci release clean logs history config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -182,6 +182,9 @@ _base_basectl_completion() {
             ;;
         logs)
             _base_basectl_completion_compgen "--command --limit --path --tail --open --lines -v -h --help" "$cur"
+            ;;
+        history)
+            _base_basectl_completion_compgen "--project --command --status --limit --format -v -h --help" "$cur"
             ;;
         config)
             if ((COMP_CWORD == 2)); then

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -27,6 +27,7 @@ _base_basectl_completion() {
         'release:Inspect release readiness, notes, and publishing'
         'clean:Remove old Base CLI runtime artifacts'
         'logs:List and open recent Base CLI runtime logs'
+        'history:List recent Base command history records'
         'config:Inspect Base machine-local user config'
         'doctor:Diagnose the local Base environment'
         'gh:Manage GitHub issues, pull requests, branches, and hygiene'
@@ -285,6 +286,14 @@ _base_basectl_completion() {
                 '--tail[Tail and follow most recent log]' \
                 '--open[Open most recent log]' \
                 '--lines[Lines to show before following]:count:' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        history)
+            _arguments '--project[Filter by Base project]:project:' \
+                '--command[Filter by command]:command:' \
+                '--status[Filter by status]:status:(ok warn error)' \
+                '--limit[Number of records]:count:' \
+                '--format[Output format]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         config)


### PR DESCRIPTION
## Summary
- Record best-effort local command history records for Python-backed Base commands with persistent logs.
- Add `basectl history` with compact text output, JSON output, filtering, malformed-line tolerance, and missing-log reporting.
- Update Bash/Zsh completions, docs, and `.ai-context` for the shipped history slice.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest lib/python/base_cli/tests/test_base_cli.py lib/python/base_cli/tests/test_history.py cli/python/base_history/tests/test_engine.py cli/python/base_logs/tests/test_engine.py`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/history.bats cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

## Demo Impact
- None.

Fixes #926