### PR TITLE
Add CI supply chain hardening policy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,6 +171,10 @@ jobs:
         run: |
           bandit -q -r cli/python lib/python -x '*/tests/*' --severity-level medium
 
+      - name: Run pip-audit
+        run: |
+          python -m pip_audit --cache-dir "$RUNNER_TEMP/pip-audit" -r requirements-dev.txt
+
       - name: Run ShellCheck
         run: |
           git ls-files -z \

--- a/cli/python/base_setup/tests/test_ci_supply_chain_policy.py
+++ b/cli/python/base_setup/tests/test_ci_supply_chain_policy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FULL_SHA_RE = re.compile(r"[a-f0-9]{40}")
+FIRST_PARTY_ACTION_REF_RE = re.compile(r"v\d+|[a-f0-9]{40}")
+
+
+def load_workflow(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def workflow_steps(path: Path) -> list[dict[str, Any]]:
+    workflow = load_workflow(path)
+    steps: list[dict[str, Any]] = []
+    for job in workflow["jobs"].values():
+        steps.extend(job.get("steps", ()))
+    return steps
+
+
+def test_github_actions_references_follow_supply_chain_policy() -> None:
+    workflow_paths = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+
+    for path in workflow_paths:
+        for step in workflow_steps(path):
+            uses = step.get("uses")
+            if not uses:
+                continue
+
+            action, separator, ref = uses.partition("@")
+            assert separator, f"{path}: action reference '{uses}' must include an explicit ref."
+            owner = action.split("/", 1)[0]
+            if owner == "actions":
+                assert FIRST_PARTY_ACTION_REF_RE.fullmatch(ref), (
+                    f"{path}: first-party action '{uses}' must use a maintained major tag or full SHA."
+                )
+            else:
+                assert FULL_SHA_RE.fullmatch(ref), f"{path}: third-party action '{uses}' must be pinned to a full SHA."
+
+
+def test_security_workflow_runs_python_dependency_audit() -> None:
+    requirements = (REPO_ROOT / "requirements-dev.txt").read_text(encoding="utf-8")
+    assert re.search(r"^pip-audit==", requirements, re.MULTILINE)
+
+    security_steps = workflow_steps(REPO_ROOT / ".github" / "workflows" / "tests.yml")
+    audit_steps = [step for step in security_steps if step.get("name") == "Run pip-audit"]
+
+    assert audit_steps, "tests.yml security job must run pip-audit."
+    audit_command = audit_steps[0].get("run", "")
+    assert "--cache-dir" in audit_command
+    assert "python -m pip_audit" in audit_command
+    assert "-r requirements-dev.txt" in audit_command

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,9 @@ reference. The filename should answer "what is this about?"
   pre-1.0.0 consumer upgrade proof and records rehearsal results.
 - [Testing](testing.md) explains Base's Python, BATS, and hermetic integration
   test layers.
+- [CI Supply Chain Policy](ci-supply-chain-policy.md) defines GitHub Action
+  pinning, Python dependency auditing, and package-manager trust boundaries for
+  repository workflows.
 - [Tool Boundaries](tool-boundaries.md) records ecosystem decisions for tools
   such as `mise`, `direnv`, Homebrew, IDEs, Docker, and dotfile managers.
 

--- a/docs/ci-supply-chain-policy.md
+++ b/docs/ci-supply-chain-policy.md
@@ -1,0 +1,51 @@
+# CI Supply Chain Policy
+
+Base keeps CI hardening practical and reviewable instead of trying to make
+GitHub-hosted runners fully reproducible. The policy below applies to workflows
+under `.github/workflows/`.
+
+## GitHub Actions
+
+- Use first-party `actions/*` actions when an action is needed.
+- Pin first-party `actions/*` actions to a maintained major tag such as `v4` or
+  to a full commit SHA.
+- Pin non-GitHub third-party actions to a full 40-character commit SHA. Version
+  tags are not enough for third-party actions.
+- Prefer shell steps over adding a new action when the command is simple and the
+  runner already has the required tool or installs it through an approved
+  package manager.
+
+`cli/python/base_setup/tests/test_ci_supply_chain_policy.py` enforces the
+action-reference rule.
+
+## Python Dependencies
+
+- Keep developer and CI Python tools pinned in `requirements-dev.txt`.
+- Install CI Python tools from `requirements-dev.txt`; do not install floating
+  Python tools directly in workflow steps.
+- Run `pip-audit` in the security job against `requirements-dev.txt` so pinned
+  tool dependencies receive vulnerability coverage.
+- Put the `pip-audit` cache under the runner temp directory so the audit does
+  not depend on a writable user-home cache path.
+- Hash-locked installs are not required for this repository yet. If Base starts
+  publishing Python packages or accepting untrusted dependency input in CI, add
+  hash locking or a lockfile as a separate reviewed change.
+
+## OS Packages
+
+- Keep OS package installs minimal and local to the jobs that need them.
+- Ubuntu jobs may install `bats` and `shellcheck` from the GitHub-hosted
+  runner's configured apt repositories.
+- macOS jobs may install `bash` and `bats-core` from Homebrew on the
+  GitHub-hosted runner.
+- Do not add third-party apt repositories, curl-piped installers, or external
+  package feeds in CI without documenting the trust boundary in this file.
+
+## Existing Scanners
+
+The security job must keep these checks:
+
+- Bandit over `cli/python` and `lib/python`
+- `pip-audit` over `requirements-dev.txt`
+- ShellCheck errors over tracked shell entry points and scripts
+- ShellCheck warnings as non-blocking signal

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -50,7 +50,7 @@ them by scanning the workspace root.
 | Package management | Homebrew (tools), pip/venv (Python) |
 | Runtime versioning | `mise` (optional, per-project) |
 | Testing | BATS (Bash), pytest (Python) |
-| Static analysis | ShellCheck, Pylint, Bandit |
+| Static analysis | ShellCheck, Pylint, Bandit, pip-audit |
 | CI | GitHub Actions (tests, lint, skills) |
 
 ## Architecture: Three Layers
@@ -254,6 +254,7 @@ exec "$SHELL" -l
 | Shell static analysis | ShellCheck | All `*.sh` files |
 | Python lint | Pylint | `cli/python/`, `lib/python/` (3.10–3.13 matrix) |
 | Python security scan | Bandit | `cli/python/`, `lib/python/` |
+| Python dependency audit | pip-audit | `requirements-dev.txt` |
 
 Run everything locally with `basectl test base` or `bin/base-test`.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ click==8.4.1
 PyYAML==6.0.3
 pytest==9.0.3
 bandit==1.9.4
+pip-audit==2.10.1


### PR DESCRIPTION
## Summary
- Document the CI supply-chain policy for GitHub Actions, Python dependency auditing, and OS package trust boundaries.
- Add `pip-audit` to pinned dev requirements and run it from the security job with an explicit runner-temp cache.
- Add a policy test that enforces action-reference rules and the dependency-audit workflow step.

## Validation
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_ci_supply_chain_policy.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pip install -r requirements-dev.txt`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pip_audit --cache-dir /private/tmp/base-pip-audit-cache -r requirements-dev.txt`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/tests/test_ci_supply_chain_policy.py`
- `git diff --check`

Closes #1070