### PR TITLE
Bound diagnostic subprocess probes

### DIFF
--- a/cli/python/base_dev/ai_tools.py
+++ b/cli/python/base_dev/ai_tools.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import base_cli
 from base_setup.errors import ArtifactError
-from base_setup.process import dry_run_command, run_command
+from base_setup.process import DIAGNOSTIC_TIMEOUT_SECONDS, dry_run_command, run_command
 
 from .checks import DevCheck
 
@@ -106,13 +106,28 @@ def check_ai_tool(tool: AITool) -> DevCheck:
         )
 
     command = [executable_path, *tool.version_args]
-    completed = subprocess.run(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-    )
+    version_command = " ".join([tool.name, *tool.version_args])
+    try:
+        completed = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return DevCheck(
+            name=tool.name,
+            ok=False,
+            message=(
+                f"{tool.display_name} version check timed out after "
+                f"{DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry '{version_command}' or run '{_profile_setup_fix('ai')}'.",
+            status="warn",
+            finding_id="BASE-D107",
+        )
     if completed.returncode != 0:
         detail = summarize_command_output(completed.stderr) or summarize_command_output(completed.stdout)
         message = f"{tool.display_name} version check failed with exit {completed.returncode}."

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -9,7 +10,7 @@ from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.artifacts import homebrew_package_outdated, reconcile_artifact, resolve_artifact_definitions
 from base_setup.errors import ArtifactError
 from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError, read_manifest
-from base_setup.process import command_exists, run_check
+from base_setup.process import DIAGNOSTIC_TIMEOUT_SECONDS, command_exists, run_check
 from base_setup.registry import ArtifactDefinition
 
 from .ai_tools import ai_tool_checks, setup_ai_tools
@@ -373,7 +374,7 @@ def profile_setup_fix(profile: str) -> str:
     return f"basectl setup --profile {profile}"
 
 
-def check_homebrew_artifact(
+def check_homebrew_artifact(  # pylint: disable=too-many-return-statements
     artifact: ArtifactRequest,
     definition: ArtifactDefinition,
     profile: str = "dev",
@@ -406,8 +407,30 @@ def check_homebrew_artifact(
             finding_id="BASE-D103",
         )
 
-    if run_check(["brew", "list", definition.package]):
-        if homebrew_package_outdated(definition.package):
+    try:
+        installed = run_check(
+            ["brew", "list", definition.package],
+            timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+        outdated = installed and homebrew_package_outdated(
+            definition.package,
+            timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return DevCheck(
+            name=artifact.name,
+            ok=False,
+            message=(
+                f"Homebrew check for artifact '{artifact.name}' timed out after "
+                f"{DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry 'basectl doctor --profile {profile}' or inspect Homebrew with 'brew doctor'.",
+            status="warn",
+            finding_id="BASE-D104",
+        )
+
+    if installed:
+        if outdated:
             return DevCheck(
                 name=artifact.name,
                 ok=False,
@@ -444,7 +467,20 @@ def check_github_cli_auth() -> DevCheck:
             finding_id="BASE-D105",
         )
 
-    ok = run_check(["gh", "auth", "status"])
+    try:
+        ok = run_check(
+            ["gh", "auth", "status", "-h", "github.com"],
+            timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return DevCheck(
+            name="gh-auth",
+            ok=False,
+            message=f"GitHub CLI authentication check timed out after {DIAGNOSTIC_TIMEOUT_SECONDS} seconds.",
+            fix="Retry 'gh auth status -h github.com' or run 'gh auth login -h github.com'.",
+            status="warn",
+            finding_id="BASE-D106",
+        )
     if ok:
         return DevCheck(
             name="gh-auth",

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -222,6 +222,40 @@ class DevManifestTests(unittest.TestCase):
             ],
         )
 
+    def test_check_ai_tool_warns_when_version_probe_times_out(self) -> None:
+        tool = ai_tools.AITool(
+            name="codex",
+            display_name="Codex CLI",
+            version_args=("--version",),
+            installer_url="https://chatgpt.com/codex/install.sh",
+            installer_shell="sh",
+        )
+
+        with (
+            mock.patch("base_dev.ai_tools.shutil.which", return_value="/tmp/bin/codex"),
+            mock.patch(
+                "base_dev.ai_tools.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(
+                    ["/tmp/bin/codex", "--version"],
+                    ai_tools.DIAGNOSTIC_TIMEOUT_SECONDS,
+                ),
+            ) as run,
+        ):
+            check = ai_tools.check_ai_tool(tool)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, "Retry 'codex --version' or run 'basectl setup --profile ai'.")
+        run.assert_called_once_with(
+            ["/tmp/bin/codex", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=ai_tools.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_check_profile_sre_reports_sre_fix_guidance(self) -> None:
         with (
@@ -389,14 +423,15 @@ class DevManifestTests(unittest.TestCase):
             stderr="",
         )
 
-        def fake_run_check(command: list[str]) -> bool:
+        def fake_run_check(command: list[str], **kwargs: object) -> bool:
+            self.assertEqual(kwargs.get("timeout_seconds"), engine.DIAGNOSTIC_TIMEOUT_SECONDS)
             if command == ["brew", "list", "bats-core"]:
                 return True
             if command == ["brew", "list", "gh"]:
                 return True
             if command == ["brew", "list", "shellcheck"]:
                 return True
-            if command == ["gh", "auth", "status"]:
+            if command == ["gh", "auth", "status", "-h", "github.com"]:
                 return False
             raise AssertionError(f"Unexpected command: {command}")
 
@@ -494,7 +529,10 @@ class DevManifestTests(unittest.TestCase):
         self.assertEqual(check.name, "gh")
         self.assertEqual(check.fix, "")
         self.assertIn("is installed via Homebrew package 'gh'", check.message)
-        run_check.assert_called_once_with(["brew", "list", "gh"])
+        run_check.assert_called_once_with(
+            ["brew", "list", "gh"],
+            timeout_seconds=engine.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
     def test_check_homebrew_artifact_reports_outdated_formula(self) -> None:
         artifact = engine.ArtifactRequest("tool", "gh", "latest")
@@ -532,7 +570,33 @@ class DevManifestTests(unittest.TestCase):
         self.assertFalse(check.ok)
         self.assertEqual(check.fix, "basectl setup --profile dev")
         self.assertIn("is not installed via Homebrew package 'bats-core'", check.message)
-        run_check.assert_called_once_with(["brew", "list", "bats-core"])
+        run_check.assert_called_once_with(
+            ["brew", "list", "bats-core"],
+            timeout_seconds=engine.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+
+    def test_check_homebrew_artifact_warns_when_probe_times_out(self) -> None:
+        artifact = engine.ArtifactRequest("tool", "gh", "latest")
+        definition = engine.ArtifactDefinition("gh", "tool", "homebrew", "gh", "system")
+
+        with (
+            mock.patch("base_dev.engine.command_exists", return_value=True),
+            mock.patch(
+                "base_dev.engine.run_check",
+                side_effect=subprocess.TimeoutExpired(["brew", "list", "gh"], engine.DIAGNOSTIC_TIMEOUT_SECONDS),
+            ) as run_check,
+        ):
+            check = engine.check_homebrew_artifact(artifact, definition)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.finding_id, "BASE-D104")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, "Retry 'basectl doctor --profile dev' or inspect Homebrew with 'brew doctor'.")
+        run_check.assert_called_once_with(
+            ["brew", "list", "gh"],
+            timeout_seconds=engine.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
     def test_check_homebrew_artifact_reports_missing_homebrew(self) -> None:
         artifact = engine.ArtifactRequest("tool", "gh", "latest")
@@ -629,7 +693,10 @@ class DevManifestTests(unittest.TestCase):
         self.assertFalse(check.ok)
         self.assertEqual(check.message, "GitHub CLI authentication is not ready.")
         self.assertEqual(check.fix, "gh auth login -h github.com")
-        run_check.assert_called_once_with(["gh", "auth", "status"])
+        run_check.assert_called_once_with(
+            ["gh", "auth", "status", "-h", "github.com"],
+            timeout_seconds=engine.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
     def test_check_github_cli_auth_reports_authenticated_gh(self) -> None:
         with (
@@ -641,7 +708,32 @@ class DevManifestTests(unittest.TestCase):
         self.assertTrue(check.ok)
         self.assertEqual(check.message, "GitHub CLI authentication is ready.")
         self.assertEqual(check.fix, "")
-        run_check.assert_called_once_with(["gh", "auth", "status"])
+        run_check.assert_called_once_with(
+            ["gh", "auth", "status", "-h", "github.com"],
+            timeout_seconds=engine.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+
+    def test_check_github_cli_auth_warns_when_probe_times_out(self) -> None:
+        with (
+            mock.patch("base_dev.engine.command_exists", return_value=True),
+            mock.patch(
+                "base_dev.engine.run_check",
+                side_effect=subprocess.TimeoutExpired(
+                    ["gh", "auth", "status", "-h", "github.com"],
+                    engine.DIAGNOSTIC_TIMEOUT_SECONDS,
+                ),
+            ) as run_check,
+        ):
+            check = engine.check_github_cli_auth()
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, "Retry 'gh auth status -h github.com' or run 'gh auth login -h github.com'.")
+        run_check.assert_called_once_with(
+            ["gh", "auth", "status", "-h", "github.com"],
+            timeout_seconds=engine.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
     def test_doctor_returns_number_of_failed_manifest_artifacts(self) -> None:
         manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
@@ -669,14 +761,15 @@ class DevManifestTests(unittest.TestCase):
             stderr="",
         )
 
-        def fake_run_check(command: list[str]) -> bool:
+        def fake_run_check(command: list[str], **kwargs: object) -> bool:
+            self.assertEqual(kwargs.get("timeout_seconds"), engine.DIAGNOSTIC_TIMEOUT_SECONDS)
             if command == ["brew", "list", "bats-core"]:
                 return True
             if command == ["brew", "list", "gh"]:
                 return True
             if command == ["brew", "list", "shellcheck"]:
                 return True
-            if command == ["gh", "auth", "status"]:
+            if command == ["gh", "auth", "status", "-h", "github.com"]:
                 return False
             raise AssertionError(f"Unexpected command: {command}")
 

--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -36,10 +36,11 @@ def homebrew_no_auto_update_env() -> dict[str, str]:
     return env
 
 
-def homebrew_package_outdated(package: str) -> bool:
+def homebrew_package_outdated(package: str, timeout_seconds: int | None = None) -> bool:
     completed = process.run_capture(
         ["brew", "outdated", package],
         env=homebrew_no_auto_update_env(),
+        timeout_seconds=timeout_seconds,
     )
     return homebrew_outdated_output_contains_package(completed.stdout, package)
 
@@ -154,8 +155,31 @@ def check_homebrew_artifact(
             finding_id="BASE-P032",
             details=artifact_details(definition),
         )
-    if process.run_check(["brew", "list", definition.package]):
-        if homebrew_package_outdated(definition.package):
+    try:
+        installed = process.run_check(
+            ["brew", "list", definition.package],
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+        outdated = installed and homebrew_package_outdated(
+            definition.package,
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return ArtifactCheck(
+            name=artifact.name,
+            ok=False,
+            message=(
+                f"Homebrew check for artifact '{artifact.name}' timed out after "
+                f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry 'basectl doctor {project}' or inspect Homebrew with 'brew doctor'.",
+            finding_id="BASE-P033",
+            status="warn",
+            details=artifact_details(definition),
+        )
+
+    if installed:
+        if outdated:
             return ArtifactCheck(
                 name=artifact.name,
                 ok=False,

--- a/cli/python/base_setup/delegates.py
+++ b/cli/python/base_setup/delegates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -34,7 +35,24 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             finding_id="BASE-P011",
         )
 
-    ok = process.run_check(["brew", "bundle", "check", f"--file={brewfile_path}"], env=homebrew_no_auto_update_env())
+    try:
+        ok = process.run_check(
+            ["brew", "bundle", "check", f"--file={brewfile_path}"],
+            env=homebrew_no_auto_update_env(),
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return ArtifactCheck(
+            name="brewfile",
+            ok=False,
+            message=(
+                f"Homebrew Brewfile check for '{brewfile_path}' timed out after "
+                f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry 'basectl doctor {manifest.project_name}' or inspect Homebrew with 'brew doctor'.",
+            status="warn",
+            finding_id="BASE-P012",
+        )
     if ok:
         return ArtifactCheck(
             name="brewfile",
@@ -95,7 +113,25 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
 
 
 def check_mise_trust(project_root: Path, mise_path: Path, details: dict[str, object]) -> ArtifactCheck | None:
-    trust_check = process.run_capture(["mise", "trust", "--show"], cwd=project_root)
+    try:
+        trust_check = process.run_capture(
+            ["mise", "trust", "--show"],
+            cwd=project_root,
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=(
+                f"mise trust status check for '{mise_path}' timed out after "
+                f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry 'mise trust --show' in '{project_root}'.",
+            status="warn",
+            finding_id="BASE-P022",
+            details=details,
+        )
     trust_text = command_text(trust_check.stdout, trust_check.stderr)
     if trust_check.returncode != 0:
         return ArtifactCheck(
@@ -135,7 +171,25 @@ def check_mise_missing_tools(
     mise_path: Path,
     details: dict[str, object],
 ) -> ArtifactCheck | None:
-    missing_check = process.run_capture(["mise", "ls", "--missing", "--json"], cwd=project_root)
+    try:
+        missing_check = process.run_capture(
+            ["mise", "ls", "--missing", "--json"],
+            cwd=project_root,
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return ArtifactCheck(
+            name="mise",
+            ok=False,
+            message=(
+                f"mise missing-tool status check for '{mise_path}' timed out after "
+                f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry 'mise ls --missing --json' in '{project_root}'.",
+            status="warn",
+            finding_id="BASE-P022",
+            details=details,
+        )
     if missing_check.returncode != 0:
         missing_text = command_text(missing_check.stdout, missing_check.stderr)
         if mise_config_untrusted(missing_text):
@@ -209,7 +263,11 @@ def reconcile_brewfile(ctx: base_cli.Context, manifest: BaseManifest, dry_run: b
         raise ArtifactError(f"Homebrew is required to install Brewfile dependencies from '{brewfile_path}'.")
 
     env = homebrew_no_auto_update_env()
-    if process.run_check(check_command, env=env):
+    if process.run_check(
+        check_command,
+        env=env,
+        timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+    ):
         ctx.log.info("Brewfile dependencies are already satisfied for '%s'.", brewfile_path)
         return
 

--- a/cli/python/base_setup/ide.py
+++ b/cli/python/base_setup/ide.py
@@ -232,13 +232,17 @@ def reconcile_ide_extensions(ctx: base_cli.Context, manifest: BaseManifest, dry_
 
 
 def list_ide_extensions(definition: IdeDefinition) -> set[str]:
-    completed = subprocess.run(
-        [definition.cli, "--list-extensions"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-    )
+    try:
+        completed = process.run_capture(
+            [definition.cli, "--list-extensions"],
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ArtifactError(
+            f"Unable to list {definition.label} extensions with "
+            f"'{definition.cli} --list-extensions': timed out after "
+            f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+        ) from exc
     if completed.returncode:
         stderr = (completed.stderr or "").strip()
         message = f"Unable to list {definition.label} extensions with '{definition.cli} --list-extensions'."
@@ -474,7 +478,23 @@ def check_ide_install(project: str, definition: IdeDefinition) -> ArtifactCheck:
             finding_id="BASE-P130",
         )
 
-    cask_installed = process.run_check(["brew", "list", "--cask", definition.cask])
+    try:
+        cask_installed = process.run_check(
+            ["brew", "list", "--cask", definition.cask],
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return ArtifactCheck(
+            name=f"{definition.label} app",
+            ok=False,
+            message=(
+                f"Homebrew cask check for {definition.label} timed out after "
+                f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry 'basectl doctor {project}' or inspect Homebrew with 'brew doctor'.",
+            status="warn",
+            finding_id="BASE-P131",
+        )
     cli_available = process.command_exists(definition.cli)
 
     if cask_installed and cli_available:

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -18,6 +18,7 @@ from .errors import ArtifactError
 
 
 COMMAND_OUTPUT_TAIL_CHARS = 4000
+DIAGNOSTIC_TIMEOUT_SECONDS = 10
 REDACTED = "[REDACTED]"
 SECRET_VALUE_RE = re.compile(
     r"(?i)(?P<name>[A-Za-z0-9_.:-]*(?:token|password|secret|api[-_]?key|authorization)[A-Za-z0-9_.:-]*)=\S+"
@@ -80,6 +81,7 @@ def run_capture(
     command: list[str],
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
+    timeout_seconds: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
@@ -89,6 +91,7 @@ def run_capture(
         stderr=subprocess.PIPE,
         text=True,
         check=False,
+        timeout=timeout_seconds,
     )
 
 

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -493,6 +493,33 @@ class ArtifactReconcileTests(unittest.TestCase):
         )
         self.assertEqual(run_capture.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
 
+    def test_check_homebrew_artifact_warns_when_probe_times_out(self) -> None:
+        definition = get_artifact_definition("tool", "terraform")
+        self.assertIsNotNone(definition)
+        artifact = ArtifactRequest("tool", "terraform", "latest")
+
+        with (
+            mock.patch("base_setup.process.command_exists", return_value=True),
+            mock.patch(
+                "base_setup.process.run_check",
+                side_effect=subprocess.TimeoutExpired(
+                    ["brew", "list", "terraform"],
+                    process.DIAGNOSTIC_TIMEOUT_SECONDS,
+                ),
+            ) as run_check,
+        ):
+            check = artifacts.check_homebrew_artifact("demo", artifact, definition)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.finding_id, "BASE-P033")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, "Retry 'basectl doctor demo' or inspect Homebrew with 'brew doctor'.")
+        run_check.assert_called_once_with(
+            ["brew", "list", "terraform"],
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+
 
     def test_python_artifact_honors_project_venv_dir_override(self) -> None:
         definition = get_artifact_definition("python-package", "requests")

--- a/cli/python/base_setup/tests/test_brewfile.py
+++ b/cli/python/base_setup/tests/test_brewfile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -55,8 +56,45 @@ class BrewfileTests(unittest.TestCase):
         run_check.assert_called_once_with(
             ["brew", "bundle", "check", f"--file={expected_brewfile}"],
             env=mock.ANY,
+            timeout_seconds=delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
         )
         self.assertEqual(run_check.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
+
+    def test_brewfile_check_warns_when_probe_times_out(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            brewfile = project_root / "Brewfile"
+            brewfile.write_text("brew \"jq\"\n", encoding="utf-8")
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+            expected_brewfile = brewfile.resolve()
+
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch(
+                    "base_setup.process.run_check",
+                    side_effect=subprocess.TimeoutExpired(
+                        ["brew", "bundle", "check", f"--file={expected_brewfile}"],
+                        delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+                    ),
+                ) as run_check,
+            ):
+                check = delegates.check_brewfile(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.finding_id, "BASE-P012")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, "Retry 'basectl doctor demo' or inspect Homebrew with 'brew doctor'.")
+        run_check.assert_called_once_with(
+            ["brew", "bundle", "check", f"--file={expected_brewfile}"],
+            env=mock.ANY,
+            timeout_seconds=delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
     def test_brewfile_skips_brew_bundle_when_dependencies_are_satisfied(self) -> None:
         ctx = fake_context()
@@ -82,6 +120,7 @@ class BrewfileTests(unittest.TestCase):
         run_check.assert_called_once_with(
             ["brew", "bundle", "check", f"--file={expected_brewfile}"],
             env=mock.ANY,
+            timeout_seconds=delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
         )
         self.assertEqual(run_check.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
         run_command.assert_not_called()

--- a/cli/python/base_setup/tests/test_ide_extensions.py
+++ b/cli/python/base_setup/tests/test_ide_extensions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -120,12 +121,16 @@ class IdeExtensionTests(unittest.TestCase):
         definition = ide.IDE_DEFINITIONS["vscode"]
 
         with mock.patch(
-            "base_setup.ide.subprocess.run",
+            "base_setup.ide.process.run_capture",
             return_value=mock.Mock(returncode=0, stdout="ms-python.python\n\ngithub.copilot\n", stderr=""),
-        ):
+        ) as run_capture:
             extensions = ide.list_ide_extensions(definition)
 
         self.assertEqual(extensions, {"ms-python.python", "github.copilot"})
+        run_capture.assert_called_once_with(
+            ["code", "--list-extensions"],
+            timeout_seconds=ide.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
 
 
@@ -133,10 +138,23 @@ class IdeExtensionTests(unittest.TestCase):
         definition = ide.IDE_DEFINITIONS["cursor"]
 
         with mock.patch(
-            "base_setup.ide.subprocess.run",
+            "base_setup.ide.process.run_capture",
             return_value=mock.Mock(returncode=1, stdout="", stderr="extensions unavailable\n"),
         ):
             with self.assertRaisesRegex(ArtifactError, "extensions unavailable"):
+                ide.list_ide_extensions(definition)
+
+    def test_list_ide_extensions_reports_timeout(self) -> None:
+        definition = ide.IDE_DEFINITIONS["vscode"]
+
+        with mock.patch(
+            "base_setup.ide.process.run_capture",
+            side_effect=subprocess.TimeoutExpired(
+                ["code", "--list-extensions"],
+                ide.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+            ),
+        ):
+            with self.assertRaisesRegex(ArtifactError, "timed out"):
                 ide.list_ide_extensions(definition)
 
 

--- a/cli/python/base_setup/tests/test_ide_installs.py
+++ b/cli/python/base_setup/tests/test_ide_installs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -96,6 +97,27 @@ class IdeInstallTests(unittest.TestCase):
         self.assertEqual(check.name, "VS Code app")
         self.assertIn("Homebrew cask 'visual-studio-code'", check.message)
         self.assertEqual(check.fix, "basectl setup demo")
+
+    def test_check_ide_install_warns_when_cask_probe_times_out(self) -> None:
+        definition = ide.IDE_DEFINITIONS["vscode"]
+
+        with mock.patch("base_setup.process.command_exists", return_value=True), mock.patch(
+            "base_setup.process.run_check",
+            side_effect=subprocess.TimeoutExpired(
+                ["brew", "list", "--cask", "visual-studio-code"],
+                ide.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+            ),
+        ) as run_check:
+            check = ide.check_ide_install("demo", definition)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, "Retry 'basectl doctor demo' or inspect Homebrew with 'brew doctor'.")
+        run_check.assert_called_once_with(
+            ["brew", "list", "--cask", "visual-studio-code"],
+            timeout_seconds=ide.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
 
 

--- a/cli/python/base_setup/tests/test_mise.py
+++ b/cli/python/base_setup/tests/test_mise.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -144,6 +145,35 @@ class MiseTests(unittest.TestCase):
         self.assertEqual(check.fix, f"mise trust {project_root.resolve() / '.mise.toml'}")
         self.assertEqual(log_lines, [f"{project_root.resolve()} trust --show"])
 
+    def test_mise_check_warns_when_trust_probe_times_out(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = make_manifest(project_root)
+
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch(
+                    "base_setup.process.run_capture",
+                    side_effect=subprocess.TimeoutExpired(
+                        ["mise", "trust", "--show"],
+                        delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+                    ),
+                ) as run_capture,
+            ):
+                check = delegates.check_mise(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.finding_id, "BASE-P022")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, f"Retry 'mise trust --show' in '{project_root.resolve()}'.")
+        run_capture.assert_called_once_with(
+            ["mise", "trust", "--show"],
+            cwd=project_root.resolve(),
+            timeout_seconds=delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+
 
     def test_mise_check_reports_missing_tools(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -184,6 +214,47 @@ class MiseTests(unittest.TestCase):
         self.assertEqual(check.status, "warn")
         self.assertIn("could not be parsed", check.message)
         self.assertEqual(check.fix, f"Run 'mise ls --missing --json' in '{project_root.resolve()}' for details.")
+
+    def test_mise_check_warns_when_missing_tools_probe_times_out(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = make_manifest(project_root)
+            trust_check = subprocess.CompletedProcess(
+                ["mise", "trust", "--show"],
+                0,
+                stdout=f"{project_root.resolve()}: trusted",
+                stderr="",
+            )
+
+            with (
+                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch(
+                    "base_setup.process.run_capture",
+                    side_effect=[
+                        trust_check,
+                        subprocess.TimeoutExpired(
+                            ["mise", "ls", "--missing", "--json"],
+                            delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+                        ),
+                    ],
+                ) as run_capture,
+            ):
+                check = delegates.check_mise(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.finding_id, "BASE-P022")
+        self.assertIn("timed out", check.message)
+        self.assertEqual(check.fix, f"Retry 'mise ls --missing --json' in '{project_root.resolve()}'.")
+        self.assertEqual(
+            run_capture.call_args_list[0].kwargs["timeout_seconds"],
+            delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            run_capture.call_args_list[1].kwargs["timeout_seconds"],
+            delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
 
 
 

--- a/cli/python/base_setup/tests/test_process_redaction.py
+++ b/cli/python/base_setup/tests/test_process_redaction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import subprocess
 import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -11,6 +12,24 @@ from base_setup.tests.helpers import fake_context
 
 
 class ProcessCommandRedactionTests(unittest.TestCase):
+    def test_run_capture_passes_timeout_to_subprocess(self) -> None:
+        completed = subprocess.CompletedProcess(["tool", "--version"], 0, stdout="ok\n", stderr="")
+
+        with unittest.mock.patch("base_setup.process.subprocess.run", return_value=completed) as run:
+            result = process.run_capture(["tool", "--version"], timeout_seconds=7)
+
+        self.assertIs(result, completed)
+        run.assert_called_once_with(
+            ["tool", "--version"],
+            cwd=None,
+            env=None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=7,
+        )
+
     def test_run_command_redacts_sensitive_command_arguments_from_failure(self) -> None:
         ctx = fake_context()
         stdout = io.StringIO()


### PR DESCRIPTION
## Summary

- Add a shared diagnostic subprocess timeout budget and timeout support to `run_capture`.
- Bound read-only Homebrew, GitHub auth, Brewfile, mise, IDE, and AI tool probes.
- Convert timed-out probes into warning diagnostics with recovery guidance.

## Validation

- `PYTHONPATH=cli/python:lib/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_process_redaction.py cli/python/base_dev/tests/test_engine.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_brewfile.py cli/python/base_setup/tests/test_mise.py cli/python/base_setup/tests/test_ide_extensions.py cli/python/base_setup/tests/test_ide_installs.py -q`
- `PYTHONPATH=cli/python:lib/python $HOME/.base.d/base/.venv/bin/python -m pytest -q`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1150 ./bin/base-test`

## Demo Impact

None. Diagnostics-only hardening.

Fixes #1150
