### PR TITLE
Render CI setup JSON in Python

### DIFF
--- a/cli/bash/commands/basectl/subcommands/ci.sh
+++ b/cli/bash/commands/basectl/subcommands/ci.sh
@@ -168,125 +168,29 @@ base_ci_check_or_doctor_delegate_args() {
     printf '%s\n' "$BASE_CI_PROJECT" --format "$BASE_CI_FORMAT"
 }
 
-base_ci_json_escape() {
-    local value="${1:-}"
-    local char code escaped i
-    local output=""
-    local LC_ALL=C
-
-    for ((i = 0; i < ${#value}; i++)); do
-        char="${value:i:1}"
-        case "$char" in
-            '"')
-                output+='\"'
-                ;;
-            '\')
-                output+='\\'
-                ;;
-            $'\b')
-                output+='\b'
-                ;;
-            $'\f')
-                output+='\f'
-                ;;
-            $'\n')
-                output+='\n'
-                ;;
-            $'\r')
-                output+='\r'
-                ;;
-            $'\t')
-                output+='\t'
-                ;;
-            *)
-                printf -v code '%d' "'$char"
-                if ((code < 32 || code == 127)); then
-                    printf -v escaped '\\u%04x' "$code"
-                    output+="$escaped"
-                else
-                    output+="$char"
-                fi
-                ;;
-        esac
-    done
-
-    printf '%s' "$output"
-}
-
 base_ci_print_setup_json() {
-    local command_output="$1"
-    local exit_code="$2"
-    local status="ok"
-    local output_lines=()
-    local index
+    local exit_code="$1"
+    local stdout_file="$2"
+    local stderr_file="$3"
+    local python_bin
 
-    shift 2
-    output_lines=("$@")
-
-    if ((exit_code)); then
-        status="error"
-    fi
-
-    printf '{\n'
-    printf '  "schema_version": 1,\n'
-    printf '  "command": "setup",\n'
-    printf '  "status": "%s",\n' "$status"
-    printf '  "project": "%s",\n' "$(base_ci_json_escape "$BASE_CI_PROJECT")"
-    printf '  "output": "%s"' "$(base_ci_json_escape "$command_output")"
-    if ((exit_code)) && ((${#output_lines[@]})); then
-        printf ',\n'
-        printf '  "output_lines": [\n'
-        for index in "${!output_lines[@]}"; do
-            printf '    "%s"' "$(base_ci_json_escape "${output_lines[$index]}")"
-            if ((index < ${#output_lines[@]} - 1)); then
-                printf ','
-            fi
-            printf '\n'
-        done
-        printf '  ]\n'
-    else
-        printf '\n'
-    fi
-    printf '}\n'
-}
-
-base_ci_compact_setup_output_lines() {
-    local output_file="$1"
-    local line
-    local message
-
-    [[ -f "$output_file" ]] || return 0
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        [[ -n "$line" ]] || continue
-        if [[ "$line" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]][A-Z]+[[:space:]]+[^[:space:]]+[[:space:]]+(.*)$ ]]; then
-            message="${BASH_REMATCH[1]}"
-        else
-            message="$line"
-        fi
-        printf '%s\n' "$message"
-    done < "$output_file"
-}
-
-base_ci_compact_setup_output() {
-    local output_file="$1"
-    local line
-    local message=""
-
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        message="$line"
-    done < <(base_ci_compact_setup_output_lines "$output_file")
-
-    printf '%s\n' "$message"
+    python_bin="$(setup_diagnostics_python_bin)" ||
+        fatal_error "Python is required to render Base CI setup JSON."
+    setup_ensure_cached_paths
+    env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+        "$python_bin" -m base_setup.ci_json setup-json \
+        --project "$BASE_CI_PROJECT" \
+        --exit-code "$exit_code" \
+        --stdout-file "$stdout_file" \
+        --stderr-file "$stderr_file"
 }
 
 base_ci_run_setup_json() {
     local args=("$@")
     local stdout_file
     local stderr_file
-    local command_output
     local exit_code
-    local output_lines=()
-    local output_source_file
+    local render_status
 
     stdout_file="$(mktemp "${TMPDIR:-/tmp}/base-ci-setup-stdout.XXXXXX")" || return 1
     stderr_file="$(mktemp "${TMPDIR:-/tmp}/base-ci-setup-stderr.XXXXXX")" || {
@@ -304,18 +208,12 @@ base_ci_run_setup_json() {
         cat "$stderr_file" >&2
     fi
 
-    command_output="$(base_ci_compact_setup_output "$stderr_file")"
-    output_source_file="$stderr_file"
-    if [[ -z "$command_output" ]]; then
-        command_output="$(base_ci_compact_setup_output "$stdout_file")"
-        output_source_file="$stdout_file"
-    fi
-    if ((exit_code)); then
-        mapfile -t output_lines < <(base_ci_compact_setup_output_lines "$output_source_file")
-    fi
-
+    base_ci_print_setup_json "$exit_code" "$stdout_file" "$stderr_file"
+    render_status=$?
     rm -f "$stdout_file" "$stderr_file"
-    base_ci_print_setup_json "$command_output" "$exit_code" "${output_lines[@]}"
+    if ((render_status)); then
+        return "$render_status"
+    fi
     return "$exit_code"
 }
 

--- a/cli/bash/commands/basectl/tests/ci.bats
+++ b/cli/bash/commands/basectl/tests/ci.bats
@@ -121,6 +121,25 @@ prepare_ci_runtime() {
     [[ "$stderr" == *"Python project setup layer failed."* ]]
 }
 
+@test "basectl ci setup json output preserves utf8" {
+    local workspace="$TEST_TMPDIR/workspace"
+
+    prepare_ci_runtime "$workspace"
+    printf '%s\n' \
+        "2026-06-10 10:15:33 ERROR   setup_common.sh:801 Café setup failed for 東京." \
+        > "$TEST_STATE_DIR/project-setup-stderr"
+    printf '%s\n' 17 > "$TEST_STATE_DIR/project-setup-exit-code"
+
+    run_base_command_separate_stderr BASE_SETUP_TEST_WORKSPACE="$workspace" ci setup demo --format json
+
+    [ "$status" -eq 17 ]
+    [[ "$output" == *'"status": "error"'* ]]
+    [[ "$output" == *'"Café setup failed for 東京."'* ]]
+    [[ "$output" != *"\\u00e9"* ]]
+    [[ "$output" != *"\\u6771"* ]]
+    [[ "$stderr" == *"Café setup failed for 東京."* ]]
+}
+
 @test "basectl ci check supports Linux runtime-only JSON checks" {
     create_system_python3_stub
     create_project_setup_venv_stub "$TEST_HOME/.base.d/base/.venv"

--- a/cli/python/base_setup/ci_json.py
+++ b/cli/python/base_setup/ci_json.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+LOG_LINE_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}\s+"
+    r"\d{2}:\d{2}:\d{2}\s+"
+    r"[A-Z]+\s+"
+    r"\S+\s+"
+    r"(?P<message>.*)$"
+)
+
+
+def compact_setup_output_lines(lines: list[str]) -> list[str]:
+    messages: list[str] = []
+    for line in lines:
+        if line == "":
+            continue
+        match = LOG_LINE_RE.match(line)
+        if match is not None:
+            messages.append(match.group("message"))
+        else:
+            messages.append(line)
+    return messages
+
+
+def read_output_lines(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    return path.read_text(encoding="utf-8", errors="replace").splitlines()
+
+
+def build_setup_payload(
+    *,
+    project: str,
+    exit_code: int,
+    stdout_lines: list[str],
+    stderr_lines: list[str],
+) -> dict[str, Any]:
+    compact_stderr = compact_setup_output_lines(stderr_lines)
+    compact_stdout = compact_setup_output_lines(stdout_lines)
+    output_lines = compact_stderr or compact_stdout
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "command": "setup",
+        "status": "error" if exit_code else "ok",
+        "project": project,
+        "output": output_lines[-1] if output_lines else "",
+    }
+    if exit_code and output_lines:
+        payload["output_lines"] = output_lines
+    return payload
+
+
+def build_setup_payload_from_files(
+    *,
+    project: str,
+    exit_code: int,
+    stdout_file: Path,
+    stderr_file: Path,
+) -> dict[str, Any]:
+    return build_setup_payload(
+        project=project,
+        exit_code=exit_code,
+        stdout_lines=read_output_lines(stdout_file),
+        stderr_lines=read_output_lines(stderr_file),
+    )
+
+
+def serialize_payload(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def write_payload(payload: dict[str, Any]) -> None:
+    rendered = serialize_payload(payload) + "\n"
+    sys.stdout.buffer.write(rendered.encode("utf-8"))
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="base_setup.ci_json")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    setup_json = subparsers.add_parser("setup-json")
+    setup_json.add_argument("--project", required=True)
+    setup_json.add_argument("--exit-code", required=True, type=int)
+    setup_json.add_argument("--stdout-file", required=True, type=Path)
+    setup_json.add_argument("--stderr-file", required=True, type=Path)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "setup-json":
+        write_payload(
+            build_setup_payload_from_files(
+                project=args.project,
+                exit_code=args.exit_code,
+                stdout_file=args.stdout_file,
+                stderr_file=args.stderr_file,
+            )
+        )
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/cli/python/base_setup/tests/test_ci_json.py
+++ b/cli/python/base_setup/tests/test_ci_json.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from base_setup import ci_json
+
+
+class BinaryStdout:
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+
+class BaseCiRendererTests(unittest.TestCase):
+    def test_compact_setup_output_lines_strips_log_prefixes(self) -> None:
+        self.assertEqual(
+            ci_json.compact_setup_output_lines(
+                [
+                    "2026-06-10 10:15:32 INFO    setup_common.sh:122 Homebrew is already installed.",
+                    "",
+                    "plain detail",
+                    "2026-06-10 10:15:33 ERROR   setup_common.sh:801 Python project setup layer failed.",
+                ]
+            ),
+            [
+                "Homebrew is already installed.",
+                "plain detail",
+                "Python project setup layer failed.",
+            ],
+        )
+
+    def test_error_payload_prefers_stderr_and_includes_output_lines(self) -> None:
+        payload = ci_json.build_setup_payload(
+            project="demo",
+            exit_code=17,
+            stdout_lines=["stdout fallback"],
+            stderr_lines=[
+                "2026-06-10 10:15:32 INFO    setup_common.sh:122 Homebrew is already installed.",
+                "2026-06-10 10:15:33 ERROR   setup_common.sh:801 Python project setup layer failed.",
+            ],
+        )
+
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["output"], "Python project setup layer failed.")
+        self.assertEqual(
+            payload["output_lines"],
+            [
+                "Homebrew is already installed.",
+                "Python project setup layer failed.",
+            ],
+        )
+
+    def test_success_payload_omits_output_lines(self) -> None:
+        payload = ci_json.build_setup_payload(
+            project="demo",
+            exit_code=0,
+            stdout_lines=["Project setup finished."],
+            stderr_lines=[],
+        )
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["output"], "Project setup finished.")
+        self.assertNotIn("output_lines", payload)
+
+    def test_serialized_payload_preserves_utf8_characters(self) -> None:
+        payload = ci_json.build_setup_payload(
+            project="démo",
+            exit_code=17,
+            stdout_lines=[],
+            stderr_lines=["2026-06-10 10:15:33 ERROR   setup_common.sh:801 Café setup failed for 東京."],
+        )
+
+        rendered = ci_json.serialize_payload(payload)
+
+        self.assertIn('"project": "démo"', rendered)
+        self.assertIn('"output": "Café setup failed for 東京."', rendered)
+        self.assertNotIn("\\u00e9", rendered)
+        self.assertNotIn("\\u6771", rendered)
+        self.assertEqual(json.loads(rendered), payload)
+
+    def test_main_renders_payload_from_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stdout_file = Path(tmpdir) / "stdout.log"
+            stderr_file = Path(tmpdir) / "stderr.log"
+            stdout_file.write_text("ignored stdout\n", encoding="utf-8")
+            stderr_file.write_text(
+                "2026-06-10 10:15:33 ERROR   setup_common.sh:801 Café setup failed for 東京.\n",
+                encoding="utf-8",
+            )
+            stdout = BinaryStdout()
+
+            original_stdout = ci_json.sys.stdout
+            try:
+                ci_json.sys.stdout = stdout  # type: ignore[assignment]
+                status = ci_json.main(
+                    [
+                        "setup-json",
+                        "--project",
+                        "démo",
+                        "--exit-code",
+                        "17",
+                        "--stdout-file",
+                        str(stdout_file),
+                        "--stderr-file",
+                        str(stderr_file),
+                    ]
+                )
+            finally:
+                ci_json.sys.stdout = original_stdout
+
+        self.assertEqual(status, 0)
+        payload = json.loads(stdout.buffer.getvalue().decode("utf-8"))
+        self.assertEqual(payload["project"], "démo")
+        self.assertEqual(payload["output"], "Café setup failed for 東京.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Move `basectl ci setup --format json` rendering and setup-log compaction into a Python helper.
- Preserve UTF-8 JSON output with `ensure_ascii=False` and byte-level stdout writing.
- Add Python renderer tests and a BATS integration regression for non-ASCII setup output.

## Validation
- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-worktrees/1094-move-basectl-ci-json-rendering-to-python/cli/python:/Users/rameshhp/work/base-worktrees/1094-move-basectl-ci-json-rendering-to-python/lib/python BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash python3 -m unittest cli/python/base_setup/tests/test_ci_json.py`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/ci.bats`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`
- `git diff --check`

Fixes #1094
