### PR TITLE
Document first external PR path

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -26,6 +26,11 @@ Issue creation is unassigned by default unless `basectl gh issue create`
 receives `--assignee <login>` or `.github/base-project.yml` sets
 `project.issue_defaults.assignee`; use `--no-assignee` to skip that repo-local
 default for a specific issue.
+Starter issues for first external contributors use the `good first issue`
+label only when the issue has explicit acceptance criteria, concrete Project
+metadata, `Size` `T` or `S`, and local validation that does not require private
+state. Use `help wanted` without `good first issue` for broader work where
+outside help is useful but deeper Base context is needed.
 
 Base-managed repositories should carry `.github/workflows/project-intake.yml`
 as the fallback for issues created outside `basectl gh issue create`.
@@ -101,6 +106,9 @@ behavior, installation layout assumptions, or public behavior that cannot be
 proven by a focused unit test.
 
 Documentation-only changes usually need `git diff --check`.
+First external PRs should start from an issue labeled `good first issue`.
+Contributor-facing guidance lives in `CONTRIBUTING.md`; the workflow policy and
+starter-issue criteria live in `docs/github-workflow.md`.
 
 ## Release Flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,35 @@ Base source development resolves reusable Bash libraries from the sibling
 `~/work/base-bash-libs` checkout. If that checkout already exists, update it
 instead of cloning a second copy.
 
+## First External PR
+
+Start with an open issue labeled `good first issue`. A good first contribution
+should be real Base work, but it should also be small enough to review without
+private maintainer context: documentation corrections, narrow test coverage,
+small fixture updates, or tightly scoped command-output polish are usually good
+fits.
+
+Before opening the PR:
+
+1. Read the issue acceptance notes and ask for clarification on the issue when
+   the expected result is not explicit.
+2. Create an issue branch and worktree using the workflow above.
+3. Make the smallest change that satisfies the issue.
+4. Run the narrowest validation command that proves the change.
+
+For documentation-only starter issues, `git diff --check` is usually enough.
+For Python-only changes, run the focused pytest target with
+`PYTHONPATH=lib/python:cli/python python -m pytest`. For shell command or
+runtime changes, run the focused BATS test when one exists and broaden only
+when the change crosses command boundaries.
+
+When the full source-checkout suite is needed from a linked worktree under
+`~/work/base-worktrees`, export the reusable Bash library path first:
+
+```bash
+BASE_BASH_LIBS_DIR=~/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test
+```
+
 ## Running Tests
 
 Run the narrowest relevant checks first, then broaden when the change touches

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -24,10 +24,40 @@ Use one primary category label on each issue:
 - `needs-demo`
   Changes that should update Base's self-demo, the `base-demo` reference
   project, or demo documentation. See [Demo Maintenance](demo-maintenance.md).
+- `good first issue`
+  Small, well-scoped issues that an external contributor can complete without
+  private maintainer context.
+- `help wanted`
+  Issues where maintainers want outside contribution, even if the work is too
+  broad or specialized to be a first contribution.
 
 Avoid creating new `type:*` labels. Older issues may still carry historical
 `type:fix`, `type:feat`, `type:chore`, or `type:docs` labels, but new work
 should use the labels above.
+
+## Starter Issues
+
+Use `good first issue` only when the issue is genuinely ready for a first
+external PR. Starter issues should have:
+
+- clear acceptance criteria in the issue body
+- one primary category label, usually `documentation`, `ci`, or a very narrow
+  `enhancement`
+- Project fields set before advertising the issue: `Status` `Ready`,
+  `Priority` `P3` or `P2`, a concrete `Area`, `Initiative`, and `Size` `T` or
+  `S`
+- a validation path that can be run locally without credentials, paid services,
+  or private repository state
+
+Good first issues should not require architectural decisions, cross-command
+refactors, release coordination, secret configuration, or knowledge that only
+maintainers have. Use `help wanted` without `good first issue` when outside
+help is welcome but the work needs deeper Base context.
+
+Maintainers should keep at least one real starter issue open when the project is
+inviting new contributors. If no open backlog item qualifies, create a small
+documentation, fixture, or test-hygiene issue instead of labeling broad design
+work as a starter task.
 
 ## Issue Assignment
 


### PR DESCRIPTION
## Summary
- Add first external PR guidance to CONTRIBUTING.
- Document good first issue/help wanted criteria and starter issue expectations.
- Update .ai-context workflow notes for contributor issue handling.
- Seed starter issue #1006 as a real docs-only first-contribution candidate.

## Issue
Fixes #930

## Validation
- git diff --check

## Demo Impact
None.

## Notes
.ai-context/ was updated because contributor workflow guidance changed.