### PR TITLE
Add workspace init command

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -25,16 +25,18 @@ the canonical current command list.
   prompt to an AI provider.
 - `basectl projects list` - list Base-managed projects discovered in the
   workspace.
-- `basectl workspace <status|check|doctor|clone|pull|configure>` - inspect
+- `basectl workspace <status|check|doctor|clone|pull|init|configure>` - inspect
   workspace status, checks, and diagnostics; explicitly clone expected
-  repositories from a manifest; explicitly sync a local manifest from a
-  configured canonical source; or apply repo configuration across a workspace.
+  repositories from a manifest; initialize a workspace from a workspace
+  configuration repo; explicitly sync a local manifest from a configured
+  canonical source; or apply repo configuration across a workspace.
   - `workspace status`, `workspace check`, and `workspace doctor` support
-    `--format json`; `workspace clone`, `workspace pull`, and
+    `--format json`; `workspace clone`, `workspace pull`, `workspace init`, and
     `workspace configure` use text output.
   - `workspace clone` mutates repository checkouts only when invoked directly;
     `workspace pull` mutates only the local workspace manifest after validating
-    the source.
+    the source; `workspace init` can clone the workspace configuration repo,
+    update `~/.base.d/config.yaml`, and materialize manifest repositories.
   - `workspace configure --dry-run` previews delegated `repo configure` calls;
     without `--dry-run`, it skips missing or non-Base-managed repos, continues
     after per-repo failures, and reports configured/skipped/failed counts.

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -47,8 +47,8 @@ Recent released work includes:
 
 - local command-history index with future report surfaces still deferred
 - project Python version requirements for Base-managed virtualenv creation
-- workspace manifest status/check/doctor reporting plus explicit clone and pull
-  support
+- workspace manifest status/check/doctor reporting plus explicit init, clone,
+  and pull support
 - guarded `basectl release publish`
 - release check, plan, and notes commands
 - local `.ai-context/` export bundles through `basectl export-context`

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ basectl workspace status --format json
 basectl workspace status --manifest ~/work/workspace.yaml
 basectl workspace check
 basectl workspace doctor
