### PR TITLE
Compact lifecycle usage errors

### DIFF
--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -45,6 +45,12 @@ Check does:
 EOF
 }
 
+base_check_usage_error() {
+    print_error "$*"
+    printf "Run 'basectl check --help' for usage.\n" >&2
+    return 2
+}
+
 base_check_subcommand_main() {
     local output_format="text"
     local project=""
@@ -61,40 +67,35 @@ base_check_subcommand_main() {
             --format)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--format' requires an argument."
-                    base_check_subcommand_usage >&2
-                    return 2
+                    base_check_usage_error "Option '--format' requires an argument."
+                    return $?
                 fi
                 case "$1" in
                     text|json)
                         output_format="$1"
                         ;;
                     *)
-                        print_error "Unsupported check output format '$1'."
-                        base_check_subcommand_usage >&2
-                        return 2
+                        base_check_usage_error "Unsupported check output format '$1'."
+                        return $?
                         ;;
                 esac
                 ;;
             --profile)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--profile' requires an argument."
-                    base_check_subcommand_usage >&2
-                    return 2
+                    base_check_usage_error "Option '--profile' requires an argument."
+                    return $?
                 fi
                 if ! setup_enable_profile_argument "$1"; then
-                    print_error "$BASE_SETUP_PROFILE_ERROR"
-                    base_check_subcommand_usage >&2
-                    return 2
+                    base_check_usage_error "$BASE_SETUP_PROFILE_ERROR"
+                    return $?
                 fi
                 ;;
             --manifest)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--manifest' requires an argument."
-                    base_check_subcommand_usage >&2
-                    return 2
+                    base_check_usage_error "Option '--manifest' requires an argument."
+                    return $?
                 fi
                 BASE_SETUP_MANIFEST="$1"
                 export BASE_SETUP_MANIFEST
@@ -107,14 +108,12 @@ base_check_subcommand_main() {
                 ;;
             *)
                 if [[ "$1" == -* ]]; then
-                    print_error "Unknown option '$1'."
-                    base_check_subcommand_usage >&2
-                    return 2
+                    base_check_usage_error "Unknown option '$1'."
+                    return $?
                 fi
                 if [[ -n "$project" ]]; then
-                    print_error "The 'check' command accepts at most one project name."
-                    base_check_subcommand_usage >&2
-                    return 2
+                    base_check_usage_error "The 'check' command accepts at most one project name."
+                    return $?
                 fi
                 project="$1"
                 ;;

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -37,6 +37,12 @@ See also:
 EOF
 }
 
+base_doctor_usage_error() {
+    print_error "$*"
+    printf "Run 'basectl doctor --help' for usage.\n" >&2
+    return 2
+}
+
 base_doctor_print_finding() {
     local status="$1"
     local finding_id="$2"
@@ -321,40 +327,35 @@ base_doctor_subcommand_main() {
             --profile)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--profile' requires an argument."
-                    base_doctor_subcommand_usage >&2
-                    return 2
+                    base_doctor_usage_error "Option '--profile' requires an argument."
+                    return $?
                 fi
                 if ! setup_enable_profile_argument "$1"; then
-                    print_error "$BASE_SETUP_PROFILE_ERROR"
-                    base_doctor_subcommand_usage >&2
-                    return 2
+                    base_doctor_usage_error "$BASE_SETUP_PROFILE_ERROR"
+                    return $?
                 fi
                 ;;
             --format)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--format' requires an argument."
-                    base_doctor_subcommand_usage >&2
-                    return 2
+                    base_doctor_usage_error "Option '--format' requires an argument."
+                    return $?
                 fi
                 case "$1" in
                     text|json)
                         output_format="$1"
                         ;;
                     *)
-                        print_error "Unsupported doctor output format '$1'."
-                        base_doctor_subcommand_usage >&2
-                        return 2
+                        base_doctor_usage_error "Unsupported doctor output format '$1'."
+                        return $?
                         ;;
                 esac
                 ;;
             --manifest)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--manifest' requires an argument."
