### PR TITLE
Deduplicate Base diagnostic probes

### DIFF
--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -66,35 +66,6 @@ base_doctor_count_check_errors() {
     printf '%s\n' "$errors"
 }
 
-base_doctor_base_check_finding_id() {
-    case "$1" in
-        homebrew)
-            printf '%s\n' "BASE-D001"
-            ;;
-        xcode_command_line_tools)
-            printf '%s\n' "BASE-D002"
-            ;;
-        python)
-            printf '%s\n' "BASE-D003"
-            ;;
-        base_virtualenv)
-            printf '%s\n' "BASE-D004"
-            ;;
-        pyyaml)
-            printf '%s\n' "BASE-D005"
-            ;;
-        click)
-            printf '%s\n' "BASE-D006"
-            ;;
-        base_bash_libraries)
-            printf '%s\n' "BASE-D007"
-            ;;
-        *)
-            printf '%s\n' "BASE-D000"
-            ;;
-    esac
-}
-
 base_doctor_print_collected_check_results() {
     local count fix i status
 
@@ -111,8 +82,8 @@ base_doctor_print_collected_check_results() {
 
         base_doctor_print_finding \
             "$status" \
-            "$(base_doctor_base_check_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
-            "${_BASE_SETUP_CHECK_NAMES[$i]}" \
+            "$(setup_base_check_finding_id "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
+            "$(setup_base_check_display_name "${_BASE_SETUP_CHECK_NAMES[$i]}")" \
             "${_BASE_SETUP_CHECK_MESSAGES[$i]}" \
             "$fix"
     done
@@ -156,119 +127,6 @@ base_doctor_run_ci_runtime_text() {
     else
         printf 'Base CI doctor found %s blocking issue(s).\n' "$errors"
     fi
-    return 1
-}
-
-base_doctor_check_homebrew() {
-    local brew_bin
-
-    if brew_bin="$(setup_find_brew_bin)"; then
-        if setup_refresh_brew_path; then
-            base_doctor_print_finding "ok" "BASE-D001" "Homebrew" "Homebrew is installed."
-            log_debug "Resolved Homebrew binary: $brew_bin"
-            return 0
-        fi
-        base_doctor_print_finding "error" "BASE-D001" "Homebrew" \
-            "Homebrew is installed, but its bin directory could not be added to PATH." \
-            "Check Homebrew installation and PATH."
-        return 1
-    fi
-
-    base_doctor_print_finding "error" "BASE-D001" "Homebrew" "Homebrew is not installed." "basectl setup"
-    return 1
-}
-
-base_doctor_check_xcode() {
-    if setup_xcode_tools_installed; then
-        if setup_homebrew_reports_xcode_tools_issue; then
-            base_doctor_print_finding \
-                "warn" \
-                "BASE-D002" \
-                "Xcode Command Line Tools" \
-                "Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete." \
-                "$(setup_recovery_xcode_tools_update)"
-            return 0
-        fi
-        base_doctor_print_finding \
-            "ok" \
-            "BASE-D002" \
-            "Xcode Command Line Tools" \
-            "Xcode Command Line Tools are installed."
-        return 0
-    fi
-
-    base_doctor_print_finding "error" "BASE-D002" "Xcode Command Line Tools" \
-        "Xcode Command Line Tools are not installed." \
-        "basectl setup"
-    return 1
-}
-
-base_doctor_check_base_bash_libraries() {
-    local fix=""
-    local status
-
-    status="$(setup_base_bash_libraries_status)"
-    if [[ "$status" != ok ]]; then
-        fix="$(setup_recovery_base_bash_libraries)"
-    fi
-
-    base_doctor_print_finding \
-        "$status" \
-        "BASE-D007" \
-        "Base Bash libraries" \
-        "$(setup_base_bash_libraries_check_message)" \
-        "$fix"
-    return 0
-}
-
-base_doctor_check_python() {
-    local formula
-
-    formula="$(setup_python_formula)"
-    if setup_python_installed; then
-        base_doctor_print_finding "ok" "BASE-D003" "Python" "Python formula '$formula' is installed via Homebrew."
-        return 0
-    fi
-
-    base_doctor_print_finding "error" "BASE-D003" "Python" \
-        "Python formula '$formula' is not installed via Homebrew." \
-        "basectl setup"
-    return 1
-}
-
-base_doctor_check_virtualenv() {
-    setup_ensure_cached_paths
-    if setup_virtualenv_healthy; then
-        base_doctor_print_finding "ok" "BASE-D004" "Base virtualenv" "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
-        return 0
-    fi
-
-    base_doctor_print_finding "error" "BASE-D004" "Base virtualenv" \
-        "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
-        "basectl setup --recreate-venv"
-    return 1
-}
-
-base_doctor_check_python_package() {
-    local package="$1"
-    local finding_id="BASE-D005"
-
-    if [[ "$package" == "$(setup_click_package)" ]]; then
-        finding_id="BASE-D006"
-    fi
-
-    if setup_base_python_package_installed "$package"; then
-        base_doctor_print_finding \
-            "ok" \
-            "$finding_id" \
-            "$package" \
-            "$(setup_base_python_package_check_message "$package" true)"
-        return 0
-    fi
-
-    base_doctor_print_finding "error" "$finding_id" "$package" \
-        "$(setup_base_python_package_check_message "$package" false)" \
-        "basectl setup"
     return 1
 }
 
@@ -412,13 +270,9 @@ base_doctor_subcommand_main() {
         printf 'Base doctor\n\n'
     fi
 
-    base_doctor_check_homebrew || errors=$((errors + 1))
-    base_doctor_check_base_bash_libraries
-    base_doctor_check_xcode || errors=$((errors + 1))
-    base_doctor_check_python || errors=$((errors + 1))
-    base_doctor_check_virtualenv || errors=$((errors + 1))
-    base_doctor_check_python_package "$(setup_pyyaml_package)" || errors=$((errors + 1))
-    base_doctor_check_python_package "$(setup_click_package)" || errors=$((errors + 1))
+    BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true setup_collect_base_check_results warn || true
+    errors="$(base_doctor_count_check_errors)"
+    base_doctor_print_collected_check_results
     if setup_profiles_enabled; then
         setup_run_base_dev_layer doctor
         profile_errors=$?

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -801,6 +801,64 @@ setup_add_base_bash_libraries_check_result() {
         "$recovery"
 }
 
+setup_base_check_finding_id() {
+    case "$1" in
+        homebrew)
+            printf '%s\n' "BASE-D001"
+            ;;
+        xcode_command_line_tools)
+            printf '%s\n' "BASE-D002"
+            ;;
+        python)
+            printf '%s\n' "BASE-D003"
+            ;;
+        base_virtualenv)
+            printf '%s\n' "BASE-D004"
+            ;;
+        pyyaml)
+            printf '%s\n' "BASE-D005"
+            ;;
+        click)
+            printf '%s\n' "BASE-D006"
+            ;;
+        base_bash_libraries)
+            printf '%s\n' "BASE-D007"
+            ;;
+        *)
+            printf '%s\n' "BASE-D000"
+            ;;
+    esac
+}
+
+setup_base_check_display_name() {
+    case "$1" in
+        homebrew)
+            printf '%s\n' "Homebrew"
+            ;;
+        xcode_command_line_tools)
+            printf '%s\n' "Xcode Command Line Tools"
+            ;;
+        python)
+            printf '%s\n' "Python"
+            ;;
+        base_virtualenv)
+            printf '%s\n' "Base virtualenv"
+            ;;
+        pyyaml)
+            setup_pyyaml_package
+            ;;
+        click)
+            setup_click_package
+            ;;
+        base_bash_libraries)
+            printf '%s\n' "Base Bash libraries"
+            ;;
+        *)
+            printf '%s\n' "$1"
+            ;;
+    esac
+}
+
 setup_pythonpath() {
     setup_ensure_cached_paths
     printf '%s\n' "$_BASE_SETUP_PYTHONPATH_CACHE"

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -424,8 +424,23 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"Base doctor"* ]]
     [[ "$output" == *"error"*"Homebrew"*"Homebrew is not installed."* ]]
