### PR TITLE
Add basectl product self-review prompt

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -19,6 +19,10 @@ the canonical current command list.
 - `basectl run <project> <command>` - run a declared project command.
 - `basectl export-context [project]` - export `.ai-context/` as a Markdown or
   Zip bundle for manual upload or copy/paste into AI tools.
+- `basectl prompt <list|name>` - list and render repo-owned Markdown prompts
+  for AI-assisted Base workflows. `product-self-review` prints the periodic
+  product assessment prompt with current Base metadata; Base does not send the
+  prompt to an AI provider.
 - `basectl projects list` - list Base-managed projects discovered in the
   workspace.
 - `basectl workspace <status|check|doctor|clone|pull|configure>` - inspect
@@ -119,5 +123,7 @@ Important Python packages include:
 - `base_export_context` - deterministic local Markdown and Zip exports from a
   project's `.ai-context/` directory. Provider uploads are intentionally out of
   scope.
+- `base_prompt` - repo-owned prompt listing and rendering. AI execution and
+  provider integration are intentionally out of scope.
 - `base_github_projects` - GitHub Project V2 schema inspection, configuration,
   and issue field updates for Base roadmap metadata.

--- a/.ai-context/INDEX.md
+++ b/.ai-context/INDEX.md
@@ -9,6 +9,8 @@ Recommended read order for an AI assistant:
 5. `WORKFLOWS.md` - read when doing repo work, PRs, validation, or releases.
 6. `DECISIONS.md` - read when evaluating proposals against durable choices.
 7. `README.md` - read when maintaining this context pack.
+8. `prompts/product-self-review.md` - read when revising the maintained product
+   assessment prompt.
 
 ## Canonical Sources
 
@@ -32,3 +34,5 @@ below when precise detail matters:
 - `docs/release-process.md` - release ceremony and Homebrew tap handoff.
 - `CHANGELOG.md` - current release and unreleased changes.
 - `AGENTS.md` - repo-specific instructions for AI coding agents.
+- `.ai-context/prompts/` - repo-owned prompt templates rendered by
+  `basectl prompt`.

--- a/.ai-context/README.md
+++ b/.ai-context/README.md
@@ -24,6 +24,8 @@ conversations.
 - `WORKFLOWS.md` - issue, branch, PR, validation, release, and cleanup flow.
 - `DECISIONS.md` - durable product and architecture decisions.
 - `STATUS.md` - current version, active work, and recent changes.
+- `prompts/` - repo-owned prompts that `basectl prompt` can render for
+  AI-assisted Base workflows.
 
 ## Maintenance
 

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -29,6 +29,7 @@ The current command surface covers:
 - workspace status/check/doctor/configure flows
 - release readiness inspection and guarded GitHub release publishing
 - local AI context export bundles
+- repo-owned prompt rendering through `basectl prompt`
 - explicit `ai` prerequisite profile for Codex CLI and Claude Code
 
 ## Active Development Direction

--- a/.ai-context/prompts/product-self-review.md
+++ b/.ai-context/prompts/product-self-review.md
@@ -1,0 +1,52 @@
+# Base Product Self-Review
+
+Generated: {{ generated_date }}
+Project: {{ project_name }}
+Version: {{ version }}
+
+You are reviewing Base as it exists today. Do not rely on old conclusions
+unless current repo evidence still supports them.
+
+## Evidence To Read
+
+- VERSION
+- README.md
+- CHANGELOG.md
+- FAQ.md
+- docs/product-assessment.md
+- docs/why-base.md
+- docs/tool-boundaries.md
+- docs/architecture.md
+- .ai-context/PROJECT.md
+- .ai-context/STATUS.md
+
+## Review Questions
+
+1. How original is Base?
+2. How useful is Base, and for whom?
+3. What is the realistic adoption potential?
+4. What engineering/product skill level is evidenced by the current product?
+5. What risks, stale claims, or weak spots are visible?
+6. What are the highest-leverage next directions?
+
+## Output Format
+
+Return:
+
+- bottom-line verdict
+- ratings table
+- evidence-backed assessment
+- adoption risks
+- recommended next directions
+- issue-shaped follow-up items
+- documentation that appears stale
+
+## Rules
+
+- Separate evidence from opinion.
+- Be candid, not promotional.
+- Compare Base against adjacent tools without treating them as competitors by default.
+- Call out stale documentation.
+- Propose issue-shaped follow-ups.
+- Update ratings only when current shipped behavior justifies it.
+- Do not update files unless explicitly asked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `basectl prompt list` and `basectl prompt product-self-review` to render
+  repo-owned Markdown prompts for periodic AI-assisted Base workflow reviews.
+
 ### Changed
 
 - Added `ctx.workspace_root` to `base_cli.Context` so workspace-aware commands

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Current implemented commands include:
 - `basectl release plan --version <version>`
 - `basectl release notes --version <version>`
 - `basectl release publish --version <version>`
