### PR TITLE
Cross-link base-wrapper and base_cli FAQ entries

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -125,6 +125,10 @@ For example, Homebrew exposes both executables under the Homebrew prefix, but
 `basectl` or a project-owned launcher instead of invoking `base-wrapper`
 directly.
 
+`base-wrapper` answers "which Python environment should run this package?",
+while `base_cli` answers "how should a Base Python CLI behave?" See the
+`base_cli` question below for that package's role.
+
 ### Why does Base require an external base-bash-libs checkout or package?
 
 Base's reusable Bash helpers live in the standalone


### PR DESCRIPTION
## Summary
- Add a transitional sentence from the `base-wrapper` FAQ entry to the adjacent `base_cli` explanation.
- Clarify the boundary between environment selection and Python CLI behavior.

## Issue
Fixes #989

## Validation
- `git diff --check`

## Docs Impact
- Documentation-only FAQ cross-link update.

## AI Context Impact
- None.

## Demo Impact
- None.