### PR TITLE
Extract helpers for oversized test suites

### DIFF
--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -2,6 +2,34 @@
 
 load ./basectl_helpers.bash
 
+write_gh_args_recorder() {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+}
+
+run_gh_subcommand() {
+    local cwd="${BASE_GH_TEST_CWD:-$TEST_HOME}"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_CWD="$cwd" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_GH_PROJECT_WRAPPER="${BASE_GH_PROJECT_WRAPPER:-}" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$BASE_GH_TEST_CWD"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main "$@"
+        ' bash "$@"
+}
 
 @test "basectl gh prints help" {
     run_basectl gh --help
@@ -133,25 +161,10 @@ load ./basectl_helpers.bash
 }
 
 @test "basectl gh issue create accepts explicit assignee" {
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_gh_args_recorder
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_HOME="$BASE_REPO_ROOT" \
-        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:$PATH" \
-        bash -c '
-            source "$BASE_HOME/base_init.sh"
-            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main issue create --category bug --title "Repair branch pruning" --repo codeforester/base --assignee codeforester --no-project
-        '
+    run_gh_subcommand issue create --category bug --title "Repair branch pruning" \
+        --repo codeforester/base --assignee codeforester --no-project
 
     [ "$status" -eq 0 ]
     [[ "$output" != *"Using default --category"* ]]
@@ -159,26 +172,10 @@ EOF
 }
 
 @test "basectl gh issue create announces default category without forcing an assignee" {
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_gh_args_recorder
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_HOME="$BASE_REPO_ROOT" \
-        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:$PATH" \
-        bash -c '
-            cd "$HOME"
-            source "$BASE_HOME/base_init.sh"
-            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main issue create --title "Default category issue" --repo codeforester/base --no-project
-        '
+    run_gh_subcommand issue create --title "Default category issue" \
+        --repo codeforester/base --no-project
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Using default --category: enhancement"* ]]
@@ -186,14 +183,7 @@ EOF
 }
 
 @test "basectl gh issue create uses repo config assignee default" {
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_gh_args_recorder
     cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
@@ -203,18 +193,10 @@ fi
 EOF
     chmod +x "$TEST_MOCKBIN/project-wrapper"
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_HOME="$BASE_REPO_ROOT" \
-        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+    BASE_GH_TEST_CWD="$BASE_REPO_ROOT" \
         BASE_GH_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
-        PATH="$TEST_MOCKBIN:$PATH" \
-        bash -c '
-            cd "$BASE_HOME"
-            source "$BASE_HOME/base_init.sh"
-            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main issue create --category bug --title "Base repo issue" --repo basefoundry/base --no-project
-        '
+        run_gh_subcommand issue create --category bug --title "Base repo issue" \
+            --repo basefoundry/base --no-project
 
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Base repo issue --label bug --assignee codeforester --repo basefoundry/base" ]
@@ -234,14 +216,7 @@ EOF
 project:
   issue_defaults: {assignee: codeforester}
 EOF
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_gh_args_recorder
     cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/wrapper-args"
@@ -251,18 +226,10 @@ fi
 EOF
     chmod +x "$TEST_MOCKBIN/project-wrapper"
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_HOME="$BASE_REPO_ROOT" \
-        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+    BASE_GH_TEST_CWD="$repo" \
         BASE_GH_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
-        PATH="$TEST_MOCKBIN:$PATH" \
-        bash -c '
-            cd "$1"
-            source "$BASE_HOME/base_init.sh"
-            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main issue create --category bug --title "Base-like repo issue" --repo basefoundry/base-like --no-project
-        ' bash "$repo"
+        run_gh_subcommand issue create --category bug --title "Base-like repo issue" \
+            --repo basefoundry/base-like --no-project
 
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Base-like repo issue --label bug --assignee codeforester --repo basefoundry/base-like" ]
@@ -270,26 +237,11 @@ EOF
 }
 
 @test "basectl gh issue create --no-assignee ignores repo config assignee default" {
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_gh_args_recorder
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_HOME="$BASE_REPO_ROOT" \
-        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:$PATH" \
-        bash -c '
-            cd "$BASE_HOME"
-            source "$BASE_HOME/base_init.sh"
-            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main issue create --category bug --title "Unassigned Base repo issue" --repo basefoundry/base --no-assignee --no-project
-        '
+    BASE_GH_TEST_CWD="$BASE_REPO_ROOT" \
+        run_gh_subcommand issue create --category bug --title "Unassigned Base repo issue" \
+            --repo basefoundry/base --no-assignee --no-project
 
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_STATE_DIR/gh-args")" = "issue create --title Unassigned Base repo issue --label bug --repo basefoundry/base" ]

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -9,6 +9,32 @@ line_at() {
     printf '%s\n' "$text" | sed -n "${line_number}p"
 }
 
