### PR TITLE
Lazy-load repo installer-template helpers

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -25,11 +25,6 @@ BASE_REPO_AGENT_GUIDANCE_FILES=(
     .github/pull_request_template.md
 )
 
-_base_repo_installer_template_module_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/repo_installer_template.sh"
-# shellcheck source=cli/bash/commands/basectl/subcommands/repo_installer_template.sh
-source "$_base_repo_installer_template_module_path"
-unset _base_repo_installer_template_module_path
-
 base_repo_subcommand_usage() {
     cat <<'EOF'
 Usage:
@@ -213,6 +208,22 @@ base_repo_configure_usage_error() {
 
 base_repo_installer_template_usage_error() {
     base_repo_print_usage_error "basectl repo installer-template" "$@"
+}
+
+base_repo_load_installer_template() {
+    local module_path
+
+    if declare -F base_repo_installer_template >/dev/null 2>&1; then
+        return 0
+    fi
+
+    module_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/repo_installer_template.sh" || return 1
+    [[ -f "$module_path" ]] || {
+        log_error "repo installer-template helper was not found at '$module_path'."
+        return 1
+    }
+    # shellcheck source=cli/bash/commands/basectl/subcommands/repo_installer_template.sh
+    source "$module_path"
 }
 
 base_repo_agent_guidance_usage() {
@@ -3189,6 +3200,7 @@ base_repo_subcommand_main() {
             ;;
         installer-template)
             shift
+            base_repo_load_installer_template || return 1
             base_repo_installer_template "$@"
             ;;
         *)

--- a/cli/bash/commands/basectl/subcommands/repo_installer_template.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_installer_template.sh
@@ -79,15 +79,14 @@ EOF
 }
 
 base_repo_finish_installer_template_pr() {
-    local body_file
+    local dry_run="$1"
+    local target_path="$2"
+    local root="$3"
+    local repo="$4"
     local branch="$5"
     local default_branch="$6"
-    local dry_run="$1"
     local rel_path="$7"
-    local repo="$4"
-    local root="$3"
-    local status
-    local target_path="$2"
+    local body_file status
 
     if [[ "$dry_run" == "1" ]]; then
         base_repo_finish_generated_pr \

--- a/cli/bash/commands/basectl/tests/repo-installer-template.bats
+++ b/cli/bash/commands/basectl/tests/repo-installer-template.bats
@@ -9,7 +9,7 @@ line_at() {
     printf '%s\n' "$text" | sed -n "${line_number}p"
 }
 
-run_repo_helper_script() {
+run_loaded_repo_helper_script() {
     local bash_libs_dir
     local script="$1"
 
@@ -18,11 +18,35 @@ run_repo_helper_script() {
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
         BASE_BASH_LIBS_DIR="$bash_libs_dir" \
-        bash -c "source \"\$BASE_HOME/base_init.sh\"; source \"\$BASE_HOME/cli/bash/commands/basectl/subcommands/repo.sh\"; $script"
+        bash -c "source \"\$BASE_HOME/base_init.sh\"; source \"\$BASE_HOME/cli/bash/commands/basectl/subcommands/repo.sh\"; base_repo_load_installer_template || exit \$?; $script"
+}
+
+@test "repo check help does not source installer-template helpers" {
+    local bash_libs_dir
+    local module_dir="$TEST_TMPDIR/repo-module"
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+    mkdir -p "$module_dir"
+    cp "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/repo.sh" "$module_dir/repo.sh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        BASE_REPO_TEST_MODULE_DIR="$module_dir" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_REPO_TEST_MODULE_DIR/repo.sh"
+            base_repo_subcommand_main check --help
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl repo check [path] [options]"* ]]
+    [[ "$output" != *"repo_installer_template.sh"* ]]
 }
 
 @test "repo installer-template helper rejects an empty --repo assignment" {
-    run_repo_helper_script 'base_repo_installer_template "$HOME/install.sh" --repo= --pr --dry-run'
+    run_loaded_repo_helper_script 'base_repo_installer_template "$HOME/install.sh" --repo= --pr --dry-run'
 
     [ "$status" -eq 2 ]
     [ "$(line_at "$output" 1)" = "ERROR: Option '--repo' requires an argument." ]
@@ -32,14 +56,14 @@ run_repo_helper_script() {
 }
 
 @test "repo installer-template helper resolves the maintained template path" {
-    run_repo_helper_script 'base_repo_installer_template_path'
+    run_loaded_repo_helper_script 'base_repo_installer_template_path'
 
     [ "$status" -eq 0 ]
     [ "$output" = "$BASE_REPO_ROOT/templates/project-install.sh" ]
 }
 
 @test "repo installer-template helper renders the pull request body command" {
-    run_repo_helper_script 'base_repo_create_installer_template_pr_body "/tmp/My Project/install.sh" "codeforester/base-demo"'
+    run_loaded_repo_helper_script 'base_repo_create_installer_template_pr_body "/tmp/My Project/install.sh" "codeforester/base-demo"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Add the maintained Base project installer template."* ]]


### PR DESCRIPTION
## Summary
- Lazy-load repo installer-template helpers only when the installer-template subcommand runs.
- Add focused coverage proving unrelated repo commands do not source the installer-template module.
- Reorder installer-template PR helper locals to match positional arguments.

## Validation
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo-installer-template.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/source_guards.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl repo installer-template --print
- git diff --check
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test

Fixes #1104