### PR TITLE
Explain repo configure origin inference

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -3226,7 +3226,10 @@ base_repo_configure() {
     fi
     [[ -n "$github_repo" ]] || {
         log_error "Unable to infer GitHub repository from '$path'."
-        log_error "Pass --repo <owner/name> to configure a GitHub repository explicitly."
+        printf "       Inference requires a git remote named 'origin' that points to github.com.\n" >&2
+        printf "       Pass --repo <owner/name> to configure explicitly, or run:\n" >&2
+        printf "         git -C %s remote -v\n" "$(base_repo_pretty_arg "$path")" >&2
+        printf "       to inspect the current remotes.\n" >&2
         return 1
     }
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -1059,6 +1059,21 @@ EOF
     [[ "$output" != *'Change\ should\ update\ a\ project\ demo'* ]]
 }
 
+@test "basectl repo configure explains GitHub origin inference failures" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+
+    run_basectl repo configure "$repo_dir" --dry-run --no-project
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unable to infer GitHub repository from '$repo_dir'."* ]]
+    [[ "$output" == *"Inference requires a git remote named 'origin' that points to github.com."* ]]
+    [[ "$output" == *"Pass --repo <owner/name> to configure explicitly, or run:"* ]]
+    [[ "$output" == *"git -C $repo_dir remote -v"* ]]
+    [[ "$output" == *"to inspect the current remotes."* ]]
+}
+
 @test "basectl repo configure dry-run protects the default branch by default" {
     local repo_dir="$TEST_TMPDIR/repo"
 


### PR DESCRIPTION
## Summary
- Expand `repo configure` inference failure output to explain the `origin` GitHub remote prerequisite.
- Show a `git -C <path> remote -v` inspection command.
- Add regression coverage for non-inferable configure targets.

## Validation
- Focused repo.bats regression filter
- Full repo.bats
- git diff --check
- ./bin/base-test

Fixes #1026