### PR TITLE
Document workspace manifest source formats

### DIFF
--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -162,6 +162,34 @@ default. Remote source fetching is therefore an explicit manifest-file update,
 not passive workspace discovery, and it does not clone, pull, reset, or rewrite
 project repositories.
 
+### Accepted Source Formats
+
+`workspace.manifest_source` accepts these source shapes:
+
+```yaml
+workspace:
+  manifest_source: file:///Users/alex/work/platform/workspace.yaml
+```
+
+```yaml
+workspace:
+  manifest_source: https://raw.githubusercontent.com/example/platform/main/workspace.yaml
+```
+
+```yaml
+workspace:
+  manifest_source: ~/work/platform/workspace.yaml
+```
+
+```yaml
+workspace:
+  manifest_source: /opt/base/workspaces/platform.yaml
+```
+
+Use Git SSH clone URLs such as `git@github.com:example/service.git` only in
+workspace manifest `repos[].url` entries. They identify repositories to clone;
+they are not workspace manifest source URLs.
+
 ## Trust And Authentication
 
 Base should delegate repository authentication to Git, SSH, and the GitHub CLI.


### PR DESCRIPTION
## Summary
- Add concrete `workspace.manifest_source` examples for `file:///`, raw HTTPS, relative/user-local paths, and absolute local paths.
- Clarify that SSH clone URLs belong in workspace manifest `repos[].url`, not `manifest_source`.

## Issue
Fixes #980

## Validation
- `git diff --check`

## Docs Impact
- Documentation-only examples in `docs/workspace-manifest.md`.

## AI Context Impact
- None.

## Demo Impact
- None.