### PR TITLE
Expose project Python runtime diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,9 @@ For uv-managed projects, Base delegates setup to `uv sync`, uses the
 project-local `.venv` for activation and project commands, and skips
 Base-managed `python-package` reconciliation. See
 [Python Manifest Section](docs/python-manifest.md).
+Use `basectl check <project> --format json` for detailed runtime diagnostics
+and `basectl workspace status --format json` to compare actual project Python
+versions across a workspace.
 
 Artifacts may include `bootstrap: true` when they are part of the minimum Python
 runtime contract needed before Base can reconcile a project's remaining

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -48,6 +48,12 @@ def write_ready_python_bin(python_bin: Path) -> None:
     python_bin.chmod(0o755)
 
 
+def write_versioned_python_bin(python_bin: Path, version: str) -> None:
+    python_bin.parent.mkdir(parents=True, exist_ok=True)
+    python_bin.write_text(f"#!/bin/sh\nprintf '{version}\\n'\n", encoding="utf-8")
+    python_bin.chmod(0o755)
+
+
 _engine_homes: list[Path] = []
 
 
@@ -396,6 +402,34 @@ class ProjectDiscoveryTests(unittest.TestCase):
             },
         )
         self.assertIn("project virtual environment missing", payload["projects"][0]["issues"][0])
