### PR TITLE
Enforce space-separated option values

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -3,6 +3,11 @@
 `basectl` is the public Base control-plane command. Run `basectl --help` for
 the canonical current command list.
 
+Long options with values use space-separated syntax, such as `--format json`.
+Base rejects `--option=value` before command delegation. Arguments after `--`
+belong to the delegated project command and may use that command's native
+syntax.
+
 ## Current Public Commands
 
 - `basectl activate <project>` - start an interactive Base Bash runtime shell

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -12,6 +12,11 @@ It is invoked through:
 basectl <subcommand> [args...]
 ```
 
+Long options with values use the space-separated form, for example
+`--format json`. The umbrella command rejects `--option=value` before command
+delegation. Arguments after a `--` separator belong to the delegated project
+command and may use that command's native syntax.
+
 The public entrypoint lives at `bin/basectl`. It establishes the Base runtime
 for command implementations, then sources this command implementation and calls
 `main`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -77,6 +77,9 @@ Notes:
   - `basectl setup` is the preferred entrypoint for machine bootstrap.
   - `basectl check` verifies the same local requirements without making changes.
     Pass a project name to include that project's manifest artifacts.
+  - Use space-separated values for long options, for example `--format json`.
+    Base rejects `--option=value` syntax before command delegation. Arguments
+    after `--` belong to the delegated project command.
   - Invoking `basectl` with no command starts a Base runtime shell for the
     nearest project manifest above the current directory, preserving that
     directory. If no manifest is found, it falls back to project `base`. In
@@ -94,6 +97,34 @@ basectl_usage_error() {
     basectl_error "$*"
     basectl_show_help >&2
     return 2
+}
+
+basectl_equals_option_usage_error() {
+    local argument="$1"
+    local option="${argument%%=*}"
+    local value="${argument#*=}"
+
+    if [[ -n "$value" ]]; then
+        basectl_usage_error "Option '$option' uses unsupported equals syntax. Use '$option $value' instead."
+    else
+        basectl_usage_error "Option '$option' uses unsupported equals syntax. Pass its value as the next argument."
+    fi
+}
+
+basectl_reject_equals_option_values() {
+    local argument
+
+    for argument in "$@"; do
+        [[ "$argument" == "--" ]] && return 0
+        case "$argument" in
+            --?*=*)
+                basectl_equals_option_usage_error "$argument"
+                return $?
+                ;;
+        esac
+    done
+
+    return 0
 }
 
 basectl_get_base_home() {
@@ -342,6 +373,10 @@ basectl_main() {
     fi
 
     case "${1:-}" in
+        --?*=*)
+            basectl_equals_option_usage_error "$1"
+            return $?
+            ;;
         --*)
             basectl_usage_error "Unknown option '$1'"
             return $?
@@ -372,6 +407,8 @@ basectl_main() {
 
     command="${1:-}"
     [[ -n "$command" ]] && shift
+
+    basectl_reject_equals_option_values "$@" || return $?
 
     basectl_get_base_home || return 1
     ((base_debug)) && basectl_enable_debug_logging

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -67,6 +67,20 @@ load ./basectl_helpers.bash
     [[ "$output" != *"-V"* ]]
 }
 
+@test "basectl rejects equals-form long option values before command delegation" {
+    run_basectl history --limit=2
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--limit' uses unsupported equals syntax. Use '--limit 2' instead."* ]]
+    [[ "$output" != *"Project virtual environment Python was not found"* ]]
+
+    run_basectl export-context demo --format=zip
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--format' uses unsupported equals syntax. Use '--format zip' instead."* ]]
+    [[ "$output" != *"Project virtual environment Python was not found"* ]]
+}
+
 @test "AI command context includes current clone and update surfaces" {
     local commands_file="$BASE_REPO_ROOT/.ai-context/COMMANDS.md"
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -43,11 +43,14 @@ def main(ctx: base_cli.Context, name: str) -> None:
 
 
 if __name__ == "__main__":
-    app()
+    raise SystemExit(base_cli.run_app(app))
 ```
 
 The command function receives `ctx` as its first argument. Infrastructure is
 created immediately before command execution and cleaned up afterward.
+`base_cli.run_app()` applies Base's command syntax guard before Click parses
+arguments: long options with values must use space-separated syntax, such as
+`--name Ada`; equals-form values such as `--name=Ada` are rejected.
 
 ## Package Layout
 
@@ -299,6 +302,10 @@ Every `base_cli.App` command gets:
 | `--log-file <path>` | override the persistent log file |
 | `--version` | show the CLI version when configured |
 | `--help` | Click help |
+
+Long option values must use the space-separated form, for example
+`--environment prod`. Base rejects `--option=value` before Click parses
+arguments.
 
 ## Interrupt And Cleanup
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -3,6 +3,11 @@
 This page is a compact lookup table for the current `basectl` command surface.
 Run `basectl --help` or `basectl <command> --help` for full usage.
 
