### PR TITLE
Extract base project discovery cache

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -2,31 +2,31 @@ from __future__ import annotations
 
 # pylint: disable=too-many-lines
 
-import hashlib
 import json
-import os
 import subprocess
 import shlex
 import sys
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 from urllib.parse import urlparse
 
 import base_cli
 from base_cli.config import load_user_config
 from base_cli.config import user_config_path
-from base_cli.paths import base_cache_root, discover_manifest
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
+from base_projects.project_discovery import Project
+from base_projects.project_discovery import discover_projects_cached
+from base_projects.project_discovery import find_project_in_projects
+from base_projects.project_discovery import current_project
+from base_projects.project_discovery import read_project
+from base_projects.project_discovery import resolve_active_project
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_configure import workspace_configure_from_options
 from base_projects.workspace_pull import pull_workspace_manifest
-from base_projects.workspace_reports import ManifestEntry
 from base_projects.workspace_reports import ProjectDiscoveryError
 from base_projects.workspace_reports import dumps_json
 from base_projects.workspace_reports import print_workspace_check
@@ -36,7 +36,6 @@ from base_projects.workspace_reports import resolve_workspace_manifest
 from base_projects.workspace_reports import workspace_check_to_json
 from base_projects.workspace_reports import workspace_doctor_to_json
 from base_projects.workspace_reports import workspace_error_count
-from base_projects.workspace_reports import workspace_manifest_entries
 from base_projects.workspace_reports import workspace_project_check_results
 from base_projects.workspace_reports import workspace_project_statuses
 from base_projects.workspace_reports import workspace_status_to_json
@@ -47,13 +46,6 @@ from base_setup.project_routing import route_for_manifest
 
 
 app = base_cli.App(name="base_projects")
-
-
-@dataclass(frozen=True, order=True)
-class Project:
-    name: str
-    root: Path
-    manifest_path: Path
 
 
 @dataclass(frozen=True)
@@ -913,14 +905,6 @@ def current_project_command(ctx: base_cli.Context) -> int:
     return 0
 
 
-def current_project() -> Project:
-    manifest_path = discover_manifest(Path.cwd())
-    if manifest_path is None:
-        raise ProjectDiscoveryError(f"No base_manifest.yaml found from '{Path.cwd()}' upward.")
-
-    return read_project(manifest_path)
-
-
 def test_command(test_config: TestConfig) -> CommandConfig:
     if test_config.command is not None:
         return CommandConfig(command=test_config.command, runner=test_config.runner)
@@ -1078,161 +1062,3 @@ def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: s
     workspace_root = resolve_workspace_root(ctx, workspace)
     projects = discover_projects_cached(ctx, workspace_root)
     return find_project_in_projects(projects, workspace_root, project_name)
