### PR TITLE
Use effective argv for base_cli history

### DIFF
--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import os
 import sys
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Callable
 
@@ -17,6 +18,7 @@ from .redaction import parameter_name_from_decls
 _STANDARD_OPTION_KEYS = ("debug", "quiet", "environment", "config", "keep_temp", "log_file")
 _GROUP_STANDARD_OPTIONS_KEY = "base_cli_standard_options"
 DISPLAY_COMMAND_ENV = "BASE_CLI_DISPLAY_COMMAND"
+_INVOCATION_ARGV: ContextVar[list[str] | None] = ContextVar("base_cli_invocation_argv", default=None)
 
 
 def _require_click():
@@ -127,8 +129,9 @@ class App:
             token = set_current_context(context)
             started_at = utc_now()
             exit_code = 0
+            invocation_argv = _current_invocation_argv()
             try:
-                log_invocation(context.log, sys.argv, sensitive_options)
+                log_invocation(context.log, invocation_argv, sensitive_options)
                 if context.project_root is not None:
                     context.log.debug("project_root=%s", context.project_root)
                 if context.manifest_path is not None:
@@ -140,7 +143,7 @@ class App:
                 exit_code = 1
                 raise
             finally:
-                write_finished_record(context, sys.argv, sensitive_options, started_at, exit_code)
+                write_finished_record(context, invocation_argv, sensitive_options, started_at, exit_code)
                 reset_current_context(token)
                 context.cleanup()
 
@@ -233,18 +236,42 @@ def run_app(app: App, argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
+    explicit_argv = argv is not None
     args = list(sys.argv[1:] if argv is None else argv)
     try:
         _reject_equals_option_values(click, args)
         display_command = delegated_display_command()
-        if display_command:
-            result = app.click_command.main(args=args, prog_name=display_command, standalone_mode=False)
-        else:
-            result = app.click_command.main(args=args, standalone_mode=False)
+        invocation_argv = _effective_invocation_argv(app, args, explicit_argv, display_command)
+        invocation_token = _INVOCATION_ARGV.set(invocation_argv)
+        try:
+            if display_command:
+                result = app.click_command.main(args=args, prog_name=display_command, standalone_mode=False)
+            else:
+                result = app.click_command.main(args=args, standalone_mode=False)
+        finally:
+            _INVOCATION_ARGV.reset(invocation_token)
     except click.ClickException as exc:
         exc.show()
         return int(exc.exit_code)
     return int(result or 0)
+
+
+def _effective_invocation_argv(
+    app: App,
+    args: list[str],
+    explicit_argv: bool,
+    display_command: str | None,
+) -> list[str]:
+    if not explicit_argv:
+        return list(sys.argv)
+    return [display_command or app.name, *args]
+
+
+def _current_invocation_argv() -> list[str]:
+    invocation_argv = _INVOCATION_ARGV.get()
+    if invocation_argv is not None:
+        return list(invocation_argv)
+    return list(sys.argv)
 
 
 def delegated_display_command(default: str | None = None) -> str | None:

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -87,6 +87,57 @@ class BaseCliHistoryTests(unittest.TestCase):
         self.assertNotIn("super-secret", json.dumps(record))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_run_app_uses_explicit_argv_for_history_and_log_metadata(self) -> None:
+        app = base_cli.App(name="history-explicit", version="0.1.0")
+        seen = {}
+        current_endpoint = "https://current.example/path"
+        stale_endpoint = "https://stale.invalid/path"
+
+        @app.command()
+        @base_cli.option("--endpoint", required=True)
+        @base_cli.option("--token", sensitive=True, required=True)
+        def main(ctx: base_cli.Context, endpoint: str, token: str) -> None:
+            seen["endpoint"] = endpoint
+            seen["token"] = token
+            seen["log_file"] = ctx.log_file
+            ctx.log.info("processed request")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            home.mkdir()
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": str(home), "BASE_CACHE_DIR": str(home / ".cache" / "base")},
+            ):
+                with mock.patch.object(
+                    os.sys,
+                    "argv",
+                    ["stale-wrapper", "--debug", "--endpoint", stale_endpoint, "--token", "stale-secret"],
+                ):
+                    with redirect_stderr(stderr):
+                        status = base_cli.run_app(
+                            app,
+                            ["--debug", "--endpoint", current_endpoint, "--token", "super-secret"],
+                        )
+            records = read_history_records(home / ".cache" / "base")
+            log_text = seen["log_file"].read_text(encoding="utf-8")
+
+        self.assertEqual(status, 0, stderr.getvalue())
+        self.assertEqual(seen["endpoint"], current_endpoint)
+        self.assertEqual(seen["token"], "super-secret")
+        self.assertEqual(len(records), 1)
+        record_text = json.dumps(records[0])
+        self.assertIn(current_endpoint, record_text)
+        self.assertNotIn(stale_endpoint, record_text)
+        self.assertNotIn("super-secret", record_text)
+        self.assertNotIn("stale-secret", record_text)
+        self.assertIn(current_endpoint, log_text)
+        self.assertNotIn(stale_endpoint, log_text)
+        self.assertNotIn("super-secret", log_text)
+        self.assertNotIn("stale-secret", log_text)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_records_failed_command_history(self) -> None:
         app = base_cli.App(name="failing-history")
 


### PR DESCRIPTION
Summary:
- Bind the effective argv used by `run_app(app, argv)` for the duration of Click execution.
- Use that effective argv for invocation debug logging and finished history records instead of stale process-level `sys.argv`.
- Add a regression proving explicit argv metadata wins over unrelated process argv while sensitive values remain redacted.

Validation:
- Regression before fix: `test_run_app_uses_explicit_argv_for_history_and_log_metadata` failed because history contained the stale endpoint from `sys.argv`.
- Focused Python: env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_history.py -q
- Neighboring Python: env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_base_cli.py lib/python/base_cli/tests/test_app_subcommands.py -q
- Touched-file pylint: env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint lib/python/base_cli/app.py lib/python/base_cli/tests/test_history.py
- git diff --check
- Full base-test: Python 640 passed, 1 skipped; Bats ok 1..545

Demo Impact: none

Fixes #1154
