### PR TITLE
Add basectl docs shortcut

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -33,6 +33,7 @@ options.
   for AI-assisted Base workflows. `product-self-review` prints the periodic
   product assessment prompt with current Base metadata; Base does not send the
   prompt to an AI provider.
+- `basectl docs` - open the Base documentation home page on GitHub.
 - `basectl projects list` - list Base-managed projects discovered in the
   workspace.
 - `basectl workspace <status|check|doctor|clone|pull|init|configure>` - inspect

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ basectl test <project>
 basectl demo [project]
 basectl run <project> <command>
 basectl export-context <project>
+basectl docs
 basectl activate <project>
 ```
 
@@ -222,6 +223,7 @@ Current implemented commands include:
 - `basectl build <project> [target...]`
 - `basectl run <project> <command>`
 - `basectl export-context [project]`
+- `basectl docs`
 - `basectl onboard`
 - `basectl version`
 
@@ -725,6 +727,17 @@ Base-managed project. Markdown exports combine context Markdown files with
 stable source headings, using `.ai-context/INDEX.md` order when available and
 falling back to deterministic filename order for unlisted files. Zip exports
 contain only files from `.ai-context/` so they can be uploaded manually.
+
+Open Base's documentation home page on GitHub with:
+
+```bash
+basectl docs
+basectl docs --show-url
+```
+
+`basectl docs` opens the GitHub README because the README is the starting point
+for the rest of Base's documentation. Use `--show-url` to print the URL without
+opening a browser.
 
 Print repo-owned AI workflow prompts with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -39,6 +39,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `clean`
 - `config`
 - `doctor`
+- `docs`
 - `export-context`
 - `gh`
 - `onboard`
@@ -150,6 +151,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
   directory for manual AI tool upload or copy/paste. Markdown exports include
   stable file headings and use `INDEX.md` ordering when available. Zip exports
   contain only files from `.ai-context`.
+- `basectl docs` opens the Base documentation home page on GitHub. Use
+  `--show-url` to print the URL without opening a browser.
 - `basectl prompt list` lists repo-owned Markdown prompts that Base can render
   for AI-assisted workflows. `basectl prompt product-self-review` prints the
   periodic Base product self-review prompt with current Base metadata. Base

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -53,6 +53,8 @@ Commands:
     Inspect release readiness, plan, notes, and guarded GitHub publishing.
   prompt <list|name> [options]
     Print repo-owned Markdown prompts for AI-assisted Base workflows.
+  docs [options]
+    Open the Base documentation home page on GitHub.
   clean [--older-than <age>] [--keep-last <count>] [options]
     Remove old Base CLI runtime logs, temp files, and cache entries.
   logs [options]
@@ -310,6 +312,11 @@ basectl_do_prompt() {
     base_prompt_subcommand_main "$@"
 }
 
+basectl_do_docs() {
+    basectl_source_subcommand_module docs || return 1
+    base_docs_subcommand_main "$@"
+}
+
 basectl_do_clean() {
     basectl_source_subcommand_module clean || return 1
     base_clean_subcommand_main "$@"
@@ -492,6 +499,7 @@ basectl_main() {
         ci)               basectl_do_ci "$@" ;;
         release)          basectl_do_release "$@" ;;
         prompt)           basectl_do_prompt "$@" ;;
+        docs)             basectl_do_docs "$@" ;;
         clean)            basectl_do_clean "$@" ;;
         logs)             basectl_do_logs "$@" ;;
         history)          basectl_do_history "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/docs.sh
+++ b/cli/bash/commands/basectl/subcommands/docs.sh
@@ -1,0 +1,82 @@
+# shellcheck shell=bash
+[[ -n "${_base_docs_subcommand_sourced:-}" ]] && return 0
+_base_docs_subcommand_sourced=1
+readonly _base_docs_subcommand_sourced
+
+BASE_DOCS_URL="https://github.com/basefoundry/base#readme"
+readonly BASE_DOCS_URL
+
+base_docs_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl docs [options]
+
+Options:
+  --show-url   Print the documentation URL without opening a browser.
+  -h, --help   Show this help text.
+
+Open the Base documentation home page on GitHub.
+EOF
+}
+
+base_docs_usage_error() {
+    base_docs_subcommand_usage >&2
+    print_error "$*"
+    return 2
+}
+
+base_docs_platform_opener() {
+    local opener
+
+    for opener in open xdg-open wslview; do
+        if command -v "$opener" >/dev/null 2>&1; then
+            printf '%s\n' "$opener"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+base_docs_open_url() {
+    local opener
+
+    if ! opener="$(base_docs_platform_opener)"; then
+        print_error "No supported browser opener was found. Use 'basectl docs --show-url' to print the URL."
+        return 1
+    fi
+
+    "$opener" "$BASE_DOCS_URL"
+}
+
+base_docs_subcommand_main() {
+    local show_url=0
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_docs_subcommand_usage
+                return 0
+                ;;
+            --show-url)
+                show_url=1
+                shift
+                ;;
+            -*)
+                base_docs_usage_error "Unknown docs option '$1'."
+                return $?
+                ;;
+            *)
+                base_docs_usage_error "The 'docs' command does not accept positional arguments."
+                return $?
+                ;;
+        esac
+    done
+
+    if ((show_url)); then
+        printf '%s\n' "$BASE_DOCS_URL"
+        return 0
+    fi
+
+    base_docs_open_url
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -139,6 +139,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "prompt_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl docs --); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "docs_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl clean --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -242,6 +246,7 @@ EOF
     [[ "$output" == *"onboard_profiles=dev sre ai dev,sre dev,ai sre,ai dev,sre,ai"* ]]
     [[ "$output" == *"prompt_names=list product-self-review"* ]]
     [[ "$output" == *"prompt_options=--help"* ]]
+    [[ "$output" == *"docs_options=--show-url"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"history_options=--project --command --status --limit --format"* ]]

--- a/cli/bash/commands/basectl/tests/docs.bats
+++ b/cli/bash/commands/basectl/tests/docs.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+readonly BASE_DOCS_URL="https://github.com/basefoundry/base#readme"
+
+
+@test "basectl docs prints help without requiring the Base Python venv" {
+    run_basectl docs --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl docs [options]"* ]]
+    [[ "$output" == *"--show-url"* ]]
+    [[ "$output" == *"Open the Base documentation home page on GitHub."* ]]
+}
+
+@test "basectl docs opens the GitHub README in the platform browser" {
+    local state_file="$TEST_TMPDIR/docs-open-state"
+
+    cat > "$TEST_MOCKBIN/open" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_TEST_DOCS_OPEN_STATE:?}"
+EOF
+    chmod +x "$TEST_MOCKBIN/open"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_DOCS_OPEN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" docs
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state_file")" = "$BASE_DOCS_URL" ]
+}
+
+@test "basectl docs --show-url prints the GitHub README URL without opening a browser" {
+    local state_file="$TEST_TMPDIR/docs-open-state"
+
+    cat > "$TEST_MOCKBIN/open" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${BASE_TEST_DOCS_OPEN_STATE:?}"
+EOF
+    chmod +x "$TEST_MOCKBIN/open"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_DOCS_OPEN_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" docs --show-url
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$BASE_DOCS_URL" ]
+    [ ! -e "$state_file" ]
+}
+
+@test "basectl docs reports invalid arguments as usage errors" {
+    run_basectl docs extra
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"basectl docs [options]"* ]]
+    [[ "$output" == *"The 'docs' command does not accept positional arguments."* ]]
+
+    run_basectl docs --unknown
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"basectl docs [options]"* ]]
+    [[ "$output" == *"Unknown docs option '--unknown'."* ]]
+}

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -18,6 +18,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
     [[ "$output" == *"release <check|plan|notes|publish> --version <version> [options]"* ]]
     [[ "$output" == *"prompt <list|name> [options]"* ]]
+    [[ "$output" == *"docs [options]"* ]]
     [[ "$output" == *"clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"logs [options]"* ]]
     [[ "$output" == *"history [options]"* ]]
@@ -60,6 +61,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"
     grep -Fqx '  prompt <list|name> [options]' <<<"$output"
+    grep -Fqx '  docs [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  history [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor|clone|pull|init|configure> [options]' <<<"$output"
@@ -151,6 +153,7 @@ load ./basectl_helpers.bash
     grep -Fqx -- "  - \`workspace clone\` mutates repository checkouts only when invoked directly;" "$commands_file"
     grep -Fqx -- "- \`basectl repo <init|clone|check|configure|agent-guidance|installer-template>\` -" "$commands_file"
     grep -Fqx -- "- \`basectl update [project]\` - update Base or a named project using the" "$commands_file"
+    grep -Fqx -- "- \`basectl docs\` - open the Base documentation home page on GitHub." "$commands_file"
 }
 
 @test "command reference documents workspace init help surface" {
@@ -169,6 +172,12 @@ load ./basectl_helpers.bash
         [[ "$output" == *"$flag"* ]]
         [[ "$workspace_init_row" == *"$flag"* ]]
     done
+}
+
+@test "command reference documents docs shortcut" {
+    local command_reference="$BASE_REPO_ROOT/docs/command-reference.md"
+
+    grep -Fqx -- "| \`basectl docs\` | Open the Base documentation home page on GitHub. | \`--show-url\` |" "$command_reference"
 }
 
 @test "basectl config prints help" {

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -101,6 +101,7 @@ inspect the resolved command contract first.
 | `basectl release plan --version <version>` | Print the release plan and downstream handoff details. | `--manifest <path>` |
 | `basectl release notes --version <version>` | Extract release notes for the requested version. | `--manifest <path>` |
 | `basectl release publish --version <version>` | Create the annotated Git tag and GitHub Release after checks pass. | `--manifest <path>`, `--dry-run`, `--yes` |
+| `basectl docs` | Open the Base documentation home page on GitHub. | `--show-url` |
 | `basectl export-context [project]` | Export a project's `.ai-context/` directory as Markdown or Zip. | `--workspace <path>`, `--format <markdown\|zip>`, `--output <path>`, `--print`, `--list-files` |
 | `basectl prompt list` | List repo-owned Markdown prompts that Base can render for AI-assisted workflows. | none |
 | `basectl prompt product-self-review` | Print the periodic Base product self-review prompt with current Base metadata. | none |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -132,7 +132,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test export-context build demo run repo ci release prompt clean logs history config doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test export-context build demo run repo ci release prompt docs clean logs history config doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -255,6 +255,9 @@ _base_basectl_completion() {
             else
                 _base_basectl_completion_compgen "-v -h --help" "$cur"
             fi
+            ;;
+        docs)
+            _base_basectl_completion_compgen "--show-url -h --help" "$cur"
             ;;
         clean)
             _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -92,6 +92,7 @@ _base_basectl_completion() {
         'ci:Run Base setup, checks, and diagnostics in CI'
         'release:Inspect release readiness, notes, and publishing'
         'prompt:Print repo-owned Markdown prompts'
+        'docs:Open the Base documentation home page on GitHub'
         'clean:Remove old Base CLI runtime artifacts'
         'logs:List and open recent Base CLI runtime logs'
         'history:List recent Base command history records'
@@ -249,6 +250,10 @@ _base_basectl_completion() {
         prompt)
             _arguments '1:prompt:(list product-self-review)' \
                 '-v[Enable DEBUG logging]' \
+                '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        docs)
+            _arguments '--show-url[Print the documentation URL without opening a browser]' \
                 '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         repo)


### PR DESCRIPTION
Fixes #1160

Summary
- Add `basectl docs` to open the Base GitHub README documentation entrypoint.
- Add `basectl docs --show-url` for scripts and terminals that should only print the URL.
- Wire Bash and Zsh completions, top-level help, README, command reference, basectl README, and AI command context.

Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/docs.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/source_guards.bats cli/bash/commands/basectl/tests/docs.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl docs --show-url`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl docs --help`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `shellcheck -e SC2034 cli/bash/commands/basectl/subcommands/docs.sh cli/bash/commands/basectl/basectl.sh lib/shell/completions/basectl_completion.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-docs-1160 ./bin/base-test`

AI context: updated `.ai-context/COMMANDS.md` for the new command surface.