-
-
-def discover_projects(workspace_root: Path) -> tuple[Project, ...]:
-    entries = workspace_manifest_entries(workspace_root)
-    projects = tuple(read_project(entry.path) for entry in entries)
-    return validate_unique_project_names(tuple(sorted(projects)))
-
-
-def discover_projects_cached(ctx: base_cli.Context, workspace_root: Path) -> tuple[Project, ...]:
-    start = time.perf_counter()
-    entries = workspace_manifest_entries(workspace_root)
-    cached_projects = read_project_cache(workspace_root, entries)
-    elapsed_ms = (time.perf_counter() - start) * 1000
-    if cached_projects is not None:
-        ctx.log.debug(
-            "Project discovery cache hit for '%s': %d project(s) in %.1fms.",
-            workspace_root,
-            len(cached_projects),
-            elapsed_ms,
-        )
-        return cached_projects
-
-    projects = validate_unique_project_names(tuple(sorted(read_project(entry.path) for entry in entries)))
-    write_project_cache(workspace_root, entries, projects, ctx)
-    elapsed_ms = (time.perf_counter() - start) * 1000
-    ctx.log.debug(
-        "Project discovery scanned '%s': %d project(s) in %.1fms.",
-        workspace_root,
-        len(projects),
-        elapsed_ms,
-    )
-    return projects
-
-
-def find_project(workspace_root: Path, project_name: str) -> Project:
-    projects = discover_projects(workspace_root)
-    return find_project_in_projects(projects, workspace_root, project_name)
-
-
-def find_project_in_projects(projects: tuple[Project, ...], workspace_root: Path, project_name: str) -> Project:
-    for project in projects:
-        if project.name == project_name:
-            return project
-    raise ProjectDiscoveryError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
-
-
-def resolve_active_project(project_name: str) -> Project | None:
-    if os.environ.get("BASE_PROJECT") != project_name:
-        return None
-
-    manifest = os.environ.get("BASE_PROJECT_MANIFEST")
-    if not manifest:
-        return None
-
-    project = read_project(Path(manifest).expanduser().resolve())
-    if project.name != project_name:
-        raise ProjectDiscoveryError(
-            f"BASE_PROJECT is '{project_name}' but BASE_PROJECT_MANIFEST points to project '{project.name}'."
-        )
-    return project
-
-
-def project_cache_path(workspace_root: Path) -> Path:
-    workspace_key = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[:24]
-    return base_cache_root() / "projects" / f"{workspace_key}.json"
-
-
-def read_project_cache(workspace_root: Path, entries: tuple[ManifestEntry, ...]) -> tuple[Project, ...] | None:
-    cache_path = project_cache_path(workspace_root)
-    try:
-        data = json.loads(cache_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-
-    if data.get("version") != 1 or data.get("workspace") != str(workspace_root):
-        return None
-    if data.get("manifests") != [manifest_entry_to_json(entry) for entry in entries]:
-        return None
-
-    try:
-        projects = tuple(
-            Project(
-                name=project["name"],
-                root=Path(project["root"]),
-                manifest_path=Path(project["manifest_path"]),
-            )
-            for project in data["projects"]
-        )
-    except (KeyError, TypeError):
-        return None
-    return validate_unique_project_names(tuple(sorted(projects)))
-
-
-def write_project_cache(
-    workspace_root: Path,
-    entries: tuple[ManifestEntry, ...],
-    projects: tuple[Project, ...],
-    ctx: base_cli.Context,
-) -> None:
-    cache_path = project_cache_path(workspace_root)
-    data = {
-        "version": 1,
-        "workspace": str(workspace_root),
-        "manifests": [manifest_entry_to_json(entry) for entry in entries],
-        "projects": [project_to_json(project) for project in projects],
-    }
-    try:
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
-    except OSError as exc:
-        ctx.log.debug("Unable to write project discovery cache '%s': %s", cache_path, exc)
-
-
-def manifest_entry_to_json(entry: ManifestEntry) -> dict[str, Any]:
-    return {
-        "path": str(entry.path),
-        "mtime_ns": entry.mtime_ns,
-        "size": entry.size,
-    }
-
-
-def project_to_json(project: Project) -> dict[str, str]:
-    return {
-        "name": project.name,
-        "root": str(project.root),
-        "manifest_path": str(project.manifest_path),
-    }
-
-
-def read_project(manifest_path: Path) -> Project:
-    try:
-        manifest = read_manifest(manifest_path)
-    except ManifestError as exc:
-        raise ProjectDiscoveryError(str(exc)) from exc
-    return Project(
-        name=manifest.project_name,
-        root=manifest_path.parent.resolve(),
-        manifest_path=manifest_path.resolve(),
-    )
-
-
-def validate_unique_project_names(projects: tuple[Project, ...]) -> tuple[Project, ...]:
-    seen: dict[str, Project] = {}
-    duplicates = []
-    for project in projects:
-        existing = seen.get(project.name)
-        if existing is not None:
-            duplicates.append((project, existing))
-        else:
-            seen[project.name] = project
-
-    if duplicates:
-        details = "; ".join(
-            f"{project.name}: {existing.root} and {project.root}" for project, existing in duplicates
-        )
-        raise ProjectDiscoveryError(f"Duplicate project names found: {details}.")
-
-    return projects

--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import base_cli
+from base_cli.paths import base_cache_root, discover_manifest
+from base_projects.workspace_reports import ManifestEntry
+from base_projects.workspace_reports import ProjectDiscoveryError
+from base_projects.workspace_reports import workspace_manifest_entries
+from base_setup.manifest import ManifestError, read_manifest
+
+
+@dataclass(frozen=True, order=True)
+class Project:
+    name: str
+    root: Path
+    manifest_path: Path
+
+
+def current_project() -> Project:
+    manifest_path = discover_manifest(Path.cwd())
+    if manifest_path is None:
+        raise ProjectDiscoveryError(f"No base_manifest.yaml found from '{Path.cwd()}' upward.")
+
+    return read_project(manifest_path)
+
+
+def discover_projects(workspace_root: Path) -> tuple[Project, ...]:
+    entries = workspace_manifest_entries(workspace_root)
+    projects = tuple(read_project(entry.path) for entry in entries)
+    return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def discover_projects_cached(ctx: base_cli.Context, workspace_root: Path) -> tuple[Project, ...]:
+    start = time.perf_counter()
+    entries = workspace_manifest_entries(workspace_root)
+    cached_projects = read_project_cache(workspace_root, entries)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    if cached_projects is not None:
+        ctx.log.debug(
+            "Project discovery cache hit for '%s': %d project(s) in %.1fms.",
+            workspace_root,
+            len(cached_projects),
+            elapsed_ms,
+        )
+        return cached_projects
+
+    projects = validate_unique_project_names(tuple(sorted(read_project(entry.path) for entry in entries)))
+    write_project_cache(workspace_root, entries, projects, ctx)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    ctx.log.debug(
+        "Project discovery scanned '%s': %d project(s) in %.1fms.",
+        workspace_root,
+        len(projects),
+        elapsed_ms,
+    )
+    return projects
+
+
+def find_project(workspace_root: Path, project_name: str) -> Project:
+    projects = discover_projects(workspace_root)
+    return find_project_in_projects(projects, workspace_root, project_name)
+
+
+def find_project_in_projects(projects: tuple[Project, ...], workspace_root: Path, project_name: str) -> Project:
+    for project in projects:
+        if project.name == project_name:
+            return project
+    raise ProjectDiscoveryError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
+
+
+def resolve_active_project(project_name: str) -> Project | None:
+    if os.environ.get("BASE_PROJECT") != project_name:
+        return None
+
+    manifest = os.environ.get("BASE_PROJECT_MANIFEST")
+    if not manifest:
+        return None
+
+    project = read_project(Path(manifest).expanduser().resolve())
+    if project.name != project_name:
+        raise ProjectDiscoveryError(
+            f"BASE_PROJECT is '{project_name}' but BASE_PROJECT_MANIFEST points to project '{project.name}'."
+        )
+    return project
+
+
+def project_cache_path(workspace_root: Path) -> Path:
+    workspace_key = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[:24]
+    return base_cache_root() / "projects" / f"{workspace_key}.json"
+
+
+def read_project_cache(workspace_root: Path, entries: tuple[ManifestEntry, ...]) -> tuple[Project, ...] | None:
+    cache_path = project_cache_path(workspace_root)
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if data.get("version") != 1 or data.get("workspace") != str(workspace_root):
+        return None
+    if data.get("manifests") != [manifest_entry_to_json(entry) for entry in entries]:
+        return None
+
+    try:
+        projects = tuple(
+            Project(
+                name=project["name"],
+                root=Path(project["root"]),
+                manifest_path=Path(project["manifest_path"]),
+            )
+            for project in data["projects"]
+        )
+    except (KeyError, TypeError):
+        return None
+    return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def write_project_cache(
+    workspace_root: Path,
+    entries: tuple[ManifestEntry, ...],
+    projects: tuple[Project, ...],
+    ctx: base_cli.Context,
+) -> None:
+    cache_path = project_cache_path(workspace_root)
+    data = {
+        "version": 1,
+        "workspace": str(workspace_root),
+        "manifests": [manifest_entry_to_json(entry) for entry in entries],
+        "projects": [project_to_json(project) for project in projects],
+    }
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
+    except OSError as exc:
+        ctx.log.debug("Unable to write project discovery cache '%s': %s", cache_path, exc)
+
+
+def manifest_entry_to_json(entry: ManifestEntry) -> dict[str, Any]:
+    return {
+        "path": str(entry.path),
+        "mtime_ns": entry.mtime_ns,
+        "size": entry.size,
+    }
+
+
+def project_to_json(project: Project) -> dict[str, str]:
+    return {
+        "name": project.name,
+        "root": str(project.root),
+        "manifest_path": str(project.manifest_path),
+    }
+
+
+def read_project(manifest_path: Path) -> Project:
+    try:
+        manifest = read_manifest(manifest_path)
+    except ManifestError as exc:
+        raise ProjectDiscoveryError(str(exc)) from exc
+    return Project(
+        name=manifest.project_name,
+        root=manifest_path.parent.resolve(),
+        manifest_path=manifest_path.resolve(),
+    )
+
+
+def validate_unique_project_names(projects: tuple[Project, ...]) -> tuple[Project, ...]:
+    seen: dict[str, Project] = {}
+    duplicates = []
+    for project in projects:
+        existing = seen.get(project.name)
+        if existing is not None:
+            duplicates.append((project, existing))
+        else:
+            seen[project.name] = project
+
+    if duplicates:
+        details = "; ".join(
+            f"{project.name}: {existing.root} and {project.root}" for project, existing in duplicates
+        )
+        raise ProjectDiscoveryError(f"Duplicate project names found: {details}.")
+
+    return projects

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -11,7 +11,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_projects import engine
+from base_projects import engine, project_discovery
 
 
 def write_manifest(project_root: Path, name: str) -> None:
@@ -209,6 +209,14 @@ def run_engine_with_home(args: list[str], base_home: Path, home: Path) -> tuple[
 
 
 class ProjectDiscoveryTests(unittest.TestCase):
+    def test_project_discovery_implementation_is_split_from_engine(self) -> None:
+        engine_path = Path(engine.__file__)
+        discovery_path = engine_path.with_name("project_discovery.py")
+
+        self.assertTrue(discovery_path.exists())
+        self.assertIn("def discover_projects_cached", discovery_path.read_text(encoding="utf-8"))
+        self.assertNotIn("def discover_projects_cached", engine_path.read_text(encoding="utf-8"))
+
     def test_main_reports_config_errors_without_traceback(self) -> None:
         status, _stdout, stderr = run_engine(
             ["list"],
@@ -227,7 +235,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             write_manifest(workspace / "alpha", "alpha")
             (workspace / "notes").mkdir()
 
-            projects = engine.discover_projects(workspace)
+            projects = project_discovery.discover_projects(workspace)
 
         self.assertEqual([project.name for project in projects], ["alpha", "zeta"])
 
@@ -420,7 +428,9 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home.mkdir()
             write_manifest(workspace / "demo", "demo")
 
-            with mock.patch("base_projects.engine.read_project", wraps=engine.read_project) as read_project_mock:
+            with mock.patch(
+                "base_projects.project_discovery.read_project", wraps=project_discovery.read_project
+            ) as read_project_mock:
                 status, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace)], base_home, home)
                 self.assertEqual(status, 0)
                 self.assertEqual(stderr, "")
