### PR TITLE
Ignore inherited update source guard state

### DIFF
--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 
-[[ -n "${_base_update_subcommand_sourced:-}" ]] && return 0
+if [[ -n "${_base_update_subcommand_sourced:-}" ]]; then
+    # Source guards are shell-local. Ignore exported sentinels inherited from a
+    # parent process so test and command shells still load their definitions.
+    case "$(declare -p _base_update_subcommand_sourced 2>/dev/null)" in
+        declare\ -*x*)
+            unset _base_update_subcommand_sourced 2>/dev/null || return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+fi
 _base_update_subcommand_sourced=1
 readonly _base_update_subcommand_sourced
 

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -2,6 +2,16 @@
 
 load ./basectl_helpers.bash
 
+assert_status() {
+    local expected="$1"
+
+    if [ "$status" -ne "$expected" ]; then
+        printf 'expected status %s, got %s\n' "$expected" "$status" >&3
+        printf 'output:\n%s\n' "$output" >&3
+        return 1
+    fi
+}
+
 
 @test "basectl update prints help" {
     run_basectl update --help
@@ -69,7 +79,22 @@ load ./basectl_helpers.bash
             base_update_subcommand_main demo other
         '
 
-    [ "$status" -eq 2 ]
+    assert_status 2
+    [[ "$output" == *"The 'update' command accepts at most one project name."* ]]
+}
+
+@test "basectl update ignores inherited source guard state" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        _base_update_subcommand_sourced=1 \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_subcommand_main demo other
+        '
+
+    assert_status 2
     [[ "$output" == *"The 'update' command accepts at most one project name."* ]]
 }
 
@@ -83,7 +108,7 @@ load ./basectl_helpers.bash
             base_update_subcommand_main --mystery
         '
 
-    [ "$status" -eq 2 ]
+    assert_status 2
     [[ "$output" == *"Unknown option '--mystery'."* ]]
     [[ "$output" == *"Usage:"* ]]
 }


### PR DESCRIPTION
Ignores inherited exported update source-guard state, adds a regression for #1114, and keeps same-shell re-source behavior intact. Local validation: focused update BATS, source_guards BATS, bash -n, git diff --check, and basectl test base. Fixes #1114