### PR TITLE
Route project command metadata through Python

### DIFF
--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -40,8 +40,9 @@ base_activate_project_venv_dir() {
     local project="$1"
     local project_root="${2:-}"
     local manifest_path="${3:-}"
+    shift 3
 
-    base_project_venv_dir "$project" "$project_root" "$manifest_path"
+    base_project_venv_dir "$project" "$project_root" "$manifest_path" "$@"
 }
 
 base_activate_shell_is_bash() {
@@ -56,6 +57,7 @@ base_activate_subcommand_main() {
     local resolved_name project_root manifest_path venv_dir shell_rc
     local preserve_cwd="${BASE_ACTIVATE_PRESERVE_CWD:-0}"
     local args=()
+    local resolve_fields=()
 
     while (($# > 0)); do
         case "$1" in
@@ -107,15 +109,18 @@ base_activate_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     resolve_output="$(base_activate_resolve_project "$project" "$wrapper" "${args[@]}")" || return $?
-    IFS=$'\t' read -r resolved_name project_root manifest_path <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_name="${resolve_fields[0]:-}"
+    project_root="${resolve_fields[1]:-}"
+    manifest_path="${resolve_fields[2]:-}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
         fatal_error "Unable to resolve project '$project'."
     }
 
-    venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
+    venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root" "$manifest_path" "${resolve_fields[@]:3}")"
     venv_fix="Run 'basectl setup $resolved_name' first."
-    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_project_uses_uv_manager "$manifest_path"; then
+    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_project_route_uses_uv_manager "${resolve_fields[@]:3}"; then
         venv_fix="Run 'uv sync' in '$project_root' first."
     fi
     [[ -x "$venv_dir/bin/python" ]] || {

--- a/cli/bash/commands/basectl/subcommands/build.sh
+++ b/cli/bash/commands/basectl/subcommands/build.sh
@@ -41,13 +41,22 @@ base_build_list_targets() {
     local list_output line resolved_name project_root manifest_path target_name working_dir build_command description command_runner
     local display_text
     local printed_header=0
+    local target_fields=()
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     list_output="$("$wrapper" --project base base_projects build-target-list "$project" "${args[@]}")" || return $?
     while IFS= read -r line; do
         [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description command_runner <<<"$line"
+        IFS=$'\t' read -r -a target_fields <<<"$line"
+        resolved_name="${target_fields[0]:-}"
+        project_root="${target_fields[1]:-}"
+        manifest_path="${target_fields[2]:-}"
+        target_name="${target_fields[3]:-}"
+        working_dir="${target_fields[4]:-}"
+        build_command="${target_fields[5]:-}"
+        description="${target_fields[6]:-}"
+        command_runner="$(base_project_command_runner_from_field "${target_fields[7]:-}" || true)"
         [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" ]] || {
             fatal_error "Unable to parse build targets for project '$project'."
         }
@@ -73,6 +82,7 @@ base_build_subcommand_main() {
     local venv_dir command_to_run display_command
     local dry_run=0 list_targets=0 workspace_requested=0
     local args=() extra_args=() targets=()
+    local target_fields=()
 
     while (($#)); do
         case "$1" in
@@ -158,13 +168,21 @@ base_build_subcommand_main() {
     venv_dir=""
     while IFS= read -r line; do
         [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r resolved_name project_root manifest_path target_name working_dir build_command description command_runner <<<"$line"
+        IFS=$'\t' read -r -a target_fields <<<"$line"
+        resolved_name="${target_fields[0]:-}"
+        project_root="${target_fields[1]:-}"
+        manifest_path="${target_fields[2]:-}"
+        target_name="${target_fields[3]:-}"
+        working_dir="${target_fields[4]:-}"
+        build_command="${target_fields[5]:-}"
+        description="${target_fields[6]:-}"
+        command_runner="$(base_project_command_runner_from_field "${target_fields[7]:-}" || true)"
         [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" && -n "$build_command" ]] || {
             fatal_error "Unable to parse build target '$target_name' for project '$project'."
         }
 
         if [[ -z "$venv_dir" ]]; then
-            venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
+            venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path" "${target_fields[@]:7}")"
             export BASE_PROJECT="$resolved_name"
             export BASE_PROJECT_ROOT="$project_root"
             export BASE_PROJECT_MANIFEST="$manifest_path"

--- a/cli/bash/commands/basectl/subcommands/demo.sh
+++ b/cli/bash/commands/basectl/subcommands/demo.sh
@@ -35,6 +35,7 @@ base_demo_subcommand_main() {
     local quoted_demo_script command_to_run display_command
     local dry_run=0 workspace_requested=0
     local args=() extra_args=() project_args=()
+    local resolve_fields=()
 
     while (($#)); do
         case "$1" in
@@ -95,13 +96,18 @@ base_demo_subcommand_main() {
 
     [[ -n "$project" ]] && project_args+=("$project")
     resolve_output="$("$wrapper" --project base base_projects demo-script "${project_args[@]}" "${args[@]}")" || return $?
-    IFS=$'\t' read -r resolved_name project_root manifest_path demo_script command_runner <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_name="${resolve_fields[0]:-}"
+    project_root="${resolve_fields[1]:-}"
+    manifest_path="${resolve_fields[2]:-}"
+    demo_script="${resolve_fields[3]:-}"
+    command_runner="$(base_project_command_runner_from_field "${resolve_fields[4]:-}" || true)"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$demo_script" ]] || {
         fatal_error "Unable to resolve demo script for project '${project:-current project}'."
     }
 
-    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
+    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path" "${resolve_fields[@]:4}")"
     export BASE_PROJECT="$resolved_name"
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"

--- a/cli/bash/commands/basectl/subcommands/export_context.sh
+++ b/cli/bash/commands/basectl/subcommands/export_context.sh
@@ -33,6 +33,7 @@ base_export_context_subcommand_main() {
     local project="" wrapper resolve_output resolved_name project_root manifest_path
     local output_format="markdown" output_path="" print_bundle=0 list_files=0 workspace_requested=0
     local resolve_args=() exporter_args=()
+    local resolve_fields=()
 
     while (($#)); do
         case "$1" in
@@ -137,7 +138,10 @@ base_export_context_subcommand_main() {
     else
         resolve_output="$("$wrapper" --project base base_projects current)" || return $?
     fi
-    IFS=$'\t' read -r resolved_name project_root manifest_path <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_name="${resolve_fields[0]:-}"
+    project_root="${resolve_fields[1]:-}"
+    manifest_path="${resolve_fields[2]:-}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
         fatal_error "Unable to resolve project for export-context."

--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -4,31 +4,52 @@
 _base_project_command_helpers_sourced=1
 readonly _base_project_command_helpers_sourced
 
-base_project_uses_uv_manager() {
-    local manifest_path="$1"
+base_project_route_value() {
+    local marker="$1" field
+    shift
 
-    [[ -n "$manifest_path" && -f "$manifest_path" ]] || return 1
-    awk '
-        /^[[:space:]]*#/ { next }
-        /^[^[:space:]][^:]*:/ { in_python = 0 }
-        /^[[:space:]]*python:[[:space:]]*$/ { in_python = 1; next }
-        in_python && /^[[:space:]]+manager:[[:space:]]*['\''"]?uv['\''"]?[[:space:]]*(#.*)?$/ { found = 1 }
-        END { exit found ? 0 : 1 }
-    ' "$manifest_path"
+    for field in "$@"; do
+        case "$field" in
+            "$marker"*)
+                printf '%s\n' "${field#"$marker"}"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+base_project_route_venv_dir() {
+    base_project_route_value "__base_project_venv_dir=" "$@"
+}
+
+base_project_route_uses_uv_manager() {
+    [[ "$(base_project_route_value "__base_uses_uv_manager=" "$@" || true)" == "true" ]]
+}
+
+base_project_command_runner_from_field() {
+    local candidate="${1:-}"
+
+    [[ -n "$candidate" ]] || return 1
+    [[ "$candidate" != __base_* ]] || return 1
+    printf '%s\n' "$candidate"
 }
 
 base_project_venv_dir() {
     local project="$1"
     local project_root="${2:-}"
     local manifest_path="${3:-}"
+    local route_fields=("${@:4}")
+    local route_venv_dir=""
 
     if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
         printf '%s\n' "$BASE_PROJECT_VENV_DIR"
         return 0
     fi
 
-    if [[ -n "$project_root" ]] && base_project_uses_uv_manager "$manifest_path"; then
-        printf '%s\n' "$project_root/.venv"
+    route_venv_dir="$(base_project_route_venv_dir "${route_fields[@]}" || true)"
+    if [[ -n "$route_venv_dir" ]]; then
+        printf '%s\n' "$route_venv_dir"
         return 0
     fi
 

--- a/cli/bash/commands/basectl/subcommands/run.sh
+++ b/cli/bash/commands/basectl/subcommands/run.sh
@@ -66,6 +66,7 @@ base_run_subcommand_main() {
     local command_to_run display_command
     local dry_run=0 list_commands=0 workspace_requested=0
     local args=() extra_args=()
+    local resolve_fields=()
 
     while (($#)); do
         case "$1" in
@@ -152,13 +153,18 @@ base_run_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     resolve_output="$("$wrapper" --project base base_projects run-command "$project" "$command_name" "${args[@]}")" || return $?
-    IFS=$'\t' read -r resolved_name project_root manifest_path run_command command_runner <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_name="${resolve_fields[0]:-}"
+    project_root="${resolve_fields[1]:-}"
+    manifest_path="${resolve_fields[2]:-}"
+    run_command="${resolve_fields[3]:-}"
+    command_runner="$(base_project_command_runner_from_field "${resolve_fields[4]:-}" || true)"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$run_command" ]] || {
         fatal_error "Unable to resolve command '$command_name' for project '$project'."
     }
 
-    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
+    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path" "${resolve_fields[@]:4}")"
     export BASE_PROJECT="$resolved_name"
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -837,6 +837,7 @@ setup_run_diagnostics_json() {
 setup_resolve_project_manifest() {
     local project="$1"
     local python_bin="$2"
+    local resolve_fields=()
     local resolve_output resolved_manifest resolved_name resolved_root
 
     if [[ -n "${BASE_SETUP_MANIFEST:-}" ]]; then
@@ -865,7 +866,10 @@ setup_resolve_project_manifest() {
             "$python_bin" -m base_projects resolve "$project"
     )" || return 1
 
-    IFS=$'\t' read -r resolved_name resolved_root resolved_manifest <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_name="${resolve_fields[0]:-}"
+    resolved_root="${resolve_fields[1]:-}"
+    resolved_manifest="${resolve_fields[2]:-}"
     [[ "$resolved_name" == "$project" && -n "$resolved_root" && -n "$resolved_manifest" ]] || return 1
 
     printf '%s\t%s\t%s\n' "$resolved_name" "$resolved_root" "$resolved_manifest"
@@ -1169,6 +1173,7 @@ setup_run_project_artifact_layer() {
     local exit_code manifest_path precheck_json project project_uses_uv_manager project_venv_dir python_bin remote_network resolved_name resolved_root resolve_output route_output venv_dir
     local args=()
     local project_env_args=()
+    local resolve_fields=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
         log_info "[DRY-RUN] Would run Python project setup layer after PyYAML is installed."
@@ -1185,7 +1190,10 @@ setup_run_project_artifact_layer() {
         return 1
     }
     if [[ "$resolve_output" == *$'\t'* ]]; then
-        IFS=$'\t' read -r resolved_name resolved_root manifest_path <<<"$resolve_output"
+        IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+        resolved_name="${resolve_fields[0]:-}"
+        resolved_root="${resolve_fields[1]:-}"
+        manifest_path="${resolve_fields[2]:-}"
         project="$resolved_name"
         if [[ "$output_format" != json ]]; then
             if [[ "$action" == setup ]]; then

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -35,6 +35,7 @@ base_test_subcommand_main() {
     local command_to_run display_command
     local dry_run=0 workspace_requested=0
     local args=() extra_args=()
+    local resolve_fields=()
 
     while (($#)); do
         case "$1" in
@@ -95,13 +96,18 @@ base_test_subcommand_main() {
     local command_args=(test-command)
     [[ -z "$project" ]] || command_args+=("$project")
     resolve_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}")" || return $?
-    IFS=$'\t' read -r resolved_name project_root manifest_path test_command command_runner <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_name="${resolve_fields[0]:-}"
+    project_root="${resolve_fields[1]:-}"
+    manifest_path="${resolve_fields[2]:-}"
+    test_command="${resolve_fields[3]:-}"
+    command_runner="$(base_project_command_runner_from_field "${resolve_fields[4]:-}" || true)"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$test_command" ]] || {
         fatal_error "Unable to resolve test command for project '$project'."
     }
 
-    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path")"
+    venv_dir="$(base_project_venv_dir "$resolved_name" "$project_root" "$manifest_path" "${resolve_fields[@]:4}")"
     export BASE_PROJECT="$resolved_name"
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -294,6 +294,7 @@ base_update_resolve_project() {
     local base_home="$1"
     local project="$2"
     local wrapper="$base_home/bin/base-wrapper"
+    local resolve_fields=()
     local resolve_output resolved_name resolved_root resolved_manifest
 
     if [[ -z "$project" ]]; then
@@ -311,7 +312,10 @@ base_update_resolve_project() {
     }
 
     resolve_output="$("$wrapper" --project base base_projects resolve "$project")" || return $?
-    IFS=$'\t' read -r resolved_name resolved_root resolved_manifest <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_name="${resolve_fields[0]:-}"
+    resolved_root="${resolve_fields[1]:-}"
+    resolved_manifest="${resolve_fields[2]:-}"
     [[ "$resolved_name" == "$project" && -n "$resolved_root" && -n "$resolved_manifest" ]] || {
         log_error "Unable to resolve Base project '$project'."
         return 1
@@ -334,6 +338,7 @@ base_update_subcommand_main() {
     local project=base
     local project_arg=""
     local repo
+    local resolve_fields=()
     local resolve_output
     local resolved_project
     local update_branch
@@ -370,7 +375,10 @@ base_update_subcommand_main() {
     done
 
     resolve_output="$(base_update_resolve_project "$base_home" "$project")" || return $?
-    IFS=$'\t' read -r resolved_project repo manifest_path <<<"$resolve_output"
+    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
+    resolved_project="${resolve_fields[0]:-}"
+    repo="${resolve_fields[1]:-}"
+    manifest_path="${resolve_fields[2]:-}"
     [[ -n "$resolved_project" && -n "$repo" && -n "$manifest_path" ]] || {
         log_error "Unable to resolve Base project '$project'."
         return 1

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -14,7 +14,10 @@ load ./basectl_helpers.bash
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=false\n' \
+        "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+        "${HOME:?}/.base.d/demo/.venv"
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -62,7 +65,10 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=false\n' \
+        "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+        "${HOME:?}/.base.d/demo/.venv"
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -100,7 +106,10 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=true\n' \
+        "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -140,7 +149,10 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=false\n' \
+        "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+        "${HOME:?}/.base.d/demo/.venv"
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -179,7 +191,10 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=true\n' \
+        "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/project-command-helpers.bats
+++ b/cli/bash/commands/basectl/tests/project-command-helpers.bats
@@ -36,7 +36,24 @@ source_project_command_helpers() {
     HOME="$TEST_HOME"
     unset BASE_PROJECT_VENV_DIR
 
-    run base_project_venv_dir demo "$project_root" "$manifest_path"
+    run base_project_venv_dir demo "$project_root" "$manifest_path" "__base_project_venv_dir=$project_root/.venv"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$project_root/.venv" ]
+}
+
+@test "project command helper uses Python route venv metadata" {
+    source_project_command_helpers
+
+    local project_root="$TEST_TMPDIR/demo"
+    local manifest_path="$project_root/base_manifest.yaml"
+
+    mkdir -p "$project_root"
+    printf 'project:\n  name: demo\npython: {manager: uv}\nartifacts: []\n' > "$manifest_path"
+    HOME="$TEST_HOME"
+    unset BASE_PROJECT_VENV_DIR
+
+    run base_project_venv_dir demo "$project_root" "$manifest_path" "__base_project_venv_dir=$project_root/.venv"
 
     [ "$status" -eq 0 ]
     [ "$output" = "$project_root/.venv" ]

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -88,7 +88,11 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "venv=%s\npath=%s\n" "$BASE_PROJECT_VENV_DIR" "$PATH" > "$BASE_TEST_RUN_STATE"'
+    printf 'demo\t%s\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=true\n' \
+        "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+        'printf "venv=%s\npath=%s\n" "$BASE_PROJECT_VENV_DIR" "$PATH" > "$BASE_TEST_RUN_STATE"' \
+        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -6,6 +6,7 @@ from typing import Protocol
 
 import base_cli
 from base_setup.manifest import BaseManifest, BuildTargetConfig, ManifestError, read_manifest
+from base_setup.project_routing import route_for_manifest
 
 
 class ProjectLike(Protocol):
@@ -65,7 +66,7 @@ def build_targets_project_command(
         return 1
 
     for target_name, target_config, working_dir in targets:
-        print_build_target(project, target_name, target_config, working_dir)
+        print_build_target(project, manifest, target_name, target_config, working_dir)
     return 0
 
 
@@ -88,12 +89,13 @@ def list_build_targets_command(
         return 1
 
     for target_name, target_config, working_dir in targets:
-        print_build_target(project, target_name, target_config, working_dir)
+        print_build_target(project, manifest, target_name, target_config, working_dir)
     return 0
 
 
 def print_build_target(
     project: ProjectLike,
+    manifest: BaseManifest,
     target_name: str,
     target_config: BuildTargetConfig,
     working_dir: Path,
@@ -109,7 +111,17 @@ def print_build_target(
     ]
     if target_config.runner is not None:
         fields.append(target_config.runner)
+    fields.extend(route_metadata_fields(manifest))
     print("\t".join(fields))
+
+
+def route_metadata_fields(manifest: BaseManifest) -> list[str]:
+    route = route_for_manifest(manifest)
+    uses_uv = "true" if route.uses_uv_manager else "false"
+    return [
+        f"__base_project_venv_dir={route.project_venv_dir}",
+        f"__base_uses_uv_manager={uses_uv}",
+    ]
 
 
 def selected_build_targets(

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -43,6 +43,7 @@ from base_projects.workspace_reports import workspace_status_to_json
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest, CommandConfig, ManifestError, TestConfig, read_manifest
+from base_setup.project_routing import route_for_manifest
 
 
 app = base_cli.App(name="base_projects")
@@ -781,11 +782,12 @@ def resolve_project_command(ctx: base_cli.Context, project_name: str | None, wor
 
     try:
         project = resolve_named_project(ctx, project_name, workspace)
-    except ProjectDiscoveryError as exc:
+        manifest = read_manifest(project.manifest_path)
+    except (ProjectDiscoveryError, ManifestError) as exc:
         ctx.log.error(str(exc))
         return 1
 
-    print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    print(_project_output(project.name, project.root, project.manifest_path, manifest))
     return 0
 
 
@@ -809,7 +811,7 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
         return 1
 
     command_config = test_command(manifest.test)
-    print(_command_output(project.name, project.root, project.manifest_path, command_config))
+    print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
     return 0
 
 
@@ -832,7 +834,7 @@ def demo_script_project_command(ctx: base_cli.Context, project_name: str | None,
         ctx.log.error(str(exc))
         return 1
 
-    print(_demo_output(project.name, project.root, project.manifest_path, demo_script, manifest.demo.runner))
+    print(_demo_output(project.name, project.root, project.manifest_path, demo_script, manifest))
     return 0
 
 
@@ -875,7 +877,7 @@ def run_command_project_command(
         ctx.log.error(str(exc))
         return 1
 
-    print(_command_output(project.name, project.root, project.manifest_path, command_config))
+    print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
     return 0
 
 
@@ -953,10 +955,30 @@ def project_command(manifest: BaseManifest, command_name: str) -> CommandConfig:
         ) from exc
 
 
-def _command_output(project_name: str, project_root: Path, manifest_path: Path, command: CommandConfig) -> str:
+def _route_metadata_fields(manifest: BaseManifest) -> list[str]:
+    route = route_for_manifest(manifest)
+    uses_uv = "true" if route.uses_uv_manager else "false"
+    return [
+        f"__base_project_venv_dir={route.project_venv_dir}",
+        f"__base_uses_uv_manager={uses_uv}",
+    ]
+
+
+def _project_output(project_name: str, project_root: Path, manifest_path: Path, manifest: BaseManifest) -> str:
+    return "\t".join([project_name, str(project_root), str(manifest_path), *_route_metadata_fields(manifest)])
+
+
+def _command_output(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    command: CommandConfig,
+    manifest: BaseManifest,
+) -> str:
     fields = [project_name, str(project_root), str(manifest_path), command.command]
     if command.runner is not None:
         fields.append(command.runner)
+    fields.extend(_route_metadata_fields(manifest))
     return "\t".join(fields)
 
 
@@ -978,11 +1000,12 @@ def _demo_output(
     project_root: Path,
     manifest_path: Path,
     demo_script: Path,
-    runner: str | None,
+    manifest: BaseManifest,
 ) -> str:
     fields = [project_name, str(project_root), str(manifest_path), str(demo_script)]
-    if runner is not None:
-        fields.append(runner)
+    if manifest.demo.runner is not None:
+        fields.append(manifest.demo.runner)
+    fields.extend(_route_metadata_fields(manifest))
     return "\t".join(fields)
 
 

--- a/cli/python/base_projects/tests/test_build_targets.py
+++ b/cli/python/base_projects/tests/test_build_targets.py
@@ -92,19 +92,60 @@ def write_build_manifest_with_runner(project_root: Path, name: str) -> None:
     )
 
 
+def write_inline_uv_build_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "services" / "api").mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        "\n".join(
+            [
+                "project:",
+                f"  name: {name}",
+                "python: {manager: uv}",
+                "build:",
+                "  default:",
+                "    - api",
+                "  targets:",
+                "    api:",
+                "      description: Build the API service.",
+                "      working_dir: services/api",
+                "      command: python -m build",
+                "artifacts: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+_engine_homes: list[Path] = []
+
+
 def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
-    env = {
-        "HOME": str(base_home.parent / "home"),
-        "BASE_HOME": str(base_home),
-        "BASE_PROJECT": "",
-        "BASE_PROJECT_MANIFEST": "",
-    }
-    with mock.patch.dict(os.environ, env):
-        with redirect_stdout(stdout), redirect_stderr(stderr):
-            status = engine.main(args)
+    with tempfile.TemporaryDirectory() as home_dir:
+        _engine_homes.append(Path(home_dir))
+        env = {
+            "HOME": str(_engine_homes[-1]),
+            "BASE_HOME": str(base_home),
+            "BASE_PROJECT": "",
+            "BASE_PROJECT_MANIFEST": "",
+        }
+        with mock.patch.dict(os.environ, env):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                status = engine.main(args)
     return status, stdout.getvalue(), stderr.getvalue()
+
+
+def base_route_fields(base_home: Path, project: str) -> str:
+    del base_home
+    if not _engine_homes:
+        raise AssertionError("run_engine must be called before base_route_fields")
+    venv_dir = _engine_homes[-1] / ".base.d" / project / ".venv"
+    return f"\t__base_project_venv_dir={venv_dir}\t__base_uses_uv_manager=false"
+
+
+def uv_route_fields(project_root: Path) -> str:
+    return f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}\t__base_uses_uv_manager=true"
 
 
 class BuildTargetTests(unittest.TestCase):
@@ -174,10 +215,11 @@ class BuildTargetTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"\tapi\t{(project_root / 'services' / 'api').resolve()}\tgo build ./cmd/api\tBuild the API service.\n"
+            f"\tapi\t{(project_root / 'services' / 'api').resolve()}\tgo build ./cmd/api\tBuild the API service."
+            f"{base_route_fields(base_home, 'demo')}\n"
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tworker\t{(project_root / 'services' / 'worker').resolve()}\tgo build ./cmd/worker"
-            "\tBuild the worker service.\n",
+            f"\tBuild the worker service.{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_build_targets_prints_explicit_targets(self) -> None:
@@ -196,7 +238,7 @@ class BuildTargetTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tworker\t{(project_root / 'services' / 'worker').resolve()}\tgo build ./cmd/worker"
-            "\tBuild the worker service.\n",
+            f"\tBuild the worker service.{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_build_targets_prints_runner_when_declared(self) -> None:
@@ -215,7 +257,26 @@ class BuildTargetTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tpackage\t{(project_root / 'services' / 'api').resolve()}\tpython -m build"
-            "\tBuild the Python package.\tuv\n",
+            f"\tBuild the Python package.\tuv{base_route_fields(base_home, 'demo')}\n",
+        )
+
+    def test_projects_build_targets_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_inline_uv_build_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["build-targets", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\tapi\t{(project_root / 'services' / 'api').resolve()}\tpython -m build"
+            f"\tBuild the API service.{uv_route_fields(project_root)}\n",
         )
 
     def test_projects_build_target_list_prints_all_targets(self) -> None:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -32,10 +32,35 @@ def write_uv_manifest(project_root: Path, name: str) -> None:
     write_ready_python_bin(python_bin)
 
 
+def write_inline_uv_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\npython: {{manager: uv}}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+    python_bin = project_root / ".venv" / "bin" / "python"
+    write_ready_python_bin(python_bin)
+
+
 def write_ready_python_bin(python_bin: Path) -> None:
     python_bin.parent.mkdir(parents=True)
     python_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     python_bin.chmod(0o755)
+
+
+_engine_homes: list[Path] = []
+
+
+def base_route_fields(base_home: Path, project: str) -> str:
+    del base_home
+    if not _engine_homes:
+        raise AssertionError("run_engine must be called before base_route_fields")
+    venv_dir = _engine_homes[-1] / ".base.d" / project / ".venv"
+    return f"\t__base_project_venv_dir={venv_dir}\t__base_uses_uv_manager=false"
+
+
+def uv_route_fields(project_root: Path) -> str:
+    return f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}\t__base_uses_uv_manager=true"
 
 
 def write_last_check(home: Path, project: str, checked_at: str, status: str = "ok") -> None:
@@ -147,7 +172,7 @@ def invoke_engine(
     stderr = io.StringIO()
     if user_config is not None:
         config_path = home / ".base.d" / "config.yaml"
-        config_path.parent.mkdir(parents=True)
+        config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(user_config, encoding="utf-8")
     env = {
         "HOME": str(home),
@@ -170,7 +195,8 @@ def run_engine(
     extra_env: dict[str, str] | None = None,
 ) -> tuple[int, str, str]:
     with tempfile.TemporaryDirectory() as home_dir:
-        return invoke_engine(args, base_home, Path(home_dir), user_config=user_config, extra_env=extra_env)
+        _engine_homes.append(Path(home_dir))
+        return invoke_engine(args, base_home, _engine_homes[-1], user_config=user_config, extra_env=extra_env)
 
 
 def run_engine_with_home(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
@@ -458,7 +484,29 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"{base_route_fields(base_home, 'demo')}\n",
+        )
+
+    def test_projects_resolve_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_inline_uv_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["resolve", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"{uv_route_fields(project_root)}\n",
+        )
 
     def test_projects_resolve_uses_active_project_manifest_without_workspace_scan(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -484,7 +532,10 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{manifest_path.resolve()}\n")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{manifest_path.resolve()}{base_route_fields(base_home, 'demo')}\n",
+        )
 
     def test_projects_resolve_explicit_workspace_wins_over_active_project(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -510,7 +561,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
-            f"demo\t{explicit_root.resolve()}\t{(explicit_root / 'base_manifest.yaml').resolve()}\n",
+            f"demo\t{explicit_root.resolve()}\t{(explicit_root / 'base_manifest.yaml').resolve()}"
+            f"{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_resolve_rejects_active_project_manifest_mismatch(self) -> None:
@@ -550,7 +602,11 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertEqual(stdout, f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\n")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"{base_route_fields(base_home, 'demo')}\n",
+        )
 
     def test_projects_resolve_base_uses_base_home_without_workspace_scan(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -564,7 +620,11 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertEqual(stdout, f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}\n")
+        self.assertEqual(
+            stdout,
+            f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
+            f"{base_route_fields(base_home, 'base')}\n",
+        )
 
     def test_projects_resolve_base_uses_base_home_with_configured_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -583,7 +643,11 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertEqual(stdout, f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}\n")
+        self.assertEqual(
+            stdout,
+            f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
+            f"{base_route_fields(base_home, 'base')}\n",
+        )
 
     def test_projects_test_command_prints_project_details_and_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -599,7 +663,40 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
-            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/"
+            f"{base_route_fields(base_home, 'demo')}\n",
+        )
+
+    def test_projects_test_command_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            project_root.mkdir(parents=True)
+            (project_root / "base_manifest.yaml").write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python: {manager: uv}",
+                        "test:",
+                        "  command: pytest tests/",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_engine(["test-command", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\tpytest tests/\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
+            "\t__base_uses_uv_manager=true\n",
         )
 
     def test_projects_test_command_for_base_uses_base_home_without_workspace_scan(self) -> None:
@@ -616,7 +713,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
-            f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}\t./bin/base-test\n",
+            f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}\t./bin/base-test"
+            f"{base_route_fields(base_home, 'base')}\n",
         )
 
     def test_projects_test_command_prints_mise_task_command(self) -> None:
@@ -633,7 +731,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
-            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tmise run unit\n",
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tmise run unit"
+            f"{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_activation_sources_prints_validated_source_paths(self) -> None:
@@ -755,7 +854,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
-            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/"
+            f"{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_test_command_requires_manifest_test_command(self) -> None:
@@ -785,7 +885,39 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            "\tuvicorn app:app --reload\n",
+            f"\tuvicorn app:app --reload{base_route_fields(base_home, 'demo')}\n",
+        )
+
+    def test_projects_run_command_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            project_root.mkdir(parents=True)
+            (project_root / "base_manifest.yaml").write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python: {manager: uv}",
+                        "commands:",
+                        "  dev: uvicorn app:app --reload",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_engine(["run-command", "demo", "dev"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\tuvicorn app:app --reload\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
+            "\t__base_uses_uv_manager=true\n",
         )
 
     def test_projects_run_command_test_delegates_to_test_contract(self) -> None:
@@ -802,7 +934,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
-            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/\n",
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/"
+            f"{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_run_command_prints_runner_when_declared(self) -> None:
@@ -820,7 +953,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            "\tpytest tests/audit\tuv\n",
+            f"\tpytest tests/audit\tuv{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_test_command_prints_runner_when_declared(self) -> None:
@@ -838,7 +971,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            "\tpytest tests/\tuv\n",
+            f"\tpytest tests/\tuv{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_run_command_reports_unknown_command(self) -> None:
@@ -873,7 +1006,42 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"\t{script.resolve()}\n",
+            f"\t{script.resolve()}{base_route_fields(base_home, 'demo')}\n",
+        )
+
+    def test_projects_demo_script_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            script = project_root / "demo" / "demo.sh"
+            script.parent.mkdir(parents=True)
+            script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            script.chmod(0o755)
+            (project_root / "base_manifest.yaml").write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python: {manager: uv}",
+                        "demo:",
+                        "  script: ./demo/demo.sh",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_engine(["demo-script", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            stdout,
+            f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
+            f"\t{script.resolve()}\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
+            "\t__base_uses_uv_manager=true\n",
         )
 
     def test_projects_demo_script_prints_runner_when_declared(self) -> None:
@@ -895,7 +1063,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"\t{script.resolve()}\tuv\n",
+            f"\t{script.resolve()}\tuv{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_demo_script_defaults_to_current_project(self) -> None:
@@ -924,7 +1092,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"\t{script.resolve()}\n",
+            f"\t{script.resolve()}{base_route_fields(base_home, 'demo')}\n",
         )
 
     def test_projects_demo_script_requires_demo_declaration(self) -> None:


### PR DESCRIPTION
## Summary
- Emit explicit project venv and uv-manager route markers from Python project resolvers.
- Consume route metadata in activate/run/test/demo/build and other Bash resolve consumers so Bash no longer parses python.manager: uv or folds route metadata into manifest paths.
- Add Bash and Python coverage for Base-managed and uv-managed route behavior.

## Validation
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/*.bats lib/bash/runtime/tests/runtime_bashrc.bats lib/bash/version/tests/lib_version.bats lib/shell/completions/tests/completions.bats tests/base_init.bats tests/install.bats tests/integration/base_workflows.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_INTEGRATION_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bats tests/integration/base_workflows.bats
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python lib/python
- git diff --check
- shellcheck --severity=error cli/bash/commands/basectl/subcommands/project_command_helpers.sh cli/bash/commands/basectl/subcommands/activate.sh cli/bash/commands/basectl/subcommands/run.sh cli/bash/commands/basectl/subcommands/test.sh cli/bash/commands/basectl/subcommands/demo.sh cli/bash/commands/basectl/subcommands/build.sh cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/export_context.sh cli/bash/commands/basectl/subcommands/update.sh

## Demo Impact
- None.

Fixes #1065