### PR TITLE
Refresh product records for 1.2.0

### DIFF
--- a/docs/check-parallelism.md
+++ b/docs/check-parallelism.md
@@ -1,6 +1,6 @@
 # basectl check parallelism
 
-> **NOT YET IMPLEMENTED** as of Base 1.1.0. This document records the design for
+> **NOT YET IMPLEMENTED** as of Base 1.2.0. This document records the design for
 > a future `basectl check` performance PR; current check behavior remains
 > sequential and deterministic.
 

--- a/docs/product-assessment.md
+++ b/docs/product-assessment.md
@@ -1,8 +1,8 @@
 # Base Product Assessment
 
 Status: maintained product review artifact
-Last reviewed: 2026-06-21
-Base era reviewed: 1.1.0
+Last reviewed: 2026-06-25
+Base era reviewed: 1.2.0
 
 This document records a candid assessment of Base as a product and engineering
 effort. It is not marketing copy, and it should not drift into aspiration. When
@@ -250,6 +250,57 @@ response is not an abstract split-everything campaign. Reduce ownership where a
 stable subdomain is visible, keep tests near behavior, and use #929 for the
 known `setup_common.sh` ownership-reduction path.
 
+### 2026-06-25 / 1.2.0 Product Review Delta
+
+The 1.2.0 release line strengthens Base's repeatability story more than it
+changes the core product thesis. The target user and product boundary remain
+the same: macOS-first multi-repo workspace orchestration, with mature tools
+delegated to rather than replaced.
+
+The strongest shipped signal is that Base now has a more durable review and
+workflow loop around itself:
+
+- `basectl workspace init` makes a workspace repository the entry point for
+  cloning and materializing the declared repo set.
+- `basectl prompt list` and `basectl prompt product-self-review` make
+  repo-owned prompts inspectable and repeatable instead of private chat-only
+  process.
+- local command history gives future reporting work a factual substrate without
+  making a dashboard the first step.
+- manifest-declared PR policy lets repository workflow guidance travel with the
+  project contract while GitHub Issues and PRs remain the durable execution
+  record.
+- Python runtime requirements and Base-managed artifact declarations make
+  project readiness more explicit without turning Base into a package solver.
+
+The post-release hardening train also improved product trust signals without
+changing the positioning: GitHub Project defaults route through the Python
+Project engine, `basectl config show` now redacts secret-shaped values, CI has a
+documented dependency-audit policy, nested completions are closer to command
+parity, and `basectl gh project issue set-fields --help` exposes concrete field
+options instead of a generic placeholder.
+
+The working ratings remain unchanged. 1.2.0 gives better proof that the product
+can keep its own workflow, documentation, and release record current, but it
+does not yet provide the external adoption, contributor independence, or
+cross-platform support evidence that would justify raising the adoption or
+organizational-impact assessment.
+
+Current watchlist for the next release line:
+
+- Linux remains the largest platform expansion unlock; keep #562 narrow and
+  tested before making broader claims.
+- Command history should earn user-facing reports before a local dashboard
+  becomes product surface.
+- Artifact support should stay Base-managed and manifest-explicit until real
+  adapter demand proves a constrained extension model.
+- Setup parallelism should wait behind a deterministic setup-plan/preflight
+  layer; mutating installers should remain serial.
+- Ownership pressure is still concentrated in large Bash command modules,
+  Project engines, and broad BATS files; keep #1072, #1073, #1074, and #1075 as
+  issue-backed maintainability work rather than turning this assessment into a
+  parallel backlog.
+
 ## 4. Creator And Engineering Skill Assessment
 
 Assessment: at least Staff-level; plausibly upper Staff or early Senior
@@ -321,6 +372,11 @@ the system without needing the creator in the loop.
 
 ## Assessment History
 
+- 2026-06-25: Updated for the 1.2.0 review delta, including workspace init,
+  repo-owned prompt rendering, command history, manifest PR policy, Python
+  runtime requirements, artifact declarations, and post-release hardening
+  around Project routing, config redaction, CI supply-chain checks, completions,
+  and concrete nested help.
 - 2026-06-21: Updated for the 1.1.0 review delta, including workspace clone
   onboarding, uv-managed project support, bootstrap/Homebrew release maturity,
   AI context exports, standalone `base-bash-libs`, AGPL adoption tradeoffs, and

--- a/docs/product-requirements.md
+++ b/docs/product-requirements.md
@@ -1,8 +1,8 @@
 # Base Product Requirements
 
 Status: maintained product requirements document
-Last reviewed: 2026-06-22
-Base era reviewed: 1.1.0
+Last reviewed: 2026-06-25
+Base era reviewed: 1.2.0
 
 This document is the product-facing source of truth for what Base is trying to
 be, who it serves, which outcomes matter, and what boundaries should guide
