### PR TITLE
Broaden CI test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,17 @@ concurrency:
 
 jobs:
   python:
-    name: Python tests
+    name: Python tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -114,6 +122,8 @@ jobs:
         run: |
           bats \
             cli/bash/commands/basectl/tests/update-profile.bats \
+            lib/bash/version/tests/lib_version.bats \
+            lib/shell/completions/tests/completions.bats \
             tests/base_init.bats \
             tests/install.bats
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ versions across a workspace.
 Artifacts may include `bootstrap: true` when they are part of the minimum Python
 runtime contract needed before Base can reconcile a project's remaining
 artifacts. Base currently uses this marker in `lib/base/default_manifest.yaml`
-for `click` and `PyYAML`.
+for `click`, `PyYAML`, and `tomli` for Python 3.10 TOML parsing.
 
 You can inspect the projects Base can see with:
 

--- a/cli/python/base_setup/pyproject.py
+++ b/cli/python/base_setup/pyproject.py
@@ -7,9 +7,17 @@ from .checks import ArtifactCheck
 from .manifest import BaseManifest
 
 try:
-    import tomllib
-except ImportError:  # pragma: no cover - exercised only on Python runtimes without tomllib
-    tomllib = None  # type: ignore[assignment]
+    import tomllib as _toml
+except ImportError:  # pragma: no cover - exercised on Python 3.10
+    try:
+        import tomli as _toml
+    except ImportError as exc:  # pragma: no cover - bootstrap dependency missing
+        _toml = None  # type: ignore[assignment]
+        _toml_import_error = exc
+    else:
+        _toml_import_error = None
+else:
+    _toml_import_error = None
 
 
 def check_pyproject(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
@@ -30,15 +38,15 @@ def check_pyproject(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
 
 
 def read_pyproject(path: Path) -> tuple[dict[str, Any], str | None]:
-    if tomllib is None:
-        return {}, "tomllib is not available in this Python runtime"
+    if _toml is None:
+        return {}, f"TOML parser is not available in this Python runtime: {_toml_import_error}"
     if not path.is_file():
         return {}, "path is not a regular file"
     try:
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        data = _toml.loads(path.read_text(encoding="utf-8"))
     except OSError as exc:
         return {}, str(exc)
-    except tomllib.TOMLDecodeError as exc:
+    except _toml.TOMLDecodeError as exc:
         return {}, str(exc)
     if not isinstance(data, dict):
         return {}, "top-level TOML document is not a mapping"

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -302,7 +302,10 @@ class ArtifactReconcileTests(unittest.TestCase):
             status, _stdout, stderr = run_engine(["--dry-run", "--manifest", str(manifest_path)])
 
         self.assertEqual(status, 0)
-        self.assertIn("pip install --disable-pip-version-check click==8.4.1 PyYAML==6.0.3 rich", stderr)
+        self.assertIn(
+            "pip install --disable-pip-version-check click==8.4.1 PyYAML==6.0.3 tomli==2.4.1 rich",
+            stderr,
+        )
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_dry_run_ignores_inherited_project_runtime_environment(self) -> None:
@@ -338,7 +341,10 @@ class ArtifactReconcileTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertNotIn(str(inherited_venv_dir), stderr)
-        self.assertIn("pip install --disable-pip-version-check click==8.4.1 PyYAML==6.0.3 rich", stderr)
+        self.assertIn(
+            "pip install --disable-pip-version-check click==8.4.1 PyYAML==6.0.3 tomli==2.4.1 rich",
+            stderr,
+        )
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_known_homebrew_artifact_dry_run_does_not_require_brew(self) -> None:

--- a/cli/python/base_setup/tests/test_bootstrap.py
+++ b/cli/python/base_setup/tests/test_bootstrap.py
@@ -113,5 +113,6 @@ class BootstrapManifestTests(unittest.TestCase):
             {
                 ("python-package", "click"): True,
                 ("python-package", "PyYAML"): True,
+                ("python-package", "tomli"): True,
             },
         )

--- a/lib/base/artifact-registry.yaml
+++ b/lib/base/artifact-registry.yaml
@@ -19,6 +19,15 @@ artifacts:
       kind: python_import
 
   - type: python-package
+    name: tomli
+    manager: pip
+    package: tomli
+    target: project-venv
+    version_policy: requested
+    check:
+      kind: python_import
+
+  - type: python-package
     name: pylint
     manager: pip
     package: pylint

--- a/lib/base/default_manifest.yaml
+++ b/lib/base/default_manifest.yaml
@@ -13,3 +13,8 @@ artifacts:
     name: PyYAML
     version: "6.0.3"
     bootstrap: true
+
+  - type: python-package
+    name: tomli
+    version: "2.4.1"
+    bootstrap: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ pylint==3.3.9
 click==8.4.1
 PyYAML==6.0.3
 pytest==9.0.3
+tomli==2.4.1
 bandit==1.9.4
 pip-audit==2.10.1

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -34,3 +34,41 @@ def test_all_workflow_jobs_have_timeouts() -> None:
                 missing.append(f"{path.name}:{job_name}")
 
     assert not missing, missing
+
+
+def test_python_tests_run_on_supported_minor_versions() -> None:
+    workflow = load_workflow(WORKFLOW_DIR / "tests.yml")
+    python_job = workflow["jobs"]["python"]
+
+    assert python_job["strategy"]["matrix"]["python-version"] == [
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+    ]
+    setup_steps = [
+        step
+        for step in python_job["steps"]
+        if isinstance(step, dict) and step.get("uses") == "actions/setup-python@v5"
+    ]
+
+    assert setup_steps == [
+        {
+            "name": "Set up Python",
+            "uses": "actions/setup-python@v5",
+            "with": {"python-version": "${{ matrix.python-version }}"},
+        }
+    ]
+
+
+def test_macos_smoke_tests_cover_shell_compatibility_surfaces() -> None:
+    workflow = load_workflow(WORKFLOW_DIR / "tests.yml")
+    macos_job = workflow["jobs"]["macos"]
+    run_commands = "\n".join(
+        step.get("run", "")
+        for step in macos_job["steps"]
+        if isinstance(step, dict)
+    )
+
+    assert "lib/bash/version/tests/lib_version.bats" in run_commands
+    assert "lib/shell/completions/tests/completions.bats" in run_commands


### PR DESCRIPTION
## Summary
- run pytest on Python 3.10, 3.11, 3.12, and 3.13 in the Tests workflow
- add macOS smoke coverage for version detection and shell completions
- add a `tomli` fallback/bootstrap package so pyproject diagnostics work on Python 3.10
- enforce the expected workflow coverage in tests/test_github_workflows.py

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc tests/test_github_workflows.py cli/python/base_setup/pyproject.py cli/python/base_setup/tests/test_bootstrap.py cli/python/base_setup/tests/test_artifacts.py
- git diff --check

Fixes #1171