+Use space-separated values for long options, for example `--format json`.
+Base rejects `--option=value` syntax before command delegation. Arguments after
+`--` belong to the delegated project command and may use that command's native
+syntax.
+
 ## Install And Bootstrap
 
 | Command | What it does | Important flags |

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -55,7 +55,7 @@ def main(ctx: base_cli.Context, name: str) -> None:
 
 
 if __name__ == "__main__":
-    app()
+    raise SystemExit(base_cli.run_app(app))
 ```
 
 Running this command automatically adds the standard Base options:
@@ -68,6 +68,9 @@ hello --environment prod --name Ada
 hello --keep-temp --name Ada
 hello --log-file /tmp/hello.log --name Ada
 ```
+
+Long options with values use space-separated syntax. `base_cli.run_app()` rejects
+equals-form values such as `--name=Ada` before Click parses arguments.
 
 ## Command Registration
 
@@ -154,7 +157,9 @@ def main(ctx: base_cli.Context, token: str) -> None:
     ...
 ```
 
-Both `--token secret` and `--token=secret` are redacted in debug logs.
+Both `--token secret` and an externally supplied `--token=secret` token are
+redacted in debug logs, even though Base command invocation rejects equals-form
+option values before Click parses them.
 
 Use `dry_run=True` when a nonstandard option should drive `ctx.dry_run` and
 Base's default durable-write suppression:

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -231,8 +231,10 @@ def run_app(app: App, argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
+    args = list(sys.argv[1:] if argv is None else argv)
     try:
-        result = app.click_command.main(args=argv, standalone_mode=False)
+        _reject_equals_option_values(click, args)
+        result = app.click_command.main(args=args, standalone_mode=False)
     except click.ClickException as exc:
         exc.show()
         return int(exc.exit_code)
@@ -317,6 +319,21 @@ def _merge_standard_options(group_standard: dict[str, Any], command_standard: di
 def _validate_standard_options(click: Any, standard: dict[str, Any]) -> None:
     if standard.get("debug") and standard.get("quiet"):
         raise click.UsageError("--debug and --quiet cannot be used together.")
+
+
+def _reject_equals_option_values(click: Any, argv: list[str]) -> None:
+    for token in argv:
+        if token == "--":
+            return
+        if token.startswith("--") and "=" in token and len(token) > 2:
+            option_name, value = token.split("=", 1)
+            if value:
+                raise click.UsageError(
+                    f"Option '{option_name}' uses unsupported equals syntax. Use '{option_name} {value}' instead."
+                )
+            raise click.UsageError(
+                f"Option '{option_name}' uses unsupported equals syntax. Pass its value as the next argument."
+            )
 
 
 def _group_standard_options(click: Any) -> dict[str, Any]:

--- a/lib/python/base_cli/tests/test_app_run.py
+++ b/lib/python/base_cli/tests/test_app_run.py
@@ -67,6 +67,38 @@ class RunAppTests(unittest.TestCase):
                 with self.assertRaisesRegex(RuntimeError, "boom"):
                     base_cli.run_app(app, [])
 
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_run_app_rejects_equals_form_long_option_values(self) -> None:
+        app = base_cli.App(name="space-options", log_to_file=False)
+        seen = {}
+
+        @app.command()
+        @base_cli.option("--name", required=True)
+        def main(ctx: base_cli.Context, name: str) -> None:
+            del ctx
+            seen["name"] = name
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(home),
+                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
+                },
+            ), redirect_stderr(stderr):
+                status = base_cli.run_app(app, ["--name=demo"])
+
+        self.assertEqual(status, 2)
+        self.assertEqual(seen, {})
+        self.assertIn(
+            "Option '--name' uses unsupported equals syntax. Use '--name demo' instead.",
+            stderr.getvalue(),
+        )
+        self.assertNotIn("Traceback", stderr.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Reject `--option=value` before `basectl` delegates to subcommands, while preserving delegated arguments after `--`.
- Add the same space-only value guard to `base_cli.run_app` before Click parses Python CLI arguments.
- Document the command syntax contract in help, command docs, `base_cli` docs, and `.ai-context`.

## Issue

Closes #1050

## Validation

- RED: `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME bats --filter "rejects equals-form" cli/bash/commands/basectl/tests/help.bats` failed before the fix because `history --limit=2` delegated instead of returning usage code 2.
- RED: `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest lib/python/base_cli/tests/test_app_run.py` failed before the Python framework fix because Click accepted `--name=demo`.
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/history.bats cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/export-context.bats cli/bash/commands/basectl/tests/run.bats cli/bash/commands/basectl/tests/build.bats`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q`
- `git diff --check`
- `shellcheck --severity=error cli/bash/commands/basectl/basectl.sh`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test` - 589 Python tests passed, 1 skipped; 465 BATS tests passed.

## Demo Impact

None.

## Notes

`.ai-context/COMMANDS.md` was updated because this changes the public `basectl` syntax contract.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