@@ -72,6 +72,8 @@ Base should help a target user answer these questions quickly:
   workflow conventions?
 - How do I export repo-visible AI context without depending on a
   provider-specific upload path?
+- How do I render repo-owned prompts for review workflows without moving
+  private prompt libraries into Base?
 
 ## Requirements
 
@@ -119,6 +121,9 @@ Base should help a target user answer these questions quickly:
 - Base should coexist strongly with tools such as Homebrew, `mise`, uv, Docker,
   IDEs, project task runners, Devbox, Nix, and Dev Containers where a project
   chooses them.
+- Built-in artifact support may cover Base-managed artifacts with explicit
+  manifest declarations. External artifact adapters should remain constrained
+  and evidence-driven before becoming part of Base core.
 - New tool-family support must remain explicit and opt-in until real usage
   proves a narrower Base-owned contract.
 
@@ -129,18 +134,24 @@ Base should help a target user answer these questions quickly:
 - Base repository work should use issue-backed branches, dedicated worktrees,
   pull requests, validation, and Project metadata as documented in
   [GitHub Workflow](github-workflow.md).
+- Base may render repo-declared pull request policy from project manifests, but
+  issues, pull requests, milestones, and Projects remain the durable GitHub
+  source of truth for execution state.
 - Release support must remain guarded and explicit, with changelog, version,
   GitHub Release, and Homebrew tap handoff behavior documented in
   [Release Process](release-process.md).
 
 ### AI Context
 
-- Base may maintain repo-visible `.ai-context/` files as a curated orientation
-  layer for AI assistants.
+- Base may maintain repo-visible `.ai-context/` files and repo-owned prompt
+  templates as curated orientation and review surfaces for AI assistants.
 - Canonical docs remain the source of truth. `.ai-context/` must summarize
   current repository state and must be updated when product shape,
   architecture, workflows, command surface, manifest model, or durable
   decisions change.
+- Repo-owned prompts must stay inspectable, provider-neutral, and tied to
+  current repository evidence. Private prompt libraries remain outside Base's
+  public product contract.
 - Base must not promise provider-specific AI upload support until official
   supported APIs and privacy boundaries are confirmed.
 
@@ -176,6 +187,8 @@ Base is succeeding when:
 - the release, install, upgrade, and Homebrew paths are boring and repeatable;
 - another contributor or AI-assisted agent can follow the docs, issues, tests,
   and context pack without needing private maintainer knowledge;
+- repo-owned prompts and context exports make periodic product and workflow
+  reviews repeatable without becoming hidden private process;
 - external adoption evidence grows without widening Base into a catch-all
   developer tools bundle.
 
@@ -239,6 +252,11 @@ repositioning, and after meaningful external user feedback.
 
 ## Decision Log
 
+- 2026-06-25: Reviewed for the 1.2.0 release line.
+  The 1.2.0 release adds workspace initialization, repo-owned prompt rendering,
+  local command history, manifest-declared PR policy, Python runtime
+  requirements, and Base-managed artifact declarations without changing Base's
+  target user or workspace-control-plane thesis.
 - 2026-06-22: Add a maintained PRD for Base.
   Base already has product, architecture, boundary, and assessment docs, but
   needs one concise source for accepted product intent, requirements,

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -260,14 +260,16 @@ Run everything locally with `basectl test base` or `bin/base-test`.
 
 ## Current Status
 
-Base **1.1.0** (June 2026) covers: first-mile `bootstrap.sh`
+Base **1.2.0** (June 2026) covers: first-mile `bootstrap.sh`
 installation, setup, check, doctor, project discovery, workspace
 status/check/doctor/clone/pull/configure, `basectl onboard`, project activation
 (subshell), test execution, build targets, named commands, demo scripts,
 explicit `python.manager: uv` project support, standalone and source-checkout
 `base-bash-libs` consumption, repository baseline creation, guarded GitHub
-release publishing, AI context export, `basectl ci` for non-interactive CI, IDE
-bootstrapping (VS Code/Cursor), and release readiness inspection.
+release publishing, AI context export, repo-owned prompt rendering, local
+command history, manifest-declared PR policy, Base-managed artifact
+declarations, `basectl ci` for non-interactive CI, IDE bootstrapping (VS
+Code/Cursor), and release readiness inspection.
 
 Linux support is a design target but not yet an implemented or tested contract.
 Windows is out of scope.


### PR DESCRIPTION
## Summary
- Update the maintained product requirements and product assessment records for the 1.2.0 release line.
- Add a candid 1.2.0 product review delta without changing the target user or product thesis.
- Correct adjacent stale current-version statements in the technical overview and check parallelism design note.

## Validation
- git diff --check
- rg -n "Base era reviewed: 1\.1\.0|as of Base 1\.1\.0|Base \*\*1\.1\.0\*\*|current release.*1\.1\.0|current assessed era.*1\.1\.0" docs .ai-context README.md FAQ.md -S
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl prompt product-self-review

Closes #1069