### PR TITLE
Reduce git prompt subprocess cost

### DIFF
--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -49,12 +49,20 @@ set -o vi
 
 _base_bash_defaults_git_prompt() {
     local branch
+    local git_state
+    local inside
 
     command -v git >/dev/null 2>&1 || return 0
-    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
 
-    branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)" || \
+    git_state="$(git rev-parse --is-inside-work-tree --abbrev-ref HEAD 2>/dev/null)" || return 0
+    [[ "$git_state" == *$'\n'* ]] || return 0
+    inside="${git_state%%$'\n'*}"
+    branch="${git_state#*$'\n'}"
+    branch="${branch%%$'\n'*}"
+    [[ "$inside" == "true" ]] || return 0
+    if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
         branch="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
+    fi
     [[ -n "$branch" ]] || return 0
 
     printf '(%s) ' "$branch"

--- a/lib/shell/zsh_defaults.sh
+++ b/lib/shell/zsh_defaults.sh
@@ -51,12 +51,20 @@ zstyle ':completion:*' menu select
 
 _base_zsh_defaults_git_prompt() {
     local branch
+    local git_state
+    local inside
 
     command -v git >/dev/null 2>&1 || return 0
-    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
 
-    branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)" || \
+    git_state="$(git rev-parse --is-inside-work-tree --abbrev-ref HEAD 2>/dev/null)" || return 0
+    [[ "$git_state" == *$'\n'* ]] || return 0
+    inside="${git_state%%$'\n'*}"
+    branch="${git_state#*$'\n'}"
+    branch="${branch%%$'\n'*}"
+    [[ "$inside" == "true" ]] || return 0
+    if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
         branch="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
+    fi
     [[ -n "$branch" ]] || return 0
 
     printf '(%s) ' "$branch"

--- a/tests/source_guards.bats
+++ b/tests/source_guards.bats
@@ -6,7 +6,40 @@ bats_require_minimum_version 1.5.0
 setup() {
     setup_test_tmpdir
     TEST_HOME="$TEST_TMPDIR/home"
-    mkdir -p "$TEST_HOME"
+    TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
+    mkdir -p "$TEST_HOME" "$TEST_MOCKBIN"
+}
+
+write_prompt_git_stub() {
+    cat > "$TEST_MOCKBIN/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${BASE_TEST_GIT_ARGS:?}"
+
+case "$*" in
+    "rev-parse --is-inside-work-tree --abbrev-ref HEAD")
+        [[ "${BASE_TEST_GIT_MODE:-repo}" == "repo" ]] || exit 128
+        printf 'true\nmain\n'
+        ;;
+    "rev-parse --is-inside-work-tree")
+        [[ "${BASE_TEST_GIT_MODE:-repo}" == "repo" ]] || exit 128
+        printf 'true\n'
+        ;;
+    "symbolic-ref --quiet --short HEAD")
+        [[ "${BASE_TEST_GIT_MODE:-repo}" == "repo" ]] || exit 1
+        printf 'main\n'
+        ;;
+    "rev-parse --short HEAD")
+        [[ "${BASE_TEST_GIT_MODE:-repo}" == "repo" ]] || exit 128
+        printf 'abc1234\n'
+        ;;
+    *)
+        exit 127
+        ;;
+esac
+EOF
+    chmod +x "$TEST_MOCKBIN/git"
 }
 
 @test "Bash source guard examples use explicit success returns" {
@@ -95,6 +128,51 @@ setup() {
     [[ "$output" == *"declare -r _base_defaults_sourced=\"1\""* ]]
 }
 
+@test "Bash defaults git prompt uses one Git process per branch prompt render" {
+    write_prompt_git_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_GIT_ARGS="$TEST_TMPDIR/bash-git-args" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -i -c '
+            source "$BASE_HOME/lib/shell/bash_defaults.sh"
+            printf "first=%s\n" "$(_base_bash_defaults_git_prompt)"
+            printf "second=%s\n" "$(_base_bash_defaults_git_prompt)"
+            printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
+            printf "git_args=%s\n" "$(tr "\n" "|" < "$BASE_TEST_GIT_ARGS")"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"first=(main) "* ]]
+    [[ "$output" == *"second=(main) "* ]]
+    [[ "$output" == *"git_calls=2"* ]]
+    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
+}
+
+@test "Bash defaults git prompt keeps non-Git directories quiet with one probe" {
+    write_prompt_git_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_GIT_ARGS="$TEST_TMPDIR/bash-non-git-args" \
+        BASE_TEST_GIT_MODE="non-git" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -i -c '
+            source "$BASE_HOME/lib/shell/bash_defaults.sh"
+            printf "prompt=%s\n" "$(_base_bash_defaults_git_prompt)"
+            printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
+            printf "git_args=%s\n" "$(tr "\n" "|" < "$BASE_TEST_GIT_ARGS")"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"prompt="* ]]
+    [[ "$output" == *"git_calls=1"* ]]
+    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
+}
+
 @test "Zsh defaults re-sourcing preserves local overrides" {
     command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
 
@@ -117,4 +195,51 @@ setup() {
     [[ "$output" == *"PROMPT=custom-prompt"* ]]
     [[ "$output" == *"typeset -r _base_zsh_defaults_sourced=1"* ]]
     [[ "$output" == *"typeset -r _base_defaults_sourced=1"* ]]
+}
+
+@test "Zsh defaults git prompt uses one Git process per branch prompt render" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+    write_prompt_git_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_GIT_ARGS="$TEST_TMPDIR/zsh-git-args" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        zsh -f -i -c '
+            source "$BASE_HOME/lib/shell/zsh_defaults.sh"
+            printf "first=%s\n" "$(_base_zsh_defaults_git_prompt)"
+            printf "second=%s\n" "$(_base_zsh_defaults_git_prompt)"
+            printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
+            printf "git_args=%s\n" "$(tr "\n" "|" < "$BASE_TEST_GIT_ARGS")"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"first=(main) "* ]]
+    [[ "$output" == *"second=(main) "* ]]
+    [[ "$output" == *"git_calls=2"* ]]
+    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
+}
+
+@test "Zsh defaults git prompt keeps non-Git directories quiet with one probe" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+    write_prompt_git_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_GIT_ARGS="$TEST_TMPDIR/zsh-non-git-args" \
+        BASE_TEST_GIT_MODE="non-git" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        zsh -f -i -c '
+            source "$BASE_HOME/lib/shell/zsh_defaults.sh"
+            printf "prompt=%s\n" "$(_base_zsh_defaults_git_prompt)"
+            printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
+            printf "git_args=%s\n" "$(tr "\n" "|" < "$BASE_TEST_GIT_ARGS")"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"prompt="* ]]
+    [[ "$output" == *"git_calls=1"* ]]
+    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
 }


### PR DESCRIPTION
## Summary
- Collapse Bash and Zsh default prompt Git detection to one `rev-parse` call for normal branch prompts and non-Git directories.
- Preserve the detached-HEAD short SHA fallback.
- Add shell runtime tests that count Git calls for Bash and Zsh in Git and non-Git paths.

## Validation
- `git diff --check origin/main..HEAD`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/source_guards.bats`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test` (Python: 619 passed, 1 skipped; BATS: 504 passed)

Fixes #1098