### PR TITLE
Show update hint for existing repo clone

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -2714,6 +2714,7 @@ base_repo_clone_check_destination() {
     actual_repo="$(base_repo_infer_github_repo "$target" || true)"
     if [[ "$actual_repo" == "$expected_repo" ]]; then
         printf "Repository '%s' already exists at '%s'.\n" "$expected_repo" "$target"
+        printf "To update: git -C %s pull --ff-only\n" "$(base_repo_pretty_arg "$target")"
         return 2
     fi
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -136,6 +136,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Repository 'codeforester/base-demo' already exists at '$repo_dir'."* ]]
+    [[ "$output" == *"To update: git -C $repo_dir pull --ff-only"* ]]
     [[ "$output" != *"gh repo clone"* ]]
 
     git -C "$repo_dir" remote set-url origin git@github.com:codeforester/base-demo
@@ -144,6 +145,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Repository 'codeforester/base-demo' already exists at '$repo_dir'."* ]]
+    [[ "$output" == *"To update: git -C $repo_dir pull --ff-only"* ]]
 }
 
 @test "basectl repo clone rejects conflicting existing checkouts" {


### PR DESCRIPTION
## Summary
- Print `git -C <path> pull --ff-only` when `repo clone` finds a matching existing checkout.
- Keep the already-satisfied path as exit 0.
- Cover both matching origin URL forms in the clone test.

## Validation
- Focused matching-checkout regression filter
- Full repo.bats
- git diff --check
- ./bin/base-test

Fixes #1027