### PR TITLE
Add Base pre-edit workflow gate

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -1,5 +1,20 @@
 # Base Workflow Context
 
+## Pre-Edit Workflow Gate
+
+Before modifying Base files, classify the request.
+
+For implementation work in `basefoundry/base`, do not edit on `main`. Create
+or choose the GitHub issue, set the required Project metadata, move Project
+`Status` to `In Progress`, create the issue branch and dedicated worktree, and
+verify the active branch is not `main` before editing files.
+
+Read-only investigation, design-only discussion, and requests explicitly scoped
+to local-only/no-PR work may stay outside this gate. If the scope turns into
+issue-backed implementation work after edits have started, stop, create or
+choose the issue, move the work onto the issue branch/worktree, and then
+continue.
+
 ## Issue-First Work
 
 Base uses GitHub Issues as the public product backlog. Implementation work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,24 @@ them.
 
 ## GitHub Workflow
 
+### Pre-Edit Workflow Gate
+
+Before modifying files in this repository, classify the request.
+
+- For implementation work in `basefoundry/base`, do not edit on `main`.
+- First create or choose the GitHub issue, set required Project metadata, move
+  Project `Status` to `In Progress`, create the issue branch and worktree, and
+  verify the active branch is not `main`.
+- Only start file edits after the issue-backed worktree is active.
+- Read-only investigation, design-only discussion, and requests explicitly
+  scoped to local-only/no-PR work may stay outside this gate, but keep that
+  scope explicit in the handoff.
+- If edits start before the work is recognized as issue-backed implementation
+  work, stop, create or choose the issue, move the work onto the issue
+  branch/worktree, and then continue.
+
+### Standard Issue Flow
+
 - Create or choose a GitHub issue before implementation work.
 - Use one primary category label: `bug`, `enhancement`, `documentation`, `ci`,
   or `security`.

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -4,6 +4,21 @@ Base uses GitHub Issues as the public product backlog and Git worktrees for
 parallel pull request trains. This page captures the repository workflow so
 humans and AI-assisted development agents follow the same rules.
 
+## Pre-Edit Workflow Gate
+
+Before modifying Base files, classify the request.
+
+For implementation work in `basefoundry/base`, do not edit on `main`. Create
+or choose the GitHub issue, set the required Project metadata, move Project
+`Status` to `In Progress`, create the issue branch and dedicated worktree, and
+verify the active branch is not `main` before editing files.
+
+This gate does not apply to read-only investigation, design-only discussion, or
+requests explicitly scoped to local-only/no-PR work. If the scope changes into
+issue-backed implementation work after edits have started, stop, create or
+choose the issue, move the work onto the issue branch/worktree, and then
+continue.
+
 ## Labels
 
 Base uses GitHub default-style labels instead of `type:*` labels.
@@ -193,6 +208,9 @@ security/247-20260529-restrict-log-permissions
 
 Use `enhancement/` for maintenance work unless the issue is more specifically
 `documentation`, `ci`, or `security`.
+
+Before committing or opening a pull request, verify the active branch is not
+`main` and follows the issue-backed branch convention.
 
 ## Worktrees
 


### PR DESCRIPTION
## Summary
- Add a pre-edit workflow gate to `AGENTS.md` for Base implementation work.
- Mirror the gate in `.ai-context/WORKFLOWS.md`.
- Document the canonical gate and late branch-safety check in `docs/github-workflow.md`.

## Validation
- `git diff --check`

## Demo Impact
- None. Workflow/documentation-only change.

## AI Context
- Updated `.ai-context/WORKFLOWS.md` because this changes durable Base workflow guidance.

Fixes #1021