+write_repo_configure_gh_recorder() {
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$*" == "repo view codeforester/base-demo" && "${BASE_REPO_TEST_REPO_VIEW_MISSING:-}" == "1" ]]; then
+    exit 1
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+}
+
+run_repo_command_with_mocks() {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_REPO_TEST_REPO_VIEW_MISSING="${BASE_REPO_TEST_REPO_VIEW_MISSING:-}" \
+        BASE_REPO_PROJECT_WRAPPER="${BASE_REPO_PROJECT_WRAPPER:-}" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo "$@"
+}
 
 @test "basectl repo prints help" {
     run_basectl repo --help
@@ -883,7 +909,9 @@ EOF
     grep -Fq 'Update `CHANGELOG.md` only for notable user-visible or release-worthy' "$repo_dir/CONTRIBUTING.md"
     grep -Fq "## Checklist" "$repo_dir/.github/pull_request_template.md"
     grep -Fq "CHANGELOG is updated for notable user-visible or release-worthy changes." "$repo_dir/.github/pull_request_template.md"
-    ! grep -Fq "Demo Impact" "$repo_dir/.github/pull_request_template.md"
+    if grep -Fq "Demo Impact" "$repo_dir/.github/pull_request_template.md"; then
+        fail "pull request template should not include Demo Impact by default"
+    fi
     grep -Fq "GNU Affero General Public License" "$repo_dir/LICENSE"
     run grep -F "Base - a workspace control plane" "$repo_dir/LICENSE"
     [ "$status" -eq 1 ]
@@ -1244,23 +1272,10 @@ EOF
     local repo_dir="$TEST_TMPDIR/repo"
 
     mkdir -p "$repo_dir"
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-if [[ "$*" == "repo view codeforester/base-demo" ]]; then
-    exit 1
-fi
-printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_repo_configure_gh_recorder
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
+    BASE_REPO_TEST_REPO_VIEW_MISSING=1 \
+        run_repo_command_with_mocks configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Configuring GitHub repository 'codeforester/base-demo'..."* ]]
@@ -1290,25 +1305,11 @@ fi
 exit 1
 EOF
     chmod +x "$TEST_MOCKBIN/brew"
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_repo_configure_gh_recorder
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" \
-            --repo codeforester/base-demo \
-            --no-project
+    run_repo_command_with_mocks configure "$repo_dir" \
+        --repo codeforester/base-demo \
+        --no-project
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"GitHub CLI 'gh' is outdated; run 'basectl setup --profile dev' to upgrade Base-managed developer prerequisites."* ]]
@@ -1330,25 +1331,11 @@ fi
 exit 1
 EOF
     chmod +x "$TEST_MOCKBIN/brew"
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_repo_configure_gh_recorder
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" \
-            --repo codeforester/base-demo \
-            --no-project
+    run_repo_command_with_mocks configure "$repo_dir" \
+        --repo codeforester/base-demo \
+        --no-project
 
     [ "$status" -eq 0 ]
     [[ "$output" != *"GitHub CLI 'gh' is outdated"* ]]
@@ -1371,25 +1358,11 @@ fi
 exit 1
 EOF
     chmod +x "$TEST_MOCKBIN/brew"
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_repo_configure_gh_recorder
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" \
-            --repo codeforester/base-demo \
-            --no-project
+    run_repo_command_with_mocks configure "$repo_dir" \
+        --repo codeforester/base-demo \
+        --no-project
 
     [ "$status" -eq 0 ]
     [[ "$output" != *"GitHub CLI 'gh' is outdated"* ]]
@@ -1405,29 +1378,15 @@ project:
   areas:
     - Demo App
 EOF
-    cat > "$TEST_MOCKBIN/gh" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "auth status -h github.com" ]]; then
-    exit 0
-fi
-if [[ "$1" == "api" && "$2" == "repos/codeforester/base-demo/rulesets" ]]; then
-    exit 0
-fi
-printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
-EOF
-    chmod +x "$TEST_MOCKBIN/gh"
+    write_repo_configure_gh_recorder
     cat > "$TEST_MOCKBIN/project-wrapper" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "${BASE_REPO_TEST_STATE_DIR:?}/project-args"
 EOF
     chmod +x "$TEST_MOCKBIN/project-wrapper"
 
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" \
+    BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
+        run_repo_command_with_mocks configure "$repo_dir" \
             --repo codeforester/base-demo \
             --copy-project-fields-from "Base Roadmap"
 