+basectl workspace init basefoundry/base-workspace --dry-run
 basectl workspace clone --manifest ~/work/workspace.yaml --dry-run
 basectl workspace configure --dry-run
 ```
@@ -468,8 +469,8 @@ Use `--workspace <path>` to inspect a different workspace root for one command.
 Project list output is tab-separated as `<project-name><TAB><path>`.
 `basectl projects list` and the read-only workspace status, check, and doctor
 commands support `--format json` for machine-readable output. Workspace clone,
-pull, and configure use text output only. Workspace status, check, and doctor are
-read-only. Status reports each discovered project's manifest
+pull, init, and configure use text output only. Workspace status, check, and
+doctor are read-only. Status reports each discovered project's manifest
 validity, whether the Base-managed project virtual environment is present, and
 the latest recorded `basectl check <project>` date when one exists. Check
 records live under `~/.base.d/<project>/checks/last.json`; status JSON includes
@@ -490,6 +491,15 @@ manifest. The command keeps existing repositories visible, delegates each
 repository operation to `basectl repo clone`, and supports `--dry-run` for a
 no-write preview. Optional repositories are reported but skipped unless
 `--include-optional` is supplied.
+
+Use `basectl workspace init <workspace-source>` for first-run bootstrap from a
+workspace configuration repository. The source can be a local path, GitHub URL,
+`owner/repo`, or a short repository name resolved with `--owner <owner>` or
+`github.default_owner`. `--path <path>` controls where the workspace
+configuration repo is checked out or read. `--workspace <path>` controls where
+member repositories are cloned. Init validates `workspace.yaml` before
+materializing member repositories and then delegates those clones through
+`basectl workspace clone`.
 
 Use `basectl workspace pull`, or `basectl workspace pull --dry-run`, when
 `workspace.manifest_source` and `workspace.manifest` are configured to refresh a

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -166,6 +166,11 @@ such command directories exist. Optional utility CLIs such as `caff` and
   Optional repositories are reported but skipped unless `--include-optional` is
   supplied, `--dry-run` previews the delegated clone work, and explicit
   `--manifest <path>` takes precedence over `workspace.manifest`.
+- `basectl workspace init <workspace-source>` bootstraps a workspace from a
+  workspace configuration repository. The source may be a local path, GitHub URL,
+  `owner/repo`, or a short repository name resolved by `--owner <owner>` or
+  `github.default_owner`. `--path <path>` controls the configuration repo
+  checkout, while `--workspace <path>` controls member repository destinations.
 - `basectl workspace pull` explicitly fetches and validates a canonical
   workspace manifest source from `workspace.manifest_source` in
   `~/.base.d/config.yaml`, or from an explicit `--source <url-or-path>`, and

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -53,8 +53,8 @@ Commands:
     Update Base from Git and run setup.
   projects list [options]
     List Base-managed projects discovered in the workspace.
-  workspace <status|check|doctor|clone|pull|configure> [options]
-    Show workspace status, run checks/diagnostics, clone manifest repos, or sync manifest.
+  workspace <status|check|doctor|clone|pull|init|configure> [options]
+    Show workspace status, run checks/diagnostics, initialize, clone, sync, or configure.
   version
     Show the installed Base version.
   help

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -57,6 +57,25 @@ Fetch and validate a canonical workspace manifest before updating the local mani
 EOF
 }
 
+base_workspace_init_usage() {
+    cat <<'EOF'
+Usage:
+  basectl workspace init <workspace-source> [options]
+
+Options:
+  --owner <owner>     GitHub owner for short workspace repository names.
+  --path <path>       Workspace configuration repository checkout path.
+  --workspace <path>  Workspace directory for member repositories.
+  --manifest <path>   Workspace manifest path or name. Defaults to workspace.yaml in the config repo.
+  --include-optional  Include optional workspace manifest repositories when cloning.
+  --dry-run           Show planned workspace initialization without writing.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Initialize a workspace from a workspace configuration repository.
+EOF
+}
+
 base_workspace_configure_usage() {
     cat <<'EOF'
 Usage:
@@ -85,13 +104,16 @@ base_workspace_subcommand_usage() {
         pull)
             base_workspace_pull_usage
             ;;
+        init)
+            base_workspace_init_usage
+            ;;
         configure)
             base_workspace_configure_usage
             ;;
         *)
             cat <<'EOF'
 Usage:
-  basectl workspace <status|check|doctor|clone|pull|configure> [options]
+  basectl workspace <status|check|doctor|clone|pull|init|configure> [options]
 
 Commands:
   status     Show workspace status. Supports --format text|json.
@@ -99,6 +121,7 @@ Commands:
   doctor     Run workspace diagnostics. Supports --format text|json.
   clone      Clone or validate expected repositories from a workspace manifest.
   pull       Fetch and validate a canonical workspace manifest source.
+  init       Initialize a workspace from a workspace configuration repository.
   configure  Apply repo configure across workspace repositories.
 
 Run `basectl workspace <command> --help` for command-specific options.
@@ -123,7 +146,7 @@ base_workspace_subcommand_main() {
             base_workspace_subcommand_usage
             return 0
             ;;
-        status|check|doctor|clone|pull|configure)
+        status|check|doctor|clone|pull|init|configure)
             shift
             ;;
         *)

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -111,6 +111,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "workspace_pull_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace init --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "workspace_init_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl workspace configure --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -227,10 +231,11 @@ EOF
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"export_context_options=--workspace --format --output --print --list-files"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
-    [[ "$output" == *"workspace_commands=status check doctor clone pull"* ]]
+    [[ "$output" == *"workspace_commands=status check doctor clone pull init"* ]]
     [[ "$output" == *"workspace_status_options=--workspace --manifest --format"* ]]
     [[ "$output" == *"workspace_clone_options=--workspace --manifest --include-optional --dry-run"* ]]
     [[ "$output" == *"workspace_pull_options=--source --manifest --dry-run"* ]]
+    [[ "$output" == *"workspace_init_options=--owner --path --workspace --manifest --include-optional --dry-run"* ]]
     [[ "$output" == *"workspace_configure_options=--workspace --manifest --dry-run"* ]]
     [[ "$output" == *"onboard_options=--profile --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"onboard_projects=base demo"* ]]
@@ -307,6 +312,6 @@ EOF
             printf "options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"commands=status check doctor clone pull configure"* ]]
+    [[ "$output" == *"commands=status check doctor clone pull init configure"* ]]
     [[ "$output" == *"options=--workspace --manifest --dry-run"* ]]
 }

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -27,7 +27,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"onboard [project] [options]"* ]]
     [[ "$output" == *"update [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
-    [[ "$output" == *"workspace <status|check|doctor|clone|pull|configure> [options]"* ]]
+    [[ "$output" == *"workspace <status|check|doctor|clone|pull|init|configure> [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
@@ -61,7 +61,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  prompt <list|name> [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  history [options]' <<<"$output"
-    grep -Fqx '  workspace <status|check|doctor|clone|pull|configure> [options]' <<<"$output"
+    grep -Fqx '  workspace <status|check|doctor|clone|pull|init|configure> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
@@ -70,7 +70,7 @@ load ./basectl_helpers.bash
 @test "AI command context includes current clone and update surfaces" {
     local commands_file="$BASE_REPO_ROOT/.ai-context/COMMANDS.md"
 
-    grep -Fqx -- "- \`basectl workspace <status|check|doctor|clone|pull|configure>\` - inspect" "$commands_file"
+    grep -Fqx -- "- \`basectl workspace <status|check|doctor|clone|pull|init|configure>\` - inspect" "$commands_file"
     grep -Fqx -- "  - \`workspace clone\` mutates repository checkouts only when invoked directly;" "$commands_file"
     grep -Fqx -- "- \`basectl repo <init|clone|check|configure|agent-guidance|installer-template>\` -" "$commands_file"
     grep -Fqx -- "- \`basectl update [project]\` - update Base or a named project using the" "$commands_file"

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -169,6 +169,36 @@ EOF
     [ "$output" = "ARGS=--workspace $workspace --manifest $manifest --dry-run" ]
 }
 
+@test "basectl workspace init delegates to the Python projects layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local config_repo="$TEST_TMPDIR/base-workspace"
+    local manifest="$TEST_TMPDIR/base-workspace/workspace.yaml"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base" "$config_repo"
+    touch "$manifest"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "init" ]]; then
+    printf 'ARGS=%s\n' "${*:4}"
+    exit 0
+fi
+printf 'unexpected workspace init python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+    config_repo="$(cd "$config_repo" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace init base-workspace --owner codeforester --path "$config_repo" --workspace "$workspace" --manifest workspace.yaml --include-optional --dry-run
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS=base-workspace --owner codeforester --path $config_repo --workspace $workspace --manifest workspace.yaml --include-optional --dry-run" ]
+}
+
 @test "basectl workspace commands print help without requiring the Base Python venv" {
     run_basectl workspace status --help
 
@@ -216,6 +246,18 @@ EOF
     [[ "$output" == *"basectl workspace configure [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" != *"--format <format>"* ]]
+
+    run_basectl workspace init --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl workspace init <workspace-source> [options]"* ]]
+    [[ "$output" == *"--owner <owner>"* ]]
+    [[ "$output" == *"--path <path>"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--manifest <path>"* ]]
+    [[ "$output" == *"--include-optional"* ]]
     [[ "$output" == *"--dry-run"* ]]
     [[ "$output" != *"--format <format>"* ]]
 }

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -14,6 +14,8 @@ from typing import Any
 from urllib.parse import urlparse
 
 import base_cli
+from base_cli.config import load_user_config
+from base_cli.config import user_config_path
 from base_cli.paths import base_cache_root, discover_manifest
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
@@ -57,8 +59,18 @@ class WorkspaceCommandOptions:
     output_format: str
     workspace_manifest: str | None = None
     workspace_manifest_source: str | None = None
+    workspace_config_path: str | None = None
+    workspace_owner: str | None = None
     include_optional: bool = False
     dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class WorkspaceInitSource:
+    display: str
+    repo_spec: str | None = None
+    repo_name: str | None = None
+    local_path: Path | None = None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -74,6 +86,8 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
 @base_cli.option("--manifest", "workspace_manifest", help="Local workspace manifest to read.")
 @base_cli.option("--source", "workspace_manifest_source", help="Canonical workspace manifest source URL or path.")
+@base_cli.option("--path", "workspace_config_path", help="Workspace configuration repository checkout path.")
+@base_cli.option("--owner", "workspace_owner", help="GitHub owner for short workspace repository names.")
 @base_cli.option(
     "--include-optional",
     is_flag=True,
@@ -88,6 +102,8 @@ def run(
     output_format: str,
     workspace_manifest: str | None,
     workspace_manifest_source: str | None,
+    workspace_config_path: str | None,
+    workspace_owner: str | None,
     include_optional: bool,
     dry_run: bool,
 ) -> int:
@@ -100,6 +116,8 @@ def run(
                 output_format=output_format,
                 workspace_manifest=workspace_manifest,
                 workspace_manifest_source=workspace_manifest_source,
+                workspace_config_path=workspace_config_path,
+                workspace_owner=workspace_owner,
                 include_optional=include_optional,
                 dry_run=dry_run,
             ),
@@ -154,6 +172,7 @@ def dispatch_projects_command(
             command_arguments,
             lambda: workspace_pull_command(ctx, options),
         ),
+        "init": lambda: workspace_init_from_args(ctx, command_arguments, options),
         "configure": lambda: require_no_args_and_run(
             "configure", command_arguments, lambda: workspace_configure_from_options(ctx, options)
         ),
@@ -174,7 +193,7 @@ def dispatch_projects_command(
 
     ctx.log.error(
         "Unknown projects command '%s'. Supported commands: list, current, manifest, resolve, "
-        "status, check, doctor, clone, configure, test-command, demo-script, activation-sources, run-command, "
+        "status, check, doctor, clone, configure, init, test-command, demo-script, activation-sources, run-command, "
         "run-commands, build-targets, build-target-list, pull.",
         command,
     )
@@ -263,6 +282,15 @@ def run_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, .
 def list_run_commands_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
     project = optional_project_argument("run-commands", arguments)
     return list_run_commands_command(ctx, project, workspace)
+
+
+def workspace_init_from_args(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+) -> int:
+    require_argument_count("init", arguments, 1, 1)
+    return workspace_init_command(ctx, arguments[0], options)
 
 
 def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
@@ -443,6 +471,191 @@ def workspace_pull_command(ctx: base_cli.Context, options: WorkspaceCommandOptio
 
     print(f"Updated workspace manifest: {result.target}")
     return 0
+
+
+def workspace_init_command(ctx: base_cli.Context, workspace_source: str, options: WorkspaceCommandOptions) -> int:
+    if options.output_format != "text":
+        raise ProjectUsageError(f"Unsupported output format '{options.output_format}'. Expected: text.")
+
+    try:
+        source = resolve_workspace_init_source(ctx, workspace_source, options.workspace_owner)
+        config_repo = resolve_workspace_config_repo_path(ctx, source, options)
+        workspace_root = resolve_workspace_init_root(ctx, options.workspace, config_repo)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    print("Workspace init")
+    print(f"Workspace source: {source.display}")
+    print(f"Workspace config repo: {config_repo}")
+    print(f"Workspace root: {workspace_root}")
+
+    try:
+        if source.repo_spec is not None:
+            clone_workspace_config_repo(ctx, source.repo_spec, config_repo, dry_run=options.dry_run)
+        manifest_path = resolve_workspace_init_manifest_path(config_repo, options.workspace_manifest)
+        if options.dry_run and source.repo_spec is not None and not manifest_path.is_file():
+            print(f"[DRY-RUN] Would read workspace manifest: {manifest_path}")
+            print("[DRY-RUN] Would update user config:")
+            print(f"  workspace.root: {workspace_root}")
+            print(f"  workspace.manifest: {manifest_path}")
+            print("[DRY-RUN] Skipping member repository plan because the workspace config repo is not present.")
+            return 0
+        manifest = resolve_workspace_manifest(str(manifest_path))
+        if manifest is None:
+            raise WorkspaceManifestError(f"{manifest_path}: workspace manifest is required.")
+    except WorkspaceManifestError as exc:
+        ctx.log.error(str(exc))
+        return 1
+
+    print(f"Workspace manifest: {manifest.path} ({manifest.name})")
+
+    if options.dry_run:
+        print("[DRY-RUN] Would update user config:")
+        print(f"  workspace.root: {workspace_root}")
+        print(f"  workspace.manifest: {manifest.path}")
+    else:
+        write_workspace_init_user_config(workspace_root, manifest.path)
+        print(f"Updated user config: {user_config_path()}")
+
+    clone_options = WorkspaceCommandOptions(
+        workspace=str(workspace_root),
+        output_format="text",
+        workspace_manifest=str(manifest.path),
+        include_optional=options.include_optional,
+        dry_run=options.dry_run,
+    )
+    return workspace_clone_command(ctx, clone_options)
+
+
+def resolve_workspace_init_source(
+    ctx: base_cli.Context,
+    workspace_source: str,
+    owner: str | None,
+) -> WorkspaceInitSource:
+    source_path = Path(workspace_source).expanduser()
+    if workspace_source.startswith("file://"):
+        parsed = urlparse(workspace_source)
+        return WorkspaceInitSource(
+            display=workspace_source,
+            local_path=Path(parsed.path).expanduser().resolve(strict=False),
+        )
+    if is_workspace_init_path_source(workspace_source) or source_path.exists():
+        return WorkspaceInitSource(
+            display=workspace_source,
+            local_path=source_path.resolve(strict=False),
+        )
+
+    repo_spec = workspace_init_github_repo_spec(workspace_source)
+    if repo_spec is not None:
+        return WorkspaceInitSource(
+            display=repo_spec,
+            repo_spec=repo_spec,
+            repo_name=repo_spec.split("/", 1)[1],
+        )
+
+    if "/" in workspace_source:
+        raise ProjectUsageError("Workspace source must be a local path, GitHub URL, '<owner>/<repo>', or short repo name.")
+
+    effective_owner = owner or ctx.user_config.github.default_owner
+    if effective_owner is None:
+        raise ProjectUsageError(
+            "Workspace source owner is required for short repo names. "
+            "Pass --owner <owner> or set github.default_owner in ~/.base.d/config.yaml."
+        )
+    repo_spec = f"{effective_owner}/{workspace_source}"
+    return WorkspaceInitSource(display=repo_spec, repo_spec=repo_spec, repo_name=workspace_source)
+
+
+def is_workspace_init_path_source(workspace_source: str) -> bool:
+    return workspace_source.startswith(("/", "./", "../", "~"))
+
+
+def workspace_init_github_repo_spec(workspace_source: str) -> str | None:
+    parsed = urlparse(workspace_source)
+    if parsed.scheme and parsed.hostname == "github.com":
+        return github_repo_spec_from_path(parsed.path)
+
+    git_ssh_prefix = "git@github.com:"
+    if workspace_source.startswith(git_ssh_prefix):
+        return github_repo_spec_from_path(workspace_source[len(git_ssh_prefix) :])
+
+    if "/" in workspace_source and not parsed.scheme:
+        return github_repo_spec_from_path(workspace_source)
+    return None
+
+
+def resolve_workspace_config_repo_path(
+    ctx: base_cli.Context,
+    source: WorkspaceInitSource,
+    options: WorkspaceCommandOptions,
+) -> Path:
+    if options.workspace_config_path is not None:
+        return Path(options.workspace_config_path).expanduser().resolve(strict=False)
+    if source.local_path is not None:
+        return source.local_path
+    workspace_root = resolve_workspace_init_root(ctx, options.workspace, None)
+    assert source.repo_name is not None
+    return (workspace_root / source.repo_name).resolve(strict=False)
+
+
+def resolve_workspace_init_manifest_path(config_repo: Path, workspace_manifest: str | None) -> Path:
+    if workspace_manifest is None:
+        return (config_repo / "workspace.yaml").resolve(strict=False)
+    manifest_path = Path(workspace_manifest).expanduser()
+    if manifest_path.is_absolute():
+        return manifest_path.resolve(strict=False)
+    return (config_repo / manifest_path).resolve(strict=False)
+
+
+def resolve_workspace_init_root(ctx: base_cli.Context, workspace: str | None, config_repo: Path | None) -> Path:
+    if workspace is not None:
+        return Path(workspace).expanduser().resolve(strict=False)
+    if ctx.workspace_root is not None:
+        return ctx.workspace_root
+    if config_repo is None:
+        if ctx.base_home is None:
+            raise ProjectDiscoveryError("BASE_HOME is required to resolve the default workspace root.")
+        return ctx.base_home.parent.resolve(strict=False)
+    return config_repo.parent.resolve(strict=False)
+
+
+def clone_workspace_config_repo(ctx: base_cli.Context, repo_spec: str, target: Path, *, dry_run: bool) -> None:
+    if ctx.base_home is None:
+        raise WorkspaceManifestError("BASE_HOME is required to clone the workspace configuration repository.")
+    basectl = ctx.base_home / "bin" / "basectl"
+    command = [str(basectl), "repo", "clone", repo_spec, "--path", str(target)]
+    if dry_run:
+        command.append("--dry-run")
+    try:
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+    except OSError as exc:
+        raise WorkspaceManifestError(f"Could not run basectl repo clone for workspace source '{repo_spec}': {exc}") from exc
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    if result.returncode != 0:
+        raise WorkspaceManifestError(f"Workspace source clone failed for '{repo_spec}'.")
+
+
+def write_workspace_init_user_config(workspace_root: Path, manifest_path: Path) -> None:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise WorkspaceManifestError(
+            "PyYAML is required to update ~/.base.d/config.yaml. "
+            "Run 'basectl setup' to install Base Python bootstrap dependencies."
+        ) from exc
+
+    config_path = user_config_path()
+    raw_config = load_user_config()
+    workspace_config = dict(raw_config.get("workspace") or {})
+    workspace_config["root"] = str(workspace_root)
+    workspace_config["manifest"] = str(manifest_path)
+    raw_config["workspace"] = workspace_config
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.safe_dump(raw_config, sort_keys=False), encoding="utf-8")
 
 
 def effective_workspace_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> str | None:

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# pylint: disable=too-many-lines
+
 import hashlib
 import json
 import os
@@ -555,7 +557,10 @@ def resolve_workspace_init_source(
         )
 
     if "/" in workspace_source:
-        raise ProjectUsageError("Workspace source must be a local path, GitHub URL, '<owner>/<repo>', or short repo name.")
+        raise ProjectUsageError(
+            "Workspace source must be a local path, GitHub URL, "
+            "'<owner>/<repo>', or short repo name."
+        )
 
     effective_owner = owner or ctx.user_config.github.default_owner
     if effective_owner is None:
@@ -630,7 +635,9 @@ def clone_workspace_config_repo(ctx: base_cli.Context, repo_spec: str, target: P
     try:
         result = subprocess.run(command, check=False, capture_output=True, text=True)
     except OSError as exc:
-        raise WorkspaceManifestError(f"Could not run basectl repo clone for workspace source '{repo_spec}': {exc}") from exc
+        raise WorkspaceManifestError(
+            f"Could not run basectl repo clone for workspace source '{repo_spec}': {exc}"
+        ) from exc
     if result.stdout:
         print(result.stdout, end="")
     if result.stderr:

--- a/cli/python/base_projects/tests/test_workspace_init.py
+++ b/cli/python/base_projects/tests/test_workspace_init.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_projects import engine
+
+
+def write_workspace_manifest(path: Path) -> None:
+    path.write_text(
+        """\
+schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: api
+    url: git@github.com:codeforester/api.git
+  - name: docs
+""",
+        encoding="utf-8",
+    )
+
+
+def write_fake_basectl(base_home: Path, state_file: Path) -> None:
+    basectl = base_home / "bin" / "basectl"
+    basectl.parent.mkdir(parents=True)
+    basectl.write_text(
+        f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> {state_file}
+repo="${{3:-}}"
+path=""
+dry_run=0
+while (($#)); do
+    case "$1" in
+        --path)
+            path="$2"
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+if [[ "$repo" == "codeforester/base-workspace" && -n "$path" && "$dry_run" != "1" ]]; then
+    mkdir -p "$path"
+    cat > "$path/workspace.yaml" <<'YAML'
+schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: api
+    url: git@github.com:codeforester/api.git
+  - name: docs
+YAML
+fi
+printf 'fake basectl %s\\n' "$*"
+""",
+        encoding="utf-8",
+    )
+    basectl.chmod(0o755)
+
+
+def invoke_engine(
+    args: list[str],
+    base_home: Path,
+    home: Path,
+) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    env = {
+        "HOME": str(home),
+        "BASE_HOME": str(base_home),
+        "BASE_PROJECT": "",
+        "BASE_PROJECT_MANIFEST": "",
+    }
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class WorkspaceInitTests(unittest.TestCase):
+    def test_workspace_init_dry_run_uses_local_source_without_writing_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            source = root / "base-workspace"
+            state_file = root / "basectl-calls"
+            config_path = home / ".base.d" / "config.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            source.mkdir()
+            write_workspace_manifest(source / "workspace.yaml")
+            write_fake_basectl(base_home, state_file)
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "init",
+                    str(source),
+                    "--path",
+                    str(source),
+                    "--workspace",
+                    str(workspace),
+                    "--dry-run",
+                ],
+                base_home,
+                home,
+            )
+
+            state_lines = state_file.read_text(encoding="utf-8").splitlines() if state_file.exists() else []
+            config_exists = config_path.exists()
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertFalse(config_exists)
+        self.assertIn("Workspace init", stdout)
+        self.assertIn(f"Workspace source: {source}", stdout)
+        self.assertIn(f"Workspace config repo: {source.resolve()}", stdout)
+        self.assertIn(f"Workspace root: {workspace.resolve()}", stdout)
+        self.assertIn(f"Workspace manifest: {(source / 'workspace.yaml').resolve()} (demo-suite)", stdout)
+        self.assertIn("[DRY-RUN] Would update user config:", stdout)
+        self.assertEqual(
+            state_lines,
+            [
+                f"repo clone codeforester/api --path {(workspace / 'api').resolve()} --dry-run",
+                f"repo clone docs --path {(workspace / 'docs').resolve()} --dry-run",
+            ],
+        )
+
+    def test_workspace_init_writes_config_and_clones_repositories_under_workspace_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            source = workspace / "base-workspace"
+            state_file = root / "basectl-calls"
+            config_path = home / ".base.d" / "config.yaml"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                "github:\n"
+                "  default_owner: codeforester\n"
+                "  clone_protocol: https\n",
+                encoding="utf-8",
+            )
+            base_home.mkdir()
+            workspace.mkdir()
+            source.mkdir()
+            write_workspace_manifest(source / "workspace.yaml")
+            write_fake_basectl(base_home, state_file)
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "init",
+                    str(source),
+                    "--path",
+                    str(source),
+                ],
+                base_home,
+                home,
+            )
+            config_content = config_path.read_text(encoding="utf-8")
+            state_lines = state_file.read_text(encoding="utf-8").splitlines() if state_file.exists() else []
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace root: {workspace.resolve()}", stdout)
+        self.assertIn(f"Updated user config: {config_path}", stdout)
+        self.assertIn("github:", config_content)
+        self.assertIn("default_owner: codeforester", config_content)
+        self.assertIn("clone_protocol: https", config_content)
+        self.assertIn("workspace:", config_content)
+        self.assertIn(f"root: {workspace.resolve()}", config_content)
+        self.assertIn(f"manifest: {(source / 'workspace.yaml').resolve()}", config_content)
+        self.assertEqual(
+            state_lines,
+            [
+                f"repo clone codeforester/api --path {(workspace / 'api').resolve()}",
+                f"repo clone docs --path {(workspace / 'docs').resolve()}",
+            ],
+        )
+
+    def test_workspace_init_clones_short_workspace_source_with_owner_before_reading_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            source = workspace / "base-workspace"
+            state_file = root / "basectl-calls"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_fake_basectl(base_home, state_file)
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "init",
+                    "base-workspace",
+                    "--owner",
+                    "codeforester",
+                    "--path",
+                    str(source),
+                    "--workspace",
+                    str(workspace),
+                ],
+                base_home,
+                home,
+            )
+            state_lines = state_file.read_text(encoding="utf-8").splitlines() if state_file.exists() else []
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace source: codeforester/base-workspace", stdout)
+        self.assertIn(f"Workspace manifest: {(source / 'workspace.yaml').resolve()} (demo-suite)", stdout)
+        self.assertEqual(
+            state_lines,
+            [
+                f"repo clone codeforester/base-workspace --path {source.resolve()}",
+                f"repo clone codeforester/api --path {(workspace / 'api').resolve()}",
+                f"repo clone docs --path {(workspace / 'docs').resolve()}",
+            ],
+        )
+
+    def test_workspace_init_remote_dry_run_without_local_manifest_stops_after_config_repo_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            source = workspace / "base-workspace"
+            state_file = root / "basectl-calls"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_fake_basectl(base_home, state_file)
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "init",
+                    "base-workspace",
+                    "--owner",
+                    "codeforester",
+                    "--path",
+                    str(source),
+                    "--workspace",
+                    str(workspace),
+                    "--dry-run",
+                ],
+                base_home,
+                home,
+            )
+            state_lines = state_file.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("Workspace init", stdout)
+        self.assertIn(f"Workspace source: codeforester/base-workspace", stdout)
+        self.assertIn(f"Workspace config repo: {source.resolve()}", stdout)
+        self.assertIn(f"Workspace root: {workspace.resolve()}", stdout)
+        self.assertIn(f"[DRY-RUN] Would read workspace manifest: {(source / 'workspace.yaml').resolve()}", stdout)
+        self.assertIn("[DRY-RUN] Skipping member repository plan because the workspace config repo is not present.", stdout)
+        self.assertEqual(
+            state_lines,
+            [f"repo clone codeforester/base-workspace --path {source.resolve()} --dry-run"],
+        )

--- a/cli/python/base_projects/tests/test_workspace_init.py
+++ b/cli/python/base_projects/tests/test_workspace_init.py
@@ -223,7 +223,7 @@ class WorkspaceInitTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertIn(f"Workspace source: codeforester/base-workspace", stdout)
+        self.assertIn("Workspace source: codeforester/base-workspace", stdout)
         self.assertIn(f"Workspace manifest: {(source / 'workspace.yaml').resolve()} (demo-suite)", stdout)
         self.assertEqual(
             state_lines,
@@ -267,11 +267,14 @@ class WorkspaceInitTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertIn("Workspace init", stdout)
-        self.assertIn(f"Workspace source: codeforester/base-workspace", stdout)
+        self.assertIn("Workspace source: codeforester/base-workspace", stdout)
         self.assertIn(f"Workspace config repo: {source.resolve()}", stdout)
         self.assertIn(f"Workspace root: {workspace.resolve()}", stdout)
         self.assertIn(f"[DRY-RUN] Would read workspace manifest: {(source / 'workspace.yaml').resolve()}", stdout)
-        self.assertIn("[DRY-RUN] Skipping member repository plan because the workspace config repo is not present.", stdout)
+        self.assertIn(
+            "[DRY-RUN] Skipping member repository plan because the workspace config repo is not present.",
+            stdout,
+        )
         self.assertEqual(
             state_lines,
             [f"repo clone codeforester/base-workspace --path {source.resolve()} --dry-run"],

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -278,6 +278,28 @@ With a configured or explicit manifest, commands report both expected
 repositories and discovered projects, including missing expected repositories
 and extra discovered projects.
 
+The init path bootstraps a workspace from a workspace configuration repository:
+
+```bash
+basectl workspace init basefoundry/base-workspace --dry-run
+basectl workspace init basefoundry/base-workspace
+basectl workspace init base-workspace --owner basefoundry --path ~/work/base-workspace
+```
+
+The positional argument is a workspace source, not the workspace name. The
+source can be a local path, a GitHub URL, `owner/repo`, or a short repository
+name resolved by `--owner <owner>` or `github.default_owner`. `--path` controls
+where the workspace configuration repository is checked out or read.
+`--workspace` controls where member repositories are cloned. If neither
+`--workspace` nor configured `workspace.root` is available, init uses the parent
+of the workspace configuration repo path as the workspace root.
+
+Init validates the workspace manifest before cloning member repositories. When
+the workspace source is remote, init first delegates the workspace configuration
+repo checkout to `basectl repo clone`, then delegates member repository
+materialization to `basectl workspace clone`. A remote dry-run can stop after the
+configuration repo clone plan when the local manifest is not available yet.
+
 The clone path requires a manifest from either config or the command line:
 
 ```bash

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -91,7 +91,7 @@ _base_basectl_completion() {
             ;;
         workspace)
             if ((COMP_CWORD == 2)); then
