### PR TITLE
Normalize lifecycle usage exit codes

### DIFF
--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -63,7 +63,7 @@ base_check_subcommand_main() {
                 if [[ -z "${1:-}" ]]; then
                     print_error "Option '--format' requires an argument."
                     base_check_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 case "$1" in
                     text|json)
@@ -72,7 +72,7 @@ base_check_subcommand_main() {
                     *)
                         print_error "Unsupported check output format '$1'."
                         base_check_subcommand_usage >&2
-                        return 1
+                        return 2
                         ;;
                 esac
                 ;;
@@ -81,12 +81,12 @@ base_check_subcommand_main() {
                 if [[ -z "${1:-}" ]]; then
                     print_error "Option '--profile' requires an argument."
                     base_check_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 if ! setup_enable_profile_argument "$1"; then
                     print_error "$BASE_SETUP_PROFILE_ERROR"
                     base_check_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 ;;
             --manifest)
@@ -94,7 +94,7 @@ base_check_subcommand_main() {
                 if [[ -z "${1:-}" ]]; then
                     print_error "Option '--manifest' requires an argument."
                     base_check_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 BASE_SETUP_MANIFEST="$1"
                 export BASE_SETUP_MANIFEST
@@ -109,12 +109,12 @@ base_check_subcommand_main() {
                 if [[ "$1" == -* ]]; then
                     print_error "Unknown option '$1'."
                     base_check_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 if [[ -n "$project" ]]; then
                     print_error "The 'check' command accepts at most one project name."
                     base_check_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 project="$1"
                 ;;

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -119,12 +119,12 @@ base_onboard_subcommand_main() {
                 if [[ -z "${1:-}" ]]; then
                     print_error "Option '--profile' requires an argument."
                     base_onboard_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 if ! setup_enable_profile_argument "$1"; then
                     print_error "$BASE_SETUP_PROFILE_ERROR"
                     base_onboard_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 ;;
             --dry-run)
@@ -146,13 +146,13 @@ base_onboard_subcommand_main() {
             -*)
                 print_error "Unknown option '$1'."
                 base_onboard_subcommand_usage >&2
-                return 1
+                return 2
                 ;;
             *)
                 if ((project_explicit)); then
                     print_error "The onboard command accepts at most one project."
                     base_onboard_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 project="$1"
                 project_explicit=1

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -70,12 +70,12 @@ base_setup_subcommand_main() {
                 if [[ -z "${1:-}" ]]; then
                     print_error "Option '--profile' requires an argument."
                     base_setup_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 if ! setup_enable_profile_argument "$1"; then
                     print_error "$BASE_SETUP_PROFILE_ERROR"
                     base_setup_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 ;;
             --manifest)
@@ -83,7 +83,7 @@ base_setup_subcommand_main() {
                 if [[ -z "${1:-}" ]]; then
                     print_error "Option '--manifest' requires an argument."
                     base_setup_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 BASE_SETUP_MANIFEST="$1"
                 export BASE_SETUP_MANIFEST
@@ -103,13 +103,13 @@ base_setup_subcommand_main() {
             --*)
                 print_error "Unknown option '$1'."
                 base_setup_subcommand_usage >&2
-                return 1
+                return 2
                 ;;
             *)
                 if [[ -n "$project_name" ]]; then
                     print_error "Only one project argument is supported."
                     base_setup_subcommand_usage >&2
-                    return 1
+                    return 2
                 fi
                 project_name="$1"
                 ;;

--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -192,7 +192,7 @@ base_update_profile_subcommand_main() {
             *)
                 print_error "Unknown option '$1'."
                 base_update_profile_subcommand_usage >&2
-                return 1
+                return 2
                 ;;
         esac
         shift
@@ -201,7 +201,7 @@ base_update_profile_subcommand_main() {
     if ((enable_defaults && disable_defaults)); then
         print_error "Options '--defaults' and '--no-defaults' cannot be used together."
         base_update_profile_subcommand_usage >&2
-        return 1
+        return 2
     fi
 
     log_debug "Running 'basectl update-profile'."

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -192,14 +192,14 @@ load ./setup_helpers.bash
 @test "basectl check rejects unknown profiles" {
     run_base_command check --profile ops
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Unsupported profile 'ops'. Expected one of: dev, sre, ai."* ]]
 }
 
 @test "basectl check rejects empty profile list entries" {
     run_base_command check --profile dev,,sre
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Profile list must not contain empty entries."* ]]
 }
 
@@ -708,6 +708,6 @@ load ./setup_helpers.bash
 @test "basectl check rejects unsupported output formats" {
     run_base_command check --format xml
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Unsupported check output format 'xml'."* ]]
 }

--- a/cli/bash/commands/basectl/tests/lifecycle-usage.bats
+++ b/cli/bash/commands/basectl/tests/lifecycle-usage.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load ./setup_helpers.bash
+
+
+@test "basectl setup usage errors return exit code 2" {
+    run_base_command setup --badopt
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown option '--badopt'."* ]]
+}
+
+@test "basectl check usage errors return exit code 2" {
+    run_base_command check --badopt
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown option '--badopt'."* ]]
+}
+
+@test "basectl onboard usage errors return exit code 2" {
+    run_base_command onboard --badopt
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown option '--badopt'."* ]]
+}
+
+@test "basectl update-profile usage errors return exit code 2" {
+    run_base_command update-profile --badopt
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown option '--badopt'."* ]]
+}

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -85,9 +85,9 @@ load ./basectl_helpers.bash
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
             base_onboard_subcommand_main bankbuddy base-demo --dry-run
-        '
+    '
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"The onboard command accepts at most one project."* ]]
 }
 
@@ -99,9 +99,9 @@ load ./basectl_helpers.bash
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
             base_onboard_subcommand_main --profile ops
-        '
+    '
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Unsupported profile 'ops'. Expected one of: dev, sre, ai."* ]]
 }
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -694,14 +694,14 @@ EOF
 @test "basectl setup rejects unknown profiles" {
     run_base_command setup --profile ops
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Unsupported profile 'ops'. Expected one of: dev, sre, ai."* ]]
 }
 
 @test "basectl setup rejects empty profile list entries" {
     run_base_command setup --profile dev,,sre
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Profile list must not contain empty entries."* ]]
 }
 

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -583,7 +583,7 @@ EOF
 @test "basectl update-profile rejects conflicting defaults options" {
     run_base_command update-profile --defaults --no-defaults
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"Options '--defaults' and '--no-defaults' cannot be used together."* ]]
     [[ "$output" == *"Usage:"* ]]
     [ ! -e "$TEST_HOME/.base.d/profile.conf" ]


### PR DESCRIPTION
## Summary
- return exit code 2 for usage errors in setup, check, onboard, and update-profile
- update existing assertions that covered invalid lifecycle arguments
- add a focused lifecycle usage regression suite

## Validation
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/lifecycle-usage.bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/onboard.bats cli/bash/commands/basectl/tests/update-profile.bats

Fixes #1031