### PR TITLE
Document Base self-demo script path

### DIFF
--- a/docs/project-demo-workflow.md
+++ b/docs/project-demo-workflow.md
@@ -123,9 +123,11 @@ Base has its own self-demo:
 basectl demo base -- --non-interactive
 ```
 
-That script lives in the Base repository at `demo/demo.sh`. It demonstrates the
-Base control-plane workflow using Base itself and does not depend on the
-external reference repository.
+That script lives in the Base repository at `$BASE_HOME/demo/demo.sh`. It
+demonstrates the Base control-plane workflow using Base itself and does not
+depend on the external reference repository. It follows the same
+`--non-interactive` pattern described above, so contributors can compare their
+own demo scripts against a working reference.
 
 ## Reference Project
 


### PR DESCRIPTION
## Summary
- Document the Base self-demo script as `$BASE_HOME/demo/demo.sh`.
- Note that it follows the same `--non-interactive` pattern as project demo scripts.

## Issue
Fixes #988

## Validation
- `git diff --check`

## Docs Impact
- Documentation-only self-demo reference update.

## AI Context Impact
- None.

## Demo Impact
- Clarifies the existing Base self-demo reference path; no demo behavior changed.