### PR TITLE
Use history status for log entries

### DIFF
--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import shlex
@@ -9,8 +10,10 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import base_cli
+from base_cli.history import HISTORY_PATH
 from base_cli.paths import base_cache_root
 
 
@@ -27,6 +30,7 @@ class LogEntry:
     path: Path
     timestamp: datetime
     status: str
+    exit_code: int | None = None
 
 
 @dataclass(frozen=True)
@@ -37,6 +41,18 @@ class LogCommandOptions:
     tail: bool
     open_file: bool
     lines: int
+
+
+@dataclass(frozen=True)
+class HistoryLogStatus:
+    status: str
+    exit_code: int | None
+
+
+@dataclass(frozen=True)
+class HistoryLogStatusIndex:
+    by_run_id: dict[str, HistoryLogStatus]
+    by_log_path: dict[str, HistoryLogStatus]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -137,6 +153,7 @@ def discover_log_entries(cache_root: Path) -> list[LogEntry]:
     if not cli_root.is_dir():
         return []
 
+    history_statuses = read_history_log_statuses(cache_root)
     entries: list[LogEntry] = []
     for logs_dir in sorted(cli_root.glob("*/logs"), key=str):
         if not logs_dir.is_dir():
@@ -145,6 +162,7 @@ def discover_log_entries(cache_root: Path) -> list[LogEntry]:
         for path in sorted(logs_dir.glob("*.log"), key=lambda item: item.name):
             if not path.is_file():
                 continue
+            history_status = history_status_for_log(history_statuses, run_id=path.stem, path=path)
             entries.append(
                 LogEntry(
                     command=infer_display_command(raw_command, path),
@@ -152,10 +170,67 @@ def discover_log_entries(cache_root: Path) -> list[LogEntry]:
                     run_id=path.stem,
                     path=path,
                     timestamp=entry_timestamp(path),
-                    status=infer_status(path),
+                    status=history_status.status if history_status is not None else infer_status(path),
+                    exit_code=history_status.exit_code if history_status is not None else None,
                 )
             )
     return entries
+
+
+def read_history_log_statuses(cache_root: Path) -> HistoryLogStatusIndex:
+    path = cache_root / HISTORY_PATH
+    index = HistoryLogStatusIndex(by_run_id={}, by_log_path={})
+    if not path.is_file():
+        return index
+
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            record = parse_history_log_status_line(line)
+            if record is None:
+                continue
+            run_id, log_path, history_status = record
+            index.by_run_id[run_id] = history_status
+            if log_path is not None:
+                index.by_log_path[normalize_history_log_path(log_path)] = history_status
+    return index
+
+
+def parse_history_log_status_line(line: str) -> tuple[str, str | None, HistoryLogStatus] | None:
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        return None
+    if payload.get("event") != "finished":
+        return None
+
+    run_id = optional_string(payload.get("run_id"))
+    status = optional_string(payload.get("status"))
+    if run_id is None or status is None:
+        return None
+
+    return (
+        run_id,
+        optional_string(payload.get("log_path")),
+        HistoryLogStatus(status=status, exit_code=optional_int(payload.get("exit_code"))),
+    )
+
+
+def optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def optional_int(value: Any) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def history_status_for_log(index: HistoryLogStatusIndex, run_id: str, path: Path) -> HistoryLogStatus | None:
+    return index.by_run_id.get(run_id) or index.by_log_path.get(normalize_history_log_path(str(path)))
+
+
+def normalize_history_log_path(value: str) -> str:
+    return str(Path(value).expanduser().resolve(strict=False))
 
 
 def infer_display_command(raw_command: str, path: Path) -> str:

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 import os
 import tempfile
 import unittest
@@ -16,6 +17,14 @@ def write_log(cache_root: Path, cli_name: str, run_id: str, text: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
     return path
+
+
+def write_history_line(cache_root: Path, payload: dict | str) -> None:
+    path = cache_root / "history" / "runs.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{text}\n")
 
 
 def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
@@ -74,6 +83,72 @@ class BaseLogsTests(unittest.TestCase):
                         "2026-06-01 01:00:01 ERROR failed",
                     ]
                 ),
+            )
+
+            entries = engine.recent_logs(cache_root)
+
+        self.assertEqual(entries[0].status, "error")
+
+    def test_history_status_overrides_last_log_line_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            run_id = "20260601T010000_aaaaaaaa"
+            log_path = write_log(
+                cache_root,
+                "base_release",
+                run_id,
+                "\n".join(
+                    [
+                        "2026-06-01 01:00:00 INFO preparing release",
+                        "2026-06-01 01:00:01 INFO wrote release plan",
+                    ]
+                ),
+            )
+            write_history_line(cache_root, "{not json")
+            write_history_line(
+                cache_root,
+                {
+                    "schema_version": 1,
+                    "run_id": run_id,
+                    "event": "finished",
+                    "command": "release",
+                    "raw_command": "base_release",
+                    "ended_at": "2026-06-01T01:00:02Z",
+                    "exit_code": 2,
+                    "status": "error",
+                    "log_path": str(log_path),
+                },
+            )
+
+            entries = engine.recent_logs(cache_root)
+            display_filtered = engine.recent_logs(cache_root, command_filter="release")
+            raw_filtered = engine.recent_logs(cache_root, command_filter="base_release")
+
+        self.assertEqual(entries[0].status, "error")
+        self.assertEqual([entry.path for entry in display_filtered], [log_path])
+        self.assertEqual([entry.path for entry in raw_filtered], [log_path])
+
+    def test_history_status_can_match_by_log_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            log_path = write_log(
+                cache_root,
+                "base_clean",
+                "20260601T010000_aaaaaaaa",
+                "2026-06-01 01:00:01 INFO clean finished\n",
+            )
+            write_history_line(
+                cache_root,
+                {
+                    "schema_version": 1,
+                    "run_id": "history-only-run-id",
+                    "event": "finished",
+                    "command": "clean",
+                    "ended_at": "2026-06-01T01:00:02Z",
+                    "exit_code": 1,
+                    "status": "error",
+                    "log_path": str(log_path),
+                },
             )
 
             entries = engine.recent_logs(cache_root)


### PR DESCRIPTION
## Summary

- Load the structured command history index when listing runtime logs.
- Prefer history `status` and `exit_code` for matching log entries by run ID or log path.
- Preserve existing last-log-line status inference when no matching history record exists.

## Issue

Closes #1052

## Validation

- RED: `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_logs/tests/test_engine.py -q` failed before the fix because a history-backed failed release log still displayed `ok`.
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_logs/tests/test_engine.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_logs/tests cli/python/base_history/tests lib/python/base_cli/tests/test_history.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_logs/engine.py cli/python/base_logs/tests/test_engine.py`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test` - 591 Python tests passed, 1 skipped; 466 BATS tests passed.

## Demo Impact

None.

## Notes

No `.ai-context` update: this changes runtime observability correctness but not the public command surface or product shape.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
