### PR TITLE
Route Python command packages through base_cli lifecycle

### DIFF
--- a/cli/bash/commands/basectl/subcommands/config.sh
+++ b/cli/bash/commands/basectl/subcommands/config.sh
@@ -51,12 +51,8 @@ base_config_subcommand_main() {
             ;;
         show|doctor)
             shift
-            if (($#)); then
-                base_config_usage_error "config $config_command does not accept arguments."
-                return $?
-            fi
             [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-            "$wrapper" --project base base_config "$config_command"
+            BASE_CLI_DISPLAY_COMMAND="basectl config" "$wrapper" --project base base_config "$config_command" "$@"
             ;;
         *)
             base_config_usage_error "Unknown config command '$config_command'."

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -169,6 +169,29 @@ load ./basectl_helpers.bash
     [ "$output" = "$TEST_HOME/.base.d/config.yaml" ]
 }
 
+@test "basectl config show forwards standard Python lifecycle options" {
+    local base_home="$TEST_TMPDIR/base-home"
+    mkdir -p "$base_home/bin"
+    cat > "$base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'display=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$base_home/bin/base-wrapper"
+
+    run env \
+        BASE_HOME="$base_home" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/config.sh"
+            base_config_subcommand_main show --debug --log-file /tmp/base-config.log
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"display=basectl config"* ]]
+    [[ "$output" == *"args=--project base base_config show --debug --log-file /tmp/base-config.log"* ]]
+}
+
 @test "basectl config reports unknown command as a usage error" {
     run_basectl config unknown
 

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -4,22 +4,37 @@ import json
 import sys
 from pathlib import Path
 
+import base_cli
 from base_cli.config import UserConfig, load_user_config, read_user_config, user_config_path
 
 
+app = base_cli.App(
+    name="base_config",
+    help="Inspect Base's machine-local user config.",
+)
+
+
 def main(argv: list[str] | None = None) -> int:
-    args = list(sys.argv[1:] if argv is None else argv)
-    command = args[0] if args else "show"
-    if command in ("-h", "--help", "help"):
-        print_usage()
-        return 0
-    if len(args) > 1:
-        print_usage(file=sys.stderr)
-        print(f"ERROR: config {command} does not accept arguments.", file=sys.stderr)
-        return 2
+    return base_cli.run_app(app, argv)
+
+
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("command", required=False, metavar="[show|doctor]")
+@base_cli.argument("arguments", nargs=-1)
+def run(ctx: base_cli.Context, command: str | None, arguments: tuple[str, ...]) -> int:
+    del ctx
+    command = command or "show"
     if command == "show":
+        if arguments:
+            print_usage(file=sys.stderr)
+            print("ERROR: config show does not accept arguments.", file=sys.stderr)
+            return 2
         return show_config_command()
     if command == "doctor":
+        if arguments:
+            print_usage(file=sys.stderr)
+            print("ERROR: config doctor does not accept arguments.", file=sys.stderr)
+            return 2
         return doctor_config_command()
 
     print_usage(file=sys.stderr)

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -9,7 +9,9 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.history import HISTORY_PATH
 from base_cli.config import user_config_path
+from base_cli.testing import invoke
 from base_config import engine
 
 
@@ -59,6 +61,21 @@ class BaseConfigCommandTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(json.loads(stdout.getvalue()), {})
+
+    def test_show_config_uses_base_cli_lifecycle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            result = invoke(engine.app, ["show"], home=home)
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(json.loads(result.stdout), {})
+            log_dir = home / ".cache" / "base" / "cli" / "base_config" / "logs"
+            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 1)
+            history_path = home / ".cache" / "base" / HISTORY_PATH
+            history_record = json.loads(history_path.read_text(encoding="utf-8").splitlines()[-1])
+            self.assertEqual(history_record["raw_command"], "base_config")
+            self.assertEqual(history_record["status"], "ok")
 
     def test_show_config_prints_parsed_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+import click
 
 from . import graphql_queries as queries
 from .project_configure import standard_template_view_errors
@@ -34,6 +35,11 @@ class ProjectAuthError(ProjectError):
     pass
 
 
