### PR TITLE
Normalize repo clone dry-run output

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -2749,10 +2749,10 @@ base_repo_clone_with_gh() {
     esac
 
     if [[ "$dry_run" == "1" ]]; then
-        printf "Repository: %s\n" "$repo"
-        printf "Destination: %s\n" "$target"
-        printf "Tool: gh repo clone\n"
-        printf "Clone URL: %s\n" "$clone_url"
+        printf "[DRY-RUN] Would clone %s (%s) into %s.\n" \
+            "$repo" \
+            "$clone_url" \
+            "$(base_repo_pretty_arg "$target")"
         printf "[DRY-RUN] Would run: "
         base_repo_pretty_command gh repo clone "$repo" "$target"
         printf "\n"

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -79,11 +79,12 @@ EOF
     run_basectl repo clone base-demo --dry-run
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Repository: codeforester/base-demo"* ]]
-    [[ "$output" == *"Destination: $repo_dir"* ]]
-    [[ "$output" == *"Tool: gh repo clone"* ]]
-    [[ "$output" == *"Clone URL: git@github.com:codeforester/base-demo.git"* ]]
-    [[ "$output" == *"[DRY-RUN] Would run: gh repo clone codeforester/base-demo $repo_dir"* ]]
+    [ "$(line_at "$output" 1)" = "[DRY-RUN] Would clone codeforester/base-demo (git@github.com:codeforester/base-demo.git) into $repo_dir." ]
+    [ "$(line_at "$output" 2)" = "[DRY-RUN] Would run: gh repo clone codeforester/base-demo $repo_dir" ]
+    [[ "$output" != *"Repository:"* ]]
+    [[ "$output" != *"Destination:"* ]]
+    [[ "$output" != *"Tool:"* ]]
+    [[ "$output" != *"Clone URL:"* ]]
     [ ! -e "$repo_dir" ]
 }
 
@@ -93,9 +94,8 @@ EOF
     run_basectl repo clone base-demo --owner codeforester --path "~/work/base-demo" --dry-run
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Repository: codeforester/base-demo"* ]]
-    [[ "$output" == *"Destination: $repo_dir"* ]]
-    [[ "$output" == *"Clone URL: git@github.com:codeforester/base-demo.git"* ]]
+    [ "$(line_at "$output" 1)" = "[DRY-RUN] Would clone codeforester/base-demo (git@github.com:codeforester/base-demo.git) into $repo_dir." ]
+    [ "$(line_at "$output" 2)" = "[DRY-RUN] Would run: gh repo clone codeforester/base-demo $repo_dir" ]
     [ ! -e "$repo_dir" ]
 }
 
@@ -112,9 +112,8 @@ EOF
     run_basectl repo clone codeforester/bankbuddy --path "$repo_dir" --dry-run
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Repository: codeforester/bankbuddy"* ]]
-    [[ "$output" == *"Destination: $repo_dir"* ]]
-    [[ "$output" == *"Clone URL: https://github.com/codeforester/bankbuddy.git"* ]]
+    [ "$(line_at "$output" 1)" = "[DRY-RUN] Would clone codeforester/bankbuddy (https://github.com/codeforester/bankbuddy.git) into $repo_dir." ]
+    [ "$(line_at "$output" 2)" = "[DRY-RUN] Would run: gh repo clone codeforester/bankbuddy $repo_dir" ]
 }
 
 @test "basectl repo clone requires an owner for short names" {


### PR DESCRIPTION
## Summary
- Replace `repo clone --dry-run` labeled summary lines with a `[DRY-RUN] Would clone ...` line.
- Preserve the concrete `[DRY-RUN] Would run: gh repo clone ...` command preview.
- Update clone dry-run tests for SSH, explicit path, and HTTPS protocols.

## Validation
- Focused repo clone dry-run regression filters
- Full repo.bats
- git diff --check
- ./bin/base-test

Fixes #1025