### PR TITLE
Redact sensitive values from config show

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,8 +820,9 @@ basectl config doctor
 
 Base creates `~/.base.d/config.yaml` with a small first-run default when the file
 is missing, then leaves user edits and symlinks alone. Base owns the meaning of
-that file, but users own how it is edited, backed up, or synced. See
-[docs/local-config.md](docs/local-config.md).
+that file, but users own how it is edited, backed up, or synced. `config show`
+prints redacted JSON for routine inspection; Base config is not a secret store.
+See [docs/local-config.md](docs/local-config.md).
 
 Inspect release readiness for a Base-managed repository with:
 

--- a/cli/bash/commands/basectl/subcommands/config.sh
+++ b/cli/bash/commands/basectl/subcommands/config.sh
@@ -16,6 +16,7 @@ Purpose:
 
 Notes:
   - The default config path is ~/.base.d/config.yaml.
+  - config show redacts secret-shaped keys and URL credentials.
   - Missing config is treated as an empty config.
   - Base does not edit or sync this file.
 EOF

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import base_cli
 from base_cli.config import UserConfig, load_user_config, read_user_config, user_config_path
+from base_cli.redaction import REDACTED, is_secret_key, redact_text_value
 
 
 app = base_cli.App(
@@ -49,7 +51,10 @@ def print_usage(file=sys.stdout) -> None:
   base_config doctor
 
 Purpose:
-  Inspect Base's machine-local user config.""",
+  Inspect Base's machine-local user config.
+
+Notes:
+  - config show redacts secret-shaped keys and URL credentials.""",
         file=file,
     )
 
@@ -61,8 +66,20 @@ def show_config_command() -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    print(json.dumps(config, indent=2, sort_keys=True))
+    print(json.dumps(redact_config(config), indent=2, sort_keys=True))
     return 0
+
+
+def redact_config(value: Any, key: str | None = None) -> Any:
+    if key is not None and is_secret_key(key):
+        return REDACTED
+    if isinstance(value, dict):
+        return {name: redact_config(item, str(name)) for name, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redact_config(item) for item in value]
+    if isinstance(value, str):
+        return redact_text_value(value)
+    return value
 
 
 def doctor_config_command() -> int:

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -90,6 +90,46 @@ class BaseConfigCommandTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(json.loads(stdout.getvalue()), {"ide": {"enabled": True}})
 
+    def test_show_config_redacts_secret_shaped_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"HOME": tmpdir}):
+                path = user_config_path(Path(tmpdir))
+                path.parent.mkdir(parents=True)
+                path.write_text(
+                    "\n".join(
+                        (
+                            "workspace:",
+                            "  root: /tmp/work",
+                            "github:",
+                            "  default_owner: codeforester",
+                            "private:",
+                            "  github_token: ghp_super_secret",
+                            "  service:",
+                            "    password: local-password",
+                            "    url: https://user:local-secret@example.invalid/repo.git",
+                            "  mirrors:",
+                            "    - https://user:mirror-secret@example.invalid/repo.git",
+                        )
+                    ),
+                    encoding="utf-8",
+                )
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    status = engine.show_config_command()
+
+        config = json.loads(stdout.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(config["workspace"]["root"], "/tmp/work")
+        self.assertEqual(config["github"]["default_owner"], "codeforester")
+        self.assertEqual(config["private"]["github_token"], "[REDACTED]")
+        self.assertEqual(config["private"]["service"]["password"], "[REDACTED]")
+        self.assertEqual(config["private"]["service"]["url"], "https://[REDACTED]@example.invalid/repo.git")
+        self.assertEqual(config["private"]["mirrors"], ["https://[REDACTED]@example.invalid/repo.git"])
+        self.assertNotIn("super_secret", stdout.getvalue())
+        self.assertNotIn("local-password", stdout.getvalue())
+        self.assertNotIn("local-secret", stdout.getvalue())
+        self.assertNotIn("mirror-secret", stdout.getvalue())
+
     def test_show_config_reports_invalid_yaml(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch.dict(os.environ, {"HOME": tmpdir}):

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -57,7 +57,7 @@ inspect the resolved command contract first.
 | `basectl history` | List recent structured Base command runs. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--format <text\|json>` |
 | `basectl clean` | Remove old Base runtime logs, temp files, and cache entries. | `--older-than <age>`, `--keep-last <count>`, `--dry-run` |
 | `basectl config path` | Print the local Base config path. | none |
-| `basectl config show` | Show local Base config. | none |
+| `basectl config show` | Show local Base config as redacted JSON. | none |
 | `basectl config doctor` | Diagnose local Base config. | none |
 
 ## Workspace

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -26,9 +26,9 @@ basectl config doctor
 ```
 
 `basectl config path` prints the default path without requiring the Base Python
-environment. `show` prints the parsed config as JSON. `doctor` reports whether
-the file exists, whether it is valid YAML, whether it is a mapping, and whether
-the path is a symlink.
+environment. `show` prints the parsed config as JSON with secret-shaped keys and
+URL credentials redacted. `doctor` reports whether the file exists, whether it
+is valid YAML, whether it is a mapping, and whether the path is a symlink.
 
 ## Complete Example
 
@@ -241,6 +241,12 @@ Aside from the first-run seed, Base does not edit this file. There is no
 `basectl config set` or IDE preference editor command by design; developers can
 edit YAML directly, and Base keeps the runtime behavior inspectable through
 `basectl config show` and `basectl config doctor`.
+
+`basectl config show` is intended for routine inspection and support-safe
+copy/paste. It redacts values under keys that look like tokens, passwords,
+secrets, API keys, or authorization data, and it redacts credentials embedded in
+URLs. Keep actual secrets in a password manager, shell secret store, or the
+target tool's own credential system rather than in Base config.
 
 ## Sync Guidance
 

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import platform
-import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -11,13 +10,11 @@ from typing import Any
 from .config import load_yaml_file
 from .context import Context
 from .paths import base_cache_root
-from .redaction import REDACTED, option_name_to_parameter, redact_argv
+from .redaction import REDACTED, is_secret_key, option_name_to_parameter, redact_argv, redact_text_value
 
 
 SCHEMA_VERSION = 1
 HISTORY_PATH = Path("history") / "runs.jsonl"
-SECRET_KEY_RE = re.compile(r"(token|password|secret|api[-_]?key|authorization)", re.IGNORECASE)
-URL_CREDENTIALS_RE = re.compile(r"://[^/@\s]+@")
 
 
 def utc_now() -> datetime:
@@ -168,12 +165,7 @@ def redact_history_text(value: str) -> str:
     key, separator, _value = value.partition("=")
     if separator and is_secret_key(key):
         return f"{key}={REDACTED}"
-    redacted = URL_CREDENTIALS_RE.sub(f"://{REDACTED}@", value)
-    return compact_home_text(redacted)
-
-
-def is_secret_key(value: str) -> bool:
-    return SECRET_KEY_RE.search(value) is not None
+    return compact_home_text(redact_text_value(value))
 
 
 def compact_optional_path(path: Path | None) -> str | None:

--- a/lib/python/base_cli/redaction.py
+++ b/lib/python/base_cli/redaction.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import re
 
 REDACTED = "[REDACTED]"
+SECRET_KEY_RE = re.compile(r"(token|password|secret|api[-_]?key|authorization)", re.IGNORECASE)
+URL_CREDENTIALS_RE = re.compile(r"(?P<prefix>[a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\s]+@")
 
 
 def option_name_to_parameter(param_decl: str) -> str:
@@ -37,3 +40,11 @@ def redact_argv(argv: list[str], sensitive_options: set[str]) -> list[str]:
 
         redacted.append(arg)
     return redacted
+
+
+def is_secret_key(value: str) -> bool:
+    return SECRET_KEY_RE.search(value) is not None
+
+
+def redact_text_value(value: str) -> str:
+    return URL_CREDENTIALS_RE.sub(lambda match: f"{match.group('prefix')}{REDACTED}@", value)


### PR DESCRIPTION
## Summary
- Redact secret-shaped config keys and URL credentials before `basectl config show` prints JSON.
- Move shared secret-key and URL credential redaction primitives into `base_cli.redaction`.
- Document the redacted `config show` contract and keep Base config outside secret-store responsibilities.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_config/tests/test_engine.py lib/python/base_cli/tests/test_history.py lib/python/base_cli/tests/test_base_cli.py -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_config/engine.py cli/python/base_config/tests/test_engine.py lib/python/base_cli/redaction.py lib/python/base_cli/history.py`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/config.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Closes #1071