+
+    def test_workspace_status_json_reports_uv_project_python_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            project_root = workspace / "bankbuddy"
+            home.mkdir()
+            base_home.mkdir()
+            write_uv_manifest(project_root, "bankbuddy")
+            python_bin = project_root / ".venv" / "bin" / "python"
+            write_versioned_python_bin(python_bin, "3.12")
+
+            status, stdout, stderr = invoke_engine(
+                ["status", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        runtime = payload["projects"][0]["python_runtime"]
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(runtime["manager"], "uv")
+        self.assertEqual(runtime["version"], "3.12")
+        self.assertEqual(runtime["python"], str(python_bin.resolve()))
+        self.assertEqual(runtime["venv"], str(python_bin.parent.parent.resolve()))
 
     def test_workspace_status_reports_invalid_manifest_without_stopping_scan(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/workspace_reports.py
+++ b/cli/python/base_projects/workspace_reports.py
@@ -22,6 +22,8 @@ from base_setup.engine import manifest_checks
 from base_setup.engine import pre_venv_manifest_checks
 from base_setup.engine import read_default_manifest
 from base_setup.manifest import BaseManifest, ManifestError, read_manifest
+from base_setup.python_runtime import ProjectPythonRuntime
+from base_setup.python_runtime import project_python_runtime
 from base_setup.uv import manifest_uses_uv_project_manager
 
 
@@ -58,6 +60,7 @@ class WorkspaceProjectStatus:
     repository: str | None = None
     url: str | None = None
     default_branch: str | None = None
+    python_runtime: ProjectPythonRuntime | None = None
 
 
 @dataclass(frozen=True)
@@ -213,6 +216,7 @@ def workspace_project_status(entry: ManifestEntry) -> WorkspaceProjectStatus:
             manifest="valid",
             issues=(),
             last_check=last_check,
+            python_runtime=project_python_runtime(manifest, venv_dir=venv_dir),
         )
 
     return WorkspaceProjectStatus(
@@ -582,6 +586,8 @@ def workspace_status_item_to_json(
     }
     if workspace_manifest is not None:
         item.update(workspace_manifest_item_metadata(status))
+    if status.python_runtime is not None:
+        item["python_runtime"] = status.python_runtime.to_json()
     return item
 
 

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -43,6 +43,7 @@ from .pyproject import check_pyproject
 from .project_routing import route_for_manifest
 from .project_routing import route_to_text
 from .python_policy import python_requirement_checks
+from .python_runtime import project_python_runtime_check
 from .uv import check_uv
 from .uv import manifest_uses_uv_project_manager
 from .uv import reconcile_uv_project
@@ -409,6 +410,7 @@ def manifest_checks(
     checks.extend(check_ide_settings(effective_manifest))
     checks.extend(check_uv(effective_manifest))
     checks.extend(check_pyproject(effective_manifest))
+    checks.extend(project_python_runtime_check(effective_manifest))
 
     for artifact, definition in zip(artifacts, definitions, strict=True):
         checks.append(check_artifact(effective_manifest.project_name, artifact, definition))

--- a/cli/python/base_setup/python_runtime.py
+++ b/cli/python/base_setup/python_runtime.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .checks import ArtifactCheck
+from .manifest import BaseManifest
+from .project_routing import route_for_manifest
+from .pyproject import read_pyproject
+from .python_policy import inspect_python_interpreter
+from .python_policy import version_label
+
+PYTHON_RUNTIME_FINDING_ID = "BASE-P172"
+
+
+@dataclass(frozen=True)
+class ProjectPythonRuntime:
+    manager: str
+    venv: Path
+    python: Path
+    version: str
+    requires_python: str | None = None
+    pyproject_requires_python: str | None = None
+
+    def to_json(self) -> dict[str, str]:
+        payload = {
+            "manager": self.manager,
+            "venv": str(self.venv),
+            "python": str(self.python),
+            "version": self.version,
+        }
+        if self.requires_python is not None:
+            payload["requires_python"] = self.requires_python
+        if self.pyproject_requires_python is not None:
+            payload["pyproject_requires_python"] = self.pyproject_requires_python
+        return payload
+
+    def to_check_details(self) -> dict[str, str]:
+        payload = self.to_json()
+        payload["python_version"] = payload["version"]
+        return payload
+
+
+def project_python_runtime(manifest: BaseManifest, venv_dir: Path | None = None) -> ProjectPythonRuntime | None:
+    if venv_dir is None:
+        venv_dir = route_for_manifest(manifest).project_venv_dir
+    python_bin = venv_dir / "bin" / "python"
+    interpreter = inspect_python_interpreter(python_bin)
+    if interpreter is None:
+        return None
+    return ProjectPythonRuntime(
+        manager=manifest.python.manager or "base",
+        venv=venv_dir,
+        python=interpreter.path,
+        version=version_label(interpreter.version),
+        requires_python=manifest.python.requires_python,
+        pyproject_requires_python=pyproject_requires_python(manifest.path.parent / "pyproject.toml"),
+    )
+
+
+def project_python_runtime_check(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+    runtime = project_python_runtime(manifest)
+    if runtime is None:
+        return ()
+    return (
+        ArtifactCheck(
+            name="project_python_runtime",
+            ok=True,
+            message=f"Project Python runtime uses Python {runtime.version} at '{runtime.python}'.",
+            fix="",
+            finding_id=PYTHON_RUNTIME_FINDING_ID,
+            details=runtime.to_check_details(),
+        ),
+    )
+
+
+def pyproject_requires_python(path: Path) -> str | None:
+    data, error = read_pyproject(path)
+    if error is not None:
+        return None
+    project_data: Any = data.get("project")
+    if not isinstance(project_data, dict):
+        return None
+    requires_python = project_data.get("requires-python")
+    return requires_python if isinstance(requires_python, str) and requires_python else None

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -20,6 +20,7 @@ from base_setup.manifest import IdeConfig
 from base_setup.manifest import PortHealthConfig
 from base_setup.manifest import PythonConfig
 from base_setup.manifest import read_manifest
+from base_setup.python_policy import PythonInterpreter
 from base_setup.registry import get_artifact_definition
 from base_setup.tests.helpers import fake_context, run_engine
 
@@ -506,6 +507,45 @@ class ProjectCheckTests(unittest.TestCase):
         self.assertEqual([check["id"] for check in payload["checks"]], ["BASE-P170", "BASE-P171"])
         self.assertEqual([check["status"] for check in payload["checks"]], ["ok", "error"])
         self.assertIn("Python 3.12 is not available", payload["checks"][1]["message"])
+
+    def test_check_json_reports_actual_project_python_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project_root = root / "demo"
+            home.mkdir()
+            project_root.mkdir()
+            manifest_path = project_root / "base_manifest.yaml"
+            manifest_path.write_text(
+                "project:\n  name: demo\npython:\n  requires_python: '3.12'\nartifacts: []\n",
+                encoding="utf-8",
+            )
+            python_bin = home / ".base.d" / "demo" / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/bin/sh\nprintf '3.12\\n'\n", encoding="utf-8")
+            python_bin.chmod(0o755)
+            default_manifest = BaseManifest(
+                path=Path("default_manifest.yaml"),
+                project_name="base-defaults",
+                brewfile=None,
+                artifacts=(),
+            )
+            manifest = read_manifest(manifest_path)
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}), mock.patch(
+                "base_setup.python_policy.resolve_python_interpreter",
+                return_value=PythonInterpreter(path=python_bin, version=(3, 12)),
+            ), redirect_stdout(io.StringIO()) as stdout:
+                status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+
+        payload = json.loads(stdout.getvalue())
+        runtime_check = next(check for check in payload["checks"] if check["id"] == "BASE-P172")
+        self.assertEqual(status, 0)
+        self.assertEqual(runtime_check["status"], "ok")
+        self.assertEqual(runtime_check["details"]["python_version"], "3.12")
+        self.assertEqual(runtime_check["details"]["python"], str(python_bin))
+        self.assertEqual(runtime_check["details"]["venv"], str(python_bin.parent.parent))
+        self.assertEqual(runtime_check["details"]["requires_python"], "3.12")
 
     def test_manifest_checks_include_same_directory_pyproject(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -180,6 +180,11 @@ interpreter when it creates a Base-managed project virtual environment and
 requires `--recreate-venv` before replacing an existing venv with a different
 Python minor.
 
+`BASE-P172` reports the actual inspectable project Python runtime: environment
+manager, virtualenv path, interpreter path, and Python minor version. Missing or
+broken virtual environments continue to use their existing readiness findings
+instead of emitting runtime version data.
+
 `BASE-P080` through `BASE-P083` are read-only project Git remote diagnostics.
 They report whether the project directory is inside a Git repository, whether
 `origin` is configured and parseable, and whether GitHub CLI authentication is

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -208,6 +208,8 @@ Python manifest support adds these project diagnostics:
 - `BASE-P170`: project `python.requires_python` compatibility with Base's
   supported Python runtime window
 - `BASE-P171`: selected project Python interpreter availability
+- `BASE-P172`: actual project Python runtime path and version when the project
+  virtual environment can be inspected
 - `BASE-P150`: uv CLI availability for uv-managed projects or uv runners
 - `BASE-P151`: uv-managed project `pyproject.toml` presence
 - `BASE-P152`: uv-managed project `uv.lock` presence
@@ -223,6 +225,11 @@ These diagnostics are warning-oriented in `check` and `doctor`; they explain
 readiness without performing dependency resolution or executing project command
 strings. Command linting is advisory and does not replace reviewing manifests
 from unfamiliar repositories before running their declared commands.
+
+`basectl workspace status --format json` also includes a `python_runtime`
+object for each ready, inspectable project environment. That summary reports
+the environment manager, virtualenv path, interpreter path, and actual Python
+minor version for both Base-managed and uv-managed projects.
 
 ## Non-Goals
 

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -361,6 +361,11 @@ Missing required repositories are errors. Missing optional repositories are
 warnings. Present repositories without `base_manifest.yaml` are allowed and
 reported with project diagnostics skipped.
 
+With `--format json`, workspace status includes `python_runtime` for each
+ready, inspectable Base-managed project environment. The object reports the
+environment manager, virtualenv path, interpreter path, and actual Python minor
+version so users can quickly compare project runtimes across a workspace.
+
 `basectl workspace check --manifest <path>` and
 `basectl workspace doctor --manifest <path>` include normal project diagnostics
 for present Base-managed projects. They also emit stable workspace findings for


### PR DESCRIPTION
## Summary
- Add a `BASE-P172` project runtime diagnostic that reports inspectable project Python manager, venv path, interpreter path, and version.
- Include `python_runtime` summaries in `basectl workspace status --format json` for ready Base-managed and uv-managed project environments.
- Document where users can find project Python runtime versions.

## Issue
Fixes #1090

## Validation
- `PYTHONPATH=/Users/rameshhp/work/base-worktrees/1090-python-runtime-status/lib/python:/Users/rameshhp/work/base-worktrees/1090-python-runtime-status/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_diagnostics.py cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_workspace_checks.py cli/python/base_setup/tests/test_project_routing.py`
- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1090-python-runtime-status/lib/python:/Users/rameshhp/work/base-worktrees/1090-python-runtime-status/cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc cli/python/base_setup/python_runtime.py cli/python/base_setup/engine.py cli/python/base_projects/workspace_reports.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_projects/tests/test_engine.py`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1090-validation ./bin/base-test`

## Demo Impact
None. Diagnostics/status output only.