### PR TITLE
Fix prompt verbose argument handling

### DIFF
--- a/cli/bash/commands/basectl/subcommands/prompt.sh
+++ b/cli/bash/commands/basectl/subcommands/prompt.sh
@@ -30,7 +30,9 @@ base_prompt_usage_error() {
 
 base_prompt_subcommand_main() {
     local wrapper="$BASE_HOME/bin/base-wrapper"
-    local args=()
+    local debug=0
+    local prompt_args=()
+    local renderer_args=()
 
     while (($#)); do
         case "$1" in
@@ -39,7 +41,7 @@ base_prompt_subcommand_main() {
                 return 0
                 ;;
             -v)
-                args+=(--debug)
+                debug=1
                 shift
                 ;;
             -*)
@@ -47,21 +49,23 @@ base_prompt_subcommand_main() {
                 return $?
                 ;;
             *)
-                args+=("$1")
+                prompt_args+=("$1")
                 shift
                 ;;
         esac
     done
 
-    if ((${#args[@]} == 0)); then
+    if ((${#prompt_args[@]} == 0)); then
         base_prompt_usage_error "The 'prompt' command requires 'list' or a prompt name."
         return $?
     fi
-    if ((${#args[@]} > 1)); then
+    if ((${#prompt_args[@]} > 1)); then
         base_prompt_usage_error "The 'prompt' command accepts exactly one argument."
         return $?
     fi
 
+    ((debug)) && renderer_args+=(--debug)
+
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    "$wrapper" --project base base_prompt "${args[@]}"
+    "$wrapper" --project base base_prompt "${renderer_args[@]}" "${prompt_args[@]}"
 }

--- a/cli/bash/commands/basectl/tests/prompt.bats
+++ b/cli/bash/commands/basectl/tests/prompt.bats
@@ -42,6 +42,35 @@ EOF
     [ "$(cat "$state_file")" = "product-self-review" ]
 }
 
+@test "basectl prompt -v forwards debug without counting it as a prompt name" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local state_file="$TEST_TMPDIR/prompt-debug-state"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" ]]; then
+    shift 2
+    printf '%s\n' "$*" > "${BASE_TEST_PROMPT_STATE:?}"
+    printf '# rendered prompt\n'
+    exit 0
+fi
+printf 'unexpected prompt python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROMPT_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" prompt -v product-self-review
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"# rendered prompt"* ]]
+    [ "$(cat "$state_file")" = "--debug product-self-review" ]
+}
+
 @test "basectl prompt list delegates to the Python prompt renderer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
 


### PR DESCRIPTION
Summary:
- Parse `basectl prompt -v` separately from the required prompt operand.
- Forward `--debug` to the Python prompt renderer without counting it as a second prompt argument.
- Add a regression test for `basectl prompt -v product-self-review`.

Validation:
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME bats cli/bash/commands/basectl/tests/prompt.bats
- git diff --check
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test

Fixes #1029