@@ -1784,7 +1743,9 @@ EOF
     [[ "$commit_files" == *"base_manifest.yaml"* ]]
     [[ "$commit_files" != *"src/app.txt"* ]]
     grep -Fq "pr create --repo codeforester/base-demo --base master --head base/repo-baseline-base-demo --title Add Base repository baseline --body-file" "$TEST_STATE_DIR/gh-args"
-    ! grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
+    if grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"; then
+        fail "repo init --pr should not configure GitHub when opening a baseline pull request"
+    fi
     grep -Fq "Add Base-managed repository baseline files." "$TEST_STATE_DIR/pr-body"
     grep -Fq "basectl repo init base-demo --path" "$TEST_STATE_DIR/pr-body"
     [[ "$output" == *"Baseline PR opened: https://github.com/codeforester/base-demo/pull/1"* ]]
@@ -1841,7 +1802,9 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"No repository baseline changes to commit; continuing with GitHub repository configuration."* ]]
     grep -Fq "repo edit codeforester/base-demo" "$TEST_STATE_DIR/gh-args"
-    ! grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"
+    if grep -Fq "pr create" "$TEST_STATE_DIR/gh-args"; then
+        fail "repo init --pr should not open a pull request when there are no baseline changes"
+    fi
     [ "$(cat "$TEST_STATE_DIR/project-args")" = "--project base base_github_projects project configure --project base-demo --owner codeforester --repo codeforester/base-demo --schema base-project --config $repo_dir/.github/base-project.yml --copy-fields-from Base Roadmap" ]
 }
 

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -6,29 +6,29 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from base_setup.manifest import ManifestError, read_manifest
+from base_setup.manifest import BaseManifest, ManifestError, read_manifest
+
 
 class ManifestParsingTests(unittest.TestCase):
 
-    def test_reads_basic_manifest(self) -> None:
+    @staticmethod
+    def read_manifest_lines(*lines: str) -> BaseManifest:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"
-            manifest_path.write_text(
-                "\n".join(
-                    [
-                        "project:",
-                        "  name: demo",
-                        "",
-                        "artifacts:",
-                        "  - type: tool",
-                        "    name: terraform",
-                        "    version: \"1.8.5\"",
-                    ]
-                ),
-                encoding="utf-8",
-            )
+            manifest_path.write_text("\n".join(lines), encoding="utf-8")
 
-            manifest = read_manifest(manifest_path)
+            return read_manifest(manifest_path)
+
+    def test_reads_basic_manifest(self) -> None:
+        manifest = self.read_manifest_lines(
+            "project:",
+            "  name: demo",
+            "",
+            "artifacts:",
+            "  - type: tool",
+            "    name: terraform",
+            "    version: \"1.8.5\"",
+        )
 
         self.assertEqual(manifest.schema_version, 1)
         self.assertEqual(manifest.project_name, "demo")
