### PR TITLE
Fix nested completion parity gaps

### DIFF
--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -251,7 +251,7 @@ EOF
     [[ "$output" == *"repo_check_options=--agent-guidance"* ]]
     [[ "$output" == *"repo_configure_options=--repo --no-protect-default-branch --project --project-owner --project-schema --initiative-option --copy-project-fields-from --replace-project --no-project --dry-run"* ]]
     [[ "$output" == *"repo_agent_guidance_options=--repo --repo-name --default-branch --validation-command --pr --dry-run"* ]]
-    [[ "$output" == *"repo_installer_template_options=--repo --pr --dry-run"* ]]
+    [[ "$output" == *"repo_installer_template_options=--print --stdout --repo --pr --dry-run"* ]]
     [[ "$output" == *"ci_commands=setup check doctor"* ]]
     [[ "$output" == *"ci_check_options=--format --manifest --profile"* ]]
     [[ "$output" == *"gh_areas=issue pr branch worktree project"* ]]

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -156,7 +156,7 @@ _base_basectl_completion() {
                     _base_basectl_completion_compgen "--repo --repo-name --default-branch --validation-command --pr --dry-run -v -h --help" "$cur"
                     ;;
                 installer-template)
-                    _base_basectl_completion_compgen "--repo --pr --dry-run -v -h --help" "$cur"
+                    _base_basectl_completion_compgen "--print --stdout --repo --pr --dry-run -v -h --help" "$cur"
                     ;;
             esac
             ;;

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -263,6 +263,8 @@ _base_basectl_completion() {
                 installer-template)
                     _arguments '1:repo command:(init clone check configure agent-guidance installer-template)' \
                         '2:path:_files' \
+                        '--print[Print the maintained template to stdout instead of writing a file]' \
+                        '--stdout[Alias for --print]' \
                         '--repo[GitHub repository for pull request]:repo:' \
                         '--pr[Commit generated installer template and open a draft pull request]' \
                         '--dry-run[Print planned changes]' \
@@ -360,6 +362,13 @@ _base_basectl_completion() {
                         '--category[Issue category]:category:(bug enhancement documentation ci security)' \
                         '--title[Issue title]:title:' \
                         '--body[Issue body]:body:' \
+                        '--repo[GitHub repository]:repo:' \
+                        '--assignee[Issue assignee]:login:' \
+                        '--no-assignee[Do not assign the issue]' \
+                        '--project[GitHub Project title]:title:' \
+                        '--project-owner[GitHub Project owner]:owner:' \
+                        '--size[Project size option]:size:(T S M L)' \
+                        '--no-project[Skip Project metadata updates]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 pr)
@@ -400,6 +409,7 @@ _base_basectl_completion() {
                                 '--schema[Project metadata schema]:schema:(base-project)' \
                                 '--initiative-option[Initiative option to seed]:name:' \
                                 '--repo[GitHub repository]:repo:' \
+                                '--replace-project[Replace a nonstandard existing Project from base-project-template]' \
                                 '--dry-run[Print planned changes]' \
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -94,6 +94,38 @@ zsh_completion_nested_commands() {
         sort -u
 }
 
+zsh_completion_nested_block() {
+    local parent="$1"
+    local child="$2"
+
+    awk -v parent="$parent" -v child="$child" '
+        $0 ~ "^[[:space:]]*" parent "\\)" { in_parent = 1 }
+        in_parent && $0 ~ "^[[:space:]]*" child "\\)" {
+            in_block = 1
+            next
+        }
+        in_block && /^[[:space:]]*;;/ { exit }
+        in_block { print }
+    ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
+}
+
+zsh_completion_deep_nested_block() {
+    local parent="$1"
+    local child="$2"
+    local grandchild="$3"
+
+    awk -v parent="$parent" -v child="$child" -v grandchild="$grandchild" '
+        $0 ~ "^[[:space:]]*" parent "\\)" { in_parent = 1 }
+        in_parent && $0 ~ "^[[:space:]]*" child "\\)" { in_child = 1 }
+        in_child && $0 ~ "^[[:space:]]*" grandchild "\\)" {
+            in_block = 1
+            next
+        }
+        in_block && /^[[:space:]]*;;/ { exit }
+        in_block { print }
+    ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
+}
+
 long_options_from_help() {
     "$BASE_REPO_ROOT/bin/basectl" "$@" --help |
         awk '
@@ -180,4 +212,36 @@ assert_bash_completion_options_match_help() {
     assert_bash_completion_options_match_help doctor doctor
     assert_bash_completion_options_match_help repo-init repo init
     assert_bash_completion_options_match_help repo-configure repo configure
+    assert_bash_completion_options_match_help repo-installer-template repo installer-template
+}
+
+@test "Zsh repo installer-template completion includes print options" {
+    local block
+
+    block="$(zsh_completion_nested_block repo installer-template)"
+
+    [[ "$block" == *"--print"* ]]
+    [[ "$block" == *"--stdout"* ]]
+}
+
+@test "Zsh gh issue completion includes issue create project options" {
+    local block
+
+    block="$(zsh_completion_nested_block gh issue)"
+
+    [[ "$block" == *"--repo"* ]]
+    [[ "$block" == *"--assignee"* ]]
+    [[ "$block" == *"--no-assignee"* ]]
+    [[ "$block" == *"--project"* ]]
+    [[ "$block" == *"--project-owner"* ]]
+    [[ "$block" == *"--size"* ]]
+    [[ "$block" == *"--no-project"* ]]
+}
+
+@test "Zsh gh project configure completion includes replace-project option" {
+    local block
+
+    block="$(zsh_completion_deep_nested_block gh project configure)"
+
+    [[ "$block" == *"--replace-project"* ]]
 }


### PR DESCRIPTION
## Summary
- Add missing Bash `repo installer-template` print/stdout completions.
- Add missing Zsh nested completions for `repo installer-template`, `gh issue`, and `gh project configure`.
- Add completion tests that catch the documented nested parity gaps.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/completions.bats`
- `shellcheck --severity=error lib/shell/completions/basectl_completion.sh`
- `git diff --check`

Closes #1067