### PR TITLE
Add direct basectl helper coverage

### DIFF
--- a/cli/bash/commands/basectl/subcommands/config.sh
+++ b/cli/bash/commands/basectl/subcommands/config.sh
@@ -28,8 +28,8 @@ base_config_path() {
 }
 
 base_config_usage_error() {
-    base_config_subcommand_usage >&2
     print_error "$*"
+    printf "Run 'basectl config --help' for usage.\n" >&2
     return 2
 }
 

--- a/cli/bash/commands/basectl/subcommands/repo_installer_template.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_installer_template.sh
@@ -153,6 +153,10 @@ base_repo_installer_template() {
                 ;;
             --repo=*)
                 github_repo="${1#--repo=}"
+                [[ -n "$github_repo" ]] || {
+                    base_repo_installer_template_usage_error "Option '--repo' requires an argument."
+                    return $?
+                }
                 shift
                 ;;
             --print|--stdout)

--- a/cli/bash/commands/basectl/tests/config.bats
+++ b/cli/bash/commands/basectl/tests/config.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+line_at() {
+    local text="$1"
+    local line_number="$2"
+
+    printf '%s\n' "$text" | sed -n "${line_number}p"
+}
+
+@test "basectl config path rejects extra arguments with focused usage hint" {
+    run_basectl config path extra
+
+    [ "$status" -eq 2 ]
+    [ "$(line_at "$output" 1)" = "ERROR: config path does not accept arguments." ]
+    [ "$(line_at "$output" 2)" = "Run 'basectl config --help' for usage." ]
+    [[ "$output" != *"Usage:"* ]]
+}
+
+@test "basectl config doctor forwards through the Python wrapper" {
+    local base_home="$TEST_TMPDIR/base-home"
+
+    mkdir -p "$base_home/bin"
+    cat > "$base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'display=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$base_home/bin/base-wrapper"
+
+    run env \
+        BASE_HOME="$base_home" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/config.sh"
+            base_config_subcommand_main doctor --format json
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"display=basectl config"* ]]
+    [[ "$output" == *"args=--project base base_config doctor --format json"* ]]
+}

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -196,8 +196,9 @@ EOF
     run_basectl config unknown
 
     [ "$status" -eq 2 ]
-    [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"ERROR: Unknown config command 'unknown'."* ]]
+    [[ "$output" == *"Run 'basectl config --help' for usage."* ]]
+    [[ "$output" != *"Usage:"* ]]
     [[ "$output" != *"FATAL"* ]]
     [[ "$output" != *"Encountered a fatal error"* ]]
 }

--- a/cli/bash/commands/basectl/tests/repo-installer-template.bats
+++ b/cli/bash/commands/basectl/tests/repo-installer-template.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+line_at() {
+    local text="$1"
+    local line_number="$2"
+
+    printf '%s\n' "$text" | sed -n "${line_number}p"
+}
+
+run_repo_helper_script() {
+    local bash_libs_dir
+    local script="$1"
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        bash -c "source \"\$BASE_HOME/base_init.sh\"; source \"\$BASE_HOME/cli/bash/commands/basectl/subcommands/repo.sh\"; $script"
+}
+
+@test "repo installer-template helper rejects an empty --repo assignment" {
+    run_repo_helper_script 'base_repo_installer_template "$HOME/install.sh" --repo= --pr --dry-run'
+
+    [ "$status" -eq 2 ]
+    [ "$(line_at "$output" 1)" = "ERROR: Option '--repo' requires an argument." ]
+    [ "$(line_at "$output" 2)" = "Run 'basectl repo installer-template --help' for usage." ]
+    [[ "$output" != *"Usage:"* ]]
+    [ ! -e "$TEST_HOME/install.sh" ]
+}
+
+@test "repo installer-template helper resolves the maintained template path" {
+    run_repo_helper_script 'base_repo_installer_template_path'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$BASE_REPO_ROOT/templates/project-install.sh" ]
+}
+
+@test "repo installer-template helper renders the pull request body command" {
+    run_repo_helper_script 'base_repo_create_installer_template_pr_body "/tmp/My Project/install.sh" "codeforester/base-demo"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Add the maintained Base project installer template."* ]]
+    [[ "$output" == *'basectl repo installer-template "/tmp/My Project/install.sh" --repo codeforester/base-demo --pr'* ]]
+}

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load ./setup_helpers.bash
+
+run_setup_common_script() {
+    local bash_libs_dir
+    local script="$1"
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        PYTHONPATH="${BASE_SETUP_TEST_PYTHONPATH:-}" \
+        bash -c "source \"\$BASE_HOME/base_init.sh\"; source \"\$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_common.sh\"; $script"
+}
+
+@test "setup_common caches Base virtualenv and Python import paths" {
+    run_setup_common_script 'setup_refresh_cached_paths; printf "venv=%s\n" "$(setup_venv_dir)"; printf "pythonpath=%s\n" "$(setup_pythonpath)"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"venv=$TEST_HOME/.base.d/base/.venv"* ]]
+    [[ "$output" == *"pythonpath=$BASE_REPO_ROOT/lib/python:$BASE_REPO_ROOT/cli/python"* ]]
+}
+
+@test "setup_common appends an inherited PYTHONPATH after Base paths" {
+    BASE_SETUP_TEST_PYTHONPATH="/opt/example/python" \
+        run_setup_common_script 'setup_refresh_cached_paths; setup_pythonpath'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$BASE_REPO_ROOT/lib/python:$BASE_REPO_ROOT/cli/python:/opt/example/python" ]
+}
+
+@test "setup_common parses explicit warning check results" {
+    local result_file="$TEST_STATE_DIR/check.result"
+
+    run_setup_common_script "setup_write_check_result_file \"$result_file\" base_bash_libraries true 'libraries available' 'install libraries' 'used sibling checkout' warn; setup_parse_check_result_file \"$result_file\"; printf 'name=%s\n' \"\$_BASE_SETUP_PARSED_CHECK_NAME\"; printf 'ok=%s\n' \"\$_BASE_SETUP_PARSED_CHECK_OK\"; printf 'status=%s\n' \"\$_BASE_SETUP_PARSED_CHECK_STATUS\"; printf 'message=%s\n' \"\$_BASE_SETUP_PARSED_CHECK_MESSAGE\"; printf 'recovery=%s\n' \"\$_BASE_SETUP_PARSED_CHECK_RECOVERY\"; printf 'debug=%s\n' \"\$_BASE_SETUP_PARSED_CHECK_DEBUG_MESSAGE\""
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"name=base_bash_libraries"* ]]
+    [[ "$output" == *"ok=true"* ]]
+    [[ "$output" == *"status=warn"* ]]
+    [[ "$output" == *"message=libraries available"* ]]
+    [[ "$output" == *"recovery=install libraries"* ]]
+    [[ "$output" == *"debug=used sibling checkout"* ]]
+}


### PR DESCRIPTION
## Summary
- Add direct BATS coverage for config dispatch, repo installer-template helpers, and setup_common helper contracts.
- Align config usage errors with focused command usage hints.
- Reject empty repo installer-template --repo= helper values directly.

## Validation
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/config.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo-installer-template.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup-common.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats
- git diff --check
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test

Fixes #1103