### PR TITLE
Move diagnostic JSON rendering into Python

### DIFF
--- a/cli/bash/commands/basectl/subcommands/ci.sh
+++ b/cli/bash/commands/basectl/subcommands/ci.sh
@@ -168,6 +168,51 @@ base_ci_check_or_doctor_delegate_args() {
     printf '%s\n' "$BASE_CI_PROJECT" --format "$BASE_CI_FORMAT"
 }
 
+base_ci_json_escape() {
+    local value="${1:-}"
+    local char code escaped i
+    local output=""
+    local LC_ALL=C
+
+    for ((i = 0; i < ${#value}; i++)); do
+        char="${value:i:1}"
+        case "$char" in
+            '"')
+                output+='\"'
+                ;;
+            '\')
+                output+='\\'
+                ;;
+            $'\b')
+                output+='\b'
+                ;;
+            $'\f')
+                output+='\f'
+                ;;
+            $'\n')
+                output+='\n'
+                ;;
+            $'\r')
+                output+='\r'
+                ;;
+            $'\t')
+                output+='\t'
+                ;;
+            *)
+                printf -v code '%d' "'$char"
+                if ((code < 32 || code == 127)); then
+                    printf -v escaped '\\u%04x' "$code"
+                    output+="$escaped"
+                else
+                    output+="$char"
+                fi
+                ;;
+        esac
+    done
+
+    printf '%s' "$output"
+}
+
 base_ci_print_setup_json() {
     local command_output="$1"
     local exit_code="$2"
@@ -186,13 +231,13 @@ base_ci_print_setup_json() {
     printf '  "schema_version": 1,\n'
     printf '  "command": "setup",\n'
     printf '  "status": "%s",\n' "$status"
-    printf '  "project": "%s",\n' "$(setup_json_escape "$BASE_CI_PROJECT")"
-    printf '  "output": "%s"' "$(setup_json_escape "$command_output")"
+    printf '  "project": "%s",\n' "$(base_ci_json_escape "$BASE_CI_PROJECT")"
+    printf '  "output": "%s"' "$(base_ci_json_escape "$command_output")"
     if ((exit_code)) && ((${#output_lines[@]})); then
         printf ',\n'
         printf '  "output_lines": [\n'
         for index in "${!output_lines[@]}"; do
-            printf '    "%s"' "$(setup_json_escape "${output_lines[$index]}")"
+            printf '    "%s"' "$(base_ci_json_escape "${output_lines[$index]}")"
             if ((index < ${#output_lines[@]} - 1)); then
                 printf ','
             fi

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -60,6 +60,35 @@ base_doctor_count_check_errors() {
     printf '%s\n' "$errors"
 }
 
+base_doctor_base_check_finding_id() {
+    case "$1" in
+        homebrew)
+            printf '%s\n' "BASE-D001"
+            ;;
+        xcode_command_line_tools)
+            printf '%s\n' "BASE-D002"
+            ;;
+        python)
+            printf '%s\n' "BASE-D003"
+            ;;
+        base_virtualenv)
+            printf '%s\n' "BASE-D004"
+            ;;
+        pyyaml)
+            printf '%s\n' "BASE-D005"
+            ;;
+        click)
+            printf '%s\n' "BASE-D006"
+            ;;
+        base_bash_libraries)
+            printf '%s\n' "BASE-D007"
+            ;;
+        *)
+            printf '%s\n' "BASE-D000"
+            ;;
+    esac
+}
+
 base_doctor_print_collected_check_results() {
     local count fix i status
 
@@ -76,7 +105,7 @@ base_doctor_print_collected_check_results() {
 
         base_doctor_print_finding \
             "$status" \
-            "$(setup_base_check_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
+            "$(base_doctor_base_check_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
             "${_BASE_SETUP_CHECK_NAMES[$i]}" \
             "${_BASE_SETUP_CHECK_MESSAGES[$i]}" \
             "$fix"
@@ -238,68 +267,43 @@ base_doctor_check_python_package() {
 }
 
 base_doctor_run_json() {
-    local errors=0 profile_errors=0 profile_json="[]"
+    local args=()
+    local count fix i
+    local profile_json="[]"
     local project="$1"
-    local project_errors=0 project_json="[]"
+    local project_json="[]"
     local remote_network="${2:-${BASE_SETUP_REMOTE_NETWORK:-}}"
-    local status="ok"
 
     BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true setup_collect_base_check_results warn || true
-    errors="$(base_doctor_count_check_errors)"
-    status="$(setup_check_results_status)"
 
     if setup_profiles_enabled; then
-        if profile_json="$(setup_run_base_dev_layer doctor --format json)"; then
-            profile_errors=0
-        else
-            profile_errors=$?
+        if ! profile_json="$(setup_run_base_dev_layer doctor --format json)"; then
             [[ -n "$profile_json" ]] || profile_json="[]"
-            errors=$((errors + profile_errors))
         fi
-        status="$(setup_merge_diagnostic_status "$status" "$(setup_json_payload_status "$profile_json")")"
     fi
 
     if [[ -n "$project" ]]; then
-        if project_json="$(setup_run_project_artifact_doctor_json "$remote_network")"; then
-            project_errors=0
-        else
-            project_errors=$?
+        if ! project_json="$(setup_run_project_artifact_doctor_json "$remote_network")"; then
             [[ -n "$project_json" ]] || project_json="[]"
-            errors=$((errors + project_errors))
         fi
-        status="$(setup_merge_diagnostic_status "$status" "$(setup_json_payload_status "$project_json")")"
     fi
 
-    printf '{\n'
-    printf '  "schema_version": 1,\n'
-    printf '  "status": "%s"' "$(setup_json_escape "$status")"
+    args+=(doctor-json)
     if [[ -n "$project" ]]; then
-        printf ',\n'
-        printf '  "project": "%s"' "$(setup_json_escape "$project")"
+        args+=(--project "$project")
     fi
-    printf ',\n'
-    printf '  "findings": [\n'
-    setup_print_check_json_results
-    printf '  ]'
-    if setup_profiles_enabled || [[ -n "$project" ]]; then
-        printf ',\n'
-    else
-        printf '\n'
-    fi
+    count="${#_BASE_SETUP_CHECK_NAMES[@]}"
+    for ((i = 0; i < count; i++)); do
+        fix="$(setup_check_result_recovery "$i")"
+        args+=(--finding "${_BASE_SETUP_CHECK_NAMES[$i]}" "$(setup_check_result_status "$i")" "${_BASE_SETUP_CHECK_MESSAGES[$i]}" "$fix")
+    done
     if setup_profiles_enabled; then
-        setup_print_json_property_value "$(setup_profile_json_key findings)" "$profile_json"
-        if [[ -n "$project" ]]; then
-            printf ',\n'
-        else
-            printf '\n'
-        fi
+        args+=(--embedded-payload "$(setup_profile_json_key findings)" "$profile_json")
     fi
     if [[ -n "$project" ]]; then
-        setup_print_json_property_value "project_findings" "$project_json"
+        args+=(--embedded-payload "project_findings" "$project_json")
     fi
-    printf '}\n'
-
-    [[ "$errors" -eq 0 ]]
+    setup_run_diagnostics_json "${args[@]}"
 }
 
 base_doctor_subcommand_main() {

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -796,6 +796,44 @@ setup_pythonpath() {
     printf '%s\n' "$_BASE_SETUP_PYTHONPATH_CACHE"
 }
 
+setup_diagnostics_python_bin() {
+    local candidate python_bin venv_dir
+    local candidates=()
+
+    setup_ensure_cached_paths
+    if command -v python3 >/dev/null 2>&1; then
+        candidates+=("$(command -v python3)")
+    fi
+    if python_bin="$(setup_find_python_bin)"; then
+        candidates+=("$python_bin")
+    fi
+    candidates+=("/usr/bin/python3")
+    for candidate in "${candidates[@]}"; do
+        if [[ -x "$candidate" ]] && env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+            "$candidate" -c 'import base_setup.diagnostics' >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+    if python_bin="$(setup_base_venv_python_bin "$venv_dir")" && env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+        "$python_bin" -c 'import base_setup.diagnostics' >/dev/null 2>&1; then
+        printf '%s\n' "$python_bin"
+        return 0
+    fi
+    return 1
+}
+
+setup_run_diagnostics_json() {
+    local python_bin
+
+    python_bin="$(setup_diagnostics_python_bin)" ||
+        fatal_error "Python is required to render Base diagnostic JSON."
+    setup_ensure_cached_paths
+    env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+        "$python_bin" -m base_setup.diagnostics "$@"
+}
+
 setup_resolve_project_manifest() {
     local project="$1"
     local python_bin="$2"
@@ -866,7 +904,7 @@ setup_project_check_record_path() {
 }
 
 setup_record_project_check_result() {
-    local checked_at path project="$1" status="$2" temp_file
+    local checked_at path project="$1" status="$2"
 
     [[ -n "$project" ]] || return 0
     case "$status" in
@@ -878,26 +916,12 @@ setup_record_project_check_result() {
     esac
 
     path="$(setup_project_check_record_path "$project")"
-    safe_mkdir -p "$(dirname "$path")" || return 0
-    temp_file="$path.$$"
     checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 0
-
-    {
-        printf '{\n'
-        printf '  "schema_version": 1,\n'
-        printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
-        printf '  "command": "basectl check",\n'
-        printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
-        printf '  "checked_at": "%s"\n' "$(setup_json_escape "$checked_at")"
-        printf '}\n'
-    } >"$temp_file" || {
-        rm -f -- "$temp_file"
-        return 0
-    }
-    mv -- "$temp_file" "$path" || {
-        rm -f -- "$temp_file"
-        return 0
-    }
+    setup_run_diagnostics_json record-check \
+        --project "$project" \
+        --status "$status" \
+        --checked-at "$checked_at" \
+        --output-path "$path" >/dev/null || return 0
 }
 
 setup_user_config_path() {
@@ -956,16 +980,6 @@ setup_recovery_project_venv() {
     local project="$1"
 
     printf "Run 'basectl setup %s --recreate-venv' to back up and recreate the project virtual environment.\n" "$project"
-}
-
-setup_json_array_items() {
-    local value="$1"
-
-    value="${value//$'\n'/}"
-    value="${value//$'\r'/}"
-    value="${value#\[}"
-    value="${value%\]}"
-    printf '%s' "$value"
 }
 
 setup_doctor_visual_status_enabled() {
@@ -1031,30 +1045,15 @@ setup_print_project_check_json_with_venv() {
     local message="$3"
     local fix="$4"
     local project="$5"
-    local items precheck_status status venv_status
+    local status
 
-    venv_status="$(setup_diagnostic_status_from_ok "$ok")"
-    precheck_status="$(setup_json_payload_status "$precheck_json")"
-    status="$(setup_merge_diagnostic_status "$precheck_status" "$venv_status")"
-    items="$(setup_json_array_items "$precheck_json")"
-
-    printf '{\n'
-    printf '  "schema_version": 1,\n'
-    printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
-    printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
-    printf '  "checks": [\n'
-    if [[ -n "$items" ]]; then
-        printf '    %s,\n' "$items"
-    fi
-    setup_print_check_json_item \
-        "" \
-        "BASE-P050" \
-        "$venv_status" \
-        "project_virtualenv" \
-        "$message" \
-        "$fix"
-    printf '  ]\n'
-    printf '}\n'
+    status="$(setup_diagnostic_status_from_ok "$ok")"
+    setup_run_diagnostics_json project-venv-check-json \
+        --project "$project" \
+        --status "$status" \
+        --message "$message" \
+        --fix "$fix" \
+        --precheck-json "$precheck_json"
 }
 
 setup_print_project_venv_check_json() {
@@ -1065,17 +1064,11 @@ setup_print_project_venv_check_json() {
     local status
 
     status="$(setup_diagnostic_status_from_ok "$ok")"
-    printf '{\n'
-    printf '  "schema_version": 1,\n'
-    printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
-    printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
-    printf '  "checks": [\n'
-    printf '    {"id":"BASE-P050","status":"%s","name":"project_virtualenv","message":"%s","fix":"%s"}\n' \
-        "$(setup_json_escape "$status")" \
-        "$(setup_json_escape "$message")" \
-        "$(setup_json_escape "$fix")"
-    printf '  ]\n'
-    printf '}\n'
+    setup_run_diagnostics_json project-venv-check-json \
+        --project "$project" \
+        --status "$status" \
+        --message "$message" \
+        --fix "$fix"
 }
 
 setup_print_project_venv_doctor_json() {
@@ -1083,18 +1076,12 @@ setup_print_project_venv_doctor_json() {
     local status="$2"
     local message="$3"
     local fix="$4"
-    local items
 
-    items="$(setup_json_array_items "$precheck_json")"
-
-    printf '['
-    if [[ -n "$items" ]]; then
-        printf '%s,' "$items"
-    fi
-    printf '{"id":"BASE-P050","status":"%s","name":"project_virtualenv","message":"%s","fix":"%s"}]\n' \
-        "$(setup_json_escape "$status")" \
-        "$(setup_json_escape "$message")" \
-        "$(setup_json_escape "$fix")"
+    setup_run_diagnostics_json project-venv-doctor-json \
+        --status "$status" \
+        --message "$message" \
+        --fix "$fix" \
+        --precheck-json "$precheck_json"
 }
 
 setup_run_project_pre_venv_layer() {
@@ -1883,53 +1870,6 @@ setup_run_check() {
     return 1
 }
 
-setup_json_escape() {
-    local value="${1:-}"
-    local char code escaped i
-    local output=""
-    local LC_ALL=C
-
-    for ((i = 0; i < ${#value}; i++)); do
-        char="${value:i:1}"
-        case "$char" in
-            '"')
-                output+='\"'
-                ;;
-            '\')
-                output+='\\'
-                ;;
-            $'\b')
-                output+='\b'
-                ;;
-            $'\f')
-                output+='\f'
-                ;;
-            $'\n')
-                output+='\n'
-                ;;
-            $'\r')
-                output+='\r'
-                ;;
-            $'\t')
-                output+='\t'
-                ;;
-            *)
-                printf -v code '%d' "'$char"
-                # JSON requires escaping C0 controls and DEL. C1 controls are
-                # valid UTF-8 codepoints and are intentionally left as-is here.
-                if ((code < 32 || code == 127)); then
-                    printf -v escaped '\\u%04x' "$code"
-                    output+="$escaped"
-                else
-                    output+="$char"
-                fi
-                ;;
-        esac
-    done
-
-    printf '%s' "$output"
-}
-
 setup_diagnostic_status_from_ok() {
     if [[ "$1" == true ]]; then
         printf '%s\n' "ok"
@@ -1938,137 +1878,16 @@ setup_diagnostic_status_from_ok() {
     fi
 }
 
-setup_merge_diagnostic_status() {
-    local current="$1"
-    local next="$2"
-
-    if [[ "$current" == error || "$next" == error ]]; then
-        printf '%s\n' "error"
-    elif [[ "$current" == warn || "$next" == warn ]]; then
-        printf '%s\n' "warn"
-    else
-        printf '%s\n' "ok"
-    fi
-}
-
-setup_json_payload_status() {
-    local payload="$1"
-
-    if [[ "$payload" == *'"status":"error"'* || "$payload" == *'"status": "error"'* ]]; then
-        printf '%s\n' "error"
-    elif [[ "$payload" == *'"status":"warn"'* || "$payload" == *'"status": "warn"'* ]]; then
-        printf '%s\n' "warn"
-    else
-        printf '%s\n' "ok"
-    fi
-}
-
-setup_check_results_status() {
-    local count i status="ok"
-
-    count="${#_BASE_SETUP_CHECK_NAMES[@]}"
-    for ((i = 0; i < count; i++)); do
-        status="$(setup_merge_diagnostic_status "$status" "$(setup_check_result_status "$i")")"
-    done
-
-    printf '%s\n' "$status"
-}
-
-setup_base_check_finding_id() {
-    case "$1" in
-        homebrew)
-            printf '%s\n' "BASE-D001"
-            ;;
-        xcode_command_line_tools)
-            printf '%s\n' "BASE-D002"
-            ;;
-        python)
-            printf '%s\n' "BASE-D003"
-            ;;
-        base_virtualenv)
-            printf '%s\n' "BASE-D004"
-            ;;
-        pyyaml)
-            printf '%s\n' "BASE-D005"
-            ;;
-        click)
-            printf '%s\n' "BASE-D006"
-            ;;
-        base_bash_libraries)
-            printf '%s\n' "BASE-D007"
-            ;;
-        *)
-            printf '%s\n' "BASE-D000"
-            ;;
-    esac
-}
-
-setup_print_check_json_item() {
-    local trailing_comma="$1"
-    local finding_id="$2"
-    local status="$3"
-    local name="$4"
-    local message="$5"
-    local fix="${6:-}"
-
-    printf '    {"id":"%s","status":"%s","name":"%s","message":"%s","fix":"%s"}%s\n' \
-        "$(setup_json_escape "$finding_id")" \
-        "$(setup_json_escape "$status")" \
-        "$(setup_json_escape "$name")" \
-        "$(setup_json_escape "$message")" \
-        "$(setup_json_escape "$fix")" \
-        "$trailing_comma"
-}
-
-setup_print_check_json_results() {
-    local count fix i status trailing_comma
-
-    count="${#_BASE_SETUP_CHECK_NAMES[@]}"
-    for ((i = 0; i < count; i++)); do
-        trailing_comma=","
-        if ((i == count - 1)); then
-            trailing_comma=""
-        fi
-        status="$(setup_check_result_status "$i")"
-        fix="$(setup_check_result_recovery "$i")"
-        setup_print_check_json_item \
-            "$trailing_comma" \
-            "$(setup_base_check_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
-            "$status" \
-            "${_BASE_SETUP_CHECK_NAMES[$i]}" \
-            "${_BASE_SETUP_CHECK_MESSAGES[$i]}" \
-            "$fix"
-    done
-}
-
-setup_print_json_property_value() {
-    local first_line=true
-    local key="$1"
-    local line
-    local value="$2"
-
-    printf '  "%s": ' "$(setup_json_escape "$key")"
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        if [[ "$first_line" == true ]]; then
-            printf '%s\n' "$line"
-            first_line=false
-        else
-            printf '  %s\n' "$line"
-        fi
-    done <<<"$value"
-}
-
 setup_run_check_json() {
+    local args=()
+    local checked_at=""
+    local count fix i
     local profile_json=""
-    local profile_status="ok"
     local project="${BASE_SETUP_PROJECT_NAME:-}"
     local project_json=""
-    local project_status="ok"
     local remote_network="${1:-${BASE_SETUP_REMOTE_NETWORK:-}}"
-    local status
 
     setup_collect_base_check_results warn || true
-    status="$(setup_check_results_status)"
 
     if setup_profiles_enabled; then
         if ! profile_json="$(setup_run_base_dev_layer check --format json)"; then
@@ -2076,8 +1895,6 @@ setup_run_check_json() {
                 return 1
             fi
         fi
-        profile_status="$(setup_json_payload_status "$profile_json")"
-        status="$(setup_merge_diagnostic_status "$status" "$profile_status")"
     fi
 
     if [[ -n "$project" ]]; then
@@ -2086,40 +1903,26 @@ setup_run_check_json() {
                 return 1
             fi
         fi
-        project_status="$(setup_json_payload_status "$project_json")"
-        status="$(setup_merge_diagnostic_status "$status" "$project_status")"
+        checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 1
     fi
 
-    setup_record_project_check_result "$project" "$status"
-
-    printf '{\n'
-    printf '  "schema_version": 1,\n'
-    printf '  "status": "%s",\n' "$(setup_json_escape "$status")"
+    args+=(check-json)
     if [[ -n "$project" ]]; then
-        printf '  "project": "%s",\n' "$(setup_json_escape "$project")"
+        args+=(--project "$project")
     fi
-    printf '  "checks": [\n'
-    setup_print_check_json_results
-    printf '  ]'
-    if setup_profiles_enabled || [[ -n "$project" ]]; then
-        printf ',\n'
-    else
-        printf '\n'
-    fi
+    count="${#_BASE_SETUP_CHECK_NAMES[@]}"
+    for ((i = 0; i < count; i++)); do
+        fix="$(setup_check_result_recovery "$i")"
+        args+=(--check "${_BASE_SETUP_CHECK_NAMES[$i]}" "$(setup_check_result_status "$i")" "${_BASE_SETUP_CHECK_MESSAGES[$i]}" "$fix")
+    done
     if setup_profiles_enabled; then
-        setup_print_json_property_value "$(setup_profile_json_key checks)" "$profile_json"
-        if [[ -n "$project" ]]; then
-            printf ',\n'
-        else
-            printf '\n'
-        fi
+        args+=(--embedded-payload "$(setup_profile_json_key checks)" "$profile_json")
     fi
     if [[ -n "$project" ]]; then
-        setup_print_json_property_value "project_checks" "$project_json"
+        args+=(--embedded-payload "project_checks" "$project_json")
+        args+=(--record-path "$(setup_project_check_record_path "$project")" --checked-at "$checked_at")
     fi
-    printf '}\n'
-
-    [[ "$status" != error ]]
+    setup_run_diagnostics_json "${args[@]}"
 }
 
 setup_run_ci_runtime_install() {

--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
+
+
+VALID_STATUSES = {"ok", "warn", "error"}
+BASE_CHECK_FINDING_IDS = {
+    "homebrew": "BASE-D001",
+    "xcode_command_line_tools": "BASE-D002",
+    "python": "BASE-D003",
+    "base_virtualenv": "BASE-D004",
+    "pyyaml": "BASE-D005",
+    "click": "BASE-D006",
+    "base_bash_libraries": "BASE-D007",
+}
+
+
+@dataclass(frozen=True)
+class DiagnosticCheck:
+    name: str
+    status: str
+    message: str
+    fix: str = ""
+
+
+def validate_status(status: str) -> str:
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Invalid diagnostic status '{status}'.")
+    return status
+
+
+def merge_statuses(*statuses: str) -> str:
+    normalized = tuple(validate_status(status) for status in statuses if status)
+    if "error" in normalized:
+        return "error"
+    if "warn" in normalized:
+        return "warn"
+    return "ok"
+
+
+def payload_status(payload: Any) -> str:
+    if isinstance(payload, dict):
+        status = payload.get("status", "ok")
+        return validate_status(status) if isinstance(status, str) else "ok"
+    if isinstance(payload, list):
+        return merge_statuses(
+            *(
+                item.get("status", "ok")
+                for item in payload
+                if isinstance(item, dict) and isinstance(item.get("status", "ok"), str)
+            )
+        )
+    return "ok"
+
+
+def check_item(finding_id: str, check: DiagnosticCheck) -> dict[str, str]:
+    return {
+        "id": finding_id,
+        "status": validate_status(check.status),
+        "name": check.name,
+        "message": check.message,
+        "fix": check.fix,
+    }
+
+
+def base_check_item(check: DiagnosticCheck) -> dict[str, str]:
+    return check_item(BASE_CHECK_FINDING_IDS.get(check.name, "BASE-D000"), check)
+
+
+def project_venv_check_item(status: str, message: str, fix: str) -> dict[str, str]:
+    return check_item(
+        "BASE-P050",
+        DiagnosticCheck(
+            name="project_virtualenv",
+            status=status,
+            message=message,
+            fix=fix,
+        ),
+    )
+
+
+def compact_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+
+
+def render_top_level_payload(payload: dict[str, Any]) -> str:
+    lines = ["{"]
+    items = list(payload.items())
+    for index, (key, value) in enumerate(items):
+        suffix = "," if index < len(items) - 1 else ""
+        if isinstance(value, list):
+            lines.append(f'  {json.dumps(key)}: [')
+            for item_index, item in enumerate(value):
+                item_suffix = "," if item_index < len(value) - 1 else ""
+                lines.append(f"    {compact_json(item)}{item_suffix}")
+            lines.append(f"  ]{suffix}")
+        elif isinstance(value, dict):
+            lines.append(f'  {json.dumps(key)}: {compact_json(value)}{suffix}')
+        else:
+            lines.append(f'  {json.dumps(key)}: {json.dumps(value, ensure_ascii=True)}{suffix}')
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def render_base_diagnostic_payload(
+    checks: tuple[DiagnosticCheck, ...],
+    item_key: str,
+    project: str | None = None,
+    embedded_payloads: tuple[tuple[str, str], ...] = (),
+) -> str:
+    embedded = tuple((key, json.loads(payload_text)) for key, payload_text in embedded_payloads)
+    base_status = merge_statuses(*(check.status for check in checks))
+    status = merge_statuses(base_status, *(payload_status(payload) for _key, payload in embedded))
+    payload: dict[str, Any] = {
+        "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
+        "status": status,
+    }
+    if project:
+        payload["project"] = project
+    payload[item_key] = [base_check_item(check) for check in checks]
+    for key, embedded_payload in embedded:
+        payload[key] = embedded_payload
+    return render_top_level_payload(payload)
+
+
+def render_base_check_payload(
+    checks: tuple[DiagnosticCheck, ...],
+    project: str | None = None,
+    embedded_payloads: tuple[tuple[str, str], ...] = (),
+) -> str:
+    return render_base_diagnostic_payload(
+        checks=checks,
+        item_key="checks",
+        project=project,
+        embedded_payloads=embedded_payloads,
+    )
+
+
+def render_base_doctor_payload(
+    checks: tuple[DiagnosticCheck, ...],
+    project: str | None = None,
+    embedded_payloads: tuple[tuple[str, str], ...] = (),
+) -> str:
+    return render_base_diagnostic_payload(
+        checks=checks,
+        item_key="findings",
+        project=project,
+        embedded_payloads=embedded_payloads,
+    )
+
+
+def render_project_venv_check_payload(
+    project: str,
+    status: str,
+    message: str,
+    fix: str,
+    precheck_json: str = "[]",
+) -> str:
+    precheck_payload = json.loads(precheck_json)
+    checks = precheck_payload if isinstance(precheck_payload, list) else precheck_payload.get("checks", [])
+    check_items = [*checks, project_venv_check_item(status, message, fix)]
+    payload = {
+        "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
+        "status": merge_statuses(payload_status(precheck_payload), status),
+        "project": project,
+        "checks": check_items,
+    }
+    return render_top_level_payload(payload)
+
+
+def render_project_venv_doctor_payload(
+    status: str,
+    message: str,
+    fix: str,
+    precheck_json: str = "[]",
+) -> str:
+    precheck_payload = json.loads(precheck_json)
+    checks = precheck_payload if isinstance(precheck_payload, list) else precheck_payload.get("checks", [])
+    return compact_json([*checks, project_venv_check_item(status, message, fix)]) + "\n"
+
+
+def render_check_record(project: str, status: str, checked_at: str) -> str:
+    payload = {
+        "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
+        "project": project,
+        "command": "basectl check",
+        "status": validate_status(status),
+        "checked_at": checked_at,
+    }
+    return json.dumps(payload, ensure_ascii=True, indent=2) + "\n"
+
+
+def write_check_record(path: Path, project: str, status: str, checked_at: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f"{path.name}.tmp")
+    temp_path.write_text(render_check_record(project, status, checked_at), encoding="utf-8")
+    temp_path.replace(path)
+
+
+def parse_check(values: list[str]) -> DiagnosticCheck:
+    name, status, message, fix = values
+    return DiagnosticCheck(name=name, status=status, message=message, fix=fix)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="base_setup.diagnostics")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_json = subparsers.add_parser("check-json")
+    check_json.add_argument("--project")
+    check_json.add_argument(
+        "--check",
+        action="append",
+        nargs=4,
+        default=[],
+        metavar=("NAME", "STATUS", "MESSAGE", "FIX"),
+    )
+    check_json.add_argument("--embedded-payload", action="append", nargs=2, default=[], metavar=("KEY", "JSON"))
+    check_json.add_argument("--record-path")
+    check_json.add_argument("--checked-at")
+
+    doctor_json = subparsers.add_parser("doctor-json")
+    doctor_json.add_argument("--project")
+    doctor_json.add_argument(
+        "--finding",
+        action="append",
+        nargs=4,
+        default=[],
+        metavar=("NAME", "STATUS", "MESSAGE", "FIX"),
+    )
+    doctor_json.add_argument("--embedded-payload", action="append", nargs=2, default=[], metavar=("KEY", "JSON"))
+
+    record_check = subparsers.add_parser("record-check")
+    record_check.add_argument("--project", required=True)
+    record_check.add_argument("--status", required=True)
+    record_check.add_argument("--checked-at", required=True)
+    record_check.add_argument("--output-path", required=True)
+
+    venv_check = subparsers.add_parser("project-venv-check-json")
+    venv_check.add_argument("--project", required=True)
+    venv_check.add_argument("--status", required=True)
+    venv_check.add_argument("--message", required=True)
+    venv_check.add_argument("--fix", default="")
+    venv_check.add_argument("--precheck-json", default="[]")
+
+    venv_doctor = subparsers.add_parser("project-venv-doctor-json")
+    venv_doctor.add_argument("--status", required=True)
+    venv_doctor.add_argument("--message", required=True)
+    venv_doctor.add_argument("--fix", default="")
+    venv_doctor.add_argument("--precheck-json", default="[]")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "check-json":
+        checks = tuple(parse_check(check) for check in args.check)
+        embedded_payloads = tuple((key, payload) for key, payload in args.embedded_payload)
+        payload = render_base_check_payload(checks, project=args.project, embedded_payloads=embedded_payloads)
+        print(payload, end="")
+        status = payload_status(json.loads(payload))
+        if args.record_path and args.project and args.checked_at:
+            write_check_record(Path(args.record_path), args.project, status, args.checked_at)
+        return 0 if status != "error" else 1
+    if args.command == "doctor-json":
+        checks = tuple(parse_check(finding) for finding in args.finding)
+        embedded_payloads = tuple((key, payload) for key, payload in args.embedded_payload)
+        payload = render_base_doctor_payload(checks, project=args.project, embedded_payloads=embedded_payloads)
+        print(payload, end="")
+        status = payload_status(json.loads(payload))
+        return 0 if status != "error" else 1
+    if args.command == "record-check":
+        write_check_record(Path(args.output_path), args.project, args.status, args.checked_at)
+        return 0
+    if args.command == "project-venv-check-json":
+        print(
+            render_project_venv_check_payload(
+                project=args.project,
+                status=args.status,
+                message=args.message,
+                fix=args.fix,
+                precheck_json=args.precheck_json,
+            ),
+            end="",
+        )
+        return 0 if args.status != "error" else 1
+    if args.command == "project-venv-doctor-json":
+        print(
+            render_project_venv_doctor_payload(
+                status=args.status,
+                message=args.message,
+                fix=args.fix,
+                precheck_json=args.precheck_json,
+            ),
+            end="",
+        )
+        return 0 if args.status != "error" else 1
+    parser.error(f"Unsupported diagnostics command '{args.command}'.")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_setup/tests/test_diagnostics_payloads.py
+++ b/cli/python/base_setup/tests/test_diagnostics_payloads.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from base_setup.diagnostics import DiagnosticCheck
+from base_setup.diagnostics import render_base_check_payload
+from base_setup.diagnostics import render_base_doctor_payload
+from base_setup.diagnostics import render_check_record
+from base_setup.diagnostics import render_project_venv_check_payload
+from base_setup.diagnostics import render_project_venv_doctor_payload
+
+
+class DiagnosticsPayloadTests(unittest.TestCase):
+    def test_render_base_check_payload_merges_embedded_statuses(self) -> None:
+        payload_text = render_base_check_payload(
+            checks=(
+                DiagnosticCheck("homebrew", "ok", "Homebrew is installed.", ""),
+                DiagnosticCheck("xcode_command_line_tools", "warn", "Xcode is incomplete.", "Repair Xcode."),
+            ),
+            project="demo",
+            embedded_payloads=(
+                (
+                    "profile_checks",
+                    '{"schema_version":1,"status":"error","checks":[{"id":"BASE-D104","status":"error"}]}',
+                ),
+                (
+                    "project_checks",
+                    '{"schema_version":1,"status":"ok","project":"demo","checks":[]}',
+                ),
+            ),
+        )
+
+        payload = json.loads(payload_text)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["project"], "demo")
+        self.assertEqual(payload["checks"][0]["id"], "BASE-D001")
+        self.assertEqual(payload["checks"][0]["status"], "ok")
+        self.assertEqual(payload["checks"][1]["id"], "BASE-D002")
+        self.assertEqual(payload["checks"][1]["status"], "warn")
+        self.assertEqual(payload["profile_checks"]["status"], "error")
+        self.assertEqual(payload["project_checks"]["status"], "ok")
+        self.assertNotIn('"ok":', payload_text)
+
+    def test_render_base_doctor_payload_uses_findings_key(self) -> None:
+        payload_text = render_base_doctor_payload(
+            checks=(DiagnosticCheck("python", "ok", "Python is installed.", ""),),
+            embedded_payloads=(("project_findings", '[{"id":"BASE-P040","status":"error"}]'),),
+        )
+
+        payload = json.loads(payload_text)
+        self.assertEqual(payload["status"], "error")
+        self.assertIn("findings", payload)
+        self.assertNotIn("checks", payload)
+        self.assertEqual(payload["findings"][0]["id"], "BASE-D003")
+        self.assertEqual(payload["project_findings"][0]["id"], "BASE-P040")
+
+    def test_render_base_check_payload_uses_python_json_escaping(self) -> None:
+        payload_text = render_base_check_payload(
+            checks=(
+                DiagnosticCheck("pyyaml", "ok", "Python package 'Py\vYAML\177' is installed.", ""),
+            )
+        )
+
+        self.assertIn("Py\\u000bYAML\\u007f", payload_text)
+        self.assertNotIn("Py\vYAML\177", payload_text)
+        payload = json.loads(payload_text)
+        self.assertEqual(payload["checks"][0]["message"], "Python package 'Py\vYAML\177' is installed.")
+
+    def test_render_project_venv_check_payload_merges_precheck_status(self) -> None:
+        payload_text = render_project_venv_check_payload(
+            project="demo",
+            status="error",
+            message="Virtual environment is missing.",
+            fix="basectl setup demo --recreate-venv",
+            precheck_json='[{"id":"BASE-P080","status":"ok","name":"git_repository","message":"ok","fix":""}]',
+        )
+
+        payload = json.loads(payload_text)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["project"], "demo")
+        self.assertEqual(payload["checks"][0]["id"], "BASE-P080")
+        self.assertEqual(payload["checks"][1]["id"], "BASE-P050")
+
+    def test_render_project_venv_doctor_payload_appends_virtualenv_finding(self) -> None:
+        payload_text = render_project_venv_doctor_payload(
+            status="error",
+            message="Virtual environment is broken.",
+            fix="basectl setup demo --recreate-venv",
+            precheck_json='[{"id":"BASE-P080","status":"ok","name":"git_repository","message":"ok","fix":""}]',
+        )
+
+        payload = json.loads(payload_text)
+        self.assertEqual(payload[0]["id"], "BASE-P080")
+        self.assertEqual(payload[1]["id"], "BASE-P050")
+        self.assertEqual(payload[1]["status"], "error")
+
+    def test_render_check_record_uses_python_json_escaping(self) -> None:
+        payload = json.loads(
+            render_check_record(project='demo"quoted', status="ok", checked_at="2026-06-23T01:00:00Z")
+        )
+
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["project"], 'demo"quoted')
+        self.assertEqual(payload["command"], "basectl check")
+        self.assertEqual(payload["status"], "ok")

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -205,7 +205,7 @@ run_basectl_separate_stderr() {
     [[ "$output" == *'"project": "demo"'* ]]
     [[ "$output" == *'"project_checks":'* ]]
     [[ "$output" != *'"ok":'* ]]
-    [[ "$output" == *'"name": "click"'* ]]
+    [[ "$output" == *'"name":"click"'* || "$output" == *'"name": "click"'* ]]
 
     run_basectl_separate_stderr doctor demo --format json
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Add a Python diagnostics renderer for Base check/doctor JSON payloads and project check records.
- Move check, doctor, and project-venv JSON assembly out of setup_common.sh.
- Keep Bash responsible for host probes, text output, and command orchestration.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/diagnostics.py cli/python/base_setup/tests/test_diagnostics_payloads.py
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/check.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/doctor.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/ci.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats
- bash -n cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/doctor.sh cli/bash/commands/basectl/subcommands/ci.sh
- git diff --check
- rg -n 'setup_json_escape|setup_print_check_json|setup_print_json_property_value|setup_json_payload_status|setup_merge_diagnostic_status|setup_json_array_items|setup_base_check_finding_id|setup_check_results_status' cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/doctor.sh (no matches)

Closes #1009