### PR TITLE
Support project Python version requirements

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -70,6 +70,8 @@ Base orchestrates mature tools instead of replacing them:
 - uv owns Python dependency resolution, lockfiles, and project-local `.venv`
   environments when a manifest declares `python.manager: uv`; individual
   commands can opt into `uv run` with `runner: uv`.
+- Base owns the supported Python runtime window for `python.requires_python`
+  and uses that declaration when creating Base-managed project virtualenvs.
 - IDEs own editor behavior; Base can install apps/extensions/settings
   additively.
 - Docker, `just`, Taskfile, Devbox, Nix, and similar tools can be project-level

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -20,6 +20,7 @@ The current command surface covers:
 - mise integration
 - bundled declarative artifact registry for Base-managed built-in artifacts
 - explicit uv-managed Python project setup through `python.manager: uv`
+- project Python runtime requirements through `python.requires_python`
 - cleanup, logs, and local command history
 - local config inspection
 - onboarding
@@ -34,8 +35,8 @@ The current command surface covers:
 
 The `v1.1.0` milestone is complete. Future work is tracked in GitHub Issues,
 with Linux runtime support, Docker/service artifacts, project-specific PR
-policy, and broader setup/Python version policy work remaining outside the
-1.1 release contract.
+policy, and broader setup policy work remaining outside the 1.1 release
+contract.
 
 The Homebrew bottle and consumer upgrade contract has passed the #526 rehearsal.
 Supported macOS installs should continue to use bottled Homebrew packages, with
@@ -44,6 +45,7 @@ source builds treated as fallback validation rather than the normal user path.
 Recent released work includes:
 
 - local command-history index with future report surfaces still deferred
+- project Python version requirements for Base-managed virtualenv creation
 - workspace manifest status/check/doctor reporting plus explicit clone and pull
   support
 - guarded `basectl release publish`

--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 import venv
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
@@ -13,9 +14,20 @@ from . import process
 from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import ArtifactRequest
+from .python_policy import evaluate_python_requirement
+from .python_policy import inspect_python_interpreter
+from .python_policy import PythonInterpreter
+from .python_policy import resolve_python_interpreter
+from .python_policy import version_label
 from .registry import ArtifactDefinition, get_artifact_definition
 
 PIP_INSTALL_COMMAND_PREFIX = ("-m", "pip", "install", "--disable-pip-version-check")
+
+
+@dataclass(frozen=True)
+class ProjectRuntimeConfig:
+    name: str
+    python_requirement: str | None = None
 
 
 def homebrew_no_auto_update_env() -> dict[str, str]:
@@ -203,14 +215,15 @@ def reconcile_artifact(
     ctx: base_cli.Context,
     definition: ArtifactDefinition,
     version: str,
-    project: str,
+    project: str | ProjectRuntimeConfig,
     dry_run: bool,
 ) -> None:
+    runtime_config = project_runtime_config(project)
     if definition.manager == "homebrew":
         reconcile_homebrew_artifact(ctx, definition, version, dry_run=dry_run)
         return
     if definition.manager == "pip":
-        reconcile_python_artifact(ctx, definition, version, project, dry_run=dry_run)
+        reconcile_python_artifact(ctx, definition, version, runtime_config, dry_run=dry_run)
         return
     raise ArtifactError(f"Artifact manager '{definition.manager}' is not implemented.")
 
@@ -219,16 +232,22 @@ def reconcile_artifacts(
     ctx: base_cli.Context,
     artifacts: tuple[ArtifactRequest, ...],
     definitions: tuple[ArtifactDefinition, ...],
-    project: str,
+    project: str | ProjectRuntimeConfig,
     dry_run: bool,
 ) -> None:
+    runtime_config = project_runtime_config(project)
     pending_python_artifacts: list[tuple[ArtifactDefinition, str]] = []
 
     def flush_python_artifacts() -> None:
         nonlocal pending_python_artifacts
         if not pending_python_artifacts:
             return
