### PR TITLE
Add workflow concurrency and timeouts

### DIFF
--- a/.github/workflows/project-intake.yml
+++ b/.github/workflows/project-intake.yml
@@ -14,10 +14,15 @@ permissions:
   contents: read
   issues: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   sync:
     name: Sync issue Project fields
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       BASE_PROJECT_OWNER: ${{ github.repository_owner }}
       BASE_PROJECT_TITLE: ${{ github.event.repository.name }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,9 +4,14 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pylint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -23,11 +23,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate skills.md
     if: github.event_name != 'workflow_dispatch' || inputs.create_pr != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +53,7 @@ jobs:
     name: Create skills.md PR
     if: github.event_name == 'workflow_dispatch' && inputs.create_pr == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,15 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   python:
     name: Python tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +36,7 @@ jobs:
   bats:
     name: BATS tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
 
@@ -63,6 +69,7 @@ jobs:
   macos:
     name: macOS smoke tests
     runs-on: macos-14
+    timeout-minutes: 25
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
 
@@ -113,6 +120,7 @@ jobs:
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
 
@@ -154,6 +162,7 @@ jobs:
   security:
     name: Security scanners
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def workflow_files() -> list[Path]:
+    return sorted(WORKFLOW_DIR.glob("*.yml"))
+
+
+def load_workflow(path: Path) -> dict:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict), f"{path} did not parse as a YAML mapping"
+    return payload
+
+
+def test_all_workflows_cancel_superseded_runs() -> None:
+    missing = [path.name for path in workflow_files() if "concurrency" not in load_workflow(path)]
+
+    assert not missing, missing
+
+
+def test_all_workflow_jobs_have_timeouts() -> None:
+    missing: list[str] = []
+    for path in workflow_files():
+        jobs = load_workflow(path).get("jobs")
+        assert isinstance(jobs, dict), f"{path} jobs did not parse as a YAML mapping"
+        for job_name, job in jobs.items():
+            assert isinstance(job, dict), f"{path} job {job_name} did not parse as a YAML mapping"
+            if "timeout-minutes" not in job:
+                missing.append(f"{path.name}:{job_name}")
+
+    assert not missing, missing


### PR DESCRIPTION
## Summary
- Add top-level concurrency groups to Base GitHub Actions workflows.
- Add explicit job-level timeouts across Tests, Pylint, Project Intake, and Skills workflows.
- Add a focused pytest policy check for workflow concurrency and job timeouts.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc tests/test_github_workflows.py`
- `git diff --check`

## Demo Impact
- None. CI workflow reliability only.

Fixes #1170