### PR TITLE
Standardize basectl logging options

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -8,6 +8,11 @@ Base rejects `--option=value` before command delegation. Arguments after `--`
 belong to the delegated project command and may use that command's native
 syntax.
 
+`basectl` exposes `-v` as the command-level debug switch. Direct `base_cli`
+package standard options such as `--debug`, `--quiet`, `--log-file`,
+`--config`, `--environment`, and `--keep-temp` are not public `basectl`
+options.
+
 ## Current Public Commands
 
 - `basectl activate <project>` - start an interactive Base Bash runtime shell

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -17,6 +17,11 @@ Long options with values use the space-separated form, for example
 delegation. Arguments after a `--` separator belong to the delegated project
 command and may use that command's native syntax.
 
+`basectl` exposes `-v` as the public command-level debug switch. Direct
+`base_cli` package standard options such as `--debug`, `--quiet`, `--log-file`,
+`--config`, `--environment`, and `--keep-temp` are not public `basectl`
+options.
+
 The public entrypoint lives at `bin/basectl`. It establishes the Base runtime
 for command implementations, then sources this command implementation and calls
 `main`.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -80,12 +80,15 @@ Notes:
   - Use space-separated values for long options, for example `--format json`.
     Base rejects `--option=value` syntax before command delegation. Arguments
     after `--` belong to the delegated project command.
+  - Use `-v` for command-level debug logs. Python package standard options such
+    as `--debug`, `--quiet`, `--log-file`, `--config`, `--environment`, and
+    `--keep-temp` are not public `basectl` options.
   - Invoking `basectl` with no command starts a Base runtime shell for the
     nearest project manifest above the current directory, preserving that
     directory. If no manifest is found, it falls back to project `base`. In
     non-interactive shells it prints this help text.
-  - Use `-v` for command-level debug logs. Use `--debug-wrapper` when debugging
-    startup before command dispatch or Base runtime initialization.
+  - Use `--debug-wrapper` when debugging startup before command dispatch or
+    Base runtime initialization.
 EOF
 }
 
@@ -119,6 +122,35 @@ basectl_reject_equals_option_values() {
         case "$argument" in
             --?*=*)
                 basectl_equals_option_usage_error "$argument"
+                return $?
+                ;;
+        esac
+    done
+
+    return 0
+}
+
+basectl_private_standard_option_usage_error() {
+    local option="$1"
+
+    case "$option" in
+        --debug)
+            basectl_usage_error "Option '--debug' is not supported by basectl. Use '-v' for command-level debug logs or '--debug-wrapper' for wrapper startup logging."
+            ;;
+        *)
+            basectl_usage_error "Option '$option' is not supported by basectl. Use command-specific options shown by 'basectl <command> --help'."
+            ;;
+    esac
+}
+
+basectl_reject_private_standard_options() {
+    local argument
+
+    for argument in "$@"; do
+        [[ "$argument" == "--" ]] && return 0
+        case "$argument" in
+            --debug|--quiet|--log-file|--config|--environment|--keep-temp)
+                basectl_private_standard_option_usage_error "$argument"
                 return $?
                 ;;
         esac
@@ -377,6 +409,10 @@ basectl_main() {
             basectl_equals_option_usage_error "$1"
             return $?
             ;;
+        --debug|--quiet|--log-file|--config|--environment|--keep-temp)
+            basectl_private_standard_option_usage_error "$1"
+            return $?
+            ;;
         --*)
             basectl_usage_error "Unknown option '$1'"
             return $?
@@ -409,6 +445,7 @@ basectl_main() {
     [[ -n "$command" ]] && shift
 
     basectl_reject_equals_option_values "$@" || return $?
+    basectl_reject_private_standard_options "$@" || return $?
 
     basectl_get_base_home || return 1
     ((base_debug)) && basectl_enable_debug_logging

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -81,6 +81,45 @@ load ./basectl_helpers.bash
     [[ "$output" != *"Project virtual environment Python was not found"* ]]
 }
 
