### PR TITLE
Standardize basectl help routing

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -388,7 +388,16 @@ basectl_main() {
     local base_debug=0 command=""
     local opt
 
-    if [[ "${1:-}" =~ ^(-h|--help|-help|help)$ ]]; then
+    if [[ "${1:-}" == "help" ]]; then
+        shift
+        if [[ $# -eq 0 || "${1:-}" == "help" ]]; then
+            basectl_show_help
+            return 0
+        fi
+        set -- "$@" --help
+    fi
+
+    if [[ "${1:-}" =~ ^(-h|--help|-help)$ ]]; then
         basectl_show_help
         return 0
     fi

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -166,6 +166,15 @@ base_gh_error() {
     print_error "$*"
 }
 
+base_gh_usage_error() {
+    local usage_function="$1"
+    shift
+
+    base_gh_error "$*"
+    "$usage_function" >&2
+    return 2
+}
+
 base_gh_require_command() {
     local command="$1"
 
@@ -257,7 +266,7 @@ base_gh_validate_category() {
         bug|enhancement|documentation|ci|security) return 0 ;;
         *)
             base_gh_error "Invalid category '$1'. Expected one of: bug, enhancement, documentation, ci, security."
-            return 1
+            return 2
             ;;
     esac
 }
@@ -562,7 +571,7 @@ base_gh_validate_project_size() {
             ;;
     esac
     base_gh_error "Invalid size '$size'. Expected one of: T, S, M, L."
-    return 1
+    return 2
 }
 
 base_gh_current_issue_from_branch() {
@@ -595,9 +604,8 @@ base_gh_do_issue() {
             base_gh_issue_usage
             ;;
         *)
-            base_gh_error "Unknown gh issue command '$command'."
-            base_gh_issue_usage >&2
-            return 1
+            base_gh_usage_error base_gh_issue_usage "Unknown gh issue command '$command'."
+            return $?
             ;;
     esac
 }
@@ -665,32 +673,38 @@ base_gh_issue_create() {
                 return 0
                 ;;
             *)
-                base_gh_error "Unknown option '$1'."
-                return 1
+                base_gh_usage_error base_gh_issue_usage "Unknown option '$1'."
+                return $?
                 ;;
         esac
         shift
     done
 
     [[ -n "$title" ]] || {
-        base_gh_error "Missing required --title."
-        return 1
+        base_gh_usage_error base_gh_issue_usage "Missing required --title."
+        return $?
     }
     if [[ -z "$category" ]]; then
         category="enhancement"
         printf 'Using default --category: enhancement\n'
     fi
-    base_gh_validate_category "$category" || return 1
+    base_gh_validate_category "$category" || {
+        base_gh_issue_usage >&2
+        return 2
+    }
     if [[ -n "$project_size" ]]; then
-        base_gh_validate_project_size "$project_size" || return 1
+        base_gh_validate_project_size "$project_size" || {
+            base_gh_issue_usage >&2
+            return 2
+        }
     fi
     if ((assignee_explicit)) && ((no_assignee)); then
-        base_gh_error "Options '--assignee' and '--no-assignee' cannot be used together."
-        return 1
+        base_gh_usage_error base_gh_issue_usage "Options '--assignee' and '--no-assignee' cannot be used together."
+        return $?
     fi
     if ((assignee_explicit)) && [[ -z "$assignee" ]]; then
-        base_gh_error "Option '--assignee' requires an argument."
-        return 1
+        base_gh_usage_error base_gh_issue_usage "Option '--assignee' requires an argument."
+        return $?
     fi
 
     [[ -n "$github_repo" ]] || github_repo="$(base_gh_infer_github_repo || true)"
@@ -791,8 +805,8 @@ base_gh_issue_start() {
     local issue="${1:-}" category="" title="" slug branch today default_branch worktree_path
 
     [[ -n "$issue" ]] || {
-        base_gh_error "Missing issue number."
-        return 1
+        base_gh_usage_error base_gh_issue_usage "Missing issue number."
+        return $?
     }
     shift
 
@@ -811,8 +825,8 @@ base_gh_issue_start() {
                 return 0
                 ;;
             *)
-                base_gh_error "Unknown option '$1'."
-                return 1
+                base_gh_usage_error base_gh_issue_usage "Unknown option '$1'."
+                return $?
                 ;;
         esac
         shift
@@ -825,7 +839,10 @@ base_gh_issue_start() {
     if [[ -z "$category" ]]; then
         category="$(base_gh_issue_category_from_labels "$issue")" || return 1
     fi
-    base_gh_validate_category "$category" || return 1
+    base_gh_validate_category "$category" || {
+        base_gh_issue_usage >&2
+        return 2
+    }
     if [[ -z "$title" ]]; then
         title="$(base_gh_issue_title "$issue")" || return 1
     fi
@@ -886,9 +903,8 @@ base_gh_do_pr() {
             base_gh_pr_usage
             ;;
         *)
-            base_gh_error "Unknown gh pr command '$command'."
-            base_gh_pr_usage >&2
-            return 1
+            base_gh_usage_error base_gh_pr_usage "Unknown gh pr command '$command'."
+            return $?
             ;;
     esac
 }
@@ -907,16 +923,16 @@ base_gh_branch_stale() {
                 return 0
                 ;;
             *)
-                base_gh_error "Unknown option '$1'."
-                return 1
+                base_gh_usage_error base_gh_branch_usage "Unknown option '$1'."
+                return $?
                 ;;
         esac
         shift
     done
 
     [[ "$days" =~ ^[0-9]+$ ]] || {
-        base_gh_error "--days must be a positive integer."
-        return 1
+        base_gh_usage_error base_gh_branch_usage "--days must be a positive integer."
+        return $?
     }
     base_gh_require_git_repo || return 1
 
@@ -1218,8 +1234,8 @@ base_gh_branch_prune() {
                 return 0
                 ;;
             *)
-                base_gh_error "Unknown option '$1'."
-                return 1
+                base_gh_usage_error base_gh_branch_usage "Unknown option '$1'."
+                return $?
                 ;;
         esac
         shift
@@ -1312,8 +1328,8 @@ base_gh_worktree_prune() {
                 return 0
                 ;;
             *)
-                base_gh_error "Unknown option '$1'."
-                return 1
+                base_gh_usage_error base_gh_worktree_usage "Unknown option '$1'."
+                return $?
                 ;;
         esac
         shift
@@ -1401,9 +1417,8 @@ base_gh_do_branch() {
         prune) base_gh_branch_prune "$@" ;;
         -h|--help|help|"") base_gh_branch_usage ;;
         *)
-            base_gh_error "Unknown gh branch command '$command'."
-            base_gh_branch_usage >&2
-            return 1
+            base_gh_usage_error base_gh_branch_usage "Unknown gh branch command '$command'."
+            return $?
             ;;
     esac
 }
