### PR TITLE
Support manifest-declared PR policy

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -55,7 +55,9 @@ the canonical current command list.
     issue. Pass `--size <T|S|M|L>` when the issue scope is clear; otherwise
     Project metadata defaults to `Size=S`.
   - `basectl gh pr create` auto-injects `Fixes #<issue>` from Base branch
-    names; pass `--no-fixes` to suppress that body injection.
+    names; pass `--no-fixes` to suppress that body injection. When
+    `base_manifest.yaml` declares `github.pr`, it renders the PR body from
+    that project policy.
   - `basectl gh project doctor --project <title>` - inspect Project metadata
     fields against the Base Project schema.
   - `basectl gh project configure --project <title>` - create or repair the

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -62,7 +62,9 @@ clean it up after merge.
 Pull requests are issue-backed by default and scoped to one issue unless there
 is a documented exception. `basectl gh pr create` adds `Fixes #<issue>` from
 Base branch names by default; pass `--no-fixes` only when the PR should not
-close the issue automatically. PR bodies should include:
+close the issue automatically. If `base_manifest.yaml` declares `github.pr`,
+the command renders required PR sections from that project policy. PR bodies
+should include:
 
 - summary of what changed and why
 - issue reference such as `Fixes #<issue>` or `Closes #<issue>`

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -25,6 +25,29 @@ release:
     formula_path: Formula/base.rb
     package: basefoundry/base/base
 
