### PR TITLE
Document BASE_BASH_LIBS_DIR for issue worktrees

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -109,6 +109,12 @@ Documentation-only changes usually need `git diff --check`.
 First external PRs should start from an issue labeled `good first issue`.
 Contributor-facing guidance lives in `CONTRIBUTING.md`; the workflow policy and
 starter-issue criteria live in `docs/github-workflow.md`.
+When running the full source-checkout suite from a linked issue worktree under
+`~/work/base-worktrees/<slug>`, set the reusable library path explicitly:
+
+```bash
+BASE_BASH_LIBS_DIR=~/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test
+```
 
 ## Release Flow
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,9 +87,14 @@ env -u BASE_HOME ./bin/base-test
 
 The full suite expects Base to resolve external reusable Bash libraries. A
 normal `~/work/base` checkout uses sibling `~/work/base-bash-libs`
-automatically. For a nonstandard worktree layout, set
-`BASE_BASH_LIBS_DIR=/path/to/base-bash-libs/lib/bash` before running
-`bin/base-test`.
+automatically. A linked issue worktree under `~/work/base-worktrees/<slug>` is a
+nonstandard layout because the sibling lookup would search
+`~/work/base-worktrees/base-bash-libs`. For the standard contributor checkout
+shape, point Base at the reusable library checkout explicitly:
+
+```bash
+BASE_BASH_LIBS_DIR=~/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test
+```
 
 `basectl test base` delegates to the same runner when the `base` project
 resolves to a source checkout. In a packaged install such as Homebrew,


### PR DESCRIPTION
## Summary
- Document why linked Base issue worktrees under `~/work/base-worktrees/<slug>` need an explicit reusable Bash library path for the full source-checkout suite.
- Replace the placeholder `BASE_BASH_LIBS_DIR` example in testing docs with the standard contributor checkout path.
- Mirror the validation reminder in `.ai-context/WORKFLOWS.md` for agent-run full-suite checks.

## Issue
Fixes #1006

## Validation
- git diff --check
- git diff --check --cached

## Demo Impact
None.

## Notes
.ai-context/ was updated because this is contributor/agent validation workflow guidance.