+app = base_cli.App(
+    name="base_github_projects",
+    help="Configure GitHub Projects for Base-managed repositories.",
+)
+
 HELP_OPTIONS = ("-h", "--help", "help")
 PROJECT_VALUE_OPTIONS = (
     "--project",
@@ -48,8 +54,22 @@ ISSUE_FIELD_OPTIONS = ("--status", "--priority", "--area", "--initiative", "--si
 
 
 def main(argv: list[str] | None = None) -> int:
+    return base_cli.run_app(app, argv)
+
+
+@app.command(
+    context_settings={
+        "allow_extra_args": True,
+        "allow_interspersed_args": False,
+        "help_option_names": ["-h", "--help"],
+        "ignore_unknown_options": True,
+    }
+)
+@base_cli.argument("arguments", nargs=-1, type=click.UNPROCESSED)
+def run(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
+    del ctx
     try:
-        args = parse_args(tuple(sys.argv[1:] if argv is None else argv))
+        args = parse_args(arguments)
         return run_command(args)
     except SystemExit as exc:
         return int(exc.code or 0)
@@ -143,9 +163,6 @@ def parse_project_options(remaining: list[str], *, allow_fields: bool, allow_iss
         if arg in HELP_OPTIONS:
             print_usage()
             raise SystemExit(0)
-        if apply_equals_option(state, arg, allow_fields=allow_fields):
-            index += 1
-            continue
         if arg == "--dry-run":
             state.dry_run = True
             index += 1
@@ -168,19 +185,6 @@ def parse_project_options(remaining: list[str], *, allow_fields: bool, allow_iss
     if not state.owner:
         state.owner = infer_owner_from_git()
     return state
-
-
-def apply_equals_option(state: OptionState, arg: str, *, allow_fields: bool) -> bool:
-    if not arg.startswith("--") or "=" not in arg:
-        return False
-    name, value = arg.split("=", 1)
-    if name in PROJECT_VALUE_OPTIONS:
-        apply_project_option(state, name, value)
-        return True
-    if allow_fields and name in ISSUE_FIELD_OPTIONS:
-        state.field_values[name[2:]] = value
-        return True
-    return False
 
 
 def apply_spaced_option(state: OptionState, remaining: list[str], index: int, *, allow_fields: bool) -> int:

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -10,8 +10,11 @@ from base_github_projects import engine, project_model
 def test_delegated_usage_uses_basectl_gh_project_prefix(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
 ) -> None:
     monkeypatch.setenv("BASE_CLI_DISPLAY_COMMAND", "basectl gh")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASE_CACHE_DIR", str(tmp_path / ".cache" / "base"))
 
     status = engine.main(["project", "configure", "--wat"])
 
@@ -20,6 +23,21 @@ def test_delegated_usage_uses_basectl_gh_project_prefix(
     assert "basectl gh project configure --project <title>" in captured.err
     assert "ERROR: Unknown option '--wat'." in captured.err
     assert "base_github_projects" not in captured.err
+
+
+def test_main_rejects_equals_form_project_options(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASE_CACHE_DIR", str(tmp_path / ".cache" / "base"))
+
+    status = engine.main(["project", "configure", "--project=Base Roadmap", "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert status == 2
+    assert "Option '--project' uses unsupported equals syntax." in captured.err
 
 
 def test_parse_project_configure_arguments() -> None:
@@ -89,38 +107,6 @@ def test_parse_project_configure_accepts_copy_fields_from_project() -> None:
     )
 
     assert args.copy_fields_from_project == "Base Roadmap"
-
-
-def test_parse_project_arguments_accept_equals_options() -> None:
-    args = engine.parse_args(
-        (
-            "project",
-            "issue",
-            "set-fields",
-            "604",
-            "--project=Base Roadmap",
-            "--repo=codeforester/base",
-            "--status=Backlog",
-            "--priority=P2",
-            "--area=CLI",
-            "--initiative=v1.0 Readiness",
-            "--size=M",
-            "--dry-run",
-        )
-    )
-
-    assert args.command == "issue-set-fields"
-    assert args.project_title == "Base Roadmap"
-    assert args.repo == "codeforester/base"
-    assert args.issue_number == 604
-    assert args.field_values == {
-        "status": "Backlog",
-        "priority": "P2",
-        "area": "CLI",
-        "initiative": "v1.0 Readiness",
-        "size": "M",
-    }
-    assert args.dry_run is True
 
 
 def test_read_project_config_loads_repo_taxonomy(tmp_path: Path) -> None:

--- a/cli/python/base_pr_policy/engine.py
+++ b/cli/python/base_pr_policy/engine.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import argparse
 import fnmatch
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import base_cli
 from base_cli.paths import discover_manifest
 from base_setup.github_manifest import GithubPrConfig
 from base_setup.manifest import ManifestError, read_manifest
@@ -92,41 +92,50 @@ def body_from_manifest(
     )
 
 
+app = base_cli.App(
+    name="base_pr_policy",
+    help="Render Base-managed GitHub pull request policy content.",
+)
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
-
-    if args.command == "body":
-        manifest_path = Path(args.manifest).expanduser().resolve() if args.manifest else discover_manifest(Path.cwd())
-        if manifest_path is None:
-            print("ERROR: No base_manifest.yaml found from the current directory upward.", file=sys.stderr)
-            return 2
-        try:
-            body = body_from_manifest(
-                manifest_path,
-                issue_number=args.issue,
-                labels=tuple(args.labels or ()),
-                paths=tuple(args.paths or ()),
-            )
-        except (ManifestError, PrPolicyError) as exc:
-            print(f"ERROR: {exc}", file=sys.stderr)
-            return 1
-        sys.stdout.write(body)
-        return 0
-
-    parser.print_usage(sys.stderr)
-    return 2
+    return base_cli.run_app(app, argv)
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="base_pr_policy")
-    subparsers = parser.add_subparsers(dest="command")
-    body_parser = subparsers.add_parser("body", help="Render a pull request body from base_manifest.yaml.")
-    body_parser.add_argument("--manifest", help="Path to base_manifest.yaml.")
-    body_parser.add_argument("--issue", type=int, help="Issue number to link with Fixes #<number>.")
-    body_parser.add_argument("--label", action="append", dest="labels", help="Issue or PR label name.")
-    body_parser.add_argument("--path", action="append", dest="paths", help="Changed path relative to the repo root.")
-    return parser
+@app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("command", required=False)
+@base_cli.option("--manifest", help="Path to base_manifest.yaml.")
+@base_cli.option("--issue", type=int, help="Issue number to link with Fixes #<number>.")
+@base_cli.option("--label", "labels", multiple=True, help="Issue or PR label name.")
+@base_cli.option("--path", "paths", multiple=True, help="Changed path relative to the repo root.")
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def run(
+    ctx: base_cli.Context,
+    command: str | None,
+    manifest: str | None,
+    issue: int | None,
+    labels: tuple[str, ...],
+    paths: tuple[str, ...],
+) -> int:
+    if command != "body":
+        ctx.log.error("Expected command 'body'.")
+        return 2
+    manifest_path = Path(manifest).expanduser().resolve() if manifest else discover_manifest(Path.cwd())
+    if manifest_path is None:
+        ctx.log.error("No base_manifest.yaml found from the current directory upward.")
+        return 2
+    try:
+        body = body_from_manifest(
+            manifest_path,
+            issue_number=issue,
+            labels=labels,
+            paths=paths,
+        )
+    except (ManifestError, PrPolicyError) as exc:
+        ctx.log.error(str(exc))
+        return 1
+    sys.stdout.write(body)
+    return 0
 
 
 def _template_body(policy: GithubPrConfig, inputs: PrPolicyInputs) -> str:

--- a/cli/python/base_pr_policy/tests/test_engine.py
+++ b/cli/python/base_pr_policy/tests/test_engine.py
@@ -2,8 +2,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from base_pr_policy import engine
 from base_pr_policy.engine import PrPolicyInputs, render_pr_body
 from base_setup.github_manifest import GithubPrConfig, GithubPrRequiredSectionsConfig
+
+
+def test_main_rejects_equals_form_options(capsys) -> None:
+    status = engine.main(["body", "--issue=403"])
+
+    captured = capsys.readouterr()
+    assert status == 2
+    assert "Option '--issue' uses unsupported equals syntax." in captured.err
 
 
 def test_render_pr_body_uses_default_label_and_path_sections() -> None:

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -455,6 +455,15 @@ explicit cache location.
 Use `base_cli` for Python commands that are part of Base or a Base-supported
 project and need standard Base behavior.
 
+Base public command engines under `cli/python/base_*/engine.py` should
+instantiate `base_cli.App` so standard options, logging, redaction, runtime
+state, and local command history stay consistent. If a future public Python
+engine intentionally bypasses this lifecycle, document the reason in code and
+in this guide, then add it as an explicit lifecycle-audit exemption. Shell-only
+helpers that avoid Python startup, such as `basectl config path`, do not create
+Python logs or history records; once a `basectl` path enters a Python command
+package, it should participate in `base_cli.App`.
+
 It is a good fit for:
 
 - project discovery commands

--- a/lib/python/base_cli/tests/test_public_command_lifecycle.py
+++ b/lib/python/base_cli/tests/test_public_command_lifecycle.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PUBLIC_COMMAND_ROOT = REPO_ROOT / "cli" / "python"
+
+
+def test_public_python_command_engines_use_base_cli_app_or_declared_exemption() -> None:
+    bypasses = []
+    for engine_path in sorted(PUBLIC_COMMAND_ROOT.glob("base_*/engine.py")):
+        source = engine_path.read_text(encoding="utf-8")
+        if "base_cli.App(" not in source:
+            bypasses.append(engine_path.parent.name)
+
+    assert not bypasses


### PR DESCRIPTION
## Summary
- Route `base_config`, `base_github_projects`, and `base_pr_policy` through `base_cli.App`.
- Keep `basectl config show|doctor` on the Python lifecycle by forwarding standard options through the Bash launcher with the `basectl config` display command.
- Remove hand-rolled equals-form Project option parsing and add an audit test for future public Python engines that bypass `base_cli.App`.
- Document the lifecycle boundary, including shell-only helpers such as `basectl config path`.

## Validation
- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/1056-python-lifecycle/lib/python:/Users/rameshhp/work/base-worktrees/1056-python-lifecycle/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_public_command_lifecycle.py cli/python/base_config/tests/test_engine.py cli/python/base_github_projects/tests/test_engine.py cli/python/base_pr_policy/tests/test_engine.py -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats`
- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/1056-python-lifecycle/lib/python:/Users/rameshhp/work/base-worktrees/1056-python-lifecycle/cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_config/engine.py cli/python/base_github_projects/engine.py cli/python/base_pr_policy/engine.py lib/python/base_cli/tests/test_public_command_lifecycle.py cli/python/base_config/tests/test_engine.py cli/python/base_github_projects/tests/test_engine.py cli/python/base_pr_policy/tests/test_engine.py`
- `bash -n cli/bash/commands/basectl/subcommands/config.sh`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test`

## Demo Impact
- None. CLI lifecycle and observability behavior only.

Closes #1056
