### PR TITLE
Render delegated errors with basectl usage

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -446,7 +446,7 @@ base_gh_project_issue_set_fields() {
         base_gh_error "Base Python wrapper '$wrapper' is missing or is not executable."
         return 1
     }
-    "$wrapper" --project base base_github_projects project issue set-fields "$@"
+    BASE_CLI_DISPLAY_COMMAND="basectl gh" "$wrapper" --project base base_github_projects project issue set-fields "$@"
 }
 
 base_gh_join_csv() {
@@ -1435,7 +1435,7 @@ base_gh_do_project() {
         base_gh_error "Base Python wrapper '$wrapper' is missing or is not executable."
         return 1
     }
-    "$wrapper" --project base base_github_projects project "$@"
+    BASE_CLI_DISPLAY_COMMAND="basectl gh" "$wrapper" --project base base_github_projects project "$@"
 }
 
 base_gh_subcommand_main() {

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -57,5 +57,5 @@ base_logs_subcommand_main() {
     done
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    "$wrapper" --project base base_logs "${args[@]}"
+    BASE_CLI_DISPLAY_COMMAND="basectl logs" "$wrapper" --project base base_logs "${args[@]}"
 }

--- a/cli/bash/commands/basectl/subcommands/release.sh
+++ b/cli/bash/commands/basectl/subcommands/release.sh
@@ -54,5 +54,5 @@ base_release_subcommand_main() {
     esac
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    "$wrapper" --project base base_release "$@"
+    BASE_CLI_DISPLAY_COMMAND="basectl release" "$wrapper" --project base base_release "$@"
 }

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1695,7 +1695,7 @@ base_repo_configure_project_metadata() {
 
     log_info "Configuring GitHub Project '$project_title' for '$repo'."
     log_info "Running: $(base_repo_pretty_command "${command[@]}")"
-    output="$("${command[@]}" 2>&1)" || status=$?
+    output="$(BASE_CLI_DISPLAY_COMMAND="basectl gh" "${command[@]}" 2>&1)" || status=$?
     if [[ "$status" -eq 0 ]]; then
         [[ -z "$output" ]] || printf '%s\n' "$output"
         printf "  GitHub Project '%s': Status, Priority, Area, Size, Initiative fields configured.\n" "$project_title"

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -429,6 +429,7 @@ EOF
     cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
+printf '%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}" > "${BASE_GH_TEST_STATE_DIR:?}/display-command"
 EOF
     chmod +x "$TEST_MOCKBIN/project-wrapper"
 
@@ -446,6 +447,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_STATE_DIR/wrapper-args")" = "--project base base_github_projects project doctor --project Base Roadmap --owner codeforester" ]
+    [ "$(cat "$TEST_STATE_DIR/display-command")" = "basectl gh" ]
 }
 
 @test "basectl gh issue list reports command failure with auth diagnostics" {

--- a/cli/bash/commands/basectl/tests/logs.bats
+++ b/cli/bash/commands/basectl/tests/logs.bats
@@ -11,6 +11,7 @@ load ./basectl_helpers.bash
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+    printf 'DISPLAY=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
     printf 'ARGS=%s\n' "${*:3}"
     exit 0
 fi
@@ -23,6 +24,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_PROJECT=base"* ]]
+    [[ "$output" == *"DISPLAY=basectl logs"* ]]
     [[ "$output" == *"ARGS=--command check --limit 3 --path"* ]]
 }
 

--- a/cli/bash/commands/basectl/tests/release.bats
+++ b/cli/bash/commands/basectl/tests/release.bats
@@ -40,6 +40,7 @@ load ./basectl_helpers.bash
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_release" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT" > "${BASE_TEST_RELEASE_STATE:?}"
+    printf 'DISPLAY=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
     printf 'ARGS=%s\n' "${*:3}"
     exit 0
 fi
@@ -55,7 +56,8 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" release publish --dry-run --version 1.2.3 --manifest "$manifest"
 
     [ "$status" -eq 0 ]
-    [ "$output" = "ARGS=publish --dry-run --version 1.2.3 --manifest $manifest" ]
+    [[ "$output" == *"DISPLAY=basectl release"* ]]
+    [[ "$output" == *"ARGS=publish --dry-run --version 1.2.3 --manifest $manifest"* ]]
     [ "$(cat "$TEST_TMPDIR/release-state")" = "BASE_PROJECT=base" ]
 }
 

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -6,6 +6,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import base_cli
+
 from . import graphql_queries as queries
 from .project_configure import standard_template_view_errors
 from .project_item_fields import FieldCopySummary
