### PR TITLE
Document GitHub API budget discipline

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -60,6 +60,15 @@ views, use `basectl repo configure --replace-project` with `--repo`; Base
 archives the old Project and recreates it from `base-project-template`.
 Already-standard Projects are left intact and continue through metadata repair.
 
+Treat GitHub API budget as shared infrastructure. Serialize mutating issue, PR,
+and Project writes; prefer exact-item GraphQL or `basectl gh` operations over
+broad scans; read current field values before writing; and update only fields
+whose values differ. If GitHub reports rate or secondary-limit pressure, stop
+mutating, wait for the indicated retry window when available, retry the smallest
+failed operation once, and otherwise report the blocked write instead of
+retry-looping. Consider GitHub Apps only for recurring multi-repo automation
+that needs a separate installation budget and narrowly scoped permissions.
+
 ## Branch And Worktree Flow
 
 Use a dedicated worktree for PR work. Branch names follow:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ Before modifying files in this repository, classify the request.
   operations.
 - Fall back to the GitHub connector, raw `gh`, or `git` when `basectl gh` does
   not support the needed operation or local tooling is unavailable.
+- Treat GitHub API budget as shared infrastructure: serialize mutating issue and
+  Project writes, prefer exact-item reads/writes over broad scans, compute
+  minimal diffs before writing fields, and back off instead of retry-looping when
+  GitHub reports rate or secondary-limit pressure.
 - Branch from `origin/main` with
   `<category>/<issue>-<YYYYMMDD>-<slug>`.
 - Use a dedicated worktree under `~/work/base-worktrees/<slug>` for PR work.

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -188,6 +188,37 @@ GitHub connector, raw `gh`, or `git` as appropriate and keep the resulting
 issue labels, branch names, assignments, and PR bodies aligned with this
 policy.
 
+## GitHub API Budget Discipline
+
+Treat GitHub API budget, especially Project V2 mutation capacity, as shared
+infrastructure. Agents and scripts should be quiet, exact, and idempotent.
+
+Use these rules for issue and Project writes:
+
+- Serialize mutating requests. Do not run parallel `gh issue`, `gh pr`, or
+  Project field writes against the same repository or Project.
+- Prefer exact-item GraphQL or Base wrapper operations when the issue, PR, or
+  Project item is already known. Avoid broad Project scans to update one issue.
+- Read the current item state first, compute the minimal diff, and write only
+  fields that actually need to change.
+- Reuse data gathered earlier in the run instead of refetching the same issue,
+  Project item, or field schema repeatedly.
+- Page through lists only when the task genuinely needs a list. Stop once the
+  target item is found.
+- Keep dry runs read-only. They may explain planned writes, but should not probe
+  by performing and undoing mutations.
+
+If GitHub reports rate limiting, abuse detection, or a secondary limit, stop
+mutating immediately. Wait for any reset or retry window GitHub provides, then
+retry the smallest failed operation once. If pressure continues, leave the item
+unchanged, report the exact operation that failed, and resume later instead of
+looping or widening the scan.
+
+GitHub Apps are appropriate for recurring multi-repo automation that needs its
+own installation-level rate budget and narrowly scoped permissions. They are not
+required for ordinary one-off Base issue, PR, or Project updates from a local
+development session.
+
 ## Branch Names
 
 Branch names should be derived from the issue category:


### PR DESCRIPTION
## Summary
- Add concise GitHub API budget rules to AGENTS.md.
- Document exact-item mutation, minimal-diff writes, retry behavior, and GitHub App boundaries in docs/github-workflow.md.
- Mirror the condensed guidance in .ai-context/WORKFLOWS.md for exported AI context.

## Validation
- git diff --check

## Demo Impact
- None. Documentation-only change.

Fixes #1077