### PR TITLE
Redact setup command arguments

### DIFF
--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -18,9 +18,11 @@ from .errors import ArtifactError
 
 
 COMMAND_OUTPUT_TAIL_CHARS = 4000
+REDACTED = "[REDACTED]"
 SECRET_VALUE_RE = re.compile(
     r"(?i)(?P<name>[A-Za-z0-9_.:-]*(?:token|password|secret|api[-_]?key|authorization)[A-Za-z0-9_.:-]*)=\S+"
 )
+SECRET_NAME_RE = re.compile(r"(?i)(?:token|password|secret|api[-_]?key|authorization)")
 URL_CREDENTIALS_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/\s:@]+:[^@\s/]+@")
 HOMEBREW_LINK_FAILURE = "The `brew link` step did not complete successfully"
 HOMEBREW_LINK_DRY_RUN_RE = re.compile(r"(?m)^\s*(brew link --overwrite [^\r\n]+ --dry-run)\s*$")
@@ -123,7 +125,7 @@ def run_command(
         for thread in threads:
             thread.join()
     if returncode:
-        message = f"Command failed with exit {returncode}: {redact_command_output(format_command(command))}"
+        message = f"Command failed with exit {returncode}: {format_command_for_logging(command)}"
         stdout_tail = stdout_recorder.text()
         stderr_tail = stderr_recorder.text()
         if stdout_tail:
@@ -135,20 +137,50 @@ def run_command(
             message = f"{message}\n\n{guidance}"
         raise ArtifactError(message)
     if cwd is not None:
-        ctx.log.debug("Command succeeded in '%s': %s", cwd, format_command(command))
+        ctx.log.debug("Command succeeded in '%s': %s", cwd, format_command_for_logging(command))
     else:
-        ctx.log.debug("Command succeeded: %s", format_command(command))
+        ctx.log.debug("Command succeeded: %s", format_command_for_logging(command))
 
 
 def dry_run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = None) -> None:
     if cwd is not None:
-        ctx.log.info("[DRY-RUN] Would run in '%s': %s", cwd, format_command(command))
+        ctx.log.info("[DRY-RUN] Would run in '%s': %s", cwd, format_command_for_logging(command))
         return
-    ctx.log.info("[DRY-RUN] Would run: %s", format_command(command))
+    ctx.log.info("[DRY-RUN] Would run: %s", format_command_for_logging(command))
 
 
 def format_command(command: list[str]) -> str:
     return shlex.join(command)
+
+
+def format_command_for_logging(command: list[str]) -> str:
+    return format_command(redact_command_argv(command))
+
+
+def redact_command_argv(command: list[str]) -> list[str]:
+    redacted: list[str] = []
+    redact_next = False
+    for arg in command:
+        if redact_next:
+            redacted.append(REDACTED)
+            redact_next = False
+            continue
+
+        option, separator, _value = arg.partition("=")
+        if option.startswith("--") and SECRET_NAME_RE.search(option):
+            if separator:
+                redacted.append(f"{option}={REDACTED}")
+            else:
+                redacted.append(option)
+                redact_next = True
+            continue
+
+        if separator and SECRET_NAME_RE.search(option):
+            redacted.append(f"{option}={REDACTED}")
+            continue
+
+        redacted.append(redact_command_output(arg))
+    return redacted
 
 
 def redact_command_output(text: str) -> str:

--- a/cli/python/base_setup/tests/test_process_redaction.py
+++ b/cli/python/base_setup/tests/test_process_redaction.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+
+from base_setup import process
+from base_setup.errors import ArtifactError
+from base_setup.tests.helpers import fake_context
+
+
+class ProcessCommandRedactionTests(unittest.TestCase):
+    def test_run_command_redacts_sensitive_command_arguments_from_failure(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            "import sys; raise SystemExit(9)",
+            "--token",
+            "super-secret",
+            "--api-key=api-secret",
+            "https://user:url-secret@example.invalid/pkg.whl",
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            with self.assertRaises(ArtifactError) as exc:
+                process.run_command(ctx, command)
+
+        message = str(exc.exception)
+        self.assertNotIn("super-secret", message)
+        self.assertNotIn("api-secret", message)
+        self.assertNotIn("url-secret", message)
+        self.assertIn("[REDACTED]", message)
+
+    def test_run_command_redacts_sensitive_command_arguments_from_success_logs(self) -> None:
+        ctx = fake_context()
+        command = [
+            sys.executable,
+            "-c",
+            "import sys; assert sys.argv[1:]",
+            "--token",
+            "super-secret",
+            "--api-key=api-secret",
+            "https://user:url-secret@example.invalid/pkg.whl",
+        ]
+
+        process.run_command(ctx, command)
+
+        debug_text = "\n".join(str(call.args) for call in ctx.log.debug.call_args_list)
+        self.assertNotIn("super-secret", debug_text)
+        self.assertNotIn("api-secret", debug_text)
+        self.assertNotIn("url-secret", debug_text)
+        self.assertIn("[REDACTED]", debug_text)
+
+    def test_dry_run_command_redacts_sensitive_command_arguments(self) -> None:
+        ctx = fake_context()
+        command = [
+            "pip",
+            "install",
+            "--token",
+            "super-secret",
+            "--api-key=api-secret",
+            "https://user:url-secret@example.invalid/pkg.whl",
+        ]
+
+        process.dry_run_command(ctx, command)
+
+        info_text = "\n".join(str(call.args) for call in ctx.log.info.call_args_list)
+        self.assertNotIn("super-secret", info_text)
+        self.assertNotIn("api-secret", info_text)
+        self.assertNotIn("url-secret", info_text)
+        self.assertIn("[REDACTED]", info_text)


### PR DESCRIPTION
## Summary
- Redact sensitive setup command arguments before formatting command lines for errors, debug logs, and dry-run logs.
- Add tests for split secret flags, equals-form secret flags, and credential-bearing URLs across failure, success, and dry-run paths.

## Issue
Fixes #1129

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py -q -k 'sensitive_command_arguments'`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q`

## Security Notes
- Prevents token, API key, authorization, password, secret, and URL credential values from being written through Base setup command display paths.