@@ -65,16 +67,17 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def print_usage(file=sys.stdout) -> None:
+    command = base_cli.delegated_display_command("base_github_projects")
     print(
         "\n".join(
             (
                 "Usage:",
-                "  base_github_projects project doctor --project <title> "
+                f"  {command} project doctor --project <title> "
                 "[--owner <login>] [--schema base-project]",
-                "  base_github_projects project configure --project <title> "
+                f"  {command} project configure --project <title> "
                 "[--owner <login>] [--repo <owner/name>] [--schema base-project] [--config <path>] "
                 "[--copy-fields-from <title>] [--replace-project] [--initiative-option <name>] [--dry-run]",
-                "  base_github_projects project issue set-fields <number> "
+                f"  {command} project issue set-fields <number> "
                 "--repo <owner/name> --project <title> [--config <path>] [field options...]",
             )
         ),

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -7,6 +7,21 @@ import pytest
 from base_github_projects import engine, project_model
 
 
+def test_delegated_usage_uses_basectl_gh_project_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("BASE_CLI_DISPLAY_COMMAND", "basectl gh")
+
+    status = engine.main(["project", "configure", "--wat"])
+
+    captured = capsys.readouterr()
+    assert status == 2
+    assert "basectl gh project configure --project <title>" in captured.err
+    assert "ERROR: Unknown option '--wat'." in captured.err
+    assert "base_github_projects" not in captured.err
+
+
 def test_parse_project_configure_arguments() -> None:
     args = engine.parse_args(
         (

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -30,13 +30,34 @@ def write_history_line(cache_root: Path, payload: dict | str) -> None:
 def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
-    with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+    with mock.patch.dict(
+        os.environ,
+        {"BASE_CACHE_DIR": str(cache_root), "BASE_CLI_DISPLAY_COMMAND": ""},
+    ):
         with redirect_stdout(stdout), redirect_stderr(stderr):
             status = engine.main(args)
     return status, stdout.getvalue(), stderr.getvalue()
 
 
 class BaseLogsTests(unittest.TestCase):
+    def test_delegated_unknown_option_usage_uses_basectl_logs(self) -> None:
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BASE_CACHE_DIR": str(Path(tmpdir)),
+                    "BASE_CLI_DISPLAY_COMMAND": "basectl logs",
+                },
+            ), redirect_stderr(stderr):
+                status = engine.main(["--bad-option"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("Usage: basectl logs", stderr.getvalue())
+        self.assertIn("No such option '--bad-option'.", stderr.getvalue())
+        self.assertNotIn("python -m base_logs", stderr.getvalue())
+        self.assertNotIn("base_logs", stderr.getvalue())
+
     def test_recent_logs_sorts_by_run_id_timestamp(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -162,12 +162,13 @@ def require_publish_option(command: str, option_name: str) -> None:
 
 
 def print_usage(file=sys.stdout) -> None:
+    command = base_cli.delegated_display_command("base_release")
     print(
-        """Usage:
-  base_release check --version <version> [--manifest <path>]
-  base_release plan --version <version> [--manifest <path>]
-  base_release notes --version <version> [--manifest <path>]
-  base_release publish --version <version> [--manifest <path>] [--dry-run] [--yes]
+        f"""Usage:
+  {command} check --version <version> [--manifest <path>]
+  {command} plan --version <version> [--manifest <path>]
+  {command} notes --version <version> [--manifest <path>]
+  {command} publish --version <version> [--manifest <path>] [--dry-run] [--yes]
 
 Purpose:
   Inspect release readiness and guarded GitHub publishing for a Base-managed

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -37,14 +37,19 @@ def pushd(path: Path):
         os.chdir(old_cwd)
 
 
-def run_engine(args: list[str], cwd: Path) -> tuple[int, str, str]:
+def run_engine(args: list[str], cwd: Path, extra_env: dict[str, str] | None = None) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
+    env = {
+        "BASE_CLI_DISPLAY_COMMAND": "",
+        "BASE_HOME": str(Path(__file__).resolve().parents[4]),
+        "HOME": "",
+    }
+    if extra_env:
+        env.update(extra_env)
     with tempfile.TemporaryDirectory() as home_dir:
-        with mock.patch.dict(
-            os.environ,
-            {"BASE_HOME": str(Path(__file__).resolve().parents[4]), "HOME": home_dir},
-        ):
+        env["HOME"] = home_dir
+        with mock.patch.dict(os.environ, env):
             with pushd(cwd), redirect_stdout(stdout), redirect_stderr(stderr):
                 status = main(args)
     return status, stdout.getvalue(), stderr.getvalue()
@@ -119,6 +124,36 @@ def add_origin_with_remote_tag(root: Path, tag_name: str) -> None:
     subprocess.run(["git", "tag", tag_name], cwd=root, check=True)
     subprocess.run(["git", "push", "origin", tag_name], cwd=root, check=True, stdout=subprocess.DEVNULL)
     subprocess.run(["git", "tag", "-d", tag_name], cwd=root, check=True, stdout=subprocess.DEVNULL)
+
+
+class ReleaseUsageTests(unittest.TestCase):
+    def test_delegated_unknown_option_usage_uses_basectl_release(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = run_engine(
+                ["check", "--wat"],
+                Path(tmpdir),
+                {"BASE_CLI_DISPLAY_COMMAND": "basectl release"},
+            )
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("basectl release check --version <version>", stderr)
+        self.assertIn("ERROR: Unknown release check option '--wat'.", stderr)
+        self.assertNotIn("base_release", stderr)
+
+    def test_delegated_missing_required_option_usage_uses_basectl_release(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = run_engine(
+                ["check"],
+                Path(tmpdir),
+                {"BASE_CLI_DISPLAY_COMMAND": "basectl release"},
+            )
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("basectl release check --version <version>", stderr)
+        self.assertIn("ERROR: The 'release check' command requires --version.", stderr)
+        self.assertNotIn("base_release", stderr)
 
 
 class ReleaseEngineTests(unittest.TestCase):

--- a/lib/python/base_cli/__init__.py
+++ b/lib/python/base_cli/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from . import history
-from .app import App, argument, command, option, run_app
+from .app import App, argument, command, delegated_display_command, option, run_app
 from .context import Context, get_current_context
 from .exit_codes import ExitCode
 from .logging import configure_logger, log_critical, log_debug, log_error, log_info, log_warning
@@ -14,6 +14,7 @@ __all__ = [
     "argument",
     "command",
     "configure_logger",
+    "delegated_display_command",
     "get_current_context",
     "log_critical",
     "log_debug",

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any, Callable
@@ -15,6 +16,7 @@ from .redaction import parameter_name_from_decls
 
 _STANDARD_OPTION_KEYS = ("debug", "quiet", "environment", "config", "keep_temp", "log_file")
 _GROUP_STANDARD_OPTIONS_KEY = "base_cli_standard_options"
+DISPLAY_COMMAND_ENV = "BASE_CLI_DISPLAY_COMMAND"
 
 
 def _require_click():
@@ -234,11 +236,22 @@ def run_app(app: App, argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     try:
         _reject_equals_option_values(click, args)
-        result = app.click_command.main(args=args, standalone_mode=False)
+        display_command = delegated_display_command()
+        if display_command:
+            result = app.click_command.main(args=args, prog_name=display_command, standalone_mode=False)
+        else:
+            result = app.click_command.main(args=args, standalone_mode=False)
     except click.ClickException as exc:
         exc.show()
         return int(exc.exit_code)
     return int(result or 0)
+
+
+def delegated_display_command(default: str | None = None) -> str | None:
+    display_command = os.environ.get(DISPLAY_COMMAND_ENV, "").strip()
+    if display_command:
+        return display_command
+    return default
 
 
 def command(*args: Any, **kwargs: Any):

--- a/lib/python/base_cli/tests/test_app_run.py
+++ b/lib/python/base_cli/tests/test_app_run.py
@@ -99,6 +99,26 @@ class RunAppTests(unittest.TestCase):
         )
         self.assertNotIn("Traceback", stderr.getvalue())
 
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_run_app_uses_delegated_display_command_for_usage_errors(self) -> None:
+        app = base_cli.App(name="internal-cli", log_to_file=False)
+
+        @app.command(context_settings={"help_option_names": ["-h", "--help"]})
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+
+        stderr = io.StringIO()
+        with mock.patch.dict(
+            os.environ,
+            {"BASE_CLI_DISPLAY_COMMAND": "basectl demo"},
+        ), redirect_stderr(stderr):
+            status = base_cli.run_app(app, ["--bad-option"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("Usage: basectl demo", stderr.getvalue())
+        self.assertIn("No such option '--bad-option'.", stderr.getvalue())
+        self.assertNotIn("internal-cli", stderr.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add an opt-in `BASE_CLI_DISPLAY_COMMAND` hook so delegated Click errors can render public `basectl` command paths.
- Use the hook for `basectl release`, `basectl logs`, and GitHub Project delegation paths.
- Update release, logs, and GitHub Project tests to cover public usage rendering and delegated propagation.

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_app_run.py cli/python/base_release/tests/test_engine.py cli/python/base_github_projects/tests/test_engine.py cli/python/base_logs/tests/test_engine.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc lib/python/base_cli/app.py lib/python/base_cli/__init__.py lib/python/base_cli/tests/test_app_run.py cli/python/base_release/engine.py cli/python/base_release/tests/test_engine.py cli/python/base_github_projects/engine.py cli/python/base_github_projects/tests/test_engine.py cli/python/base_logs/tests/test_engine.py`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/release.bats cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/gh.bats`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. CLI error/help polish only.

Closes #1053