-                    base_doctor_subcommand_usage >&2
-                    return 2
+                    base_doctor_usage_error "Option '--manifest' requires an argument."
+                    return $?
                 fi
                 BASE_SETUP_MANIFEST="$1"
                 export BASE_SETUP_MANIFEST
@@ -371,14 +372,12 @@ base_doctor_subcommand_main() {
                 ;;
             *)
                 if [[ "$1" == -* ]]; then
-                    print_error "Unknown option '$1'."
-                    base_doctor_subcommand_usage >&2
-                    return 2
+                    base_doctor_usage_error "Unknown option '$1'."
+                    return $?
                 fi
                 if [[ -n "$project" ]]; then
-                    print_error "The 'doctor' command accepts at most one project name."
-                    base_doctor_subcommand_usage >&2
-                    return 2
+                    base_doctor_usage_error "The 'doctor' command accepts at most one project name."
+                    return $?
                 fi
                 project="$1"
                 ;;

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -30,6 +30,12 @@ Project:
 EOF
 }
 
+base_onboard_usage_error() {
+    print_error "$*"
+    printf "Run 'basectl onboard --help' for usage.\n" >&2
+    return 2
+}
+
 base_onboard_print_heading() {
     printf '\n%s\n' "$1"
     printf '%s\n' "----------------"
@@ -117,14 +123,12 @@ base_onboard_subcommand_main() {
             --profile)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--profile' requires an argument."
-                    base_onboard_subcommand_usage >&2
-                    return 2
+                    base_onboard_usage_error "Option '--profile' requires an argument."
+                    return $?
                 fi
                 if ! setup_enable_profile_argument "$1"; then
-                    print_error "$BASE_SETUP_PROFILE_ERROR"
-                    base_onboard_subcommand_usage >&2
-                    return 2
+                    base_onboard_usage_error "$BASE_SETUP_PROFILE_ERROR"
+                    return $?
                 fi
                 ;;
             --dry-run)
@@ -144,15 +148,13 @@ base_onboard_subcommand_main() {
                 return 0
                 ;;
             -*)
-                print_error "Unknown option '$1'."
-                base_onboard_subcommand_usage >&2
-                return 2
+                base_onboard_usage_error "Unknown option '$1'."
+                return $?
                 ;;
             *)
                 if ((project_explicit)); then
-                    print_error "The onboard command accepts at most one project."
-                    base_onboard_subcommand_usage >&2
-                    return 2
+                    base_onboard_usage_error "The onboard command accepts at most one project."
+                    return $?
                 fi
                 project="$1"
                 project_explicit=1

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -50,6 +50,12 @@ Notes:
 EOF
 }
 
+base_setup_usage_error() {
+    print_error "$*"
+    printf "Run 'basectl setup --help' for usage.\n" >&2
+    return 2
+}
+
 base_setup_subcommand_main() {
     local exit_code
     local project_name=""
@@ -68,22 +74,19 @@ base_setup_subcommand_main() {
             --profile)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--profile' requires an argument."
-                    base_setup_subcommand_usage >&2
-                    return 2
+                    base_setup_usage_error "Option '--profile' requires an argument."
+                    return $?
                 fi
                 if ! setup_enable_profile_argument "$1"; then
-                    print_error "$BASE_SETUP_PROFILE_ERROR"
-                    base_setup_subcommand_usage >&2
-                    return 2
+                    base_setup_usage_error "$BASE_SETUP_PROFILE_ERROR"
+                    return $?
                 fi
                 ;;
             --manifest)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    print_error "Option '--manifest' requires an argument."
-                    base_setup_subcommand_usage >&2
-                    return 2
+                    base_setup_usage_error "Option '--manifest' requires an argument."
+                    return $?
                 fi
                 BASE_SETUP_MANIFEST="$1"
                 export BASE_SETUP_MANIFEST
@@ -101,15 +104,13 @@ base_setup_subcommand_main() {
                 setup_enable_debug_logging
                 ;;
             --*)