@@ -1416,9 +1431,8 @@ base_gh_do_worktree() {
         prune) base_gh_worktree_prune "$@" ;;
         -h|--help|help|"") base_gh_worktree_usage ;;
         *)
-            base_gh_error "Unknown gh worktree command '$command'."
-            base_gh_worktree_usage >&2
-            return 1
+            base_gh_usage_error base_gh_worktree_usage "Unknown gh worktree command '$command'."
+            return $?
             ;;
     esac
 }
@@ -1450,9 +1464,8 @@ base_gh_subcommand_main() {
         worktree) base_gh_do_worktree "$@" ;;
         -h|--help|help|"") base_gh_usage ;;
         *)
-            base_gh_error "Unknown gh area '$area'."
-            base_gh_usage >&2
-            return 1
+            base_gh_usage_error base_gh_usage "Unknown gh area '$area'."
+            return $?
             ;;
     esac
 }

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -142,7 +142,7 @@ base_workspace_subcommand_main() {
     local args=()
 
     case "$workspace_command" in
-        ""|-h|--help)
+        ""|-h|--help|help)
             base_workspace_subcommand_usage
             return 0
             ;;

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -89,10 +89,33 @@ load ./basectl_helpers.bash
 @test "basectl gh rejects retired todo area" {
     run_basectl gh todo --help
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 2 ]
     [[ "$output" == *"ERROR: Unknown gh area 'todo'."* ]]
     [[ "$output" != *"TODO.md"* ]]
     [[ "$output" != *"basectl gh todo plan"* ]]
+}
+
+@test "basectl gh usage errors return status 2" {
+    run_basectl gh issue unknown
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unknown gh issue command 'unknown'."* ]]
+    [[ "$output" == *"basectl gh issue create"* ]]
+
+    run_basectl gh issue create
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Missing required --title."* ]]
+
+    run_basectl gh issue create --bad-option
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unknown option '--bad-option'."* ]]
+
+    run_basectl gh branch stale --days never
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: --days must be a positive integer."* ]]
 }
 
 @test "basectl gh issue create accepts explicit assignee" {

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -67,6 +67,29 @@ load ./basectl_helpers.bash
     [[ "$output" != *"-V"* ]]
 }
 
+@test "basectl help routes to command-specific help" {
+    run_basectl help repo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl repo init <name>"* ]]
+    [[ "$output" != *"Usage: basectl [options] <command> [args...]"* ]]
+
+    run_basectl help workspace
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull|init|configure> [options]"* ]]
+    [[ "$output" != *"Usage: basectl [options] <command> [args...]"* ]]
+
+    run_basectl help release
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl release check --version <version>"* ]]
+    [[ "$output" != *"Usage: basectl [options] <command> [args...]"* ]]
+}
+
 @test "basectl rejects equals-form long option values before command delegation" {
     run_basectl history --limit=2
 

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -260,6 +260,12 @@ EOF
     [[ "$output" == *"--include-optional"* ]]
     [[ "$output" == *"--dry-run"* ]]
     [[ "$output" != *"--format <format>"* ]]
+
+    run_basectl workspace help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull|init|configure> [options]"* ]]
+    [[ "$output" != *"Project virtual environment Python was not found"* ]]
 }
 
 @test "basectl workspace rejects unknown subcommands" {


### PR DESCRIPTION
## Summary
- Route `basectl help <command>` through command-specific help.
- Accept `basectl workspace help` as workspace namespace help.
- Return usage-error status 2 for representative `basectl gh` parser failures while preserving runtime failure behavior.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/gh.bats`
- `git diff --check`
- `bash -n cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/workspace.sh cli/bash/commands/basectl/subcommands/gh.sh`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. CLI help and exit-code polish only.

Closes #1057