+github:
+  pr:
+    required_sections:
+      default:
+        - Summary
+        - Issue
+        - Validation
+      labels:
+        needs-demo:
+          - Demo Impact
+        security:
+          - Security Notes
+        breaking-change:
+          - Migration Notes
+      paths:
+        docs/**:
+          - Docs Impact
+        .ai-context/**:
+          - AI Context Impact
+        migrations/**:
+          - Migration Plan
+          - Rollback Plan
+
 # Optional relative path to a Homebrew Brewfile for ordinary macOS tools.
 # Base runs `brew bundle --file=<path>` during setup when this is set.
 # Keep Base-specific managed dependencies in `artifacts`; use Brewfile for

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -49,7 +49,9 @@ Notes:
   - When the GitHub repo is known, issue create also adds the issue to the
     repo-named Project and applies defaults from .github/base-project.yml.
   - PR creation auto-injects Fixes #<issue> when the branch follows the Base
-    naming convention. Pass --no-fixes to suppress that body injection.
+    naming convention. If base_manifest.yaml declares github.pr, the generated
+    body also follows that project policy. Pass --no-fixes to suppress body
+    injection.
   - Pull request implementation work should happen in a dedicated worktree.
   - Branch and worktree pruning are dry-run by default and apply only when --yes is passed.
 EOF
@@ -99,6 +101,7 @@ Purpose:
 Notes:
   - PR creation links the current issue automatically when the branch follows
     <category>/<issue>-<YYYYMMDD>-<slug>.
+  - base_manifest.yaml may declare github.pr sections for generated PR bodies.
   - --no-fixes disables automatic Fixes #<issue> body injection for create.
   - Pull request implementation work should happen in a dedicated worktree.
 EOF
@@ -287,6 +290,26 @@ base_gh_issue_title() {
     gh issue view "$issue" --json title --jq '.title'
 }
 
+base_gh_issue_labels() {
+    local issue="$1"
+
+    gh issue view "$issue" --json labels --jq '.labels[].name' 2>/dev/null || true
+}
+
+base_gh_pr_changed_paths() {
+    local default_branch base_ref candidate
+
+    default_branch="$(base_gh_default_branch)"
+    for candidate in "origin/$default_branch" "$default_branch"; do
+        if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then
+            base_ref="$candidate"
+            break
+        fi
+    done
+    [[ -n "${base_ref:-}" ]] || return 0
+    git diff --name-only "$base_ref"...HEAD
+}
+
 base_gh_infer_github_repo() {
     local remote_url
 
@@ -332,6 +355,16 @@ base_gh_project_config_path() {
     root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
     [[ -n "$root" ]] || return 1
     path="$root/.github/base-project.yml"
+    [[ -f "$path" ]] || return 1
+    printf '%s\n' "$path"
+}
+
+base_gh_manifest_path() {
+    local root path
+
+    root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    [[ -n "$root" ]] || return 1
+    path="$root/base_manifest.yaml"
     [[ -f "$path" ]] || return 1
     printf '%s\n' "$path"
 }
@@ -397,6 +430,34 @@ base_gh_project_issue_set_fields() {
         return 1
     }
     "$wrapper" --project base base_github_projects project issue set-fields "$@"
+}
+
+base_gh_pr_policy_body() {
+    local issue="$1"
+    local manifest wrapper label path
+    local policy_args=()
+
+    manifest="$(base_gh_manifest_path || true)"
+    if [[ -z "$manifest" ]]; then
+        printf 'Fixes #%s\n' "$issue"
+        return 0
+    fi
+
+    wrapper="${BASE_GH_PYTHON_WRAPPER:-${BASE_GH_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}}"
+    [[ -x "$wrapper" ]] || {
+        printf 'Fixes #%s\n' "$issue"
+        return 0
+    }
+
+    policy_args=(--project base base_pr_policy body --manifest "$manifest" --issue "$issue")
+    while IFS= read -r label || [[ -n "$label" ]]; do
+        [[ -n "$label" ]] && policy_args+=(--label "$label")
+    done < <(base_gh_issue_labels "$issue")
+    while IFS= read -r path || [[ -n "$path" ]]; do
+        [[ -n "$path" ]] && policy_args+=(--path "$path")
+    done < <(base_gh_pr_changed_paths)
+
+    "$wrapper" "${policy_args[@]}"
 }
 
 base_gh_validate_project_size() {
@@ -616,7 +677,11 @@ base_gh_pr_create() {
     issue="$(base_gh_current_issue_from_branch || true)"
     if [[ -n "$issue" && "$no_fixes" -eq 0 ]]; then
         body_file="$(mktemp "${TMPDIR:-/tmp}/basectl-gh-pr.XXXXXX")" || return 1
-        printf 'Fixes #%s\n' "$issue" > "$body_file"
+        base_gh_pr_policy_body "$issue" > "$body_file" || {
+            status=$?
+            rm -f "$body_file"
+            return "$status"
+        }
         printf 'Auto-linking PR to issue #%s from branch name. Pass --no-fixes to suppress.\n' "$issue"
         base_gh_run pr create --fill --body-file "$body_file" "${passthrough[@]}"
         status=$?

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -1064,6 +1064,101 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/body")" = "Fixes #117" ]
 }
 
+@test "basectl gh pr create renders project PR policy body" {
+    local repo repo_root
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    repo_root="$(cd "$repo" && pwd -P)"
+    mkdir -p "$repo/docs"
+    cat > "$repo/base_manifest.yaml" <<'EOF'
+project:
+  name: demo
+github:
+  pr:
+    required_sections:
+      default:
+        - Summary
+        - Issue
+        - Validation
+      labels:
+        needs-demo:
+          - Demo Impact
+      paths:
+        docs/**:
+          - Docs Impact
+artifacts: []
+EOF
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c "enhancement/117-20260528-basectl-gh-workflow" >/dev/null
+    printf 'docs\n' > "$repo/docs/workflow.md"
+    commit_all "$repo" "Update docs"
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1 $2 $3" == "issue view 117" ]]; then
+    printf 'needs-demo\n'
+    exit 0
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+body_file=""
+while (($#)); do
+    if [[ "$1" == "--body-file" ]]; then
+        body_file="$2"
+        break
+    fi
+    shift
+done
+[[ -n "$body_file" ]] && cat "$body_file" > "${BASE_GH_TEST_STATE_DIR:?}/body"
+exit 0
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
+cat <<'BODY'
+## Summary
+
+## Issue
+
+Fixes #117
+
+## Validation
+
+## Demo Impact
+
+## Docs Impact
+BODY
+EOF
+    chmod +x "$TEST_MOCKBIN/base-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_PYTHON_WRAPPER="$TEST_MOCKBIN/base-wrapper" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main pr create
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Auto-linking PR to issue #117 from branch name. Pass --no-fixes to suppress."* ]]
+    [[ "$(cat "$TEST_STATE_DIR/gh-args")" == pr\ create\ --fill\ --body-file* ]]
+    [[ "$(cat "$TEST_STATE_DIR/wrapper-args")" == *"base_pr_policy body --manifest $repo_root/base_manifest.yaml --issue 117"* ]]
+    [[ "$(cat "$TEST_STATE_DIR/wrapper-args")" == *"--label needs-demo"* ]]
+    [[ "$(cat "$TEST_STATE_DIR/wrapper-args")" == *"--path docs/workflow.md"* ]]
+    [[ "$(cat "$TEST_STATE_DIR/body")" == *"## Demo Impact"* ]]
+    [[ "$(cat "$TEST_STATE_DIR/body")" == *"## Docs Impact"* ]]
+}
+
 @test "basectl gh pr create supports no-fixes opt out" {
     local repo
 

--- a/cli/python/base_pr_policy/__init__.py
+++ b/cli/python/base_pr_policy/__init__.py
@@ -1,0 +1,1 @@
+"""Pull request policy helpers for Base-managed projects."""

--- a/cli/python/base_pr_policy/__main__.py
+++ b/cli/python/base_pr_policy/__main__.py
@@ -1,0 +1,5 @@
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_pr_policy/engine.py
+++ b/cli/python/base_pr_policy/engine.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from base_cli.paths import discover_manifest
+from base_setup.github_manifest import GithubPrConfig
+from base_setup.manifest import ManifestError, read_manifest
+
+
+class PrPolicyError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PrPolicyInputs:
+    issue_number: int | None = None
+    labels: tuple[str, ...] = ()
+    paths: tuple[str, ...] = ()
+    template_body: str | None = None
+    project_root: Path | None = None
+
+
+def render_pr_body(policy: GithubPrConfig, inputs: PrPolicyInputs) -> str:
+    body = _template_body(policy, inputs).rstrip()
+    section_names = required_section_names(policy, labels=inputs.labels, paths=inputs.paths)
+    existing_sections = _existing_section_names(body)
+    issue_link_added = _has_issue_link(body, inputs.issue_number)
+
+    blocks = [body] if body else []
+    for section_name in section_names:
+        normalized_name = _normalize_section_name(section_name)
+        if normalized_name in existing_sections:
+            continue
+        if normalized_name == "issue" and inputs.issue_number is not None:
+            blocks.append(f"## {section_name}\n\nFixes #{inputs.issue_number}")
+            issue_link_added = True
+        else:
+            blocks.append(f"## {section_name}")
+        existing_sections.add(normalized_name)
+
+    if inputs.issue_number is not None and not issue_link_added:
+        blocks.append(f"Fixes #{inputs.issue_number}")
+
+    if not blocks:
+        return ""
+    return "\n\n".join(blocks).rstrip() + "\n"
+
+
+def required_section_names(
+    policy: GithubPrConfig,
+    *,
+    labels: tuple[str, ...] = (),
+    paths: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    sections: list[str] = list(policy.required_sections.default)
+    normalized_labels = {_normalize_label(label) for label in labels}
+
+    for label, label_sections in policy.required_sections.labels.items():
+        if _normalize_label(label) in normalized_labels:
+            sections.extend(label_sections)
+
+    for path_pattern, path_sections in policy.required_sections.paths.items():
+        if any(fnmatch.fnmatchcase(path, path_pattern) for path in paths):
+            sections.extend(path_sections)
+
+    return _dedupe_section_names(sections)
+
+
+def body_from_manifest(
+    manifest_path: Path,
+    *,
+    issue_number: int | None = None,
+    labels: tuple[str, ...] = (),
+    paths: tuple[str, ...] = (),
+) -> str:
+    manifest = read_manifest(manifest_path)
+    if manifest.github.pr is None:
+        return f"Fixes #{issue_number}\n" if issue_number is not None else ""
+    return render_pr_body(
+        manifest.github.pr,
+        PrPolicyInputs(
+            issue_number=issue_number,
+            labels=labels,
+            paths=paths,
+            project_root=manifest.path.parent,
+        ),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    if args.command == "body":
+        manifest_path = Path(args.manifest).expanduser().resolve() if args.manifest else discover_manifest(Path.cwd())
+        if manifest_path is None:
+            print("ERROR: No base_manifest.yaml found from the current directory upward.", file=sys.stderr)
+            return 2
+        try:
+            body = body_from_manifest(
+                manifest_path,
+                issue_number=args.issue,
+                labels=tuple(args.labels or ()),
+                paths=tuple(args.paths or ()),
+            )
+        except (ManifestError, PrPolicyError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+        sys.stdout.write(body)
+        return 0
+
+    parser.print_usage(sys.stderr)
+    return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="base_pr_policy")
+    subparsers = parser.add_subparsers(dest="command")
+    body_parser = subparsers.add_parser("body", help="Render a pull request body from base_manifest.yaml.")
+    body_parser.add_argument("--manifest", help="Path to base_manifest.yaml.")
+    body_parser.add_argument("--issue", type=int, help="Issue number to link with Fixes #<number>.")
+    body_parser.add_argument("--label", action="append", dest="labels", help="Issue or PR label name.")
+    body_parser.add_argument("--path", action="append", dest="paths", help="Changed path relative to the repo root.")
+    return parser
+
+
+def _template_body(policy: GithubPrConfig, inputs: PrPolicyInputs) -> str:
+    if inputs.template_body is not None:
+        return inputs.template_body
+    if policy.template is None:
+        return ""
+    if inputs.project_root is None:
+        return ""
+
+    project_root = inputs.project_root.resolve()
+    template_path = (project_root / policy.template).resolve()
+    try:
+        template_path.relative_to(project_root)
+    except ValueError as exc:
+        raise PrPolicyError(f"{policy.template}: PR template must stay inside the project root.") from exc
+    try:
+        return template_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PrPolicyError(f"{template_path}: unable to read PR template: {exc}") from exc
+
+
+def _existing_section_names(body: str) -> set[str]:
+    names: set[str] = set()
+    for line in body.splitlines():
+        match = re.match(r"^#{1,6}\s+(.+?)\s*(?:#+\s*)?$", line)
+        if match:
+            names.add(_normalize_section_name(match.group(1)))
+    return names
+
+
+def _has_issue_link(body: str, issue_number: int | None) -> bool:
+    if issue_number is None:
+        return False
+    pattern = re.compile(rf"\b(?:Fixes|Closes|Resolves)\s+#{issue_number}\b", re.IGNORECASE)
+    return bool(pattern.search(body))
+
+
+def _dedupe_section_names(sections: list[str]) -> tuple[str, ...]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for section in sections:
+        normalized = _normalize_section_name(section)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(section)
+    return tuple(deduped)
+
+
+def _normalize_label(label: str) -> str:
+    return label.strip().casefold()
+
+
+def _normalize_section_name(section_name: str) -> str:
+    return re.sub(r"\s+", " ", section_name.strip()).casefold()

--- a/cli/python/base_pr_policy/tests/test_engine.py
+++ b/cli/python/base_pr_policy/tests/test_engine.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from base_pr_policy.engine import PrPolicyInputs, render_pr_body
+from base_setup.github_manifest import GithubPrConfig, GithubPrRequiredSectionsConfig
+
+
+def test_render_pr_body_uses_default_label_and_path_sections() -> None:
+    policy = GithubPrConfig(
+        template=None,
+        required_sections=GithubPrRequiredSectionsConfig(
+            default=("Summary", "Issue", "Validation"),
+            labels={
+                "needs-demo": ("Demo Impact",),
+                "security": ("Security Notes",),
+            },
+            paths={
+                "docs/**": ("Docs Impact",),
+                "migrations/**": ("Migration Plan", "Rollback Plan"),
+            },
+        ),
+    )
+
+    body = render_pr_body(
+        policy,
+        PrPolicyInputs(
+            issue_number=403,
+            labels=("Needs-Demo",),
+            paths=("docs/github-workflow.md", "migrations/001.sql"),
+        ),
+    )
+
+    assert body == (
+        "## Summary\n\n"
+        "## Issue\n\n"
+        "Fixes #403\n\n"
+        "## Validation\n\n"
+        "## Demo Impact\n\n"
+        "## Docs Impact\n\n"
+        "## Migration Plan\n\n"
+        "## Rollback Plan\n"
+    )
+
+
+def test_render_pr_body_keeps_existing_template_sections_and_issue_link() -> None:
+    policy = GithubPrConfig(
+        template=".github/pull_request_template.md",
+        required_sections=GithubPrRequiredSectionsConfig(
+            default=("Summary", "Issue", "Validation"),
+            labels={},
+            paths={},
+        ),
+    )
+
+    body = render_pr_body(
+        policy,
+        PrPolicyInputs(issue_number=403, template_body="## Summary\n\nDone.\n"),
+    )
+
+    assert body == "## Summary\n\nDone.\n\n## Issue\n\nFixes #403\n\n## Validation\n"
+
+
+def test_render_pr_body_appends_issue_link_without_issue_section() -> None:
+    policy = GithubPrConfig(
+        template=None,
+        required_sections=GithubPrRequiredSectionsConfig(
+            default=("Summary",),
+            labels={},
+            paths={},
+        ),
+    )
+
+    body = render_pr_body(policy, PrPolicyInputs(issue_number=403))
+
+    assert body == "## Summary\n\nFixes #403\n"
+
+
+def test_render_pr_body_deduplicates_triggered_sections() -> None:
+    policy = GithubPrConfig(
+        template=None,
+        required_sections=GithubPrRequiredSectionsConfig(
+            default=("Summary", "Validation"),
+            labels={"needs-demo": ("Validation", "Demo Impact")},
+            paths={"demo/**": ("Demo Impact",)},
+        ),
+    )
+
+    body = render_pr_body(
+        policy,
+        PrPolicyInputs(labels=("needs-demo",), paths=("demo/run.sh",)),
+    )
+
+    assert body == "## Summary\n\n## Validation\n\n## Demo Impact\n"
+
+
+def test_template_body_from_policy_reads_relative_template(tmp_path: Path) -> None:
+    template_path = tmp_path / ".github" / "pull_request_template.md"
+    template_path.parent.mkdir()
+    template_path.write_text("## Summary\n\nSeeded.\n", encoding="utf-8")
+    policy = GithubPrConfig(
+        template=".github/pull_request_template.md",
+        required_sections=GithubPrRequiredSectionsConfig(default=(), labels={}, paths={}),
+    )
+
+    body = render_pr_body(policy, PrPolicyInputs(project_root=tmp_path))
+
+    assert body == "## Summary\n\nSeeded.\n"

--- a/cli/python/base_setup/github_manifest.py
+++ b/cli/python/base_setup/github_manifest.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+
+class GithubManifestError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class GithubPrRequiredSectionsConfig:
+    default: tuple[str, ...] = ()
+    labels: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    paths: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GithubPrConfig:
+    template: str | None = None
+    required_sections: GithubPrRequiredSectionsConfig = field(default_factory=GithubPrRequiredSectionsConfig)
+
+
+@dataclass(frozen=True)
+class GithubConfig:
+    pr: GithubPrConfig | None = None
+
+
+def read_github_config(path: Path, github_data: Any) -> GithubConfig:
+    if github_data is None:
+        return GithubConfig()
+    if not isinstance(github_data, dict):
+        raise GithubManifestError(f"{path}: github must be a mapping when provided.")
+
+    allowed_keys = {"pr"}
+    unknown_keys = sorted(set(github_data) - allowed_keys)
+    if unknown_keys:
+        raise GithubManifestError(f"{path}: github has unsupported keys: {', '.join(unknown_keys)}.")
+
+    return GithubConfig(pr=_read_github_pr(path, github_data.get("pr")))
+
+
+def _read_github_pr(path: Path, pr_data: Any) -> GithubPrConfig | None:
+    if pr_data is None:
+        return None
+    if not isinstance(pr_data, dict):
+        raise GithubManifestError(f"{path}: github.pr must be a mapping when provided.")
+
+    allowed_keys = {"template", "required_sections"}
+    unknown_keys = sorted(set(pr_data) - allowed_keys)
+    if unknown_keys:
+        raise GithubManifestError(f"{path}: github.pr has unsupported keys: {', '.join(unknown_keys)}.")
+
+    return GithubPrConfig(
+        template=_read_github_pr_template(path, pr_data.get("template")),
+        required_sections=_read_github_pr_required_sections(path, pr_data.get("required_sections")),
+    )
+
+
+def _read_github_pr_template(path: Path, template_data: Any) -> str | None:
+    if template_data is None:
+        return None
+    template = _read_string(path, "github.pr.template", template_data)
+    parsed_path = Path(template)
+    if parsed_path.is_absolute() or ".." in parsed_path.parts:
+        raise GithubManifestError(f"{path}: github.pr.template must be a relative path inside the project.")
+    return template
+
+
+def _read_github_pr_required_sections(path: Path, sections_data: Any) -> GithubPrRequiredSectionsConfig:
+    if sections_data is None:
+        return GithubPrRequiredSectionsConfig()
+    if not isinstance(sections_data, dict):
+        raise GithubManifestError(f"{path}: github.pr.required_sections must be a mapping when provided.")
+
+    allowed_keys = {"default", "labels", "paths"}
+    unknown_keys = sorted(set(sections_data) - allowed_keys)
+    if unknown_keys:
+        raise GithubManifestError(
+            f"{path}: github.pr.required_sections has unsupported keys: {', '.join(unknown_keys)}."
+        )
+
+    return GithubPrRequiredSectionsConfig(
+        default=_read_section_list(
+            path,
+            "github.pr.required_sections.default",
+            sections_data.get("default", []),
+        ),
+        labels=_read_section_map(
+            path,
+            "github.pr.required_sections.labels",
+            sections_data.get("labels", {}),
+        ),
+        paths=_read_section_map(
+            path,
+            "github.pr.required_sections.paths",
+            sections_data.get("paths", {}),
+        ),
+    )
+
+
+def _read_section_map(path: Path, field_name: str, sections_data: Any) -> dict[str, tuple[str, ...]]:
+    if sections_data is None:
+        return {}
+    if not isinstance(sections_data, dict):
+        raise GithubManifestError(f"{path}: {field_name} must be a mapping when provided.")
+
+    section_map: dict[str, tuple[str, ...]] = {}
+    for key_data, section_list_data in sections_data.items():
+        if not isinstance(key_data, str) or not key_data.strip():
+            raise GithubManifestError(f"{path}: {field_name} keys must be non-empty strings.")
+        key = key_data.strip()
+        if _has_control_line_break(key):
+            raise GithubManifestError(f"{path}: {field_name}.{key} must not contain control line breaks.")
+        section_map[key] = _read_section_list(path, f"{field_name}.{key}", section_list_data)
+    return section_map
+
+
+def _read_section_list(path: Path, field_name: str, sections_data: Any) -> tuple[str, ...]:
+    if sections_data is None:
+        return ()
+    if not isinstance(sections_data, list):
+        raise GithubManifestError(f"{path}: {field_name} must be a list when provided.")
+
+    sections: list[str] = []
+    seen: set[str] = set()
+    for index, section_data in enumerate(sections_data, start=1):
+        if not isinstance(section_data, str) or not section_data.strip():
+            raise GithubManifestError(f"{path}: {field_name}[{index}] must be a non-empty string.")
+        section = section_data.strip()
+        if _has_control_line_break(section):
+            raise GithubManifestError(f"{path}: {field_name}[{index}] must not contain control line breaks.")
+        if section in seen:
+            raise GithubManifestError(f"{path}: {field_name}[{index}] duplicates '{section}'.")
+        seen.add(section)
+        sections.append(section)
+    return tuple(sections)
+
+
+def _read_string(path: Path, field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise GithubManifestError(f"{path}: {field_name} must be a non-empty string.")
+    value = value.strip()
+    if _has_control_line_break(value):
+        raise GithubManifestError(f"{path}: {field_name} must not contain control line breaks.")
+    return value
+
+
+def _has_control_line_break(value: str) -> bool:
+    return any(separator in value for separator in ("\0", "\n", "\r"))

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -10,6 +10,9 @@ from base_cli.ide_schema import PROJECT_AUTO_SETTING_KEYS
 from base_cli.ide_schema import SUPPORTED_IDES
 from base_cli.ide_schema import parse_ide_extensions
 from base_cli.ide_schema import parse_ide_settings
+from base_setup.github_manifest import GithubConfig
+from base_setup.github_manifest import GithubManifestError
+from base_setup.github_manifest import read_github_config
 
 try:
     import yaml
@@ -146,6 +149,7 @@ class BaseManifest:
     commands: dict[str, CommandConfig] = field(default_factory=dict)
     activate: ActivateConfig = field(default_factory=ActivateConfig)
     python: PythonConfig = field(default_factory=PythonConfig)
+    github: GithubConfig = field(default_factory=GithubConfig)
     demo: DemoConfig | None = None
     build: BuildConfig | None = None
     release: ReleaseConfig | None = None
@@ -182,6 +186,7 @@ def read_manifest(path: Path) -> BaseManifest:
         "commands",
         "activate",
         "python",
+        "github",
         "demo",
         "build",
         "release",
@@ -200,6 +205,7 @@ def read_manifest(path: Path) -> BaseManifest:
     commands = _read_commands(path, data.get("commands"))
     activate = _read_activate(path, data.get("activate"))
     python = _read_python(path, data.get("python"))
+    github = _read_github(path, data.get("github"))
     demo = _read_demo(path, data.get("demo"))
     build = _read_build(path, data.get("build"))
     release = _read_release(path, data.get("release"))
@@ -218,6 +224,7 @@ def read_manifest(path: Path) -> BaseManifest:
         commands=commands,
         activate=activate,
         python=python,
+        github=github,
         demo=demo,
         build=build,
         release=release,
@@ -712,6 +719,13 @@ def _read_python(path: Path, python_data: Any) -> PythonConfig:
         requires_python = requires_python.strip()
 
     return PythonConfig(manager=manager, requires_python=requires_python)
+
+
+def _read_github(path: Path, github_data: Any) -> GithubConfig:
+    try:
+        return read_github_config(path, github_data)
+    except GithubManifestError as exc:
+        raise ManifestError(str(exc)) from exc
 
 
 def _read_optional_runner(path: Path, field_name: str, runner_data: Any) -> str | None:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -93,6 +93,99 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.python.requires_python, ">=3.11,<3.14")
 
 
+    def test_reads_manifest_github_pr_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "github:",
+                        "  pr:",
+                        "    template: .github/pull_request_template.md",
+                        "    required_sections:",
+                        "      default:",
+                        "        - Summary",
+                        "        - Issue",
+                        "        - Validation",
+                        "      labels:",
+                        "        needs-demo:",
+                        "          - Demo Impact",
+                        "        security:",
+                        "          - Security Notes",
+                        "      paths:",
+                        "        docs/**:",
+                        "          - Docs Impact",
+                        "        migrations/**:",
+                        "          - Migration Plan",
+                        "          - Rollback Plan",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.github.pr)
+        assert manifest.github.pr is not None
+        self.assertEqual(manifest.github.pr.template, ".github/pull_request_template.md")
+        required = manifest.github.pr.required_sections
+        self.assertEqual(required.default, ("Summary", "Issue", "Validation"))
+        self.assertEqual(required.labels["needs-demo"], ("Demo Impact",))
+        self.assertEqual(required.labels["security"], ("Security Notes",))
+        self.assertEqual(required.paths["docs/**"], ("Docs Impact",))
+        self.assertEqual(required.paths["migrations/**"], ("Migration Plan", "Rollback Plan"))
+
+
+    def test_rejects_invalid_manifest_github_pr_policy(self) -> None:
+        invalid_values = {
+            "scalar_github": "github: true",
+            "unknown_github_key": "github:\n  issues: {}",
+            "scalar_pr": "github:\n  pr: true",
+            "unknown_pr_key": "github:\n  pr:\n    body: {}",
+            "absolute_template": "github:\n  pr:\n    template: /tmp/pull_request_template.md",
+            "parent_template": "github:\n  pr:\n    template: ../pull_request_template.md",
+            "scalar_required_sections": "github:\n  pr:\n    required_sections: Summary",
+            "scalar_default": "github:\n  pr:\n    required_sections:\n      default: Summary",
+            "empty_default_section": "github:\n  pr:\n    required_sections:\n      default:\n        - ''",
+            "duplicate_default_section": (
+                "github:\n  pr:\n    required_sections:\n      default:\n        - Summary\n        - Summary"
+            ),
+            "scalar_labels": "github:\n  pr:\n    required_sections:\n      labels: needs-demo",
+            "empty_label": (
+                "github:\n  pr:\n    required_sections:\n      labels:\n        '':\n          - Demo Impact"
+            ),
+            "scalar_label_sections": (
+                "github:\n  pr:\n    required_sections:\n      labels:\n        needs-demo: Demo Impact"
+            ),
+            "scalar_paths": "github:\n  pr:\n    required_sections:\n      paths: docs/**",
+            "empty_path": "github:\n  pr:\n    required_sections:\n      paths:\n        '':\n          - Docs Impact",
+            "unknown_required_sections_key": "github:\n  pr:\n    required_sections:\n      teams: {}",
+        }
+        for name, github_yaml in invalid_values.items():
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                github_yaml,
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(ManifestError):
+                        read_manifest(manifest_path)
+
+
     def test_rejects_invalid_manifest_python_config(self) -> None:
         invalid_values = {
             "scalar": "python: uv",

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -74,7 +74,7 @@ inspect the resolved command contract first.
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |
 | `basectl gh issue create` | Create an issue with Base category conventions, assign it, and add repo Project metadata when the repo is known. Defaults to `--category enhancement` and Project `Size=S` when omitted. | `--category <bug\|enhancement\|documentation\|ci\|security>`, `--title <title>`, `--body <body>`, `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--size <T\|S\|M\|L>`, `--no-project` |
 | `basectl gh issue start <number>` | Start issue-backed branch naming workflow. | `--category <category>`, `--title <title>` |
-| `basectl gh pr create/status/checks/ready/merge` | Create and manage pull requests through Base's workflow wrapper. `pr create` auto-injects `Fixes #<issue>` from Base branch names unless `--no-fixes` is passed. | passes through `gh` options; `pr create` also accepts `--no-fixes` |
+| `basectl gh pr create/status/checks/ready/merge` | Create and manage pull requests through Base's workflow wrapper. `pr create` auto-injects `Fixes #<issue>` from Base branch names unless `--no-fixes` is passed, and uses `github.pr` from `base_manifest.yaml` when present. | passes through `gh` options; `pr create` also accepts `--no-fixes` |
 | `basectl gh branch stale` | Report stale local branches. | `--days <days>` |
 | `basectl gh branch prune` | Prune safe merged branches. | `--dry-run`, `--yes`, `--remote` |
 | `basectl gh worktree prune` | Prune stale merged worktrees. | `--dry-run`, `--yes` |

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -133,7 +133,8 @@ tooling is authenticated.
 default for one issue. `basectl gh pr create` auto-injects `Fixes #<issue>`
 when the current branch follows the Base `<category>/<issue>-<YYYYMMDD>-<slug>`
 convention; pass `--no-fixes` when the PR should not close the issue
-automatically.
+automatically. When `base_manifest.yaml` declares `github.pr`, PR creation
+renders the body from that project policy and still preserves the issue link.
 
 Fallbacks are allowed when `basectl gh` does not support the needed operation,
 when local GitHub CLI authentication is unavailable, or when the GitHub
@@ -265,6 +266,36 @@ PR bodies should include:
 
 Prefer small PR trains over large mixed PRs. A train may contain several
 worktrees and PRs, but each PR should still close one issue cleanly.
+
+Projects can declare their PR body policy in `base_manifest.yaml`:
+
+```yaml
+github:
+  pr:
+    template: .github/pull_request_template.md
+    required_sections:
+      default:
+        - Summary
+        - Issue
+        - Validation
+      labels:
+        needs-demo:
+          - Demo Impact
+        security:
+          - Security Notes
+        breaking-change:
+          - Migration Notes
+      paths:
+        docs/**:
+          - Docs Impact
+        migrations/**:
+          - Migration Plan
+          - Rollback Plan
+```
+
+`default` sections are always rendered. `labels` and `paths` add sections when
+the linked issue or changed files match. Missing sections are appended to the
+configured template, and duplicate headings are skipped.
 
 ### PR Metadata Inheritance
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -293,6 +293,11 @@ portable: `Summary`, `Issue`, `Validation`, `Notes`, and a short checklist.
 Base-specific sections such as `Demo Impact` belong only in projects that
 choose that policy.
 
+Projects that need generated PR body sections can declare them in
+`base_manifest.yaml` under `github.pr.required_sections`. Use `default` for
+sections every PR should carry, `labels` for issue or PR label triggers, and
+`paths` for changed-file globs.
+
 ## GitHub Configuration
 
 `repo init` creates the GitHub repository when needed, using private visibility


### PR DESCRIPTION
## Summary
- Add `github.pr` manifest schema for default, label-triggered, and path-triggered PR sections.
- Add a `base_pr_policy` renderer and wire `basectl gh pr create` to use project policy while preserving `Fixes #<issue>`.
- Declare Base's own PR policy and update workflow docs plus `.ai-context/`.

## Issue
Fixes #403

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_manifest`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_pr_policy/tests/test_engine.py cli/python/base_github_projects/tests/test_engine.py -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats --filter 'basectl gh pr create'`
- `rg --files -g '*.py' -0 | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc`
- `git diff --check`
- `git diff --cached --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

## Docs Impact
- Updated `docs/github-workflow.md`, `docs/command-reference.md`, and `docs/repo-baseline.md`.

## AI Context Impact
- Updated `.ai-context/COMMANDS.md` and `.ai-context/WORKFLOWS.md`.

## Demo Impact
- None. CLI workflow behavior and docs only.