### PR TITLE
Print worktree command for gh issue start

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -273,6 +273,19 @@ base_gh_slug() {
     printf '%.60s\n' "$slug" | sed -E 's/-+$//'
 }
 
+base_gh_issue_worktree_path() {
+    local issue="$1" slug="$2"
+    local repo_root repo_name repo_parent slug_short
+
+    repo_root="$(git rev-parse --show-toplevel)" || return 1
+    repo_name="$(basename "$repo_root")"
+    repo_parent="$(dirname "$repo_root")"
+    slug_short="$(printf '%s\n' "$slug" | cut -c1-40 | sed -E 's/-+$//')"
+    [[ -n "$slug_short" ]] || slug_short="work"
+
+    printf '%s/%s-worktrees/%s-%s\n' "$repo_parent" "$repo_name" "$issue" "$slug_short"
+}
+
 base_gh_issue_category_from_labels() {
     local issue="$1"
     local category
@@ -692,7 +705,7 @@ base_gh_pr_create() {
 }
 
 base_gh_issue_start() {
-    local issue="${1:-}" category="" title="" slug branch today
+    local issue="${1:-}" category="" title="" slug branch today default_branch worktree_path
 
     [[ -n "$issue" ]] || {
         base_gh_error "Missing issue number."
@@ -737,9 +750,13 @@ base_gh_issue_start() {
     slug="$(base_gh_slug "$title")"
     today="$(date +%Y%m%d)"
     branch="$category/$issue-$today-$slug"
+    default_branch="$(base_gh_default_branch)"
+    worktree_path="$(base_gh_issue_worktree_path "$issue" "$slug")" || return 1
 
-    git switch --quiet -c "$branch"
     printf '%s\n' "$branch"
+    printf '\n'
+    printf 'To create a worktree:\n'
+    printf '  git worktree add -b %s %s origin/%s\n' "$branch" "$worktree_path" "$default_branch"
 }
 
 base_gh_do_pr() {

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -430,7 +430,7 @@ EOF
     [[ "$output" != *"unexpected gh args"* ]]
 }
 
-@test "basectl gh issue start creates convention branch from issue metadata" {
+@test "basectl gh issue start prints worktree command from issue metadata" {
     local repo
 
     repo="$TEST_TMPDIR/repo"
@@ -468,8 +468,11 @@ EOF
         ' bash "$repo"
 
     [ "$status" -eq 0 ]
-    [[ "$output" == "enhancement/117-"*"-add-basectl-gh-workflow-for-issues" ]]
-    [ "$(git -C "$repo" branch --show-current)" = "$output" ]
+    [[ "$(printf '%s\n' "$output" | sed -n '1p')" == "enhancement/117-"*"-add-basectl-gh-workflow-for-issues" ]]
+    [ "$(printf '%s\n' "$output" | sed -n '2p')" = "" ]
+    [ "$(printf '%s\n' "$output" | sed -n '3p')" = "To create a worktree:" ]
+    [[ "$(printf '%s\n' "$output" | sed -n '4p')" == "  git worktree add -b enhancement/117-"*"-add-basectl-gh-workflow-for-issues "*"/repo-worktrees/117-add-basectl-gh-workflow-for-issues origin/master" ]]
+    [ "$(git -C "$repo" branch --show-current)" = "master" ]
 }
 
 @test "basectl gh issue start accepts explicit category and title without gh" {
@@ -491,7 +494,11 @@ EOF
         ' bash "$repo"
 
     [ "$status" -eq 0 ]
-    [[ "$output" == "enhancement/117-"*"-prune-merged-branches" ]]
+    [[ "$(printf '%s\n' "$output" | sed -n '1p')" == "enhancement/117-"*"-prune-merged-branches" ]]
+    [ "$(printf '%s\n' "$output" | sed -n '2p')" = "" ]
+    [ "$(printf '%s\n' "$output" | sed -n '3p')" = "To create a worktree:" ]
+    [[ "$(printf '%s\n' "$output" | sed -n '4p')" == "  git worktree add -b enhancement/117-"*"-prune-merged-branches "*"/repo-worktrees/117-prune-merged-branches origin/master" ]]
+    [ "$(git -C "$repo" branch --show-current)" = "master" ]
 }
 
 @test "basectl gh branch prune falls back to main when default branch is unknown" {


### PR DESCRIPTION
## Summary
- stop `basectl gh issue start` from switching the current checkout
- print a ready-to-run `git worktree add` command for the generated issue branch
- cover both GitHub-derived and explicit issue metadata paths

## Validation
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats

Fixes #1030