### PR TITLE
Validate release title placeholders

### DIFF
--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -13,6 +13,7 @@ from base_cli.ide_schema import parse_ide_settings
 from base_setup.github_manifest import GithubConfig
 from base_setup.github_manifest import GithubManifestError
 from base_setup.github_manifest import read_github_config
+from base_setup.release_title import release_title_template_error
 
 try:
     import yaml
@@ -417,7 +418,7 @@ def _read_release_github(path: Path, github_data: Any) -> ReleaseGithubConfig:
         raise ManifestError(f"{path}: release.github has unsupported keys: {', '.join(unknown_keys)}.")
 
     repository = _read_release_repository(path, "release.github.repository", github_data.get("repository"))
-    release_title = _read_release_string(
+    release_title = _read_release_title(
         path,
         "release.github.release_title",
         github_data.get("release_title", "{repository} v{version}"),
@@ -522,6 +523,13 @@ def _read_release_string(path: Path, field_name: str, value: Any) -> str:
     if _has_control_line_break(value):
         raise ManifestError(f"{path}: {field_name} must not contain control line breaks.")
     return value
+
+
+def _read_release_title(path: Path, field_name: str, value: Any) -> str:
+    title = _read_release_string(path, field_name, value)
+    if error := release_title_template_error(title):
+        raise ManifestError(f"{path}: {field_name} {error}")
+    return title
 
 
 def _read_build_default(

--- a/cli/python/base_setup/release_title.py
+++ b/cli/python/base_setup/release_title.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import string
+
+
+RELEASE_TITLE_PLACEHOLDERS = {"repository", "version", "tag"}
+ALLOWED_RELEASE_TITLE_PLACEHOLDERS = "{repository}, {version}, {tag}"
+
+
+def release_title_template_error(value: str) -> str:
+    try:
+        parts = tuple(string.Formatter().parse(value))
+    except ValueError:
+        return f"must use valid placeholders: {ALLOWED_RELEASE_TITLE_PLACEHOLDERS}."
+
+    unsupported: list[str] = []
+    for _literal, placeholder, _format_spec, _conversion in parts:
+        if placeholder is None:
+            continue
+        if placeholder not in RELEASE_TITLE_PLACEHOLDERS:
+            unsupported.append(placeholder or "<positional>")
+    if not unsupported:
+        return ""
+
+    bad = ", ".join(sorted(set(unsupported)))
+    return f"has unsupported placeholders: {bad}. Allowed: {ALLOWED_RELEASE_TITLE_PLACEHOLDERS}."

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -482,6 +482,67 @@ class ManifestParsingTests(unittest.TestCase):
         assert manifest.release is not None
         self.assertEqual(manifest.release.runner, "uv")
 
+    def test_reads_manifest_release_title_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "",
+                        "release:",
+                        "  github:",
+                        "    repository: codeforester/demo",
+                        "    release_title: \"{repository} {version} {tag} {{literal}}\"",
+                        "",
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = read_manifest(manifest_path)
+
+        self.assertIsNotNone(manifest.release)
+        assert manifest.release is not None
+        self.assertEqual(manifest.release.github.release_title, "{repository} {version} {tag} {{literal}}")
+
+    def test_rejects_invalid_manifest_release_title_placeholders(self) -> None:
+        invalid_titles = {
+            "unknown": "{repository} {missing}",
+            "positional": "{} v{version}",
+            "attribute": "{version.major}",
+            "malformed": "{repository} {version",
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for name, title in invalid_titles.items():
+                with self.subTest(name=name):
+                    manifest_path = root / f"{name}.yaml"
+                    manifest_path.write_text(
+                        "\n".join(
+                            [
+                                "project:",
+                                "  name: demo",
+                                "",
+                                "release:",
+                                "  github:",
+                                "    repository: codeforester/demo",
+                                f"    release_title: {title!r}",
+                                "",
+                                "artifacts: []",
+                            ]
+                        ),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaisesRegex(
+                        ManifestError,
+                        r"release\.github\.release_title.*repository.*version.*tag",
+                    ):
+                        read_manifest(manifest_path)
+
 
     def test_reads_manifest_build_target_runner(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Validate `release.github.release_title` placeholders while reading manifests.
- Allow `{repository}`, `{version}`, `{tag}`, and escaped literal braces.
- Reject unknown, positional, attribute, and malformed placeholders with `ManifestError` guidance.

## Validation

- `PYTHONPATH=cli/python:lib/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py cli/python/base_release/tests/test_engine.py -q`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/manifest.py cli/python/base_setup/release_title.py cli/python/base_setup/tests/test_manifest.py cli/python/base_release/tests/test_engine.py`
- `PYTHONPATH=cli/python:lib/python $HOME/.base.d/base/.venv/bin/python -m pytest -q`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1151 ./bin/base-test`

## Demo Impact

None. Release manifest validation only.

Fixes #1151