-    [[ "$output" == *"Fix: basectl setup"* ]]
+    [[ "$output" == *"Fix: Run 'basectl setup' to install Homebrew, or install it manually from https://brew.sh/."* ]]
     [[ "$output" == *"Base doctor found"*"blocking issue(s)."* ]]
+}
+
+@test "basectl doctor text uses shared base check recovery hints" {
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_SETUP_BREW_BIN="$TEST_TMPDIR/missing-brew" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/missing-xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Fix: Run 'basectl setup' to install Homebrew, or install it manually from https://brew.sh/."* ]]
+    [[ "$output" == *"Fix: Run 'xcode-select --install' in an interactive terminal, complete the installer, then rerun 'basectl setup'."* ]]
+    [[ "$output" == *"Fix: Run 'basectl setup' to install Homebrew Python, or run 'brew install python@3.13'."* ]]
 }
 
 @test "basectl doctor reports broken Base virtualenv integrity" {
@@ -483,7 +498,7 @@ EOF
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"error"*"BASE-D004"*"Base virtualenv"*"home path '$missing_home'"* ]]
-    [[ "$output" == *"Fix: basectl setup --recreate-venv"* ]]
+    [[ "$output" == *"Fix: Run 'basectl setup --recreate-venv' to back up and recreate the Base virtual environment."* ]]
 }
 
 @test "basectl doctor --format json reports structured findings" {

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -44,3 +44,12 @@ run_setup_common_script() {
     [[ "$output" == *"recovery=install libraries"* ]]
     [[ "$output" == *"debug=used sibling checkout"* ]]
 }
+
+@test "setup_common owns base check finding metadata" {
+    run_setup_common_script 'printf "homebrew=%s/%s\n" "$(setup_base_check_finding_id homebrew)" "$(setup_base_check_display_name homebrew)"; printf "venv=%s/%s\n" "$(setup_base_check_finding_id base_virtualenv)" "$(setup_base_check_display_name base_virtualenv)"; printf "unknown=%s/%s\n" "$(setup_base_check_finding_id unexpected)" "$(setup_base_check_display_name unexpected)"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"homebrew=BASE-D001/Homebrew"* ]]
+    [[ "$output" == *"venv=BASE-D004/Base virtualenv"* ]]
+    [[ "$output" == *"unknown=BASE-D000/unexpected"* ]]
+}


### PR DESCRIPTION
## Summary
- Route macOS `basectl doctor` text diagnostics through the shared Base check collection path.
- Move Base check finding IDs and display labels into `setup_common.sh`.
- Add focused coverage for shared check metadata and doctor text recovery hints.

## Validation
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup-common.bats`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/doctor.bats`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/setup.bats`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test` from detached validation worktree `/private/tmp/base-validation-1106.k10KAD`
- `git diff --check HEAD~1..HEAD`

Fixes #1106