+- `basectl prompt list`
+- `basectl prompt product-self-review`
 - `basectl activate <project>`
 - `basectl test [project]`
 - `basectl build <project> [target...]`
@@ -710,6 +712,20 @@ Base-managed project. Markdown exports combine context Markdown files with
 stable source headings, using `.ai-context/INDEX.md` order when available and
 falling back to deterministic filename order for unlisted files. Zip exports
 contain only files from `.ai-context/` so they can be uploaded manually.
+
+Print repo-owned AI workflow prompts with:
+
+```bash
+basectl prompt list
+basectl prompt product-self-review
+```
+
+`basectl prompt` renders maintained Markdown prompts from Base's repo-visible
+prompt library. The command prints prompts to stdout for manual use with AI
+tools; Base does not run the review or send the prompt to any provider. The
+first built-in prompt, `product-self-review`, is the periodic product
+assessment ritual for revisiting Base's originality, usefulness, adoption
+potential, creator-skill evidence, risks, and next directions.
 
 Once a project is discoverable, activate it with:
 
@@ -1481,9 +1497,9 @@ setup, checks, diagnostics, project discovery, project activation, project test
 execution, mise integration, cleanup, updates, onboarding, repository baseline
 creation, CI-safe setup/check/doctor entry points, release readiness inspection,
 guarded GitHub release publishing, GitHub workflow helpers, workspace
-status/check/doctor/configure flows, local AI context exports, external reusable Bash
-library consumption, and explicit prerequisite profiles for developer, SRE, and
-AI tooling.
+status/check/doctor/configure flows, local AI context exports, repo-owned prompt
+rendering, external reusable Bash library consumption, and explicit prerequisite
+profiles for developer, SRE, and AI tooling.
 
 For the documentation map and naming convention, see
 [docs/README.md](docs/README.md). For accepted product requirements, see

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -32,6 +32,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `export-context`
 - `gh`
 - `onboard`
+- `prompt`
 - `repo init/clone/check/configure/agent-guidance/installer-template`
 - `test`
 - `build`
@@ -139,6 +140,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   directory for manual AI tool upload or copy/paste. Markdown exports include
   stable file headings and use `INDEX.md` ordering when available. Zip exports
   contain only files from `.ai-context`.
