### PR TITLE
Cache project-name shell completions

### DIFF
--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -4,11 +4,60 @@
 # Bash completion for basectl.
 #
 
-_base_basectl_completion_project_names() {
+_BASE_BASECTL_COMPLETION_PROJECT_NAMES=""
+_BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=0
+_BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=0
+
+_base_basectl_completion_project_cache_ttl() {
+    local ttl="${BASE_COMPLETION_PROJECT_CACHE_TTL:-5}"
+
+    [[ "$ttl" =~ ^[0-9]+$ ]] || ttl=5
+    printf '%s\n' "$((10#$ttl))"
+}
+
+_base_basectl_completion_now() {
+    date +%s 2>/dev/null || printf '0'
+}
+
+_base_basectl_completion_refresh_project_cache() {
+    local names now ttl
     local wrapper="${BASE_HOME:-}/bin/base-wrapper"
 
-    [[ -x "$wrapper" ]] || return 0
-    "$wrapper" --project base base_projects list 2>/dev/null | awk -F '\t' '{print $1}'
+    [[ -x "$wrapper" ]] || {
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES=""
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=1
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=0
+        return 0
+    }
+
+    ttl="$(_base_basectl_completion_project_cache_ttl)"
+    now="$(_base_basectl_completion_now)"
+    if ((ttl > 0)) &&
+        ((_BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET)) &&
+        ((_BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT > now)); then
+        return 0
+    fi
+
+    names="$("$wrapper" --project base base_projects list 2>/dev/null | awk -F '\t' '{print $1}')"
+    _BASE_BASECTL_COMPLETION_PROJECT_NAMES="$names"
+    _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=1
+    if ((ttl > 0)); then
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=$((now + ttl))
+    else
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=0
+    fi
+}
+
+_base_basectl_completion_project_names() {
+    _base_basectl_completion_refresh_project_cache || return 0
+    printf '%s\n' "$_BASE_BASECTL_COMPLETION_PROJECT_NAMES"
+}
+
+_base_basectl_completion_project_candidates() {
+    local current="$1"
+
+    _base_basectl_completion_refresh_project_cache || return 0
+    _base_basectl_completion_compgen "$_BASE_BASECTL_COMPLETION_PROJECT_NAMES" "$current"
 }
 
 _base_basectl_completion_compgen() {
@@ -31,7 +80,7 @@ _base_basectl_completion_project_or_options() {
     local current="$2"
 
     if ((COMP_CWORD == 2)) && [[ "$current" != -* ]]; then
-        _base_basectl_completion_compgen "$(_base_basectl_completion_project_names)" "$current"
+        _base_basectl_completion_project_candidates "$current"
     else
         _base_basectl_completion_compgen "$options" "$current"
     fi
@@ -77,7 +126,7 @@ _base_basectl_completion() {
     case "$command" in
         activate)
             if ((COMP_CWORD == 2)); then
-                _base_basectl_completion_compgen "$(_base_basectl_completion_project_names)" "$cur"
+                _base_basectl_completion_project_candidates "$cur"
             else
                 _base_basectl_completion_compgen "--workspace --no-cd -v -h --help" "$cur"
             fi

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -2,11 +2,63 @@
 # Zsh completion for basectl.
 #
 
-_base_basectl_completion_project_names() {
+typeset -g _BASE_BASECTL_COMPLETION_PROJECT_NAMES=''
+typeset -gi _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=0
+typeset -gi _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=0
+
+_base_basectl_completion_project_cache_ttl() {
+    local ttl="${BASE_COMPLETION_PROJECT_CACHE_TTL:-5}"
+
+    case "$ttl" in
+        ''|*[!0-9]*) ttl=5 ;;
+    esac
+    printf '%s\n' "$ttl"
+}
+
+_base_basectl_completion_now() {
+    date +%s 2>/dev/null || printf '0'
+}
+
+_base_basectl_completion_refresh_project_cache() {
+    local names now ttl
     local wrapper="${BASE_HOME:-}/bin/base-wrapper"
 
-    [[ -x "$wrapper" ]] || return 0
-    "$wrapper" --project base base_projects list 2>/dev/null | awk -F '\t' '{print $1}'
+    if [[ ! -x "$wrapper" ]]; then
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES=''
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=1
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=0
+        return 0
+    fi
+
+    ttl="$(_base_basectl_completion_project_cache_ttl)"
+    now="$(_base_basectl_completion_now)"
+    if ((ttl > 0)) &&
+        ((_BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET)) &&
+        ((_BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT > now)); then
+        return 0
+    fi
+
+    names="$("$wrapper" --project base base_projects list 2>/dev/null | awk -F '\t' '{print $1}')"
+    _BASE_BASECTL_COMPLETION_PROJECT_NAMES="$names"
+    _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=1
+    if ((ttl > 0)); then
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=$((now + ttl))
+    else
+        _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=0
+    fi
+}
+
+_base_basectl_completion_project_names() {
+    _base_basectl_completion_refresh_project_cache || return 0
+    printf '%s\n' "$_BASE_BASECTL_COMPLETION_PROJECT_NAMES"
+}
+
+_base_basectl_completion_describe_projects() {
+    local -a project_names
+
+    _base_basectl_completion_refresh_project_cache || return 0
+    project_names=("${(@f)_BASE_BASECTL_COMPLETION_PROJECT_NAMES}")
+    _describe -t projects 'Base project' project_names
 }
 
 _base_basectl_completion() {
@@ -49,8 +101,7 @@ _base_basectl_completion() {
     case "${words[2]:-}" in
         activate)
             if ((CURRENT == 3)); then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             else
                 _arguments '--workspace[Workspace directory to scan]:path:_files' \
                     '--no-cd[Preserve the caller current directory]' \
@@ -128,8 +179,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         test)
@@ -138,8 +188,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         export-context)
@@ -151,8 +200,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         build)
@@ -162,8 +210,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects' '*:Build target:'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         demo)
@@ -172,8 +219,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         run)
@@ -183,8 +229,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects' '2:Project command:'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         prompt)
@@ -302,8 +347,7 @@ _base_basectl_completion() {
                     ;;
             esac
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         release)
@@ -350,8 +394,7 @@ _base_basectl_completion() {
                 '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         gh)
@@ -449,8 +492,7 @@ _base_basectl_completion() {
                 '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
         update-profile)
@@ -463,8 +505,7 @@ _base_basectl_completion() {
                 '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then
-                project_names=("${(@f)$(_base_basectl_completion_project_names)}")
-                _describe -t projects 'Base project' project_names
+                _base_basectl_completion_describe_projects
             fi
             ;;
     esac

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -245,3 +245,43 @@ assert_bash_completion_options_match_help() {
 
     [[ "$block" == *"--replace-project"* ]]
 }
+
+@test "Bash project-name completions reuse shell-session project cache" {
+    local base_home="$TEST_TMPDIR/base"
+    local wrapper="$base_home/bin/base-wrapper"
+    local count_file="$TEST_TMPDIR/project-list-count"
+
+    mkdir -p "$(dirname "$wrapper")"
+    cat > "$wrapper" <<'EOF'
+#!/usr/bin/env bash
+count=0
+if [[ -f "${BASE_COMPLETION_TEST_COUNT_FILE:?}" ]]; then
+    read -r count < "$BASE_COMPLETION_TEST_COUNT_FILE" || count=0
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$BASE_COMPLETION_TEST_COUNT_FILE"
+printf 'base\t/Users/test/base\n'
+printf 'demo\t/Users/test/demo\n'
+EOF
+    chmod +x "$wrapper"
+
+    run env BASE_HOME="$base_home" \
+        BASE_COMPLETION_PROJECT_CACHE_TTL=60 \
+        BASE_COMPLETION_TEST_COUNT_FILE="$count_file" \
+        bash -c '\
+            source "$1"; \
+            COMP_WORDS=(basectl test ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "first=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl build ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "second=%s\n" "${COMPREPLY[*]}"' \
+            bash "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"first=base demo"* ]]
+    [[ "$output" == *"second=base demo"* ]]
+    [ "$(cat "$count_file")" = "1" ]
+}


### PR DESCRIPTION
## Summary
- Add a bounded shell-session cache for Bash and Zsh project-name completions.
- Keep cache staleness predictable with `BASE_COMPLETION_PROJECT_CACHE_TTL`, defaulting to 5 seconds and allowing `0` to disable caching.
- Add a Bash regression test proving repeated project-name completions reuse the in-shell cache.

## Measurement
Representative workspace: `/Users/rameshhp/work`, sourcing this branch's Bash completion with `BASE_HOME` pointed at the worktree.

- Before: seven consecutive project-name completion calls in one shell took about `1.90s` real time.
- After: the same loop took about `0.50s` real time.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "Bash project-name completions reuse shell-session project cache" lib/shell/completions/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/completions.bats`
- `shellcheck --severity=error lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `git diff --check`
- `git diff --cached --check`

Closes #1074