-                print_error "Unknown option '$1'."
-                base_setup_subcommand_usage >&2
-                return 2
+                base_setup_usage_error "Unknown option '$1'."
+                return $?
                 ;;
             *)
                 if [[ -n "$project_name" ]]; then
-                    print_error "Only one project argument is supported."
-                    base_setup_subcommand_usage >&2
-                    return 2
+                    base_setup_usage_error "Only one project argument is supported."
+                    return $?
                 fi
                 project_name="$1"
                 ;;

--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -33,6 +33,12 @@ Updated files:
 EOF
 }
 
+base_update_profile_usage_error() {
+    print_error "$*"
+    printf "Run 'basectl update-profile --help' for usage.\n" >&2
+    return 2
+}
+
 base_update_profile_source_file_library() {
     import_base_lib file/lib_file.sh
 }
@@ -190,18 +196,16 @@ base_update_profile_subcommand_main() {
                 setup_enable_debug_logging
                 ;;
             *)
-                print_error "Unknown option '$1'."
-                base_update_profile_subcommand_usage >&2
-                return 2
+                base_update_profile_usage_error "Unknown option '$1'."
+                return $?
                 ;;
         esac
         shift
     done
 
     if ((enable_defaults && disable_defaults)); then
-        print_error "Options '--defaults' and '--no-defaults' cannot be used together."
-        base_update_profile_subcommand_usage >&2
-        return 2
+        base_update_profile_usage_error "Options '--defaults' and '--no-defaults' cannot be used together."
+        return $?
     fi
 
     log_debug "Running 'basectl update-profile'."

--- a/cli/bash/commands/basectl/tests/lifecycle-usage.bats
+++ b/cli/bash/commands/basectl/tests/lifecycle-usage.bats
@@ -8,6 +8,8 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"Unknown option '--badopt'."* ]]
+    [[ "$output" == *"Run 'basectl setup --help' for usage."* ]]
+    [[ "$output" != *"Usage:"* ]]
 }
 
 @test "basectl check usage errors return exit code 2" {
@@ -15,6 +17,17 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"Unknown option '--badopt'."* ]]
+    [[ "$output" == *"Run 'basectl check --help' for usage."* ]]
+    [[ "$output" != *"Usage:"* ]]
+}
+
+@test "basectl doctor usage errors return exit code 2" {
+    run_base_command doctor --badopt
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown option '--badopt'."* ]]
+    [[ "$output" == *"Run 'basectl doctor --help' for usage."* ]]
+    [[ "$output" != *"Usage:"* ]]
 }
 
 @test "basectl onboard usage errors return exit code 2" {
@@ -22,6 +35,8 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"Unknown option '--badopt'."* ]]
+    [[ "$output" == *"Run 'basectl onboard --help' for usage."* ]]
+    [[ "$output" != *"Usage:"* ]]
 }
 
 @test "basectl update-profile usage errors return exit code 2" {
@@ -29,4 +44,6 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"Unknown option '--badopt'."* ]]
+    [[ "$output" == *"Run 'basectl update-profile --help' for usage."* ]]
+    [[ "$output" != *"Usage:"* ]]
 }

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -585,6 +585,7 @@ EOF
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"Options '--defaults' and '--no-defaults' cannot be used together."* ]]
-    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"Run 'basectl update-profile --help' for usage."* ]]
+    [[ "$output" != *"Usage:"* ]]
     [ ! -e "$TEST_HOME/.base.d/profile.conf" ]
 }


### PR DESCRIPTION
## Summary
- route lifecycle argument errors through compact command-specific usage helpers
- keep full help output limited to explicit `--help` requests
- extend lifecycle usage regression coverage to setup, check, doctor, onboard, and update-profile

## Validation
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/lifecycle-usage.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/lifecycle-usage.bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats cli/bash/commands/basectl/tests/onboard.bats cli/bash/commands/basectl/tests/update-profile.bats

Depends on #1043.
Fixes #1032