### PR TITLE
Quiet idempotent setup reconciliation

### DIFF
--- a/cli/python/base_setup/delegates.py
+++ b/cli/python/base_setup/delegates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -33,7 +34,7 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             finding_id="BASE-P011",
         )
 
-    ok = process.run_check(["brew", "bundle", "check", f"--file={brewfile_path}"])
+    ok = process.run_check(["brew", "bundle", "check", f"--file={brewfile_path}"], env=homebrew_no_auto_update_env())
     if ok:
         return ArtifactCheck(
             name="brewfile",
@@ -198,6 +199,7 @@ def reconcile_brewfile(ctx: base_cli.Context, manifest: BaseManifest, dry_run: b
 
     brewfile_path = resolve_brewfile_path(manifest)
     command = ["brew", "bundle", f"--file={brewfile_path}"]
+    check_command = ["brew", "bundle", "check", f"--file={brewfile_path}"]
 
     if dry_run:
         process.dry_run_command(ctx, command)
@@ -206,8 +208,13 @@ def reconcile_brewfile(ctx: base_cli.Context, manifest: BaseManifest, dry_run: b
     if not process.command_exists("brew"):
         raise ArtifactError(f"Homebrew is required to install Brewfile dependencies from '{brewfile_path}'.")
 
+    env = homebrew_no_auto_update_env()
+    if process.run_check(check_command, env=env):
+        ctx.log.info("Brewfile dependencies are already satisfied for '%s'.", brewfile_path)
+        return
+
     ctx.log.info("Installing Homebrew dependencies from Brewfile '%s'.", brewfile_path)
-    process.run_command(ctx, command)
+    process.run_command(ctx, command, env=env)
 
 
 def reconcile_mise(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
@@ -243,6 +250,12 @@ def resolve_brewfile_path(manifest: BaseManifest) -> Path:
     if not brewfile_path.is_file():
         raise ArtifactError(f"{manifest.path}: brewfile '{manifest.brewfile}' does not exist.")
     return brewfile_path
+
+
+def homebrew_no_auto_update_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+    return env
 
 
 def command_text(stdout: str, stderr: str) -> str:

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -56,8 +56,20 @@ def command_exists(name: str) -> bool:
     return shutil.which(name) is not None
 
 
-def run_check(command: list[str]) -> bool:
-    return subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False).returncode == 0
+def run_check(
+    command: list[str],
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> bool:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return completed.returncode == 0
 
 
 def run_capture(
@@ -76,12 +88,18 @@ def run_capture(
     )
 
 
-def run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = None) -> None:
+def run_command(
+    ctx: base_cli.Context,
+    command: list[str],
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> None:
     stdout_recorder = CommandOutputRecorder()
     stderr_recorder = CommandOutputRecorder()
     with subprocess.Popen(
         command,
         cwd=cwd,
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     ) as process:

--- a/cli/python/base_setup/tests/test_brewfile.py
+++ b/cli/python/base_setup/tests/test_brewfile.py
@@ -10,6 +10,7 @@ from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest
 from base_setup.tests.helpers import fake_context
 
+
 class BrewfileTests(unittest.TestCase):
 
     def test_brewfile_dry_run_invokes_brew_bundle(self) -> None:
@@ -31,9 +32,33 @@ class BrewfileTests(unittest.TestCase):
         info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
         self.assertIn(f"[DRY-RUN] Would run: brew bundle --file={expected_brewfile}", info_messages)
 
+    def test_brewfile_check_disables_homebrew_auto_update(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            brewfile = project_root / "Brewfile"
+            brewfile.write_text("brew \"jq\"\n", encoding="utf-8")
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+            expected_brewfile = brewfile.resolve()
 
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch("base_setup.process.run_check", return_value=True) as run_check,
+            ):
+                check = delegates.check_brewfile(manifest)
 
-    def test_brewfile_invokes_brew_bundle(self) -> None:
+        self.assertTrue(check.ok)
+        run_check.assert_called_once_with(
+            ["brew", "bundle", "check", f"--file={expected_brewfile}"],
+            env=mock.ANY,
+        )
+        self.assertEqual(run_check.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
+
+    def test_brewfile_skips_brew_bundle_when_dependencies_are_satisfied(self) -> None:
         ctx = fake_context()
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
@@ -47,14 +72,49 @@ class BrewfileTests(unittest.TestCase):
             )
             expected_brewfile = brewfile.resolve()
 
-            with mock.patch("base_setup.process.command_exists", return_value=True), mock.patch(
-                "base_setup.process.run_command"
-            ) as run_command:
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch("base_setup.process.run_check", return_value=True) as run_check,
+                mock.patch("base_setup.process.run_command") as run_command,
+            ):
                 delegates.reconcile_brewfile(ctx, manifest, dry_run=False)
 
-        run_command.assert_called_once_with(ctx, ["brew", "bundle", f"--file={expected_brewfile}"])
+        run_check.assert_called_once_with(
+            ["brew", "bundle", "check", f"--file={expected_brewfile}"],
+            env=mock.ANY,
+        )
+        self.assertEqual(run_check.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
+        run_command.assert_not_called()
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertIn(f"Brewfile dependencies are already satisfied for '{expected_brewfile}'.", info_messages)
 
+    def test_brewfile_invokes_brew_bundle_when_dependencies_are_missing(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            brewfile = project_root / "Brewfile"
+            brewfile.write_text("brew \"jq\"\n", encoding="utf-8")
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+            expected_brewfile = brewfile.resolve()
 
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch("base_setup.process.run_check", return_value=False),
+                mock.patch("base_setup.process.run_command") as run_command,
+            ):
+                delegates.reconcile_brewfile(ctx, manifest, dry_run=False)
+
+        run_command.assert_called_once_with(
+            ctx,
+            ["brew", "bundle", f"--file={expected_brewfile}"],
+            env=mock.ANY,
+        )
+        self.assertEqual(run_command.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
 
     def test_brewfile_missing_file_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -68,9 +128,6 @@ class BrewfileTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ArtifactError, "does not exist"):
                 delegates.resolve_brewfile_path(manifest)
-
-
-
     def test_brewfile_must_stay_inside_project_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"

--- a/cli/python/base_setup/tests/test_uv.py
+++ b/cli/python/base_setup/tests/test_uv.py
@@ -60,6 +60,60 @@ class UvProjectTests(unittest.TestCase):
                 with self.assertRaisesRegex(RuntimeError, "uv is required"):
                     reconcile_uv_project(ctx, manifest, dry_run=False)
 
+    def test_reconcile_uv_project_skips_sync_when_project_is_synchronized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            with (
+                mock.patch("base_setup.uv.process.command_exists", return_value=True),
+                mock.patch("base_setup.uv.process.run_check", return_value=True) as run_check,
+                mock.patch("base_setup.uv.process.run_command") as run_command,
+            ):
+                reconcile_uv_project(ctx, manifest, dry_run=False)
+
+        run_check.assert_called_once_with(["uv", "sync", "--check"], cwd=root)
+        run_command.assert_not_called()
+        ctx.log.info.assert_any_call("uv project environment is already synchronized for '%s'.", root)
+
+    def test_reconcile_uv_project_runs_sync_when_project_is_not_synchronized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            with (
+                mock.patch("base_setup.uv.process.command_exists", return_value=True),
+                mock.patch("base_setup.uv.process.run_check", return_value=False),
+                mock.patch("base_setup.uv.process.run_command") as run_command,
+            ):
+                reconcile_uv_project(ctx, manifest, dry_run=False)
+
+        run_command.assert_called_once_with(ctx, ["uv", "sync"], cwd=root)
+
     def test_check_uv_warns_for_missing_uv_manager_tool(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_setup/uv.py
+++ b/cli/python/base_setup/uv.py
@@ -40,6 +40,9 @@ def reconcile_uv_project(ctx: base_cli.Context, manifest: BaseManifest, dry_run:
         return
     if not process.command_exists("uv"):
         raise ArtifactError("uv is required to set up this project. Install uv and rerun basectl setup.")
+    if process.run_check(["uv", "sync", "--check"], cwd=project_root):
+        ctx.log.info("uv project environment is already synchronized for '%s'.", project_root)
+        return
     process.run_command(ctx, command, cwd=project_root)
 
 


### PR DESCRIPTION
## Summary
- Skip `brew bundle` during setup when `brew bundle check` says the project Brewfile is already satisfied.
- Disable Homebrew auto-update for Brewfile check/reconciliation paths.
- Skip `uv sync` when `uv sync --check` says the uv project environment is already synchronized.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_brewfile.py cli/python/base_setup/tests/test_uv.py -q`
- `git diff --check HEAD~1..HEAD`
- `env -u BASE_HOME ./bin/base-test`
- `/Users/rameshhp/work/base/bin/basectl setup bankbuddy`

## Demo Impact
- None. Existing BankBuddy setup dogfood now emits concise satisfied/synchronized messages on repeat setup runs.

Fixes #1019