-        reconcile_python_artifacts(ctx, tuple(pending_python_artifacts), project, dry_run=dry_run)
+        reconcile_python_artifacts(
+            ctx,
+            tuple(pending_python_artifacts),
+            runtime_config,
+            dry_run=dry_run,
+        )
         pending_python_artifacts = []
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
@@ -236,7 +255,13 @@ def reconcile_artifacts(
             pending_python_artifacts.append((definition, artifact.version))
             continue
         flush_python_artifacts()
-        reconcile_artifact(ctx, definition, artifact.version, project, dry_run=dry_run)
+        reconcile_artifact(
+            ctx,
+            definition,
+            artifact.version,
+            runtime_config,
+            dry_run=dry_run,
+        )
     flush_python_artifacts()
 
 
@@ -301,7 +326,7 @@ def reconcile_python_artifact(
     ctx: base_cli.Context,
     definition: ArtifactDefinition,
     version: str,
-    project: str,
+    project: str | ProjectRuntimeConfig,
     dry_run: bool,
 ) -> None:
     reconcile_python_artifacts(ctx, ((definition, version),), project, dry_run=dry_run)
@@ -310,16 +335,20 @@ def reconcile_python_artifact(
 def reconcile_python_artifacts(
     ctx: base_cli.Context,
     artifact_definitions: tuple[tuple[ArtifactDefinition, str], ...],
-    project: str,
+    project: str | ProjectRuntimeConfig,
     dry_run: bool,
 ) -> None:
-    venv_dir = project_venv_dir(project)
+    runtime_config = project_runtime_config(project)
+    python_requirement = runtime_config.python_requirement
+    venv_dir = project_venv_dir(runtime_config.name)
     python_bin = venv_dir / "bin" / "python"
     recreate_venv = project_venv_recreate_enabled()
     missing = []
 
     if recreate_venv:
         backup_existing_project_venv(ctx, venv_dir, dry_run=dry_run)
+    elif python_requirement is not None and python_bin.exists():
+        ensure_existing_project_venv_matches_requirement(python_bin, runtime_config.name, python_requirement)
 
     for definition, version in artifact_definitions:
         if not recreate_venv and python_artifact_installed(python_bin, definition.package, version):
@@ -328,7 +357,7 @@ def reconcile_python_artifacts(
                 definition.name,
             )
             continue
-        missing.append((definition, version, python_requirement(definition, version)))
+        missing.append((definition, version, python_package_requirement(definition, version)))
 
     if not missing:
         return
@@ -337,13 +366,21 @@ def reconcile_python_artifacts(
 
     if dry_run:
         if recreate_venv or not python_bin.exists():
-            ctx.log.info("[DRY-RUN] Would create project virtual environment at '%s'.", venv_dir)
+            if python_requirement is None:
+                ctx.log.info("[DRY-RUN] Would create project virtual environment at '%s'.", venv_dir)
+            else:
+                interpreter = project_python_interpreter(python_requirement)
+                ctx.log.info(
+                    "[DRY-RUN] Would create project virtual environment at '%s' with Python %s from '%s'.",
+                    venv_dir,
+                    version_label(interpreter.version),
+                    interpreter.path,
+                )
         process.dry_run_command(ctx, pip_install_command(python_bin, requirements))
         return
 
     if recreate_venv or not python_bin.exists():
-        ctx.log.info("Creating project virtual environment at '%s'.", venv_dir)
-        venv.create(venv_dir, with_pip=True)
+        create_project_virtualenv(ctx, venv_dir, python_requirement)
 
     names = ", ".join(definition.name for definition, _version, _requirement in missing)
     ctx.log.info("Installing Python artifacts into project virtual environment: %s.", names)
@@ -360,6 +397,69 @@ def reconcile_python_artifacts(
 
 def project_venv_recreate_enabled() -> bool:
     return os.environ.get("BASE_SETUP_RECREATE_PROJECT_VENV") == "true"
+
+
+def project_runtime_config(project: str | ProjectRuntimeConfig) -> ProjectRuntimeConfig:
+    if isinstance(project, ProjectRuntimeConfig):
+        return project
+    return ProjectRuntimeConfig(name=project)
+
+
+def create_project_virtualenv(ctx: base_cli.Context, venv_dir: Path, python_requirement: str | None) -> None:
+    if python_requirement is None:
+        ctx.log.info("Creating project virtual environment at '%s'.", venv_dir)
+        venv.create(venv_dir, with_pip=True)
+        return
+
+    interpreter = project_python_interpreter(python_requirement)
+    ctx.log.info(
+        "Creating project virtual environment at '%s' with Python %s.",
+        venv_dir,
+        version_label(interpreter.version),
+    )
+    process.run_command(ctx, [str(interpreter.path), "-m", "venv", str(venv_dir)])
+
+
+def project_python_interpreter(python_requirement: str) -> PythonInterpreter:
+    policy = evaluate_python_requirement(python_requirement)
+    if not policy.ok or policy.selected_version is None:
+        raise ArtifactError(
+            f"python.requires_python '{python_requirement}' {policy.error}. "
+            "Choose a Python version supported by Base."
+        )
+    interpreter = resolve_python_interpreter(policy.selected_version)
+    if interpreter is None:
+        selected = version_label(policy.selected_version)
+        raise ArtifactError(
+            f"Python {selected} is not available for python.requires_python '{python_requirement}'. "
+            f"Install Python {selected} or update base_manifest.yaml."
+        )
+    return interpreter
+
+
+def ensure_existing_project_venv_matches_requirement(
+    python_bin: Path,
+    project: str,
+    python_requirement: str,
+) -> None:
+    policy = evaluate_python_requirement(python_requirement)
+    if not policy.ok or policy.selected_version is None:
+        raise ArtifactError(
+            f"python.requires_python '{python_requirement}' {policy.error}. "
+            "Choose a Python version supported by Base."
+        )
+
+    interpreter = inspect_python_interpreter(python_bin)
+    if interpreter is None or interpreter.version == policy.selected_version:
+        return
+
+    expected = version_label(policy.selected_version)
+    actual = version_label(interpreter.version)
+    raise ArtifactError(
+        f"Project virtual environment '{python_bin.parent.parent}' uses Python {actual}, "
+        f"but python.requires_python '{python_requirement}' selects Python {expected}. "
+        f"Run 'basectl setup {project} --recreate-venv' to recreate the project virtual environment."
+    )
 
 
 def backup_existing_project_venv(ctx: base_cli.Context, venv_dir: Path, dry_run: bool) -> None:
@@ -396,7 +496,7 @@ def reconcile_python_artifacts_sequential(
         process.run_command(ctx, pip_install_command(python_bin, (requirement,)))
 
 
-def python_requirement(definition: ArtifactDefinition, version: str) -> str:
+def python_package_requirement(definition: ArtifactDefinition, version: str) -> str:
     return f"{definition.package}=={version}" if version != "latest" else definition.package
 
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -10,6 +10,7 @@ from base_cli.paths import discover_manifest
 
 from .artifacts import check_artifact
 from .artifacts import merge_artifacts
+from .artifacts import ProjectRuntimeConfig
 from .artifacts import reconcile_artifacts
 from .artifacts import resolve_artifact_definitions
 from .build import check_build
@@ -39,6 +40,7 @@ from .ide import reconcile_ide_installs
 from .ide import reconcile_ide_settings
 from .manifest import BaseManifest, ManifestError, read_manifest
 from .pyproject import check_pyproject
+from .python_policy import python_requirement_checks
 from .uv import check_uv
 from .uv import manifest_uses_uv_project_manager
 from .uv import reconcile_uv_project
@@ -210,7 +212,13 @@ def reconcile_manifest(
     reconcile_uv_project(ctx, effective_manifest, dry_run=dry_run)
 
     if artifacts:
-        reconcile_artifacts(ctx, artifacts, definitions, effective_manifest.project_name, dry_run=dry_run)
+        reconcile_artifacts(
+            ctx,
+            artifacts,
+            definitions,
+            project_runtime_argument(effective_manifest),
+            dry_run=dry_run,
+        )
 
     ctx.log.info("Project '%s' setup is complete.", effective_manifest.project_name)
 
@@ -229,7 +237,22 @@ def reconcile_bootstrap_artifacts(
         ctx.log.info("Base default manifest declares no bootstrap artifacts.")
         return
 
-    reconcile_artifacts(ctx, artifacts, definitions, manifest.project_name, dry_run=dry_run)
+    reconcile_artifacts(
+        ctx,
+        artifacts,
+        definitions,
+        project_runtime_argument(manifest),
+        dry_run=dry_run,
+    )
+
+
+def project_runtime_argument(manifest: BaseManifest) -> str | ProjectRuntimeConfig:
+    if manifest.python.requires_python is None:
+        return manifest.project_name
+    return ProjectRuntimeConfig(
+        name=manifest.project_name,
+        python_requirement=manifest.python.requires_python,
+    )
 
 
 def check_manifest(
@@ -329,7 +352,10 @@ def doctor_pre_venv_manifest(
 
 
 def pre_venv_manifest_checks(manifest: BaseManifest, remote_network: bool = False) -> tuple[ArtifactCheck, ...]:
-    return check_git_remote(manifest, check_network=remote_network)
+    checks: list[ArtifactCheck] = []
+    checks.extend(python_requirement_checks(manifest))
+    checks.extend(check_git_remote(manifest, check_network=remote_network))
+    return tuple(checks)
 
 
 def manifest_checks(
@@ -366,7 +392,7 @@ def manifest_checks(
     for artifact, definition in zip(artifacts, definitions, strict=True):
         checks.append(check_artifact(effective_manifest.project_name, artifact, definition))
 
-    if not checks:
+    if not pre_venv_checks and not checks:
         checks.append(
             ArtifactCheck(
                 name="manifest",

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -129,6 +129,7 @@ class ActivateConfig:
 @dataclass(frozen=True)
 class PythonConfig:
     manager: str | None = None
+    requires_python: str | None = None
 
 
 @dataclass(frozen=True)
@@ -690,21 +691,27 @@ def _read_python(path: Path, python_data: Any) -> PythonConfig:
     if not isinstance(python_data, dict):
         raise ManifestError(f"{path}: python must be a mapping when provided.")
 
-    allowed_keys = {"manager"}
+    allowed_keys = {"manager", "requires_python"}
     unknown_keys = sorted(set(python_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(f"{path}: python has unsupported keys: {', '.join(unknown_keys)}.")
 
     manager = python_data.get("manager")
-    if manager is None:
-        return PythonConfig()
-    if not isinstance(manager, str) or not manager.strip():
-        raise ManifestError(f"{path}: python.manager must be a non-empty string when provided.")
-    manager = manager.strip()
-    if manager not in SUPPORTED_PYTHON_MANAGERS:
-        supported = ", ".join(sorted(SUPPORTED_PYTHON_MANAGERS))
-        raise ManifestError(f"{path}: python.manager must be one of: {supported}.")
-    return PythonConfig(manager=manager)
+    if manager is not None:
+        if not isinstance(manager, str) or not manager.strip():
+            raise ManifestError(f"{path}: python.manager must be a non-empty string when provided.")
+        manager = manager.strip()
+        if manager not in SUPPORTED_PYTHON_MANAGERS:
+            supported = ", ".join(sorted(SUPPORTED_PYTHON_MANAGERS))
+            raise ManifestError(f"{path}: python.manager must be one of: {supported}.")
+
+    requires_python = python_data.get("requires_python")
+    if requires_python is not None:
+        if not isinstance(requires_python, str) or not requires_python.strip():
+            raise ManifestError(f"{path}: python.requires_python must be a non-empty string when provided.")
+        requires_python = requires_python.strip()
+
+    return PythonConfig(manager=manager, requires_python=requires_python)
 
 
 def _read_optional_runner(path: Path, field_name: str, runner_data: Any) -> str | None:

--- a/cli/python/base_setup/python_policy.py
+++ b/cli/python/base_setup/python_policy.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .checks import ArtifactCheck
+from .manifest import BaseManifest
+
+
+SUPPORTED_PYTHON_MIN = (3, 10)
+SUPPORTED_PYTHON_MAX = (3, 13)
+SUPPORTED_PYTHON_MINORS = tuple((3, minor) for minor in range(10, 14))
+PYTHON_REQUIREMENT_FINDING_ID = "BASE-P170"
+PYTHON_INTERPRETER_FINDING_ID = "BASE-P171"
+
+_EXACT_VERSION_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?$")
+_SPECIFIER_RE = re.compile(r"^(?P<operator>==|>=|<=|>|<)\s*(?P<version>\d+(?:\.\d+){1,2})$")
+
+
+@dataclass(frozen=True)
+class PythonRequirementPolicy:
+    requested: str
+    selected_version: tuple[int, int] | None
+    reason: str
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.selected_version is not None and not self.error
+
+
+@dataclass(frozen=True)
+class PythonSpecifier:
+    operator: str
+    version: tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class PythonInterpreter:
+    path: Path
+    version: tuple[int, int]
+
+
+ResolvePythonInterpreter = Callable[[tuple[int, int]], PythonInterpreter | None]
+
+
+def python_requirement_checks(
+    manifest: BaseManifest,
+    resolve_interpreter: ResolvePythonInterpreter = None,
+) -> tuple[ArtifactCheck, ...]:
+    policy_check = python_requirement_policy_check(manifest)
+    if policy_check is None:
+        return ()
+    checks = [policy_check]
+    if policy_check.ok:
+        interpreter_check = python_interpreter_availability_check(manifest, resolve_interpreter=resolve_interpreter)
+        if interpreter_check is not None:
+            checks.append(interpreter_check)
+    return tuple(checks)
+
+
+def python_requirement_policy_check(manifest: BaseManifest) -> ArtifactCheck | None:
+    requested = manifest.python.requires_python
+    if requested is None:
+        return None
+
+    policy = evaluate_python_requirement(requested)
+    details = {
+        "requested": requested,
+        "supported_min": version_label(SUPPORTED_PYTHON_MIN),
+        "supported_max": version_label(SUPPORTED_PYTHON_MAX),
+    }
+    if policy.selected_version is not None:
+        details["selected_version"] = version_label(policy.selected_version)
+    if policy.ok:
+        selected = version_label(policy.selected_version)
+        return ArtifactCheck(
+            name="python.requires_python",
+            ok=True,
+            message=f"Project Python requirement '{requested}' selects supported Python {selected}.",
+            fix="",
+            finding_id=PYTHON_REQUIREMENT_FINDING_ID,
+            details=details,
+        )
+
+    return ArtifactCheck(
+        name="python.requires_python",
+        ok=False,
+        message=f"Project Python requirement '{requested}' {policy.error}.",
+        fix=(
+            "Set python.requires_python to a Python version or range within "
+            f"{version_label(SUPPORTED_PYTHON_MIN)} through {version_label(SUPPORTED_PYTHON_MAX)}."
+        ),
+        finding_id=PYTHON_REQUIREMENT_FINDING_ID,
+        details=details,
+    )
+
+
+def python_interpreter_availability_check(
+    manifest: BaseManifest,
+    resolve_interpreter: ResolvePythonInterpreter = None,
+) -> ArtifactCheck | None:
+    requested = manifest.python.requires_python
+    if requested is None:
+        return None
+
+    policy = evaluate_python_requirement(requested)
+    if not policy.ok:
+        return None
+
+    selected_version = policy.selected_version
+    assert selected_version is not None
+    selected_label = version_label(selected_version)
+    if resolve_interpreter is None:
+        resolve_interpreter = resolve_python_interpreter
+    interpreter = resolve_interpreter(selected_version)
+    details = {
+        "requested": requested,
+        "selected_version": selected_label,
+    }
+    if interpreter is None:
+        return ArtifactCheck(
+            name="python.interpreter",
+            ok=False,
+            message=(
+                f"Project Python requirement '{requested}' selects supported Python {selected_label}, "
+                f"but Python {selected_label} is not available."
+            ),
+            fix=f"Install Python {selected_label} or update python.requires_python in base_manifest.yaml.",
+            finding_id=PYTHON_INTERPRETER_FINDING_ID,
+            details=details,
+        )
+
+    details["python"] = str(interpreter.path)
+    if interpreter.version != selected_version:
+        actual_label = version_label(interpreter.version)
+        return ArtifactCheck(
+            name="python.interpreter",
+            ok=False,
+            message=(
+                f"Project Python requirement '{requested}' selects Python {selected_label}, "
+                f"but '{interpreter.path}' reports Python {actual_label}."
+            ),
+            fix=f"Install Python {selected_label} or update python.requires_python in base_manifest.yaml.",
+            finding_id=PYTHON_INTERPRETER_FINDING_ID,
+            details=details | {"actual_version": actual_label},
+        )
+
+    return ArtifactCheck(
+        name="python.interpreter",
+        ok=True,
+        message=f"Python {selected_label} is available at '{interpreter.path}'.",
+        fix="",
+        finding_id=PYTHON_INTERPRETER_FINDING_ID,
+        details=details,
+    )
+
+
+def evaluate_python_requirement(requirement: str) -> PythonRequirementPolicy:
+    requirement = requirement.strip()
+    exact = parse_exact_minor(requirement)
+    if exact is not None:
+        if exact in SUPPORTED_PYTHON_MINORS:
+            return PythonRequirementPolicy(requirement, exact, "exact")
+        return PythonRequirementPolicy(requirement, None, "exact", unsupported_reason((exact,)))
+
+    specifiers = parse_specifiers(requirement)
+    if specifiers is None:
+        return PythonRequirementPolicy(requirement, None, "invalid", "cannot parse this Python requirement")
+
+    supported_matches = tuple(
+        version for version in SUPPORTED_PYTHON_MINORS if specifiers_allow_minor(specifiers, version)
+    )
+    if supported_matches:
+        return PythonRequirementPolicy(requirement, supported_matches[-1], "range")
+
+    requested_matches = tuple(
+        version for version in candidate_python_minors() if specifiers_allow_minor(specifiers, version)
+    )
+    return PythonRequirementPolicy(requirement, None, "range", unsupported_reason(requested_matches))
+
+
+def parse_exact_minor(value: str) -> tuple[int, int] | None:
+    match = _EXACT_VERSION_RE.fullmatch(value)
+    if match is None:
+        return None
+    return int(match.group("major")), int(match.group("minor"))
+
+
+def parse_specifiers(value: str) -> tuple[PythonSpecifier, ...] | None:
+    specifiers: list[PythonSpecifier] = []
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            return None
+        match = _SPECIFIER_RE.fullmatch(part)
+        if match is None:
+            return None
+        specifiers.append(
+            PythonSpecifier(
+                operator=match.group("operator"),
+                version=parse_version(match.group("version")),
+            )
+        )
+    return tuple(specifiers)
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    parts = [int(part) for part in value.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    return parts[0], parts[1], parts[2]
+
+
+def specifiers_allow_minor(specifiers: tuple[PythonSpecifier, ...], version: tuple[int, int]) -> bool:
+    candidate = version[0], version[1], 0
+    return all(specifier_allows_version(specifier, candidate) for specifier in specifiers)
+
+
+def specifier_allows_version(specifier: PythonSpecifier, candidate: tuple[int, int, int]) -> bool:
+    if specifier.operator == "==":
+        return candidate[:2] == specifier.version[:2]
+    if specifier.operator == ">=":
+        return candidate >= specifier.version
+    if specifier.operator == ">":
+        return candidate > specifier.version
+    if specifier.operator == "<=":
+        return candidate <= specifier.version
+    if specifier.operator == "<":
+        return candidate < specifier.version
+    raise AssertionError(f"unsupported Python specifier operator: {specifier.operator}")
+
+
+def candidate_python_minors() -> tuple[tuple[int, int], ...]:
+    return tuple((3, minor) for minor in range(0, 21))
+
+
+def unsupported_reason(matches: tuple[tuple[int, int], ...]) -> str:
+    if matches:
+        if max(matches) < SUPPORTED_PYTHON_MIN:
+            return "asks for Python older than Base supports"
+        if min(matches) > SUPPORTED_PYTHON_MAX:
+            return "asks for Python newer than Base supports"
+    return "does not select a Python version supported by Base"
+
+
+def version_label(version: tuple[int, int] | None) -> str:
+    if version is None:
+        return ""
+    return f"{version[0]}.{version[1]}"
+
+
+def resolve_python_interpreter(selected_version: tuple[int, int]) -> PythonInterpreter | None:
+    seen: set[Path] = set()
+    for candidate in python_interpreter_candidates(selected_version):
+        candidate = candidate.expanduser()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        interpreter = inspect_python_interpreter(candidate)
+        if interpreter is not None and interpreter.version == selected_version:
+            return interpreter
+    return None
+
+
+def python_interpreter_candidates(selected_version: tuple[int, int]) -> tuple[Path, ...]:
+    label = version_label(selected_version)
+    formula = f"python@{label}"
+    candidates: list[Path] = []
+
+    override = os.environ.get("BASE_PROJECT_PYTHON_BIN")
+    if override:
+        candidates.append(Path(override))
+
+    for prefix in ("/opt/homebrew", "/usr/local"):
+        candidates.append(Path(prefix) / "opt" / formula / "bin" / "python3")
+        candidates.append(Path(prefix) / "opt" / formula / "bin" / f"python{label}")
+        candidates.append(Path(prefix) / "opt" / formula / "libexec" / "bin" / "python3")
+        candidates.append(Path(prefix) / "opt" / formula / "libexec" / "bin" / f"python{label}")
+
+    brew = shutil.which("brew")
+    if brew:
+        brew_prefix = homebrew_formula_prefix(brew, formula)
+        if brew_prefix is not None:
+            candidates.append(brew_prefix / "bin" / "python3")
+            candidates.append(brew_prefix / "bin" / f"python{label}")
+            candidates.append(brew_prefix / "libexec" / "bin" / "python3")
+            candidates.append(brew_prefix / "libexec" / "bin" / f"python{label}")
+
+    for command in (f"python{label}", "python3"):
+        resolved = shutil.which(command)
+        if resolved:
+            candidates.append(Path(resolved))
+
+    candidates.append(Path(sys.executable))
+    return tuple(candidates)
+
+
+def homebrew_formula_prefix(brew: str, formula: str) -> Path | None:
+    try:
+        completed = subprocess.run(
+            [brew, "--prefix", formula],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    prefix = completed.stdout.strip()
+    if completed.returncode or not prefix:
+        return None
+    return Path(prefix)
+
+
+def inspect_python_interpreter(candidate: Path) -> PythonInterpreter | None:
+    if not candidate.is_file() or not os.access(candidate, os.X_OK):
+        return None
+    try:
+        completed = subprocess.run(
+            [
+                str(candidate),
+                "-c",
+                "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode:
+        return None
+    version = parse_exact_minor(completed.stdout.strip())
+    if version is None:
+        return None
+    return PythonInterpreter(path=candidate, version=version)

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -18,6 +18,7 @@ from base_setup.manifest import BaseManifest
 from base_setup.manifest import HealthConfig
 from base_setup.manifest import IdeConfig
 from base_setup.manifest import PortHealthConfig
+from base_setup.manifest import PythonConfig
 from base_setup.manifest import read_manifest
 from base_setup.registry import get_artifact_definition
 from base_setup.tests.helpers import fake_context, run_engine
@@ -440,6 +441,71 @@ class ProjectCheckTests(unittest.TestCase):
             findings[0]["fix"],
             "Start the service that should listen on 127.0.0.1:5432.",
         )
+
+    def test_check_json_reports_unsupported_python_requirement(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            python=PythonConfig(requires_python="3.9"),
+        )
+
+        with redirect_stdout(io.StringIO()) as stdout:
+            status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual([check["id"] for check in payload["checks"]], ["BASE-P170"])
+        self.assertEqual(payload["checks"][0]["status"], "error")
+        self.assertIn("older than Base supports", payload["checks"][0]["message"])
+
+    def test_pre_venv_checks_include_python_requirement_policy(self) -> None:
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            python=PythonConfig(requires_python=">=3.14"),
+        )
+
+        checks = engine.pre_venv_manifest_checks(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P170"])
+        self.assertIn("newer than Base supports", checks[0].message)
+
+    def test_check_json_reports_supported_python_requirement_without_interpreter(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            python=PythonConfig(requires_python="3.12"),
+        )
+
+        with mock.patch("base_setup.python_policy.resolve_python_interpreter", return_value=None), redirect_stdout(
+            io.StringIO()
+        ) as stdout:
+            status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 1)
+        self.assertEqual([check["id"] for check in payload["checks"]], ["BASE-P170", "BASE-P171"])
+        self.assertEqual([check["status"] for check in payload["checks"]], ["ok", "error"])
+        self.assertIn("Python 3.12 is not available", payload["checks"][1]["message"])
 
     def test_manifest_checks_include_same_directory_pyproject(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -39,6 +39,7 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertFalse(manifest.artifacts[0].bootstrap)
         self.assertEqual(manifest.activate.source, ())
         self.assertIsNone(manifest.python.manager)
+        self.assertIsNone(manifest.python.requires_python)
 
     def test_rejects_missing_manifest_path_with_manifest_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -69,6 +70,28 @@ class ManifestParsingTests(unittest.TestCase):
 
         self.assertEqual(manifest.python.manager, "uv")
 
+    def test_reads_manifest_python_requirement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "python:",
+                        "  requires_python: '>=3.11,<3.14'",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertEqual(manifest.python.requires_python, ">=3.11,<3.14")
+
 
     def test_rejects_invalid_manifest_python_config(self) -> None:
         invalid_values = {
@@ -77,6 +100,8 @@ class ManifestParsingTests(unittest.TestCase):
             "empty_manager": "python:\n  manager: ''",
             "non_string_manager": "python:\n  manager: 7",
             "unsupported_manager": "python:\n  manager: poetry",
+            "empty_requires_python": "python:\n  requires_python: ''",
+            "non_string_requires_python": "python:\n  requires_python: 7",
         }
         for name, python_yaml in invalid_values.items():
             with self.subTest(name=name):

--- a/cli/python/base_setup/tests/test_python_policy.py
+++ b/cli/python/base_setup/tests/test_python_policy.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from base_setup.manifest import BaseManifest
+from base_setup.manifest import PythonConfig
+from base_setup.python_policy import PythonInterpreter
+from base_setup.python_policy import python_interpreter_availability_check
+from base_setup.python_policy import python_requirement_policy_check
+from base_setup.python_policy import python_requirement_checks
+
+
+def manifest_with_python_requirement(requirement: str | None) -> BaseManifest:
+    return BaseManifest(
+        path=Path("base_manifest.yaml"),
+        project_name="demo",
+        brewfile=None,
+        artifacts=(),
+        python=PythonConfig(requires_python=requirement),
+    )
+
+
+class PythonPolicyTests(unittest.TestCase):
+
+    def test_default_python_requirement_has_no_policy_check(self) -> None:
+        self.assertIsNone(python_requirement_policy_check(manifest_with_python_requirement(None)))
+
+    def test_supported_exact_python_minor_requirements_are_ok(self) -> None:
+        for requirement in ("3.10", "3.11", "3.12", "3.13"):
+            with self.subTest(requirement=requirement):
+                check = python_requirement_policy_check(manifest_with_python_requirement(requirement))
+
+            self.assertIsNotNone(check)
+            assert check is not None
+            self.assertTrue(check.ok)
+            self.assertEqual(check.finding_id, "BASE-P170")
+            self.assertEqual(check.details["requested"], requirement)
+            self.assertEqual(check.details["selected_version"], requirement)
+            self.assertIn(f"selects supported Python {requirement}", check.message)
+
+    def test_supported_python_range_selects_highest_supported_minor(self) -> None:
+        check = python_requirement_policy_check(manifest_with_python_requirement(">=3.11,<3.14"))
+
+        self.assertIsNotNone(check)
+        assert check is not None
+        self.assertTrue(check.ok)
+        self.assertEqual(check.details["requested"], ">=3.11,<3.14")
+        self.assertEqual(check.details["selected_version"], "3.13")
+
+    def test_rejects_python_requirements_below_supported_window(self) -> None:
+        for requirement in ("3.9", "<3.10"):
+            with self.subTest(requirement=requirement):
+                check = python_requirement_policy_check(manifest_with_python_requirement(requirement))
+
+            self.assertIsNotNone(check)
+            assert check is not None
+            self.assertFalse(check.ok)
+            self.assertEqual(check.finding_id, "BASE-P170")
+            self.assertIn("older than Base supports", check.message)
+            self.assertIn("3.10 through 3.13", check.fix)
+
+    def test_rejects_python_requirements_above_supported_window(self) -> None:
+        check = python_requirement_policy_check(manifest_with_python_requirement(">=3.14"))
+
+        self.assertIsNotNone(check)
+        assert check is not None
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P170")
+        self.assertIn("newer than Base supports", check.message)
+        self.assertIn("3.10 through 3.13", check.fix)
+
+    def test_invalid_python_requirement_reports_policy_error(self) -> None:
+        check = python_requirement_policy_check(manifest_with_python_requirement("=>3.11"))
+
+        self.assertIsNotNone(check)
+        assert check is not None
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P170")
+        self.assertIn("cannot parse", check.message)
+
+    def test_interpreter_availability_reports_supported_but_missing_python(self) -> None:
+        check = python_interpreter_availability_check(
+            manifest_with_python_requirement("3.12"),
+            resolve_interpreter=lambda _selected_version: None,
+        )
+
+        self.assertIsNotNone(check)
+        assert check is not None
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P171")
+        self.assertIn("Python 3.12 is not available", check.message)
+        self.assertIn("Install Python 3.12", check.fix)
+
+    def test_interpreter_availability_reports_supported_python_path(self) -> None:
+        python_path = Path("/opt/homebrew/opt/python@3.11/bin/python3.11")
+        check = python_interpreter_availability_check(
+            manifest_with_python_requirement("3.11"),
+            resolve_interpreter=lambda _selected_version: PythonInterpreter(
+                path=python_path,
+                version=(3, 11),
+            ),
+        )
+
+        self.assertIsNotNone(check)
+        assert check is not None
+        self.assertTrue(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P171")
+        self.assertEqual(check.details["python"], str(python_path))
+        self.assertEqual(check.details["selected_version"], "3.11")
+
+    def test_python_requirement_checks_include_policy_and_interpreter_availability(self) -> None:
+        checks = python_requirement_checks(
+            manifest_with_python_requirement("3.10"),
+            resolve_interpreter=lambda _selected_version: PythonInterpreter(
+                path=Path("/usr/local/bin/python3.10"),
+                version=(3, 10),
+            ),
+        )
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P170", "BASE-P171"])
+        self.assertTrue(all(check.ok for check in checks))

--- a/cli/python/base_setup/tests/test_python_version_artifacts.py
+++ b/cli/python/base_setup/tests/test_python_version_artifacts.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from base_setup import artifacts
+from base_setup.artifacts import ProjectRuntimeConfig
+from base_setup.errors import ArtifactError
+from base_setup.python_policy import PythonInterpreter
+from base_setup.registry import get_artifact_definition
+from base_setup.tests.helpers import fake_context
+
+
+class PythonVersionArtifactTests(unittest.TestCase):
+
+    def test_python_artifact_creates_requested_python_version_venv(self) -> None:
+        definition = get_artifact_definition("python-package", "requests")
+        self.assertIsNotNone(definition)
+        ctx = fake_context()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv_dir = Path(tmpdir) / "demo" / ".venv"
+            python_bin = Path(tmpdir) / "python3.12"
+            with mock.patch("base_setup.artifacts.project_venv_dir", return_value=venv_dir), mock.patch(
+                "base_setup.artifacts.python_artifact_installed",
+                return_value=False,
+            ), mock.patch(
+                "base_setup.artifacts.resolve_python_interpreter",
+                return_value=PythonInterpreter(path=python_bin, version=(3, 12)),
+            ), mock.patch(
+                "base_setup.process.run_command"
+            ) as run_command:
+                artifacts.reconcile_python_artifact(
+                    ctx,
+                    definition,
+                    "latest",
+                    ProjectRuntimeConfig(name="demo", python_requirement="3.12"),
+                    dry_run=False,
+                )
+
+        self.assertEqual(
+            run_command.call_args_list,
+            [
+                mock.call(ctx, [str(python_bin), "-m", "venv", str(venv_dir)]),
+                mock.call(
+                    ctx,
+                    [
+                        str(venv_dir / "bin" / "python"),
+                        "-m",
+                        "pip",
+                        "install",
+                        "--disable-pip-version-check",
+                        "requests",
+                    ],
+                ),
+            ],
+        )
+
+    def test_python_artifact_rejects_existing_venv_with_wrong_python_version(self) -> None:
+        definition = get_artifact_definition("python-package", "requests")
+        self.assertIsNotNone(definition)
+        ctx = fake_context()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv_dir = Path(tmpdir) / "demo" / ".venv"
+            python_bin = venv_dir / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/bin/sh\nprintf '3.13\\n'\n", encoding="utf-8")
+            python_bin.chmod(0o755)
+
+            with mock.patch("base_setup.artifacts.project_venv_dir", return_value=venv_dir), mock.patch(
+                "base_setup.artifacts.python_artifact_installed",
+                return_value=False,
+            ), mock.patch("base_setup.process.run_command") as run_command:
+                with self.assertRaisesRegex(ArtifactError, "uses Python 3.13"):
+                    artifacts.reconcile_python_artifact(
+                        ctx,
+                        definition,
+                        "latest",
+                        ProjectRuntimeConfig(name="demo", python_requirement="3.12"),
+                        dry_run=False,
+                    )
+
+        run_command.assert_not_called()
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -462,11 +462,13 @@ project venv is therefore
 `~/.base.d/base/.venv`. The wrapper `bin/base-wrapper` runs Python packages
 through that project-scoped venv.
 
-A structured `python:` manifest section is the preferred future shape when
-projects need to express requirement files, package requirement strings, or venv
-settings more clearly than artifact rows allow. That section is not part of the
-current manifest contract. See [python-manifest.md](python-manifest.md) for the
-design target and migration boundary.
+A structured `python:` manifest section owns Python project runtime policy.
+`python.manager: uv` delegates environment setup to uv. `python.requires_python`
+lets a project select a supported Python 3.10 through 3.13 minor for
+Base-managed virtualenv creation, while check/doctor distinguish unsupported
+requests from supported-but-unavailable interpreters. See
+[python-manifest.md](python-manifest.md) for the current contract and migration
+boundary.
 
 Homebrew-managed `tool` artifacts currently support `version: latest`. If a
 project requests a pinned Homebrew version, setup fails clearly instead of

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -138,6 +138,8 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P154` | uv-managed project virtual environment readiness |
 | `BASE-P160` | Manifest command executable availability |
 | `BASE-P161` | Manifest command project script path readiness |
+| `BASE-P170` | Project Python version requirement support window |
+| `BASE-P171` | Selected project Python interpreter availability |
 
 `BASE-P050` is the stable project virtual-environment readiness finding. The
 Bash setup/check path reports detailed venv health messages when a project venv
@@ -165,6 +167,14 @@ for obvious missing executables or missing/non-executable project script paths
 without executing command strings or treating the manifest as safe. They should
 not reject complex shell syntax or replace human review of unfamiliar
 repositories.
+
+`BASE-P170` and `BASE-P171` are project Python runtime diagnostics for
+`python.requires_python`. `BASE-P170` validates the request against Base's
+supported Python 3.10 through 3.13 window. `BASE-P171` reports whether the
+selected supported interpreter is available locally. Setup uses the selected
+interpreter when it creates a Base-managed project virtual environment and
+requires `--recreate-venv` before replacing an existing venv with a different
+Python minor.
 
 `BASE-P080` through `BASE-P083` are read-only project Git remote diagnostics.
 They report whether the project directory is inside a Git repository, whether

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -18,6 +18,33 @@ That environment defaults to:
 ~/.base.d/<project>/.venv
 ```
 
+Projects can also declare the Python runtime they need:
+
+```yaml
+python:
+  requires_python: "3.12"
+```
+
+`requires_python` accepts an exact Python minor, such as `3.10`, `3.11`,
+`3.12`, or `3.13`, or a simple comma-separated range such as
+`>=3.11,<3.14`. Base's supported project runtime window is Python 3.10 through
+Python 3.13. `basectl check` and `basectl doctor` report requests outside that
+window as errors before project virtualenv checks hide the real cause.
+
+When a Base-managed project venv must be created, `basectl setup` uses the
+selected supported Python minor instead of blindly inheriting Base's own
+interpreter. For a range, Base selects the highest supported minor that matches
+the range. If the selected interpreter is unavailable, setup/check/doctor report
+that separately from an unsupported requirement. Base looks for
+`BASE_PROJECT_PYTHON_BIN`, common Homebrew `python@<major.minor>` locations,
+matching `python<major.minor>` commands on `PATH`, and finally the current
+interpreter when its minor matches.
+
+If an existing Base-managed project virtual environment uses a different Python
+minor than `python.requires_python` selects, setup stops and asks the user to
+rerun with `--recreate-venv`. Base does not rewrite an existing virtual
+environment in place.
+
 The uv-managed shape is explicit:
 
 ```yaml
@@ -176,8 +203,11 @@ If the uv environment does not exist yet, activation asks the user to run
 
 ## Diagnostics
 
-uv support adds these project diagnostics:
+Python manifest support adds these project diagnostics:
 
+- `BASE-P170`: project `python.requires_python` compatibility with Base's
+  supported Python runtime window
+- `BASE-P171`: selected project Python interpreter availability
 - `BASE-P150`: uv CLI availability for uv-managed projects or uv runners
 - `BASE-P151`: uv-managed project `pyproject.toml` presence
 - `BASE-P152`: uv-managed project `uv.lock` presence
@@ -204,6 +234,7 @@ Base should not:
 - infer uv behavior just because `pyproject.toml` or `uv.lock` exists
 - automatically wrap commands in `uv run` unless the command declares
   `runner: uv`
+- install every Python minor a project may request
 - support multiple project virtual environments in one Base manifest
 
 Base owns project discovery, activation, setup/check/doctor orchestration, and


### PR DESCRIPTION
## Summary
- Add `python.requires_python` manifest support with Base's Python 3.10 through 3.13 policy window.
- Report unsupported requirements separately from supported-but-unavailable interpreters through `BASE-P170` and `BASE-P171`.
- Use the selected interpreter when creating Base-managed project virtualenvs, and stop on wrong-version existing venvs until `--recreate-venv` is used.
- Document the Python runtime contract in docs and AI context.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover cli/python/base_setup/tests`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover cli/python/base_projects/tests`
- `env PYTHONPATH=lib/python:cli/python /bin/bash -lc 'rg --files -g "*.py" -0 | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc'`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

## Demo Impact
- None. Setup/check behavior only.

Fixes #855