### PR TITLE
Log workspace status discovery source in debug output

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -326,7 +326,9 @@ def workspace_status_command(
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
-        manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, workspace_manifest))
+        effective_manifest = effective_workspace_manifest(ctx, workspace_manifest)
+        log_workspace_status_discovery(ctx, workspace, workspace_root, workspace_manifest, effective_manifest)
+        manifest = resolve_workspace_manifest(effective_manifest)
         statuses = workspace_project_statuses(workspace_root, manifest)
     except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
@@ -674,6 +676,48 @@ def effective_workspace_manifest_path(ctx: base_cli.Context, workspace_manifest:
     if configured_manifest is None:
         return None
     return configured_manifest
+
+
+def log_workspace_status_discovery(
+    ctx: base_cli.Context,
+    workspace: str | None,
+    workspace_root: Path,
+    workspace_manifest: str | None,
+    effective_manifest: str | None,
+) -> None:
+    ctx.log.debug(
+        "Workspace status root: %s (source: %s).",
+        workspace_root,
+        workspace_root_source(ctx, workspace),
+    )
+    if effective_manifest is None:
+        ctx.log.debug(
+            "Workspace status manifest: none supplied or configured; scanning immediate child directories "
+            "under %s for base_manifest.yaml.",
+            workspace_root,
+        )
+        return
+    ctx.log.debug(
+        "Workspace status manifest: %s (source: %s).",
+        Path(effective_manifest).expanduser().resolve(strict=False),
+        workspace_manifest_source_label(ctx, workspace_manifest),
+    )
+
+
+def workspace_root_source(ctx: base_cli.Context, workspace: str | None) -> str:
+    if workspace:
+        return "--workspace"
+    if ctx.workspace_root is not None:
+        return "workspace.root"
+    return "BASE_HOME parent"
+
+
+def workspace_manifest_source_label(ctx: base_cli.Context, workspace_manifest: str | None) -> str:
+    if workspace_manifest is not None:
+        return "--manifest"
+    if ctx.user_config.workspace.manifest is not None:
+        return "workspace.manifest"
+    return "none"
 
 
 def effective_workspace_manifest_source(ctx: base_cli.Context, workspace_manifest_source: str | None) -> str | None:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -403,6 +403,32 @@ class ProjectDiscoveryTests(unittest.TestCase):
         )
         self.assertIn("project virtual environment missing", payload["projects"][0]["issues"][0])
 
+    def test_workspace_status_debug_logs_default_discovery_scan_without_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = workspace / "base"
+            home.mkdir()
+            write_manifest(base_home, "base")
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = invoke_engine(
+                ["--debug", "status", "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(payload["workspace"], str(workspace.resolve()))
+        self.assertIn(f"Workspace status root: {workspace.resolve()} (source: BASE_HOME parent).", stderr)
+        self.assertIn(
+            "Workspace status manifest: none supplied or configured; scanning immediate child directories "
+            f"under {workspace.resolve()} for base_manifest.yaml.",
+            stderr,
+        )
+
     def test_workspace_status_json_reports_uv_project_python_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary
- Log the resolved workspace root and source for `workspace status` when DEBUG logging is enabled.
- Log whether `workspace status` is using a workspace manifest or scanning immediate child directories for `base_manifest.yaml`.
- Add focused regression coverage for the no-manifest discovery path.

## Validation
- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1116-workspace-status-debug-discovery/lib/python:/Users/rameshhp/work/base-worktrees/1116-workspace-status-debug-discovery/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_workspace_status_manifest.py -q`
- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1116-workspace-status-debug-discovery/lib/python:/Users/rameshhp/work/base-worktrees/1116-workspace-status-debug-discovery/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_projects/engine.py cli/python/base_projects/tests/test_engine.py`
- `git diff --check`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-debug-log-check-1116 /Users/rameshhp/work/base-worktrees/1116-workspace-status-debug-discovery/bin/basectl -v workspace status --format json`

## Demo Impact
- None. DEBUG logging only.

Fixes #1116
