### PR TITLE
Cross-link activate.source setup boundary docs

### DIFF
--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -31,6 +31,9 @@ Instead, use the typed contracts Base already understands:
 `activate.source` is intentionally not a setup hook: it does not run during
 `basectl setup`, `basectl check`, or `basectl doctor`, and it exists only for
 shell state that must affect the activated interactive subshell.
+See the `activate.source` field in [Architecture - Project Manifest](architecture.md#project-manifest)
+for the full shell activation contract, including when it runs and its scope
+relative to setup.
 
 When a project needs a product-specific guided installer or imperative
 bootstrap, that logic should live in the project repository, for example:


### PR DESCRIPTION
## Summary
- Link the `activate.source` setup-hook alternative to the architecture manifest contract.
- Clarify where to read when the activation-time shell scripts run relative to setup.

## Issue
Fixes #979

## Validation
- `git diff --check`

## Docs Impact
- Documentation-only cross-reference update.

## AI Context Impact
- None.

## Demo Impact
- None.