### PR TITLE
Reduce setup/profile subprocess usage

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -119,7 +119,7 @@ base_setup_subcommand_main() {
     done
 
     BASE_SETUP_PROJECT_NAME="$project_name"
-    BASE_SETUP_START_TIME="$(date +%s)"
+    BASE_SETUP_START_TIME="$(setup_epoch_seconds)" || BASE_SETUP_START_TIME=0
     export BASE_SETUP_START_TIME
     export BASE_SETUP_PROJECT_NAME
     log_debug "Running 'basectl setup' (DRY_RUN=$(setup_is_dry_run && printf true || printf false))."

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -75,6 +75,14 @@ setup_supported_profiles_display() {
     printf '%s\n' "dev, sre, ai"
 }
 
+setup_epoch_seconds() {
+    printf '%(%s)T\n' -1
+}
+
+setup_backup_timestamp() {
+    printf '%(%Y%m%dT%H%M%S)T\n' -1
+}
+
 setup_profile_supported() {
     local profile="$1"
 
@@ -92,7 +100,7 @@ setup_normalize_profile_name() {
     local profile="$1"
 
     profile="${profile//[[:space:]]/}"
-    printf '%s' "$profile" | tr '[:upper:]' '[:lower:]'
+    printf '%s' "${profile,,}"
 }
 
 setup_profile_enabled() {
@@ -299,7 +307,7 @@ setup_backup_existing_venv_path() {
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     [[ -e "$venv_dir" ]] || return 0
 
-    timestamp="$(date +%Y%m%dT%H%M%S)"
+    timestamp="$(setup_backup_timestamp)" || fatal_error "Unable to generate virtual environment backup timestamp."
     backup_path="${venv_dir}.backup.${timestamp}"
     [[ ! -e "$backup_path" ]] || fatal_error "Virtual environment backup path already exists at '$backup_path'."
 
@@ -401,6 +409,7 @@ setup_recovery_project_layer() {
 
 setup_notify_completion() {
     local exit_code="$1"
+    local current_seconds
     local elapsed_seconds=0
     local message title
     local min_seconds
@@ -420,7 +429,8 @@ setup_notify_completion() {
         min_seconds=30
     fi
     if [[ -n "${BASE_SETUP_START_TIME:-}" && "$BASE_SETUP_START_TIME" =~ ^[0-9]+$ ]]; then
-        elapsed_seconds=$(($(date +%s) - BASE_SETUP_START_TIME))
+        current_seconds="$(setup_epoch_seconds)" || current_seconds="$BASE_SETUP_START_TIME"
+        elapsed_seconds=$((current_seconds - BASE_SETUP_START_TIME))
     fi
     if ! setup_notifications_forced && ((elapsed_seconds < min_seconds)); then
         return 0
@@ -563,10 +573,10 @@ setup_install_xcode_tools() {
 
     timeout="$(setup_xcode_wait_timeout_seconds)"
     interval="$(setup_xcode_wait_interval_seconds)"
-    start_time="$(date +%s)"
+    start_time="$(setup_epoch_seconds)" || fatal_error "Unable to read current time while waiting for Xcode Command Line Tools."
 
     until setup_xcode_tools_installed; do
-        current_time="$(date +%s)"
+        current_time="$(setup_epoch_seconds)" || fatal_error "Unable to read current time while waiting for Xcode Command Line Tools."
         if ((current_time - start_time >= timeout)); then
             fatal_error "Timed out waiting for Xcode Command Line Tools installation to complete. If the installer is still open, finish it. Otherwise $(setup_recovery_xcode_tools)"
         fi
@@ -920,6 +930,8 @@ setup_record_project_check_result() {
     esac
 
     path="$(setup_project_check_record_path "$project")"
+    # Keep external date -u here so persisted JSON records carry explicit UTC
+    # without mutating shell TZ; Bash printf time formatting follows local time.
     checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 0
     setup_run_diagnostics_json record-check \
         --project "$project" \
@@ -1911,6 +1923,8 @@ setup_run_check_json() {
                 return 1
             fi
         fi
+        # Keep external date -u here so persisted JSON records carry explicit UTC
+        # without mutating shell TZ; Bash printf time formatting follows local time.
         checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 1
     fi
 

--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -63,6 +63,14 @@ base_update_profile_source_line() {
     printf 'source %s\n' "$quoted_source_path"
 }
 
+base_update_profile_file_ends_with_newline() {
+    local target_file="$1"
+    local last_byte
+
+    last_byte="$(tail -c 1 "$target_file" 2>/dev/null || true)"
+    [[ -z "$last_byte" ]]
+}
+
 base_update_profile_section_lines() {
     local snippet_name="$1"
     local snippet_path="$BASE_SHELL_DIR/$snippet_name"
@@ -80,7 +88,7 @@ base_update_profile_prepare_section_spacing() {
     [[ -s "$target_file" ]] || return 0
     grep -qF -- "$start_marker" "$target_file" && return 0
 
-    if [[ $(tail -c 1 "$target_file" 2>/dev/null | wc -l) -eq 0 ]]; then
+    if ! base_update_profile_file_ends_with_newline "$target_file"; then
         printf '\n\n' >> "$target_file"
         return 0
     fi

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -22,6 +22,69 @@ load ./setup_helpers.bash
     [[ "$output" == *"Create ~/.base.d/config.yaml with workspace.root: ~/work if missing."* ]]
 }
 
+@test "setup profile normalization does not shell out to tr" {
+    local bash_libs_dir
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+    create_tr_failure_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_common.sh"
+            setup_enable_profile_argument " DEV , Ai " || exit $?
+            printf "profiles=%s\n" "$BASE_SETUP_PROFILES"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"profiles=dev ai"* ]]
+    [[ "$output" != *"tr should not run"* ]]
+}
+
+@test "setup time helpers use Bash formatting without date subprocesses" {
+    local bash_libs_dir
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+    create_date_logger_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_common.sh"
+            epoch="$(setup_epoch_seconds)" || exit $?
+            stamp="$(setup_backup_timestamp)" || exit $?
+            [[ "$epoch" =~ ^[0-9]+$ ]] || exit 10
+            [[ "$stamp" =~ ^[0-9]{8}T[0-9]{6}$ ]] || exit 11
+            printf "epoch=%s\n" "$epoch"
+            printf "stamp=%s\n" "$stamp"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"epoch="* ]]
+    [[ "$output" == *"stamp="* ]]
+    [ ! -e "$TEST_STATE_DIR/date-args" ]
+}
+
+@test "setup_common documents UTC date subprocess exceptions" {
+    local comment_count
+
+    comment_count="$(
+        grep -B2 "date -u '+%Y-%m-%dT%H:%M:%SZ'" \
+            "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/setup_common.sh" |
+            grep -Fc "Keep external date -u"
+    )"
+    [ "$comment_count" -eq 2 ]
+}
+
 @test "basectl setup fails on unsupported operating systems" {
     OSTYPE_OVERRIDE="linux-gnu"
 

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -78,6 +78,47 @@ EOF
     chmod +x "$TEST_MOCKBIN/osascript"
 }
 
+create_date_logger_stub() {
+    cat > "$TEST_MOCKBIN/date" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${BASE_SETUP_TEST_STATE_DIR:?}/date-args"
+case "$*" in
+    "+%s")
+        printf '1710000000\n'
+        ;;
+    "+%Y%m%dT%H%M%S")
+        printf '20240309T160000\n'
+        ;;
+    "-u +%Y-%m-%dT%H:%M:%SZ"|"-u '+%Y-%m-%dT%H:%M:%SZ'")
+        printf '2024-03-09T16:00:00Z\n'
+        ;;
+    *)
+        printf 'unexpected date args: %s\n' "$*" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod +x "$TEST_MOCKBIN/date"
+}
+
+create_tr_failure_stub() {
+    cat > "$TEST_MOCKBIN/tr" <<'EOF'
+#!/usr/bin/env bash
+printf 'tr should not run\n' >&2
+exit 97
+EOF
+    chmod +x "$TEST_MOCKBIN/tr"
+}
+
+create_wc_failure_stub() {
+    cat > "$TEST_MOCKBIN/wc" <<'EOF'
+#!/usr/bin/env bash
+printf 'wc should not run\n' >&2
+exit 98
+EOF
+    chmod +x "$TEST_MOCKBIN/wc"
+}
+
 create_system_python3_stub() {
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -101,6 +101,29 @@ EOF
     [[ "$(cat "$TEST_HOME/.bashrc")" != *"/Cellar/base/0.4.0"* ]]
 }
 
+@test "update-profile spacing helper checks trailing newline without wc" {
+    local bash_libs_dir
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+    create_wc_failure_stub
+    printf 'export CUSTOM=1' > "$TEST_HOME/.bashrc"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update_profile.sh"
+            base_update_profile_prepare_section_spacing "$HOME/.bashrc" "# >>> base: bashrc managed >>>"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"wc should not run"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc"; printf marker)" == $'export CUSTOM=1\n\nmarker' ]]
+}
+
 @test "basectl update-profile explains BASE_HOME mismatch recovery" {
     local runtime_base="$TEST_TMPDIR/runtime-base"
     local resolved_base="$TEST_TMPDIR/resolved-base"


### PR DESCRIPTION
## Summary
- Replace setup profile lowercasing, local epoch timing, and backup timestamp generation with Bash builtins.
- Simplify update-profile trailing-newline detection to avoid the `tail | wc` pipeline.
- Document the remaining UTC `date -u` calls where persisted JSON needs explicit UTC timestamps.
- Add focused BATS coverage for the changed setup/profile helpers.

## Validation
- `git diff --check`
- `rg -n "date \+%s|date \+%Y%m%dT%H%M%S|tr '[:upper:]' '[:lower:]'|tail -c 1 .*wc -l" cli/bash/commands/basectl/subcommands/setup.sh cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/update_profile.sh` (no matches)\n- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats` (47 passed)\n- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/update-profile.bats` (27 passed)\n- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test` (Python: 619 passed, 1 skipped; BATS: 508 passed)\n\nFixes #1100