-                _base_basectl_completion_compgen "status check doctor clone pull configure" "$cur"
+                _base_basectl_completion_compgen "status check doctor clone pull init configure" "$cur"
             else
                 case "${COMP_WORDS[2]:-}" in
                     status|check|doctor)
@@ -102,6 +102,9 @@ _base_basectl_completion() {
                         ;;
                     pull)
                         _base_basectl_completion_compgen "--source --manifest --dry-run -v -h --help" "$cur"
+                        ;;
+                    init)
+                        _base_basectl_completion_compgen "--owner --path --workspace --manifest --include-optional --dry-run -v -h --help" "$cur"
                         ;;
                     configure)
                         _base_basectl_completion_compgen "--workspace --manifest --dry-run -v -h --help" "$cur"


### PR DESCRIPTION
## Summary
- Add `basectl workspace init <workspace-source>` for first-run workspace bootstrap from local or GitHub workspace config repos.
- Wire Bash help, completions, Python orchestration, config updates, dry-run behavior, and docs/AI context.
- Delegate workspace config repo checkout through `basectl repo clone` and member repo materialization through existing workspace clone behavior.

## Validation
- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/1028-workspace-init/lib/python:/Users/rameshhp/work/base-worktrees/1028-workspace-init/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_workspace_init.py cli/python/base_projects/tests/test_workspace_clone.py cli/python/base_projects/tests/test_workspace_pull.py -q`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/completions.bats cli/bash/commands/basectl/tests/help.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test`
- `git diff --check`

Closes #1028