+@test "basectl rejects Python standard options consistently before command delegation" {
+    run_basectl logs --debug --path
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--debug' is not supported by basectl. Use '-v' for command-level debug logs or '--debug-wrapper' for wrapper startup logging."* ]]
+    [[ "$output" != *"Project virtual environment Python was not found"* ]]
+
+    run_basectl check --debug
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--debug' is not supported by basectl. Use '-v' for command-level debug logs or '--debug-wrapper' for wrapper startup logging."* ]]
+
+    run_basectl logs --quiet --path
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--quiet' is not supported by basectl. Use command-specific options shown by 'basectl <command> --help'."* ]]
+    [[ "$output" != *"Project virtual environment Python was not found"* ]]
+
+    run_basectl logs --log-file "$TEST_TMPDIR/base.log" --path
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--log-file' is not supported by basectl. Use command-specific options shown by 'basectl <command> --help'."* ]]
+
+    run_basectl logs --config "$TEST_TMPDIR/config.yaml" --path
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--config' is not supported by basectl. Use command-specific options shown by 'basectl <command> --help'."* ]]
+
+    run_basectl logs --environment prod --path
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--environment' is not supported by basectl. Use command-specific options shown by 'basectl <command> --help'."* ]]
+
+    run_basectl logs --keep-temp --path
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--keep-temp' is not supported by basectl. Use command-specific options shown by 'basectl <command> --help'."* ]]
+}
+
 @test "AI command context includes current clone and update surfaces" {
     local commands_file="$BASE_REPO_ROOT/.ai-context/COMMANDS.md"
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -291,7 +291,7 @@ Recommended shape:
 
 ## Standard Options
 
-Every `base_cli.App` command gets:
+Direct `base_cli.App` command packages get:
 
 | Option | Purpose |
 |---|---|
@@ -306,6 +306,12 @@ Every `base_cli.App` command gets:
 Long option values must use the space-separated form, for example
 `--environment prod`. Base rejects `--option=value` before Click parses
 arguments.
+
+These are direct Python package options. Public `basectl` launchers expose
+`-v` for command-level debug logs and command-specific flags from
+`basectl <command> --help`; they do not expose `--debug`, `--quiet`,
+`--log-file`, `--config`, `--environment`, or `--keep-temp` as public
+`basectl` options.
 
 ## Interrupt And Cleanup
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -8,6 +8,11 @@ Base rejects `--option=value` syntax before command delegation. Arguments after
 `--` belong to the delegated project command and may use that command's native
 syntax.
 
+`basectl` exposes `-v` as the public command-level debug switch. Direct
+`base_cli` package standard options such as `--debug`, `--quiet`, `--log-file`,
+`--config`, `--environment`, and `--keep-temp` are private to Python package
+execution and are rejected by `basectl`.
+
 ## Install And Bootstrap
 
 | Command | What it does | Important flags |

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -58,7 +58,8 @@ if __name__ == "__main__":
     raise SystemExit(base_cli.run_app(app))
 ```
 
-Running this command automatically adds the standard Base options:
+Running this command directly as a Python package automatically adds the
+standard Base options:
 
 ```bash
 hello --name Ada
@@ -71,6 +72,11 @@ hello --log-file /tmp/hello.log --name Ada
 
 Long options with values use space-separated syntax. `base_cli.run_app()` rejects
 equals-form values such as `--name=Ada` before Click parses arguments.
+These are direct package options. Public `basectl` launchers expose `-v` for
+command-level debug logs and command-specific flags from
+`basectl <command> --help`; they do not expose `--debug`, `--quiet`,
+`--log-file`, `--config`, `--environment`, or `--keep-temp` as public
+`basectl` options.
 
 ## Command Registration
 


### PR DESCRIPTION
## Summary

- Make `-v` the explicit public `basectl` command-level debug switch.
- Reject direct Python package standard options (`--debug`, `--quiet`, `--log-file`, `--config`, `--environment`, `--keep-temp`) consistently before command delegation.
- Document the public/private logging option contract in help, command docs, `base_cli` docs, and `.ai-context`.

## Issue

Closes #1051

## Validation

- RED: `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME bats --filter "rejects Python standard options" cli/bash/commands/basectl/tests/help.bats` failed before the fix because `basectl logs --debug --path` delegated instead of returning the focused usage error.
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/history.bats cli/bash/commands/basectl/tests/setup.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/basectl.sh`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test` - 589 Python tests passed, 1 skipped; 466 BATS tests passed.

## Demo Impact

None.

## Notes

`.ai-context/COMMANDS.md` was updated because this changes the public `basectl` option contract.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