@@ -49,86 +49,59 @@ class ManifestParsingTests(unittest.TestCase):
                 read_manifest(manifest_path)
 
     def test_reads_manifest_python_uv_manager(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest_path = Path(tmpdir) / "base_manifest.yaml"
-            manifest_path.write_text(
-                "\n".join(
-                    [
-                        "project:",
-                        "  name: demo",
-                        "",
-                        "python:",
-                        "  manager: uv",
-                        "",
-                        "artifacts: []",
-                    ]
-                ),
-                encoding="utf-8",
-            )
-
-            manifest = read_manifest(manifest_path)
+        manifest = self.read_manifest_lines(
+            "project:",
+            "  name: demo",
+            "",
+            "python:",
+            "  manager: uv",
+            "",
+            "artifacts: []",
+        )
 
         self.assertEqual(manifest.python.manager, "uv")
 
     def test_reads_manifest_python_requirement(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest_path = Path(tmpdir) / "base_manifest.yaml"
-            manifest_path.write_text(
-                "\n".join(
-                    [
-                        "project:",
-                        "  name: demo",
-                        "",
-                        "python:",
-                        "  requires_python: '>=3.11,<3.14'",
-                        "",
-                        "artifacts: []",
-                    ]
-                ),
-                encoding="utf-8",
-            )
-
-            manifest = read_manifest(manifest_path)
+        manifest = self.read_manifest_lines(
+            "project:",
+            "  name: demo",
+            "",
+            "python:",
+            "  requires_python: '>=3.11,<3.14'",
+            "",
+            "artifacts: []",
+        )
 
         self.assertEqual(manifest.python.requires_python, ">=3.11,<3.14")
 
 
     def test_reads_manifest_github_pr_policy(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest_path = Path(tmpdir) / "base_manifest.yaml"
-            manifest_path.write_text(
-                "\n".join(
-                    [
-                        "project:",
-                        "  name: demo",
-                        "",
-                        "github:",
-                        "  pr:",
-                        "    template: .github/pull_request_template.md",
-                        "    required_sections:",
-                        "      default:",
-                        "        - Summary",
-                        "        - Issue",
-                        "        - Validation",
-                        "      labels:",
-                        "        needs-demo:",
-                        "          - Demo Impact",
-                        "        security:",
-                        "          - Security Notes",
-                        "      paths:",
-                        "        docs/**:",
-                        "          - Docs Impact",
-                        "        migrations/**:",
-                        "          - Migration Plan",
-                        "          - Rollback Plan",
-                        "",
-                        "artifacts: []",
-                    ]
-                ),
-                encoding="utf-8",
-            )
-
-            manifest = read_manifest(manifest_path)
+        manifest = self.read_manifest_lines(
+            "project:",
+            "  name: demo",
+            "",
+            "github:",
+            "  pr:",
+            "    template: .github/pull_request_template.md",
+            "    required_sections:",
+            "      default:",
+            "        - Summary",
+            "        - Issue",
+            "        - Validation",
+            "      labels:",
+            "        needs-demo:",
+            "          - Demo Impact",
+            "        security:",
+            "          - Security Notes",
+            "      paths:",
+            "        docs/**:",
+            "          - Docs Impact",
+            "        migrations/**:",
+            "          - Migration Plan",
+            "          - Rollback Plan",
+            "",
+            "artifacts: []",
+        )
 
         self.assertIsNotNone(manifest.github.pr)
         assert manifest.github.pr is not None
@@ -168,22 +141,13 @@ class ManifestParsingTests(unittest.TestCase):
         }
         for name, github_yaml in invalid_values.items():
             with self.subTest(name=name):
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
-                    manifest_path.write_text(
-                        "\n".join(
-                            [
-                                "project:",
-                                "  name: demo",
-                                github_yaml,
-                                "artifacts: []",
-                            ]
-                        ),
-                        encoding="utf-8",
+                with self.assertRaises(ManifestError):
+                    self.read_manifest_lines(
+                        "project:",
+                        "  name: demo",
+                        github_yaml,
+                        "artifacts: []",
                     )
-
-                    with self.assertRaises(ManifestError):
-                        read_manifest(manifest_path)
 
 
     def test_rejects_invalid_manifest_python_config(self) -> None:
@@ -198,22 +162,13 @@ class ManifestParsingTests(unittest.TestCase):
         }
         for name, python_yaml in invalid_values.items():
             with self.subTest(name=name):
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    manifest_path = Path(tmpdir) / "base_manifest.yaml"
-                    manifest_path.write_text(
-                        "\n".join(
-                            [
-                                "project:",
-                                "  name: demo",
-                                python_yaml,
-                                "artifacts: []",
-                            ]
-                        ),
-                        encoding="utf-8",
+                with self.assertRaises(ManifestError):
+                    self.read_manifest_lines(
+                        "project:",
+                        "  name: demo",
+                        python_yaml,
+                        "artifacts: []",
                     )
-
-                    with self.assertRaises(ManifestError):
-                        read_manifest(manifest_path)
 
 
 


### PR DESCRIPTION
## Summary
- Add shared helpers in `gh.bats` for repeated `gh` argument-recorder setup and sourced `base_gh_subcommand_main` calls.
- Add shared helpers in `repo.bats` for repeated mocked repo configure command setup.
- Add a manifest parser fixture helper and convert repeated temp-manifest setup in high-churn manifest tests.
- Tighten three negative `grep` assertions in `repo.bats` so they fail explicitly without clobbering command output.

## Notes
- Product behavior is unchanged; this is test fixture and assertion cleanup only.
- Touched test files dropped from 4,661 to 4,531 total lines.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats`
- `env UV_CACHE_DIR=/private/tmp/base-uv-cache PYTHONPATH=cli/python:lib/python uv run --with pytest==9.0.3 --with PyYAML==6.0.3 pytest cli/python/base_setup/tests/test_manifest.py`
- `shellcheck --severity=error cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/repo.bats`
- `env UV_CACHE_DIR=/private/tmp/base-uv-cache PYTHONPATH=cli/python:lib/python uv run --with pylint==3.3.9 --with PyYAML==6.0.3 pylint cli/python/base_setup/tests/test_manifest.py`
- `git diff --check`
- `git diff --cached --check`

Closes #1075