### PR TITLE
Pin CI workflow dependencies

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Check required sections
         run: |
@@ -59,7 +59,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Create starter skills.md when missing
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
           - "3.13"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -49,11 +49,12 @@ jobs:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
+          ref: 34a71d08decf715f5767ab064197f7e63f418448
           path: .dependencies/base-bash-libs
 
       - name: Install BATS
@@ -82,15 +83,16 @@ jobs:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
+          ref: 34a71d08decf715f5767ab064197f7e63f418448
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.13"
 
@@ -135,15 +137,16 @@ jobs:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
+          ref: 34a71d08decf715f5767ab064197f7e63f418448
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.13"
 
@@ -175,10 +178,10 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.13"
 

--- a/cli/python/base_setup/tests/test_ci_supply_chain_policy.py
+++ b/cli/python/base_setup/tests/test_ci_supply_chain_policy.py
@@ -9,7 +9,6 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 FULL_SHA_RE = re.compile(r"[a-f0-9]{40}")
-FIRST_PARTY_ACTION_REF_RE = re.compile(r"v\d+|[a-f0-9]{40}")
 
 
 def load_workflow(path: Path) -> dict[str, Any]:
@@ -34,7 +33,7 @@ def workflow_step(path: Path, job: str, name: str) -> dict[str, Any]:
     raise AssertionError(f"{path}: job '{job}' must include step '{name}'.")
 
 
-def test_github_actions_references_follow_supply_chain_policy() -> None:
+def test_github_actions_references_are_pinned_to_full_shas() -> None:
     workflow_paths = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
 
     for path in workflow_paths:
@@ -43,15 +42,25 @@ def test_github_actions_references_follow_supply_chain_policy() -> None:
             if not uses:
                 continue
 
-            action, separator, ref = uses.partition("@")
+            _action, separator, ref = uses.partition("@")
             assert separator, f"{path}: action reference '{uses}' must include an explicit ref."
-            owner = action.split("/", 1)[0]
-            if owner == "actions":
-                assert FIRST_PARTY_ACTION_REF_RE.fullmatch(ref), (
-                    f"{path}: first-party action '{uses}' must use a maintained major tag or full SHA."
-                )
-            else:
-                assert FULL_SHA_RE.fullmatch(ref), f"{path}: third-party action '{uses}' must be pinned to a full SHA."
+            assert FULL_SHA_RE.fullmatch(ref), f"{path}: action '{uses}' must be pinned to a full SHA."
+
+
+def test_base_bash_libs_ci_checkouts_are_pinned() -> None:
+    workflow_paths = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+    checkouts: list[tuple[Path, str]] = []
+
+    for path in workflow_paths:
+        for step in workflow_steps(path):
+            with_config = step.get("with", {})
+            if isinstance(with_config, dict) and with_config.get("repository") == "basefoundry/base-bash-libs":
+                ref = with_config.get("ref")
+                checkouts.append((path, str(ref)))
+
+    assert checkouts, "CI must explicitly check out basefoundry/base-bash-libs where shell tests need it."
+    for path, ref in checkouts:
+        assert FULL_SHA_RE.fullmatch(ref), f"{path}: base-bash-libs checkout must pin a full SHA."
 
 
 def test_security_workflow_runs_python_dependency_audit() -> None:

--- a/docs/ci-supply-chain-policy.md
+++ b/docs/ci-supply-chain-policy.md
@@ -7,16 +7,40 @@ under `.github/workflows/`.
 ## GitHub Actions
 
 - Use first-party `actions/*` actions when an action is needed.
-- Pin first-party `actions/*` actions to a maintained major tag such as `v4` or
-  to a full commit SHA.
-- Pin non-GitHub third-party actions to a full 40-character commit SHA. Version
-  tags are not enough for third-party actions.
+- Pin every GitHub Action reference to a full 40-character commit SHA. Version
+  tags are useful for discovering updates, but workflow history should resolve
+  to immutable action code.
+- Pin sibling repository checkouts, including `basefoundry/base-bash-libs`, with
+  an explicit full-SHA `ref`.
 - Prefer shell steps over adding a new action when the command is simple and the
   runner already has the required tool or installs it through an approved
   package manager.
 
 `cli/python/base_setup/tests/test_ci_supply_chain_policy.py` enforces the
-action-reference rule.
+action-reference and sibling-checkout rules.
+
+## Updating CI Pins
+
+Update pins in a small PR that only changes workflow dependency references and
+this policy if the rule changes.
+
+1. Resolve the intended upstream refs:
+
+   ```bash
+   git ls-remote https://github.com/actions/checkout refs/tags/v4
+   git ls-remote https://github.com/actions/setup-python refs/tags/v5
+   git ls-remote https://github.com/basefoundry/base-bash-libs refs/heads/main
+   ```
+
+2. Replace the workflow SHAs with the resolved commits and keep the
+   `base-bash-libs` checkout pinned to the commit Base CI should test against.
+3. Run:
+
+   ```bash
+   PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_setup/tests/test_ci_supply_chain_policy.py -q
+   ```
+
+4. Let pull request CI run the pinned workflows before merging.
 
 ## Python Dependencies
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -49,16 +49,12 @@ def test_python_tests_run_on_supported_minor_versions() -> None:
     setup_steps = [
         step
         for step in python_job["steps"]
-        if isinstance(step, dict) and step.get("uses") == "actions/setup-python@v5"
+        if isinstance(step, dict) and step.get("uses", "").startswith("actions/setup-python@")
     ]
 
-    assert setup_steps == [
-        {
-            "name": "Set up Python",
-            "uses": "actions/setup-python@v5",
-            "with": {"python-version": "${{ matrix.python-version }}"},
-        }
-    ]
+    assert len(setup_steps) == 1
+    assert setup_steps[0]["name"] == "Set up Python"
+    assert setup_steps[0]["with"] == {"python-version": "${{ matrix.python-version }}"}
 
 
 def test_macos_smoke_tests_cover_shell_compatibility_surfaces() -> None:


### PR DESCRIPTION
## Summary
- pin `actions/checkout` and `actions/setup-python` to full commit SHAs
- pin CI `basefoundry/base-bash-libs` checkouts to an explicit commit ref
- tighten supply-chain policy tests and document the pin refresh procedure

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_ci_supply_chain_policy.py tests/test_github_workflows.py -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc cli/python/base_setup/tests/test_ci_supply_chain_policy.py tests/test_github_workflows.py
- git diff --check

Fixes #1172