### PR TITLE
Move GitHub Project issue defaults into Python

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -391,54 +391,6 @@ base_gh_manifest_path() {
     printf '%s\n' "$path"
 }
 
-base_gh_trim_scalar() {
-    printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
-}
-
-base_gh_issue_default_from_config() {
-    local path="$1" key="$2"
-    local in_defaults=0
-    local in_project=0
-    local line trimmed value
-
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        trimmed="$(base_gh_trim_scalar "$line")"
-        [[ -n "$trimmed" && "$trimmed" != \#* ]] || continue
-
-        if [[ "$line" != [[:space:]]* ]]; then
-            in_defaults=0
-            if [[ "$trimmed" == "project:" ]]; then
-                in_project=1
-            else
-                in_project=0
-            fi
-            continue
-        fi
-
-        if ((in_project)) && [[ "$line" == "  "* && "$line" != "    "* ]]; then
-            if [[ "$trimmed" == "issue_defaults:" ]]; then
-                in_defaults=1
-            else
-                in_defaults=0
-            fi
-            continue
-        fi
-
-        if ((in_project)) && ((in_defaults)) && [[ "$line" == "    "* && "$trimmed" == "$key":* ]]; then
-            value="$(base_gh_trim_scalar "${trimmed#"$key":}")"
-            [[ -n "$value" ]] || return 1
-            printf '%s\n' "$value"
-            return 0
-        fi
-    done <"$path"
-
-    return 1
-}
-
-base_gh_issue_default_assignee_from_config() {
-    base_gh_issue_default_from_config "$1" assignee
-}
-
 base_gh_issue_number_from_output() {
     local output="$1"
     local issue_number
@@ -456,6 +408,33 @@ base_gh_project_issue_set_fields() {
         return 1
     }
     BASE_CLI_DISPLAY_COMMAND="basectl gh" "$wrapper" --project base base_github_projects project issue set-fields "$@"
+}
+
+base_gh_project_issue_defaults() {
+    local wrapper="${BASE_GH_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
+
+    [[ -x "$wrapper" ]] || {
+        base_gh_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+    BASE_CLI_DISPLAY_COMMAND="basectl gh" "$wrapper" --project base base_github_projects project issue defaults "$@"
+}
+
+base_gh_issue_default_from_config() {
+    local path="$1" key="$2"
+    local default_key default_value
+
+    while IFS=$'\t' read -r default_key default_value; do
+        [[ "$default_key" == "$key" && -n "$default_value" ]] || continue
+        printf '%s\n' "$default_value"
+        return 0
+    done < <(base_gh_project_issue_defaults --config "$path")
+
+    return 1
+}
+
+base_gh_issue_default_assignee_from_config() {
+    base_gh_issue_default_from_config "$1" assignee
 }
 
 base_gh_join_csv() {

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -180,11 +180,20 @@ fi
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
 EOF
     chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
+if [[ "$*" == *" base_github_projects project issue defaults "* ]]; then
+    printf 'assignee\tcodeforester\n'
+fi
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
 
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
         BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_GH_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
         PATH="$TEST_MOCKBIN:$PATH" \
         bash -c '
             cd "$BASE_HOME"
@@ -195,6 +204,55 @@ EOF
 
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Base repo issue --label bug --assignee codeforester --repo basefoundry/base" ]
+    [ "$(cat "$TEST_STATE_DIR/wrapper-args")" = "--project base base_github_projects project issue defaults --config $BASE_REPO_ROOT/.github/base-project.yml" ]
+}
+
+@test "basectl gh issue create reads assignee defaults through Python project config" {
+    local repo
+    local repo_root
+
+    repo="$TEST_TMPDIR/base-like"
+    init_git_repo "$repo"
+    repo_root="$(cd "$repo" && pwd -P)"
+    git -C "$repo" remote add origin git@github.com:basefoundry/base-like.git
+    mkdir -p "$repo/.github"
+    cat > "$repo/.github/base-project.yml" <<'EOF'
+project:
+  issue_defaults: {assignee: codeforester}
+EOF
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+    cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
+if [[ "$*" == *" base_github_projects project issue defaults "* ]]; then
+    printf 'assignee\tcodeforester\n'
+fi
+EOF
+    chmod +x "$TEST_MOCKBIN/project-wrapper"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_GH_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue create --category bug --title "Base-like repo issue" --repo basefoundry/base-like --no-project
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Base-like repo issue --label bug --assignee codeforester --repo basefoundry/base-like" ]
+    [ "$(cat "$TEST_STATE_DIR/wrapper-args")" = "--project base base_github_projects project issue defaults --config $repo_root/.github/base-project.yml" ]
 }
 
 @test "basectl gh issue create --no-assignee ignores repo config assignee default" {
@@ -289,6 +347,14 @@ EOF
     chmod +x "$TEST_MOCKBIN/gh"
     cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
 #!/usr/bin/env bash
+if [[ "$*" == *" base_github_projects project issue defaults "* ]]; then
+    printf 'status\tBacklog\n'
+    printf 'priority\tP1\n'
+    printf 'size\tM\n'
+    printf 'area\tCLI\n'
+    printf 'initiative\tMVP\n'
+    exit 0
+fi
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
 EOF
     chmod +x "$TEST_MOCKBIN/project-wrapper"
@@ -342,6 +408,12 @@ EOF
     chmod +x "$TEST_MOCKBIN/gh"
     cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
 #!/usr/bin/env bash
+if [[ "$*" == *" base_github_projects project issue defaults "* ]]; then
+    printf 'status\tBacklog\n'
+    printf 'priority\tP2\n'
+    printf 'size\tS\n'
+    exit 0
+fi
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
 EOF
     chmod +x "$TEST_MOCKBIN/project-wrapper"

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -99,6 +99,7 @@ def print_usage(file=sys.stdout) -> None:
                 "[--copy-fields-from <title>] [--replace-project] [--initiative-option <name>] [--dry-run]",
                 f"  {command} project issue set-fields <number> "
                 "--repo <owner/name> --project <title> [--config <path>] [field options...]",
+                f"  {command} project issue defaults --config <path>",
             )
         ),
         file=file,
@@ -125,6 +126,11 @@ def parse_args(arguments: tuple[str, ...]) -> ProjectArguments:
         require_project_title(state)
         return state_to_args("configure", state)
     if command == "issue":
+        if remaining and remaining[0] == "defaults":
+            state = parse_project_options(remaining[1:], allow_fields=False, allow_issue=False)
+            if not state.config_path:
+                raise ProjectUsageError("The 'project issue defaults' command requires --config.")
+            return state_to_args("issue-defaults", state)
         if len(remaining) < 2 or remaining[0] != "set-fields":
             raise ProjectUsageError("Expected 'project issue set-fields <number>'.")
         try:
@@ -252,6 +258,8 @@ def run_command(args: ProjectArguments) -> int:
         return configure_command(args)
     if args.command == "issue-set-fields":
         return issue_set_fields_command(args)
+    if args.command == "issue-defaults":
+        return issue_defaults_command(args)
     raise ProjectUsageError(f"Unknown project command '{args.command}'.")
 
 
@@ -278,6 +286,18 @@ def issue_field_values_for_args(args: ProjectArguments) -> dict[str, str]:
     values = dict(config.issue_defaults)
     values.update(args.field_values or {})
     return values
+
+
+ISSUE_DEFAULT_OUTPUT_ORDER = ("status", "priority", "size", "area", "initiative", "assignee")
+
+
+def issue_defaults_command(args: ProjectArguments) -> int:
+    config = project_config_for_args(args)
+    for key in ISSUE_DEFAULT_OUTPUT_ORDER:
+        value = config.issue_defaults.get(key)
+        if value:
+            print(f"{key}\t{value}")
+    return 0
 
 
 def project_field_defaults_for_config(config: ProjectConfig) -> dict[str, str]:

--- a/cli/python/base_github_projects/project_config.py
+++ b/cli/python/base_github_projects/project_config.py
@@ -63,7 +63,7 @@ def read_yaml_mapping(path: Path) -> dict[str, Any]:
 
 
 def read_string_list(path: Path, project: dict[str, Any], key: str) -> tuple[str, ...]:
-    raw = project.get(key, ())
+    raw = project.get(key, [])
     if raw is None:
         return ()
     if not isinstance(raw, list):

--- a/cli/python/base_github_projects/tests/test_issue_defaults.py
+++ b/cli/python/base_github_projects/tests/test_issue_defaults.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from base_github_projects import engine
+
+
+def test_parse_project_issue_defaults_requires_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASE_CACHE_DIR", str(tmp_path / ".cache" / "base"))
+
+    status = engine.main(["project", "issue", "defaults"])
+
+    captured = capsys.readouterr()
+    assert status == 2
+    assert "project issue defaults --config <path>" in captured.err
+    assert "requires --config" in captured.err
+
+
+def test_project_issue_defaults_command_prints_project_config_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASE_CACHE_DIR", str(tmp_path / ".cache" / "base"))
+    config_path = tmp_path / "base-project.yml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "project:",
+                "  issue_defaults:",
+                "    status: Backlog",
+                "    priority: P1",
+                "    size: T",
+                "    area: CLI",
+                "    initiative: Adoption Polish",
+                "    assignee: codeforester",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    status = engine.main(["project", "issue", "defaults", "--config", str(config_path)])
+
+    assert status == 0
+    assert capsys.readouterr().out == (
+        "status\tBacklog\n"
+        "priority\tP1\n"
+        "size\tT\n"
+        "area\tCLI\n"
+        "initiative\tAdoption Polish\n"
+        "assignee\tcodeforester\n"
+    )
+
+
+def test_project_issue_defaults_command_rejects_invalid_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASE_CACHE_DIR", str(tmp_path / ".cache" / "base"))
+    config_path = tmp_path / "base-project.yml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "project:",
+                "  issue_defaults:",
+                "    labels: bug",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    status = engine.main(["project", "issue", "defaults", "--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    assert status == 2
+    assert "project.issue_defaults contains unsupported keys: labels" in captured.err


### PR DESCRIPTION
## Summary
- Add a Python-backed `project issue defaults --config <path>` command for schema-aware issue defaults.
- Route `basectl gh issue create` default lookup through the Python Project engine instead of Bash YAML line scanning.
- Cover missing config, invalid config, normal defaults, and Bash assignee/default metadata integration.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests/test_engine.py cli/python/base_github_projects/tests/test_issue_defaults.py -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_github_projects/engine.py cli/python/base_github_projects/project_config.py cli/python/base_github_projects/tests/test_issue_defaults.py`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/gh.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Closes #1066