@@ -444,7 +454,9 @@ class ProjectDiscoveryTests(unittest.TestCase):
             project_root = workspace / "demo"
             write_manifest(project_root, "demo")
 
-            with mock.patch("base_projects.engine.read_project", wraps=engine.read_project) as read_project_mock:
+            with mock.patch(
+                "base_projects.project_discovery.read_project", wraps=project_discovery.read_project
+            ) as read_project_mock:
                 status, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace)], base_home, home)
                 self.assertEqual(status, 0)
                 self.assertEqual(stderr, "")
@@ -1291,7 +1303,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             write_manifest(workspace / "two", "demo")
 
             with self.assertRaisesRegex(engine.ProjectDiscoveryError, "Duplicate project names"):
-                engine.discover_projects(workspace)
+                project_discovery.discover_projects(workspace)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Move project discovery, active-project resolution, duplicate-name validation, and discovery cache read/write logic out of `base_projects.engine`.
- Keep `engine.py` focused on command dispatch, workspace flows, and command output composition.
- Update discovery/cache tests to target the new `project_discovery` owner.

## Validation
- env PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py::ProjectDiscoveryTests::test_project_discovery_implementation_is_split_from_engine -q
- env PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py -q
- env PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests -q
- env PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_projects/engine.py cli/python/base_projects/project_discovery.py cli/python/base_projects/tests/test_engine.py
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/projects.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/workspace.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/run.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/test.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/build.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/demo.bats
- git diff --cached --check
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test

Closes #1073