### PR TITLE
Add optional pinned Homebrew installer support

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,8 @@
 
 # Base shell standards require explicit error handling instead of shell strict mode.
 
+BASE_DEFAULT_HOMEBREW_INSTALLER_URL="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+
 bootstrap_usage() {
     cat <<'EOF'
 Usage:
@@ -121,12 +123,125 @@ bootstrap_refresh_brew() {
     return 0
 }
 
+bootstrap_homebrew_pinned_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ||
+        -n "${BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256+x}" ]]
+}
+
+bootstrap_homebrew_pinned_url_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL+x}" ]]
+}
+
+bootstrap_homebrew_pinned_sha256_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ||
+        -n "${BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256+x}" ]]
+}
+
+bootstrap_homebrew_installer_url() {
+    if [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ]]; then
+        printf '%s\n' "$BASE_HOMEBREW_INSTALLER_URL"
+        return 0
+    fi
+    if [[ -n "${BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL+x}" ]]; then
+        printf '%s\n' "$BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL"
+        return 0
+    fi
+    printf '%s\n' "$BASE_DEFAULT_HOMEBREW_INSTALLER_URL"
+}
+
+bootstrap_homebrew_installer_sha256() {
+    if [[ -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ]]; then
+        printf '%s\n' "$BASE_HOMEBREW_INSTALLER_SHA256"
+        return 0
+    fi
+    if [[ -n "${BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256+x}" ]]; then
+        printf '%s\n' "$BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256"
+        return 0
+    fi
+}
+
+bootstrap_fetch_homebrew_installer() {
+    local installer_url="$1"
+    local target="$2"
+    local installer_path
+
+    case "$installer_url" in
+        file://*)
+            installer_path="${installer_url#file://}"
+            cp "$installer_path" "$target"
+            ;;
+        /*|./*|../*)
+            cp "$installer_url" "$target"
+            ;;
+        *)
+            command -v curl >/dev/null 2>&1 || return 127
+            curl -fsSL "$installer_url" -o "$target"
+            ;;
+    esac
+}
+
+bootstrap_run_verified_homebrew_installer() {
+    local installer_url="$1"
+    local expected_sha256="$2"
+    local installer_file
+    local checksum
+    local actual_sha256
+    local exit_code
+
+    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || bootstrap_die "Failed to create a temporary Homebrew installer file."
+    bootstrap_fetch_homebrew_installer "$installer_url" "$installer_file" || {
+        rm -f "$installer_file"
+        bootstrap_die "Failed to read pinned Homebrew installer content from '$installer_url'."
+    }
+
+    command -v shasum >/dev/null 2>&1 || {
+        rm -f "$installer_file"
+        bootstrap_die "shasum is required to verify pinned Homebrew installer content."
+    }
+    checksum="$(shasum -a 256 "$installer_file")" || {
+        rm -f "$installer_file"
+        bootstrap_die "Failed to compute Homebrew installer checksum."
+    }
+    actual_sha256="${checksum%% *}"
+    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+        rm -f "$installer_file"
+        bootstrap_die "Homebrew installer checksum mismatch (expected $expected_sha256, got $actual_sha256)."
+    fi
+
+    /bin/bash "$installer_file"
+    exit_code=$?
+    rm -f "$installer_file"
+    [[ "$exit_code" -eq 0 ]] || bootstrap_die "Homebrew installer failed."
+}
+
 bootstrap_install_homebrew() {
     local result_var="$1"
     local installer
-    local installer_url="${BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL:-https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh}"
+    local installer_url
+    local installer_sha256
 
+    installer_url="$(bootstrap_homebrew_installer_url)"
+    installer_sha256="$(bootstrap_homebrew_installer_sha256)"
     bootstrap_log "Installing Homebrew."
+    if bootstrap_homebrew_pinned_selected; then
+        bootstrap_homebrew_pinned_url_selected &&
+            bootstrap_homebrew_pinned_sha256_selected &&
+            [[ -n "$installer_url" && -n "$installer_sha256" ]] ||
+            bootstrap_die "Pinned Homebrew installer URL and SHA-256 are both required."
+        bootstrap_log "Using pinned Homebrew installer from $installer_url."
+        if [[ "${BASE_BOOTSTRAP_DRY_RUN:-false}" == "true" ]]; then
+            bootstrap_log "[DRY-RUN] Would verify Homebrew installer SHA-256 $installer_sha256"
+            bootstrap_log "[DRY-RUN] Would run: /bin/bash <verified Homebrew installer from $installer_url>"
+            printf -v "$result_var" '%s' brew
+            return 0
+        fi
+        bootstrap_run_verified_homebrew_installer "$installer_url" "$installer_sha256"
+        return 0
+    fi
+
     if [[ "${BASE_BOOTSTRAP_DRY_RUN:-false}" == "true" ]]; then
         bootstrap_log "[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from $installer_url>"
         printf -v "$result_var" '%s' brew

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -501,17 +501,139 @@ setup_xcode_homebrew_diagnostics_enabled() {
     [[ "${BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS:-false}" == true ]]
 }
 
+setup_homebrew_default_installer_url() {
+    printf '%s\n' "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+}
+
+setup_homebrew_pinned_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_SETUP_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ||
+        -n "${BASE_SETUP_HOMEBREW_INSTALLER_SHA256+x}" ]]
+}
+
+setup_homebrew_pinned_url_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_SETUP_HOMEBREW_INSTALLER_URL+x}" ]]
+}
+
+setup_homebrew_pinned_sha256_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ||
+        -n "${BASE_SETUP_HOMEBREW_INSTALLER_SHA256+x}" ]]
+}
+
+setup_homebrew_installer_url() {
+    if [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ]]; then
+        printf '%s\n' "$BASE_HOMEBREW_INSTALLER_URL"
+        return 0
+    fi
+    if [[ -n "${BASE_SETUP_HOMEBREW_INSTALLER_URL+x}" ]]; then
+        printf '%s\n' "$BASE_SETUP_HOMEBREW_INSTALLER_URL"
+        return 0
+    fi
+    setup_homebrew_default_installer_url
+}
+
+setup_homebrew_installer_sha256() {
+    if [[ -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ]]; then
+        printf '%s\n' "$BASE_HOMEBREW_INSTALLER_SHA256"
+        return 0
+    fi
+    if [[ -n "${BASE_SETUP_HOMEBREW_INSTALLER_SHA256+x}" ]]; then
+        printf '%s\n' "$BASE_SETUP_HOMEBREW_INSTALLER_SHA256"
+        return 0
+    fi
+}
+
+setup_fetch_homebrew_installer() {
+    local installer_url="$1"
+    local target="$2"
+    local installer_path
+
+    case "$installer_url" in
+        file://*)
+            installer_path="${installer_url#file://}"
+            cp "$installer_path" "$target"
+            ;;
+        /*|./*|../*)
+            cp "$installer_url" "$target"
+            ;;
+        *)
+            command -v curl >/dev/null 2>&1 || return 127
+            curl -fsSL "$installer_url" -o "$target"
+            ;;
+    esac
+}
+
+setup_run_verified_homebrew_installer() {
+    local installer_url="$1"
+    local expected_sha256="$2"
+    local installer_file
+    local checksum
+    local actual_sha256
+    local exit_code
+
+    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || fatal_error "Failed to create a temporary Homebrew installer file."
+    setup_fetch_homebrew_installer "$installer_url" "$installer_file" || {
+        rm -f "$installer_file"
+        fatal_error "Failed to read pinned Homebrew installer content from '$installer_url'."
+    }
+
+    command -v shasum >/dev/null 2>&1 || {
+        rm -f "$installer_file"
+        fatal_error "shasum is required to verify pinned Homebrew installer content."
+    }
+    checksum="$(shasum -a 256 "$installer_file")" || {
+        rm -f "$installer_file"
+        fatal_error "Failed to compute Homebrew installer checksum."
+    }
+    actual_sha256="${checksum%% *}"
+    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+        rm -f "$installer_file"
+        fatal_error "Homebrew installer checksum mismatch (expected $expected_sha256, got $actual_sha256)."
+    fi
+
+    /bin/bash "$installer_file"
+    exit_code=$?
+    rm -f "$installer_file"
+    if ((exit_code)); then
+        log_error "$(setup_recovery_homebrew)"
+    fi
+    exit_if_error "$exit_code" "Homebrew installer failed."
+}
+
 setup_install_homebrew() {
     # Trust decision: Base follows Homebrew's official install command, which
     # intentionally fetches the installer from the mutable HEAD ref. Pinning a
     # reviewed commit would reduce mutability risk, but would also make Base own
     # installer refreshes and drift from Homebrew's supported bootstrap path.
-    local installer_url="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+    local installer_url
+    local installer_sha256
     local exit_code
+
+    installer_url="$(setup_homebrew_installer_url)"
+    installer_sha256="$(setup_homebrew_installer_sha256)"
 
     if setup_find_brew_bin >/dev/null 2>&1; then
         setup_refresh_brew_path || fatal_error "Homebrew is installed, but its bin directory could not be added to PATH. $(setup_recovery_brew_path)"
         log_info "Homebrew is already installed."
+        return 0
+    fi
+
+    if setup_homebrew_pinned_selected; then
+        setup_homebrew_pinned_url_selected &&
+            setup_homebrew_pinned_sha256_selected &&
+            [[ -n "$installer_url" && -n "$installer_sha256" ]] ||
+            fatal_error "Pinned Homebrew installer URL and SHA-256 are both required."
+        log_info "Installing Homebrew."
+        log_info "Using pinned Homebrew installer from $installer_url."
+        if setup_is_dry_run; then
+            log_info "[DRY-RUN] Would verify Homebrew installer SHA-256 $installer_sha256"
+            log_info "[DRY-RUN] Would run: /bin/bash <verified Homebrew installer from $installer_url>"
+            return 0
+        fi
+        setup_run_verified_homebrew_installer "$installer_url" "$installer_sha256"
+        setup_refresh_brew_path || fatal_error "Homebrew installation finished, but 'brew' was not found on PATH. $(setup_recovery_brew_path)"
         return 0
     fi
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -877,6 +877,87 @@ EOF
     [ ! -e "$TEST_HOME/.base.d/base/.venv" ]
 }
 
+@test "basectl setup dry-run reports pinned Homebrew installer verification" {
+    local installer
+    local checksum
+
+    installer="$(create_homebrew_installer_stub)"
+    checksum="$(sha256_file "$installer")"
+
+    run_base_command \
+        BASE_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_HOMEBREW_INSTALLER_SHA256="$checksum" \
+        setup --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using pinned Homebrew installer from $installer."* ]]
+    [[ "$output" == *"[DRY-RUN] Would verify Homebrew installer SHA-256 $checksum"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: /bin/bash <verified Homebrew installer from $installer>"* ]]
+}
+
+@test "basectl setup rejects pinned Homebrew installer without checksum" {
+    local installer
+
+    create_curl_failure_stub
+    installer="$(create_homebrew_installer_stub)"
+
+    run_base_command \
+        BASE_SETUP_HOMEBREW_INSTALLER_URL="$installer" \
+        setup
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Pinned Homebrew installer URL and SHA-256 are both required."* ]]
+    [ ! -e "$TEST_STATE_DIR/homebrew-install-ran" ]
+}
+
+@test "basectl setup rejects pinned Homebrew checksum without installer location" {
+    run_base_command \
+        BASE_SETUP_HOMEBREW_INSTALLER_SHA256=0000000000000000000000000000000000000000000000000000000000000000 \
+        setup --dry-run
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Pinned Homebrew installer URL and SHA-256 are both required."* ]]
+    [ ! -e "$TEST_STATE_DIR/homebrew-install-ran" ]
+}
+
+@test "basectl setup rejects mismatched pinned Homebrew installer checksum" {
+    local installer
+
+    create_curl_failure_stub
+    installer="$(create_homebrew_installer_stub)"
+
+    run_base_command \
+        BASE_SETUP_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_SETUP_HOMEBREW_INSTALLER_SHA256=0000000000000000000000000000000000000000000000000000000000000000 \
+        setup
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Homebrew installer checksum mismatch"* ]]
+    [ ! -e "$TEST_STATE_DIR/homebrew-install-ran" ]
+}
+
+@test "basectl setup runs verified pinned Homebrew installer" {
+    local installer
+    local checksum
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_curl_failure_stub
+    create_xcode_stubs
+    installer="$(create_homebrew_installer_stub)"
+    checksum="$(sha256_file "$installer")"
+
+    run_base_command \
+        BASE_SETUP_ALLOW_NONINTERACTIVE_XCODE_INSTALL=true \
+        BASE_SETUP_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_SETUP_HOMEBREW_INSTALLER_SHA256="$checksum" \
+        setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using pinned Homebrew installer from $installer."* ]]
+    [ -f "$TEST_STATE_DIR/homebrew-install-ran" ]
+    [ -f "$venv_dir/pyvenv.cfg" ]
+}
+
 @test "basectl setup --profile dev dry-run defers developer prerequisites until Python bootstrap dependencies exist" {
     run_base_command setup --profile dev --dry-run
 

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -119,6 +119,15 @@ EOF
     chmod +x "$TEST_MOCKBIN/wc"
 }
 
+create_curl_failure_stub() {
+    cat > "$TEST_MOCKBIN/curl" <<'EOF'
+#!/usr/bin/env bash
+printf 'curl should not run for pinned local Homebrew installer: %s\n' "$*" >&2
+exit 96
+EOF
+    chmod +x "$TEST_MOCKBIN/curl"
+}
+
 create_system_python3_stub() {
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash
@@ -463,6 +472,13 @@ EOF
     chmod +x "$installer"
 
     printf '%s\n' "$installer"
+}
+
+sha256_file() {
+    local checksum
+
+    checksum="$(shasum -a 256 "$1")"
+    printf '%s\n' "${checksum%% *}"
 }
 
 run_base_command() {

--- a/docs/remote-installer-policy.md
+++ b/docs/remote-installer-policy.md
@@ -8,7 +8,7 @@ decision.
 
 | Installer | URL | Where Base may use it | Opt-in |
 | --- | --- | --- | --- |
-| Homebrew | `https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh` | `bootstrap.sh`, `install.sh`, and `basectl setup` when Homebrew is missing on macOS | First-mile setup path; `bootstrap.sh --no-homebrew-install` can refuse this path |
+| Homebrew | `https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh` by default; managed environments may provide a pinned installer location with an expected SHA-256 | `bootstrap.sh`, `install.sh`, and `basectl setup` when Homebrew is missing on macOS | First-mile setup path; `bootstrap.sh --no-homebrew-install` can refuse this path |
 | Codex CLI | `https://chatgpt.com/codex/install.sh` | `basectl setup --profile ai` | Explicit `--profile ai` |
 | Claude Code | `https://claude.ai/install.sh` | `basectl setup --profile ai` | Explicit `--profile ai` |
 
@@ -26,11 +26,25 @@ non-interactive setup stays deterministic.
 ## Managed Workstations And Pinned Installers
 
 Base intentionally follows Homebrew's official mutable installer entry point
-instead of pinning a reviewed commit. Teams that require pinned, mirrored, or
-managed installer content should install Homebrew and optional AI tools through
-their workstation management system before running Base.
+instead of pinning a reviewed commit by default. Teams that require pinned,
+mirrored, or managed Homebrew installer content can opt in by setting both a
+Homebrew installer location and its expected SHA-256 before running Base:
 
-Base does not yet provide a manifest field for pinned remote installers.
+- all Homebrew entry points: `BASE_HOMEBREW_INSTALLER_URL` and
+  `BASE_HOMEBREW_INSTALLER_SHA256`
+- `install.sh` only: `BASE_INSTALL_HOMEBREW_INSTALLER_URL` and
+  `BASE_INSTALL_HOMEBREW_INSTALLER_SHA256`
+- `bootstrap.sh` only: `BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL` and
+  `BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256`
+- `basectl setup` only: `BASE_SETUP_HOMEBREW_INSTALLER_URL` and
+  `BASE_SETUP_HOMEBREW_INSTALLER_SHA256`
+
+When any pinned Homebrew installer variable is present, Base requires both the
+installer location and expected SHA-256. Missing or mismatched values fail
+closed before installer execution. Local file paths, `file://` URLs, and remote
+URLs are accepted as installer locations.
+
+Base does not provide a manifest field for arbitrary pinned remote installers.
 
 ## Logging And Redaction
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 # Base shell standards require explicit error handling instead of shell strict mode.
 
+BASE_DEFAULT_HOMEBREW_INSTALLER_URL="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+
 install_usage() {
     cat <<'EOF'
 Usage:
@@ -100,11 +102,123 @@ install_find_brew() {
     return 1
 }
 
+install_homebrew_pinned_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_INSTALL_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ||
+        -n "${BASE_INSTALL_HOMEBREW_INSTALLER_SHA256+x}" ]]
+}
+
+install_homebrew_pinned_url_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ||
+        -n "${BASE_INSTALL_HOMEBREW_INSTALLER_URL+x}" ]]
+}
+
+install_homebrew_pinned_sha256_selected() {
+    [[ -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ||
+        -n "${BASE_INSTALL_HOMEBREW_INSTALLER_SHA256+x}" ]]
+}
+
+install_homebrew_installer_url() {
+    if [[ -n "${BASE_HOMEBREW_INSTALLER_URL+x}" ]]; then
+        printf '%s\n' "$BASE_HOMEBREW_INSTALLER_URL"
+        return 0
+    fi
+    if [[ -n "${BASE_INSTALL_HOMEBREW_INSTALLER_URL+x}" ]]; then
+        printf '%s\n' "$BASE_INSTALL_HOMEBREW_INSTALLER_URL"
+        return 0
+    fi
+    printf '%s\n' "$BASE_DEFAULT_HOMEBREW_INSTALLER_URL"
+}
+
+install_homebrew_installer_sha256() {
+    if [[ -n "${BASE_HOMEBREW_INSTALLER_SHA256+x}" ]]; then
+        printf '%s\n' "$BASE_HOMEBREW_INSTALLER_SHA256"
+        return 0
+    fi
+    if [[ -n "${BASE_INSTALL_HOMEBREW_INSTALLER_SHA256+x}" ]]; then
+        printf '%s\n' "$BASE_INSTALL_HOMEBREW_INSTALLER_SHA256"
+        return 0
+    fi
+}
+
+install_fetch_homebrew_installer() {
+    local installer_url="$1"
+    local target="$2"
+    local installer_path
+
+    case "$installer_url" in
+        file://*)
+            installer_path="${installer_url#file://}"
+            cp "$installer_path" "$target"
+            ;;
+        /*|./*|../*)
+            cp "$installer_url" "$target"
+            ;;
+        *)
+            command -v curl >/dev/null 2>&1 || return 127
+            curl -fsSL "$installer_url" -o "$target"
+            ;;
+    esac
+}
+
+install_run_verified_homebrew_installer() {
+    local installer_url="$1"
+    local expected_sha256="$2"
+    local installer_file
+    local checksum
+    local actual_sha256
+    local exit_code
+
+    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || install_die "Failed to create a temporary Homebrew installer file."
+    install_fetch_homebrew_installer "$installer_url" "$installer_file" || {
+        rm -f "$installer_file"
+        install_die "Failed to read pinned Homebrew installer content from '$installer_url'."
+    }
+
+    command -v shasum >/dev/null 2>&1 || {
+        rm -f "$installer_file"
+        install_die "shasum is required to verify pinned Homebrew installer content."
+    }
+    checksum="$(shasum -a 256 "$installer_file")" || {
+        rm -f "$installer_file"
+        install_die "Failed to compute Homebrew installer checksum."
+    }
+    actual_sha256="${checksum%% *}"
+    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+        rm -f "$installer_file"
+        install_die "Homebrew installer checksum mismatch (expected $expected_sha256, got $actual_sha256)."
+    fi
+
+    /bin/bash "$installer_file"
+    exit_code=$?
+    rm -f "$installer_file"
+    [[ "$exit_code" -eq 0 ]] || install_die "Homebrew installer failed."
+}
+
 install_homebrew() {
     local installer
-    local installer_url="${BASE_INSTALL_HOMEBREW_INSTALLER_URL:-https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh}"
+    local installer_url
+    local installer_sha256
 
+    installer_url="$(install_homebrew_installer_url)"
+    installer_sha256="$(install_homebrew_installer_sha256)"
     install_log "Installing Homebrew."
+    if install_homebrew_pinned_selected; then
+        install_homebrew_pinned_url_selected &&
+            install_homebrew_pinned_sha256_selected &&
+            [[ -n "$installer_url" && -n "$installer_sha256" ]] ||
+            install_die "Pinned Homebrew installer URL and SHA-256 are both required."
+        install_log "Using pinned Homebrew installer from $installer_url."
+        if [[ "${BASE_INSTALL_DRY_RUN:-false}" == "true" ]]; then
+            install_log "[DRY-RUN] Would verify Homebrew installer SHA-256 $installer_sha256"
+            install_log "[DRY-RUN] Would run: /bin/bash <verified Homebrew installer from $installer_url>"
+            return 0
+        fi
+        install_run_verified_homebrew_installer "$installer_url" "$installer_sha256"
+        return 0
+    fi
+
     if [[ "${BASE_INSTALL_DRY_RUN:-false}" == "true" ]]; then
         install_log "[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from $installer_url>"
         return 0

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -94,6 +94,24 @@ EOF
     chmod +x "$bash_path"
 }
 
+create_homebrew_installer_stub() {
+    local installer="$TEST_TMPDIR/homebrew-installer.sh"
+
+    cat > "$installer" <<'EOF'
+#!/usr/bin/env bash
+touch "${BASE_BOOTSTRAP_TEST_MARKER:?}"
+EOF
+    chmod +x "$installer"
+    printf '%s\n' "$installer"
+}
+
+sha256_file() {
+    local checksum
+
+    checksum="$(shasum -a 256 "$1")"
+    printf '%s\n' "${checksum%% *}"
+}
+
 @test "bootstrap prints help" {
     run_bootstrap --help
 
@@ -148,6 +166,95 @@ EOF
     [[ "$output" == *"$install_dir/bin/basectl setup"* ]]
     [[ "$output" == *"$install_dir/bin/basectl update-profile"* ]]
     [[ "$output" == *"exec \"\$SHELL\" -l"* ]]
+}
+
+@test "bootstrap dry-run reports pinned Homebrew installer verification" {
+    local install_dir="$TEST_HOME/work/base"
+    local installer
+    local checksum
+
+    create_unusable_git_stub
+    installer="$(create_homebrew_installer_stub)"
+    checksum="$(sha256_file "$installer")"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_OS=Darwin \
+        BASE_BOOTSTRAP_TEST_BASH_VERSION=32 \
+        BASE_BOOTSTRAP_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        BASE_BOOTSTRAP_BREW_CANDIDATES="$TEST_TMPDIR/missing-brew" \
+        BASE_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_HOMEBREW_INSTALLER_SHA256="$checksum" \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --dry-run --source --install-dir "$install_dir" --repo-url https://example.test/base.git
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using pinned Homebrew installer from $installer."* ]]
+    [[ "$output" == *"[DRY-RUN] Would verify Homebrew installer SHA-256 $checksum"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: /bin/bash <verified Homebrew installer from $installer>"* ]]
+}
+
+@test "bootstrap rejects pinned Homebrew installer without checksum" {
+    local installer
+
+    installer="$(create_homebrew_installer_stub)"
+
+    run env \
+        BASE_BOOTSTRAP_TESTING=true \
+        BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL="$installer" \
+        "$BASH" -c 'source "$1"; bootstrap_install_homebrew resolved_brew; printf "resolved=%s\n" "$resolved_brew"' _ "$BASE_REPO_ROOT/bootstrap.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Pinned Homebrew installer URL and SHA-256 are both required."* ]]
+}
+
+@test "bootstrap rejects pinned Homebrew checksum without installer location" {
+    run env \
+        BASE_BOOTSTRAP_TESTING=true \
+        BASE_BOOTSTRAP_DRY_RUN=true \
+        BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256=0000000000000000000000000000000000000000000000000000000000000000 \
+        "$BASH" -c 'source "$1"; bootstrap_install_homebrew resolved_brew' _ "$BASE_REPO_ROOT/bootstrap.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Pinned Homebrew installer URL and SHA-256 are both required."* ]]
+}
+
+@test "bootstrap rejects mismatched pinned Homebrew installer checksum" {
+    local installer
+    local marker="$TEST_TMPDIR/homebrew-install-ran"
+
+    installer="$(create_homebrew_installer_stub)"
+
+    run env \
+        BASE_BOOTSTRAP_TESTING=true \
+        BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256=0000000000000000000000000000000000000000000000000000000000000000 \
+        BASE_BOOTSTRAP_TEST_MARKER="$marker" \
+        "$BASH" -c 'source "$1"; bootstrap_install_homebrew resolved_brew; printf "resolved=%s\n" "$resolved_brew"' _ "$BASE_REPO_ROOT/bootstrap.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Homebrew installer checksum mismatch"* ]]
+    [ ! -e "$marker" ]
+}
+
+@test "bootstrap runs verified pinned Homebrew installer" {
+    local installer
+    local checksum
+    local marker="$TEST_TMPDIR/homebrew-install-ran"
+
+    installer="$(create_homebrew_installer_stub)"
+    checksum="$(sha256_file "$installer")"
+
+    run env \
+        BASE_BOOTSTRAP_TESTING=true \
+        BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256="$checksum" \
+        BASE_BOOTSTRAP_TEST_MARKER="$marker" \
+        "$BASH" -c 'source "$1"; bootstrap_install_homebrew resolved_brew; printf "resolved=%s\n" "$resolved_brew"' _ "$BASE_REPO_ROOT/bootstrap.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using pinned Homebrew installer from $installer."* ]]
+    [ -f "$marker" ]
 }
 
 @test "bootstrap reports source clone failures without printing handoff commands" {

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -38,6 +38,24 @@ EOF
     chmod +x "$TEST_MOCKBIN/bash"
 }
 
+create_homebrew_installer_stub() {
+    local installer="$TEST_TMPDIR/homebrew-installer.sh"
+
+    cat > "$installer" <<'EOF'
+#!/usr/bin/env bash
+touch "${BASE_INSTALL_TEST_MARKER:?}"
+EOF
+    chmod +x "$installer"
+    printf '%s\n' "$installer"
+}
+
+sha256_file() {
+    local checksum
+
+    checksum="$(shasum -a 256 "$1")"
+    printf '%s\n' "${checksum%% *}"
+}
+
 create_install_source_repo() {
     local source_dir="$TEST_TMPDIR/source-repo"
 
@@ -148,6 +166,92 @@ assert_base_init_loads() {
     [[ "$output" == *"[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh>"* ]]
     [[ "$output" == *"[DRY-RUN] Would run: brew install bash"* ]]
     [[ "$output" == *"[DRY-RUN] Would run: /opt/homebrew/bin/bash $TEST_HOME/work/base/bin/basectl setup"* ]]
+}
+
+@test "installer dry-run reports pinned Homebrew installer verification" {
+    local installer
+    local checksum
+
+    installer="$(create_homebrew_installer_stub)"
+    checksum="$(sha256_file "$installer")"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_INSTALL_TEST_BASH_VERSION=32 \
+        BASE_INSTALL_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        BASE_INSTALL_BREW_CANDIDATES="$TEST_TMPDIR/missing-brew" \
+        BASE_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_HOMEBREW_INSTALLER_SHA256="$checksum" \
+        "$BASE_REPO_ROOT/install.sh" --dry-run --dir "$TEST_HOME/work/base" --no-profile
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using pinned Homebrew installer from $installer."* ]]
+    [[ "$output" == *"[DRY-RUN] Would verify Homebrew installer SHA-256 $checksum"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: /bin/bash <verified Homebrew installer from $installer>"* ]]
+}
+
+@test "installer rejects pinned Homebrew installer without checksum" {
+    local installer
+
+    installer="$(create_homebrew_installer_stub)"
+
+    run env \
+        BASE_INSTALL_TESTING=true \
+        BASE_INSTALL_HOMEBREW_INSTALLER_URL="$installer" \
+        "$BASH" -c 'source "$1"; install_homebrew' _ "$BASE_REPO_ROOT/install.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Pinned Homebrew installer URL and SHA-256 are both required."* ]]
+}
+
+@test "installer rejects pinned Homebrew checksum without installer location" {
+    run env \
+        BASE_INSTALL_TESTING=true \
+        BASE_INSTALL_DRY_RUN=true \
+        BASE_INSTALL_HOMEBREW_INSTALLER_SHA256=0000000000000000000000000000000000000000000000000000000000000000 \
+        "$BASH" -c 'source "$1"; install_homebrew' _ "$BASE_REPO_ROOT/install.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Pinned Homebrew installer URL and SHA-256 are both required."* ]]
+}
+
+@test "installer rejects mismatched pinned Homebrew installer checksum" {
+    local installer
+    local marker="$TEST_TMPDIR/homebrew-install-ran"
+
+    installer="$(create_homebrew_installer_stub)"
+
+    run env \
+        BASE_INSTALL_TESTING=true \
+        BASE_INSTALL_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_INSTALL_HOMEBREW_INSTALLER_SHA256=0000000000000000000000000000000000000000000000000000000000000000 \
+        BASE_INSTALL_TEST_MARKER="$marker" \
+        "$BASH" -c 'source "$1"; install_homebrew' _ "$BASE_REPO_ROOT/install.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Homebrew installer checksum mismatch"* ]]
+    [ ! -e "$marker" ]
+}
+
+@test "installer runs verified pinned Homebrew installer" {
+    local installer
+    local checksum
+    local marker="$TEST_TMPDIR/homebrew-install-ran"
+
+    installer="$(create_homebrew_installer_stub)"
+    checksum="$(sha256_file "$installer")"
+
+    run env \
+        BASE_INSTALL_TESTING=true \
+        BASE_INSTALL_HOMEBREW_INSTALLER_URL="$installer" \
+        BASE_INSTALL_HOMEBREW_INSTALLER_SHA256="$checksum" \
+        BASE_INSTALL_TEST_MARKER="$marker" \
+        "$BASH" -c 'source "$1"; install_homebrew' _ "$BASE_REPO_ROOT/install.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using pinned Homebrew installer from $installer."* ]]
+    [ -f "$marker" ]
 }
 
 @test "installer rejects an existing non-git install path" {


### PR DESCRIPTION
Adds opt-in pinned Homebrew installer support across install.sh, bootstrap.sh, and basectl setup; validates URL/path plus SHA-256 before execution; full ./bin/base-test passed locally. Closes #1091