### PR TITLE
Show chmod hint for repo check

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -2330,6 +2330,8 @@ base_repo_pr_baseline_has_changes() {
 }
 
 base_repo_check_baseline() {
+    local current_dir
+    local fix_path
     local missing_files=()
     local path="$1"
     local rel
@@ -2360,8 +2362,15 @@ base_repo_check_baseline() {
         for rel in "${missing_files[@]}"; do
             printf "  Missing: %s\n" "$rel"
         done
+        current_dir="$(pwd -P)"
         for rel in "${not_executable_files[@]}"; do
             printf "  Not executable: %s\n" "$rel"
+            if [[ "$path" == "$current_dir" ]]; then
+                fix_path="$rel"
+            else
+                fix_path="$path/$rel"
+            fi
+            printf "  Fix: chmod +x %s\n" "$(base_repo_pretty_arg "$fix_path")"
         done
         if ((${#missing_files[@]})); then
             repo_name="$(basename -- "$path")"

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -997,6 +997,22 @@ EOF
     [[ "$output" == *"Run 'basectl repo init incomplete --path $repo_dir' to create the missing files."* ]]
 }
 
+@test "basectl repo check prints fix hint for non-executable validation script" {
+    local repo_dir="$TEST_TMPDIR/base-demo"
+
+    run_basectl repo init base-demo --path "$repo_dir" --no-configure
+    [ "$status" -eq 0 ]
+    chmod -x "$repo_dir/tests/validate.sh"
+
+    cd "$repo_dir"
+    run_basectl repo check .
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Repository baseline: all 12 required files present, but some requirements failed."* ]]
+    [[ "$output" == *"  Not executable: tests/validate.sh"* ]]
+    [[ "$output" == *"  Fix: chmod +x tests/validate.sh"* ]]
+}
+
 @test "basectl repo check reports missing agent guidance only when opted in" {
     local repo_dir="$TEST_TMPDIR/base-demo"
 


### PR DESCRIPTION
## Summary
- Print a `chmod +x` fix hint when `basectl repo check` finds a non-executable validation script.
- Keep the hint relative for `repo check .` and shell-safe for explicit paths.
- Add regression coverage for the non-executable `tests/validate.sh` case.

## Validation
- Focused repo.bats regression filter
- Full repo.bats
- git diff --check
- ./bin/base-test

Fixes #1024