+- `basectl prompt list` lists repo-owned Markdown prompts that Base can render
+  for AI-assisted workflows. `basectl prompt product-self-review` prints the
+  periodic Base product self-review prompt with current Base metadata. Base
+  renders the prompt only; an AI tool performs the review.
 - `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
 - `basectl update [project]` updates the selected project checkout through Git
   and then runs `basectl setup <project>`. Omitting the project selects `base`;

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -31,6 +31,8 @@ Commands:
     Run Base setup, checks, and diagnostics in non-interactive CI.
   release <check|plan|notes|publish> --version <version> [options]
     Inspect release readiness, plan, notes, and guarded GitHub publishing.
+  prompt <list|name> [options]
+    Print repo-owned Markdown prompts for AI-assisted Base workflows.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   logs [options]
@@ -220,6 +222,11 @@ basectl_do_release() {
     base_release_subcommand_main "$@"
 }
 
+basectl_do_prompt() {
+    basectl_source_subcommand_module prompt || return 1
+    base_prompt_subcommand_main "$@"
+}
+
 basectl_do_clean() {
     basectl_source_subcommand_module clean || return 1
     base_clean_subcommand_main "$@"
@@ -381,6 +388,7 @@ basectl_main() {
         repo)             basectl_do_repo "$@" ;;
         ci)               basectl_do_ci "$@" ;;
         release)          basectl_do_release "$@" ;;
+        prompt)           basectl_do_prompt "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         logs)             basectl_do_logs "$@" ;;
         history)          basectl_do_history "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/prompt.sh
+++ b/cli/bash/commands/basectl/subcommands/prompt.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_prompt_subcommand_sourced:-}" ]] && return
+_base_prompt_subcommand_sourced=1
+readonly _base_prompt_subcommand_sourced
+
+base_prompt_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl prompt list
+  basectl prompt <name>
+
+Prompts:
+  product-self-review  Periodic Base product self-review
+
+Options:
+  -v          Enable DEBUG logging for this subcommand.
+  -h, --help  Show this help text.
+
+Print repo-owned Markdown prompts for AI-assisted Base workflows. Base renders
+the prompt; an AI tool performs the review.
+EOF
+}
+
+base_prompt_usage_error() {
+    base_prompt_subcommand_usage >&2
+    print_error "$*"
+    return 2
+}
+
+base_prompt_subcommand_main() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_prompt_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            -*)
+                base_prompt_usage_error "Unknown prompt option '$1'."
+                return $?
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    if ((${#args[@]} == 0)); then
+        base_prompt_usage_error "The 'prompt' command requires 'list' or a prompt name."
+        return $?
+    fi
+    if ((${#args[@]} > 1)); then
+        base_prompt_usage_error "The 'prompt' command accepts exactly one argument."
+        return $?
+    fi
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    "$wrapper" --project base base_prompt "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -127,6 +127,14 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "onboard_profiles=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl prompt ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "prompt_names=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl prompt product-self-review --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "prompt_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl clean --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -227,6 +235,8 @@ EOF
     [[ "$output" == *"onboard_options=--profile --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"onboard_projects=base demo"* ]]
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
+    [[ "$output" == *"prompt_names=list product-self-review"* ]]
+    [[ "$output" == *"prompt_options=--help"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"history_options=--project --command --status --limit --format"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -17,6 +17,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"repo <init|clone|check|configure|agent-guidance|installer-template> [options]"* ]]
     [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
     [[ "$output" == *"release <check|plan|notes|publish> --version <version> [options]"* ]]
+    [[ "$output" == *"prompt <list|name> [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"logs [options]"* ]]
     [[ "$output" == *"history [options]"* ]]
@@ -57,6 +58,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  repo <init|clone|check|configure|agent-guidance|installer-template> [options]' <<<"$output"
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"
+    grep -Fqx '  prompt <list|name> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  history [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor|clone|pull|configure> [options]' <<<"$output"

--- a/cli/bash/commands/basectl/tests/prompt.bats
+++ b/cli/bash/commands/basectl/tests/prompt.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl prompt prints help without requiring the Base Python venv" {
+    run_basectl prompt --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl prompt list"* ]]
+    [[ "$output" == *"basectl prompt <name>"* ]]
+    [[ "$output" == *"product-self-review"* ]]
+}
+
+@test "basectl prompt forwards prompt names to the Python prompt renderer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local state_file="$TEST_TMPDIR/prompt-state"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" ]]; then
+    shift 2
+    printf '%s\n' "$*" > "${BASE_TEST_PROMPT_STATE:?}"
+    printf '# rendered prompt\n'
+    exit 0
+fi
+printf 'unexpected prompt python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROMPT_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" prompt product-self-review
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"# rendered prompt"* ]]
+    [ "$(cat "$state_file")" = "product-self-review" ]
+}
+
+@test "basectl prompt list delegates to the Python prompt renderer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" && "${3:-}" == "list" ]]; then
+    printf 'product-self-review\tPeriodic Base product self-review\n'
+    exit 0
+fi
+printf 'unexpected prompt list python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl prompt list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"product-self-review"* ]]
+    [[ "$output" == *"Periodic Base product self-review"* ]]
+}

--- a/cli/python/base_prompt/__init__.py
+++ b/cli/python/base_prompt/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt rendering command for Base."""

--- a/cli/python/base_prompt/__main__.py
+++ b/cli/python/base_prompt/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_prompt/engine.py
+++ b/cli/python/base_prompt/engine.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import base_cli
+
+
+app = base_cli.App(name="base_prompt", log_to_file=False)
+
+PROMPTS_DIR = Path(".ai-context") / "prompts"
+
+
+class PromptUsageError(RuntimeError):
+    pass
+
+
+class PromptError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PromptDefinition:
+    name: str
+    description: str
+    relative_path: Path
+
+
+PROMPTS: tuple[PromptDefinition, ...] = (
+    PromptDefinition(
+        name="product-self-review",
+        description="Periodic Base product self-review",
+        relative_path=PROMPTS_DIR / "product-self-review.md",
+    ),
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return base_cli.run_app(app, argv)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("prompt_name", required=False)
+def run(ctx: base_cli.Context, prompt_name: str | None) -> int:
+    try:
+        if prompt_name == "list":
+            return list_prompts()
+        if not prompt_name:
+            raise PromptUsageError("The 'prompt' command requires 'list' or a prompt name.")
+        prompt = prompt_definition(prompt_name)
+        print(render_prompt(ctx.base_home, prompt), end="")
+        return 0
+    except PromptUsageError as exc:
+        print_usage(file=sys.stderr)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    except PromptError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+def print_usage(file=sys.stdout) -> None:
+    print(
+        """Usage:
+  base_prompt list
+  base_prompt <name>
+
+Prompts:
+  product-self-review  Periodic Base product self-review
+
+Purpose:
+  Print repo-owned Markdown prompts for AI-assisted Base workflows. Base
+  renders the prompt; an AI tool performs the review.""",
+        file=file,
+    )
+
+
+def list_prompts() -> int:
+    for prompt in PROMPTS:
+        print(f"{prompt.name}\t{prompt.description}")
+    return 0
+
+
+def prompt_definition(name: str) -> PromptDefinition:
+    for prompt in PROMPTS:
+        if prompt.name == name:
+            return prompt
+    raise PromptUsageError(f"Unknown prompt '{name}'.")
+
+
+def render_prompt(base_home: Path, prompt: PromptDefinition) -> str:
+    template_path = base_home / prompt.relative_path
+    try:
+        template = template_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise PromptError(f"Prompt template '{prompt.relative_path}' was not found.") from exc
+    except UnicodeDecodeError as exc:
+        raise PromptError(f"Prompt template '{prompt.relative_path}' is not valid UTF-8.") from exc
+
+    values = {
+        "generated_date": date.today().isoformat(),
+        "project_name": "base",
+        "version": read_version(base_home),
+    }
+    return render_template(template, values)
+
+
+def read_version(base_home: Path) -> str:
+    version_path = base_home / "VERSION"
+    try:
+        version = version_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise PromptError("VERSION was not found in Base home.") from exc
+    return version or "unknown"
+
+
+def render_template(template: str, values: dict[str, str]) -> str:
+    rendered = template
+    for key, value in values.items():
+        rendered = rendered.replace(f"{{{{ {key} }}}}", value)
+    return rendered

--- a/cli/python/base_prompt/tests/test_engine.py
+++ b/cli/python/base_prompt/tests/test_engine.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_prompt import engine
+
+
+BASE_HOME = Path(__file__).resolve().parents[4]
+
+
+def invoke(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with tempfile.TemporaryDirectory() as home_dir:
+        with mock.patch.dict(os.environ, {"BASE_HOME": str(BASE_HOME), "HOME": home_dir}):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class BasePromptTests(unittest.TestCase):
+    def test_list_includes_product_self_review_prompt(self) -> None:
+        status, stdout, stderr = invoke(["list"])
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        self.assertIn("product-self-review", stdout)
+        self.assertIn("Periodic Base product self-review", stdout)
+
+    def test_product_self_review_prompt_includes_current_metadata_and_questions(self) -> None:
+        version = (BASE_HOME / "VERSION").read_text(encoding="utf-8").strip()
+
+        status, stdout, stderr = invoke(["product-self-review"])
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(stderr, "")
+        self.assertIn("# Base Product Self-Review", stdout)
+        self.assertIn("Generated:", stdout)
+        self.assertIn("Project: base", stdout)
+        self.assertIn(f"Version: {version}", stdout)
+        self.assertIn("docs/product-assessment.md", stdout)
+        self.assertIn("How original is Base?", stdout)
+        self.assertIn("How useful is Base, and for whom?", stdout)
+        self.assertIn("Do not update files unless explicitly asked.", stdout)
+
+    def test_unknown_prompt_reports_usage_error(self) -> None:
+        status, stdout, stderr = invoke(["missing-prompt"])
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("Usage:", stderr)
+        self.assertIn("ERROR: Unknown prompt 'missing-prompt'.", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -91,3 +91,5 @@ inspect the resolved command contract first.
 | `basectl release notes --version <version>` | Extract release notes for the requested version. | `--manifest <path>` |
 | `basectl release publish --version <version>` | Create the annotated Git tag and GitHub Release after checks pass. | `--manifest <path>`, `--dry-run`, `--yes` |
 | `basectl export-context [project]` | Export a project's `.ai-context/` directory as Markdown or Zip. | `--workspace <path>`, `--format <markdown\|zip>`, `--output <path>`, `--print`, `--list-files` |
+| `basectl prompt list` | List repo-owned Markdown prompts that Base can render for AI-assisted workflows. | none |
+| `basectl prompt product-self-review` | Print the periodic Base product self-review prompt with current Base metadata. | none |

--- a/docs/product-assessment.md
+++ b/docs/product-assessment.md
@@ -17,6 +17,8 @@ ecosystem boundary model, see [Tool Boundaries](tool-boundaries.md).
 Review this assessment:
 
 - during each minor release line, such as `1.1.0`, `1.2.0`, and later;
+- by running `basectl prompt product-self-review` to generate the current
+  review prompt before revising this document;
 - before any major repositioning of Base's product scope;
 - before public claims about Linux, Windows, WSL, or team-scale adoption;
 - after meaningful external usage, contributor growth, or support feedback;

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -164,6 +164,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | `basectl build <project> [targets] [--list\|--dry-run]` | Run build targets |
 | `basectl demo [project] [--non-interactive]` | Run project demo script |
 | `basectl export-context [project]` | Generate AI context pack from `.ai-context/` |
+| `basectl prompt <list\|name>` | List or render repo-owned AI workflow prompts |
 
 ### Diagnostics
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -63,7 +63,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test export-context build demo run repo ci release clean logs history config doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test export-context build demo run repo ci release prompt clean logs history config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -175,6 +175,13 @@ _base_basectl_completion() {
                 _base_basectl_completion_compgen "check plan notes publish" "$cur"
             else
                 _base_basectl_completion_compgen "--version --manifest --dry-run --yes -h --help" "$cur"
+            fi
+            ;;
+        prompt)
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "list product-self-review" "$cur"
+            else
+                _base_basectl_completion_compgen "-v -h --help" "$cur"
             fi
             ;;
         clean)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -25,6 +25,7 @@ _base_basectl_completion() {
         'repo:Create, check, and configure repository baseline'
         'ci:Run Base setup, checks, and diagnostics in CI'
         'release:Inspect release readiness, notes, and publishing'
+        'prompt:Print repo-owned Markdown prompts'
         'clean:Remove old Base CLI runtime artifacts'
         'logs:List and open recent Base CLI runtime logs'
         'history:List recent Base command history records'
@@ -165,6 +166,11 @@ _base_basectl_completion() {
                 project_names=("${(@f)$(_base_basectl_completion_project_names)}")
                 _describe -t projects 'Base project' project_names
             fi
+            ;;
+        prompt)
+            _arguments '1:prompt:(list product-self-review)' \
+                '-v[Enable DEBUG logging]' \
+                '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         repo)
             case "${words[3]:-}" in


### PR DESCRIPTION
## Summary
- Add `basectl prompt list` and `basectl prompt product-self-review` as a repo-owned prompt rendering surface.
- Store the maintained product self-review prompt under `.ai-context/prompts/` and inject current Base metadata when rendering.
- Update help, Bash/Zsh completions, docs, changelog, and AI context to describe prompt generation as non-provider AI workflow support.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_prompt/tests/test_engine.py -q`
- `BASE_HOME="$PWD" BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/prompt.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl prompt product-self-review`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl prompt list`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`
- `git diff --check`
- `git diff --cached --check`

## Demo Impact
- None. This adds a prompt-generation command and documentation, not demo behavior.

Fixes #1016
Follow-up: #1017
