### PR TITLE
Move project setup routing into Python

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -835,15 +835,9 @@ setup_resolve_project_manifest() {
 
 setup_project_venv_dir() {
     local project="$1"
-    local project_root="${2:-}"
-    local manifest_path="${3:-}"
 
     if [[ "$project" != base && -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
         printf '%s\n' "$BASE_PROJECT_VENV_DIR"
-        return 0
-    fi
-    if [[ "$project" != base && -n "$project_root" ]] && setup_project_uses_uv_manager "$manifest_path"; then
-        printf '%s\n' "$project_root/.venv"
         return 0
     fi
     printf '%s\n' "$HOME/.base.d/$project/.venv"
@@ -855,17 +849,14 @@ setup_project_root_from_manifest() {
     (cd -- "$(dirname -- "$manifest_path")" && pwd -P)
 }
 
-setup_project_uses_uv_manager() {
-    local manifest_path="$1"
+setup_resolve_project_route() {
+    local project="$1"
+    local manifest_path="$2"
+    local python_bin="$3"
 
-    [[ -n "$manifest_path" && -f "$manifest_path" ]] || return 1
-    awk '
-        /^[[:space:]]*#/ { next }
-        /^[^[:space:]][^:]*:/ { in_python = 0 }
-        /^[[:space:]]*python:[[:space:]]*$/ { in_python = 1; next }
-        in_python && /^[[:space:]]+manager:[[:space:]]*['\''"]?uv['\''"]?[[:space:]]*(#.*)?$/ { found = 1 }
-        END { exit found ? 0 : 1 }
-    ' "$manifest_path"
+    setup_ensure_cached_paths
+    env BASE_HOME="$BASE_HOME" BASE_PROJECT="$project" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+        "$python_bin" -m base_setup --manifest "$manifest_path" --action route "$project"
 }
 
 setup_project_check_record_path() {
@@ -1188,7 +1179,7 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path precheck_json project project_venv_dir python_bin remote_network resolved_name resolved_root resolve_output venv_dir
+    local exit_code manifest_path precheck_json project project_uses_uv_manager project_venv_dir python_bin remote_network resolved_name resolved_root resolve_output route_output venv_dir
     local args=()
     local project_env_args=()
 
@@ -1223,6 +1214,19 @@ setup_run_project_artifact_layer() {
         manifest_path="$resolve_output"
         resolved_root="$(setup_project_root_from_manifest "$manifest_path")" || return 1
     fi
+    route_output="$(setup_resolve_project_route "$project" "$manifest_path" "$python_bin")" || {
+        log_error "Unable to resolve Base project environment for '$project'."
+        return 1
+    }
+    IFS=$'\t' read -r project resolved_root manifest_path project_venv_dir project_uses_uv_manager <<<"$route_output"
+    if [[ -z "$project" || -z "$resolved_root" || -z "$manifest_path" || -z "$project_venv_dir" ]]; then
+        log_error "Python project routing returned incomplete metadata for '$project'."
+        return 1
+    fi
+    if [[ "$project_uses_uv_manager" != true && "$project_uses_uv_manager" != false ]]; then
+        log_error "Python project routing returned invalid uv-manager metadata for '$project'."
+        return 1
+    fi
     if [[ "$project" == base ]]; then
         project_env_args=(
             -u BASE_PROJECT
@@ -1255,7 +1259,7 @@ setup_run_project_artifact_layer() {
         fi
     fi
 
-    if [[ "$action" == setup ]] && ! setup_project_uses_uv_manager "$manifest_path"; then
+    if [[ "$action" == setup && "$project_uses_uv_manager" != true ]]; then
         setup_run_project_bootstrap_layer "$manifest_path" "$project" "$output_format"
         exit_code=$?
         if ((exit_code)); then
@@ -1265,8 +1269,7 @@ setup_run_project_artifact_layer() {
         fi
     fi
 
-    project_venv_dir="$(setup_project_venv_dir "$project" "$resolved_root" "$manifest_path")"
-    if ! setup_project_uses_uv_manager "$manifest_path" && ! setup_virtualenv_healthy_path "$project_venv_dir"; then
+    if [[ "$project_uses_uv_manager" != true ]] && ! setup_virtualenv_healthy_path "$project_venv_dir"; then
         if setup_is_dry_run && [[ "$action" == setup ]]; then
             log_info "[DRY-RUN] Would run Python project setup layer through base-wrapper for project '$project'."
             return 0
@@ -1309,7 +1312,7 @@ setup_run_project_artifact_layer() {
         return 1
     fi
 
-    if setup_project_uses_uv_manager "$manifest_path"; then
+    if [[ "$project_uses_uv_manager" == true ]]; then
         env "${project_env_args[@]}" \
             BASE_HOME="$BASE_HOME" \
             BASE_PROJECT="$project" \

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -627,6 +627,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "$HOME/.base.d/demo/.venv"
+        exit 0
+    fi
     printf 'ok     demo-artifact               Project artifact check passed.\n'
     exit 0
 fi
@@ -710,6 +714,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "$HOME/.base.d/demo/.venv"
+        exit 0
+    fi
     printf '%s\n' "$@" > "${BASE_TEST_PROJECT_ARGS:?}"
     printf 'ok     demo-artifact               Project artifact check passed.\n'
     exit 0
@@ -791,6 +799,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "$HOME/.base.d/demo/.venv"
+        exit 0
+    fi
     printf '[{"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"}]\n'
     exit 0
 fi
@@ -870,6 +882,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "$HOME/.base.d/demo/.venv"
+        exit 0
+    fi
     printf '%s\n' "$@" > "${BASE_TEST_PROJECT_ARGS:?}"
     shift 2
     action="setup"

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -54,6 +54,10 @@ if [[ "${1:-}" == "--version" ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        exit 0
+    fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -95,6 +95,10 @@ if [[ "${1:-}" == "--version" ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        exit 0
+    fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
@@ -172,6 +176,10 @@ if [[ "${1:-}" == "--version" ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        exit 0
+    fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
@@ -219,6 +227,10 @@ VENVEOF
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        exit 0
+    fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
@@ -320,6 +332,10 @@ if [[ "${1:-}" == "--version" ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        exit 0
+    fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
@@ -367,6 +383,10 @@ VENVEOF
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        exit 0
+    fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
@@ -530,18 +550,18 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     shift 2
-    printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-args"
-    printf '%s\n' "$0" >> "$BASE_SETUP_TEST_STATE_DIR/project-setup-python"
-    printf '%s\n' "${BASE_PROJECT:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-project"
-    printf '%s\n' "${BASE_CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-base-ci"
-    printf '%s\n' "${CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-ci"
-    printf '%s\n' "${BASE_SETUP_NOTIFY:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-notify"
-    touch "$BASE_SETUP_TEST_STATE_DIR/project-setup-ran"
+    original_args=("$@")
     action="setup"
+    manifest_path=""
     output_format="text"
+    project_arg=""
     remote_network=false
     while (($#)); do
         case "$1" in
+            --manifest)
+                shift
+                manifest_path="${1:-}"
+                ;;
             --action)
                 shift
                 action="${1:-}"
@@ -553,9 +573,52 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
             --remote-network)
                 remote_network=true
                 ;;
+            --*)
+                ;;
+            *)
+                project_arg="$1"
+                ;;
         esac
         shift || true
     done
+    if [[ "$action" == "route" ]]; then
+        project_root="$(cd -- "$(dirname -- "$manifest_path")" && pwd -P)"
+        if [[ -z "$project_arg" && -f "$manifest_path" ]]; then
+            project_arg="$(awk '/^[[:space:]]*name:/ { print $2; exit }' "$manifest_path")"
+        fi
+        if awk '
+            /^[[:space:]]*#/ { next }
+            /^[^[:space:]][^:]*:/ { in_python = 0 }
+            /^[[:space:]]*python:[[:space:]]*$/ { in_python = 1; next }
+            in_python && /^[[:space:]]+manager:[[:space:]]*['\''"]?uv['\''"]?[[:space:]]*(#.*)?$/ { found = 1 }
+            END { exit found ? 0 : 1 }
+        ' "$manifest_path"; then
+            uses_uv_manager=true
+        else
+            uses_uv_manager=false
+        fi
+        if [[ "$project_arg" != base && -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+            route_venv_dir="$BASE_PROJECT_VENV_DIR"
+        elif [[ "$project_arg" != base && "$uses_uv_manager" == true ]]; then
+            route_venv_dir="$project_root/.venv"
+        else
+            route_venv_dir="$HOME/.base.d/$project_arg/.venv"
+        fi
+        if [[ "$output_format" == "json" ]]; then
+            printf '{"schema_version":1,"project":"%s","project_root":"%s","manifest_path":"%s","project_venv_dir":"%s","uses_uv_manager":%s}\n' \
+                "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager"
+        else
+            printf '%s\t%s\t%s\t%s\t%s\n' "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager"
+        fi
+        exit 0
+    fi
+    printf '%s\n' "${original_args[@]}" > "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-args"
+    printf '%s\n' "$0" >> "$BASE_SETUP_TEST_STATE_DIR/project-setup-python"
+    printf '%s\n' "${BASE_PROJECT:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-project"
+    printf '%s\n' "${BASE_CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-base-ci"
+    printf '%s\n' "${CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-ci"
+    printf '%s\n' "${BASE_SETUP_NOTIFY:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-notify"
+    touch "$BASE_SETUP_TEST_STATE_DIR/project-setup-ran"
     if [[ "$action" == "bootstrap" ]]; then
         printf '%s\n' "${BASE_SETUP_RECREATE_PROJECT_VENV:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-bootstrap-recreate-venv"
     fi

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -40,6 +40,8 @@ from .ide import reconcile_ide_installs
 from .ide import reconcile_ide_settings
 from .manifest import BaseManifest, ManifestError, read_manifest
 from .pyproject import check_pyproject
+from .project_routing import route_for_manifest
+from .project_routing import route_to_text
 from .python_policy import python_requirement_checks
 from .uv import check_uv
 from .uv import manifest_uses_uv_project_manager
@@ -69,7 +71,7 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option(
     "--action",
     default="setup",
-    help="Action to run: setup, bootstrap, check, or doctor. Defaults to setup.",
+    help="Action to run: setup, bootstrap, check, doctor, or route. Defaults to setup.",
 )
 @base_cli.option("--format", "output_format", default="text", help="Output format for check/doctor: text or json.")
 @base_cli.option(
@@ -99,22 +101,27 @@ def run(
     try:
         base_manifest = read_manifest(manifest_path)
         validate_project_name(base_manifest, project)
-        default_manifest = read_default_manifest(ctx)
-        return run_manifest_action(
-            ctx,
-            ManifestAction(action, dry_run, output_format, remote_network),
-            default_manifest,
-            base_manifest,
-        )
+        manifest_action = ManifestAction(action, dry_run, output_format, remote_network)
+        if action == "route":
+            status = route_manifest(ctx, manifest_action, base_manifest)
+        else:
+            default_manifest = read_default_manifest(ctx)
+            status = run_manifest_action(
+                ctx,
+                manifest_action,
+                default_manifest,
+                base_manifest,
+            )
     except ManifestError as exc:
         ctx.log.error(str(exc))
-        return 1
+        status = 1
     except ValueError as exc:
         ctx.log.error(str(exc))
-        return 1
+        status = 1
     except ArtifactError as exc:
         ctx.log.error(str(exc))
-        return 1
+        status = 1
+    return status
 
 
 def run_manifest_action(
@@ -160,11 +167,25 @@ def run_manifest_action(
         )
     else:
         ctx.log.error(
-            "Unsupported base_setup action '%s'. Expected setup, bootstrap, check, doctor, precheck, or predoctor.",
+            "Unsupported base_setup action '%s'. Expected setup, bootstrap, check, doctor, "
+            "route, precheck, or predoctor.",
             action,
         )
         status = 2
     return status
+
+
+def route_manifest(
+    ctx: base_cli.Context,
+    manifest_action: ManifestAction,
+    manifest: BaseManifest,
+) -> int:
+    try:
+        print(route_to_text(route_for_manifest(manifest), manifest_action.output_format))
+    except ValueError as exc:
+        ctx.log.error(str(exc))
+        return 2
+    return 0
 
 
 def validate_project_name(manifest: BaseManifest, expected_project: str | None) -> None:

--- a/cli/python/base_setup/project_routing.py
+++ b/cli/python/base_setup/project_routing.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from .manifest import BaseManifest
+from .uv import manifest_uses_uv_project_manager
+
+
+@dataclass(frozen=True)
+class ProjectRoute:
+    project: str
+    project_root: Path
+    manifest_path: Path
+    project_venv_dir: Path
+    uses_uv_manager: bool
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "project": self.project,
+            "project_root": str(self.project_root),
+            "manifest_path": str(self.manifest_path),
+            "project_venv_dir": str(self.project_venv_dir),
+            "uses_uv_manager": self.uses_uv_manager,
+        }
+
+    def to_tsv(self) -> str:
+        uses_uv = "true" if self.uses_uv_manager else "false"
+        return "\t".join(
+            [
+                self.project,
+                str(self.project_root),
+                str(self.manifest_path),
+                str(self.project_venv_dir),
+                uses_uv,
+            ]
+        )
+
+
+def route_for_manifest(manifest: BaseManifest) -> ProjectRoute:
+    project_root = manifest.path.parent.resolve()
+    manifest_path = manifest.path.resolve()
+    uses_uv_manager = manifest_uses_uv_project_manager(manifest)
+    return ProjectRoute(
+        project=manifest.project_name,
+        project_root=project_root,
+        manifest_path=manifest_path,
+        project_venv_dir=project_venv_dir(
+            manifest.project_name,
+            project_root=project_root,
+            uses_uv_manager=uses_uv_manager,
+        ),
+        uses_uv_manager=uses_uv_manager,
+    )
+
+
+def project_venv_dir(project: str, project_root: Path | None = None, uses_uv_manager: bool = False) -> Path:
+    override = os.environ.get("BASE_PROJECT_VENV_DIR")
+    if project != "base" and override:
+        return Path(override).expanduser()
+    if project != "base" and uses_uv_manager and project_root is not None:
+        return project_root / ".venv"
+    return Path.home() / ".base.d" / project / ".venv"
+
+
+def route_to_text(route: ProjectRoute, output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(route.to_json(), indent=2)
+    if output_format == "text":
+        return route.to_tsv()
+    raise ValueError(f"Unsupported route output format '{output_format}'. Expected text or json.")

--- a/cli/python/base_setup/tests/test_project_routing.py
+++ b/cli/python/base_setup/tests/test_project_routing.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from base_setup.tests.helpers import run_engine
+
+
+def write_manifest(root: Path, content: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    manifest_path = root / "base_manifest.yaml"
+    manifest_path.write_text(content, encoding="utf-8")
+    return manifest_path
+
+
+class ProjectRoutingTests(unittest.TestCase):
+    def test_route_json_reports_uv_project_venv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "demo"
+            manifest_path = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+
+            status, stdout, stderr = run_engine(
+                ["--manifest", str(manifest_path), "--action", "route", "--format", "json", "demo"]
+            )
+
+        self.assertEqual(status, 0, stderr)
+        route = json.loads(stdout)
+        self.assertEqual(route["schema_version"], 1)
+        self.assertEqual(route["project"], "demo")
+        self.assertEqual(route["project_root"], str(root.resolve()))
+        self.assertEqual(route["manifest_path"], str(manifest_path.resolve()))
+        self.assertEqual(route["project_venv_dir"], str(root.resolve() / ".venv"))
+        self.assertTrue(route["uses_uv_manager"])
+
+    def test_route_json_reports_base_managed_project_venv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "demo"
+            manifest_path = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+
+            status, stdout, stderr = run_engine(
+                ["--manifest", str(manifest_path), "--action", "route", "--format", "json", "demo"]
+            )
+
+        self.assertEqual(status, 0, stderr)
+        route = json.loads(stdout)
+        self.assertTrue(route["project_venv_dir"].endswith("/.base.d/demo/.venv"))
+        self.assertNotEqual(route["project_venv_dir"], str(root.resolve() / ".venv"))
+        self.assertFalse(route["uses_uv_manager"])
+
+    def test_route_text_emits_shell_friendly_tsv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "demo"
+            manifest_path = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+
+            status, stdout, stderr = run_engine(["--manifest", str(manifest_path), "--action", "route", "demo"])
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(
+            stdout,
+            "\t".join(
+                [
+                    "demo",
+                    str(root.resolve()),
+                    str(manifest_path.resolve()),
+                    str(root.resolve() / ".venv"),
+                    "true",
+                ]
+            )
+            + "\n",
+        )


### PR DESCRIPTION
## Summary
- Add a Python-owned project routing action for setup/check/doctor metadata.
- Use route metadata in setup_common.sh instead of parsing python.manager: uv in Bash.
- Preserve setup/check/doctor project behavior with updated BATS fixtures and coverage.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests -q
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/check.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/doctor.bats
- git diff --check
- rg -n 'awk|python\.manager|setup_project_uses_uv_manager|manager: uv' cli/bash/commands/basectl/subcommands/setup_common.sh (no matches)

Closes #1008