### PR TITLE
Refresh CLI standards and AI context

### DIFF
--- a/.ai-context/DECISIONS.md
+++ b/.ai-context/DECISIONS.md
@@ -6,7 +6,10 @@ architecture discussion.
 ## Product And Scope
 
 - Base is a Mac-first workspace control plane.
-- Linux support is a future design target.
+- Linux runtime and CI support are actively being rolled out, with
+  `basectl ci` and Ubuntu GitHub Actions coverage as the current proof points.
+  Full Linux setup/bootstrap remains a narrower planned contract; keep platform
+  details in `docs/linux-support.md`.
 - Windows support is not currently in scope.
 - Base should solve the author's real multi-repo workflow elegantly before
   trying to be a broad general-purpose platform.

--- a/.ai-context/PROJECT.md
+++ b/.ai-context/PROJECT.md
@@ -6,8 +6,9 @@
 - Repository: `github.com/basefoundry/base`
 - Current release: `1.3.0`
 - Primary platform: macOS
-- Future platform direction: Linux support is a design target; Windows is not
-  currently in scope.
+- Linux posture: active runtime and CI rollout; full Linux bootstrap support
+  remains narrower and is tracked in `docs/linux-support.md`.
+- Windows support is not currently in scope.
 
 Base is a workspace control plane for developers who keep multiple repositories
 checked out side by side. It provides a shared layer for setup, diagnostics,

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -244,19 +244,13 @@ Base Python CLIs should use `base_cli.App`:
 from __future__ import annotations
 
 import base_cli
-import click
 
 
-app = base_cli.App(name="example_cli")
+app = base_cli.App(name="example_cli", version="0.1.0")
 
 
 def main(argv: list[str] | None = None) -> int:
-    try:
-        result = app.click_command.main(args=argv, standalone_mode=False)
-    except click.ClickException as exc:
-        exc.show()
-        return int(exc.exit_code)
-    return int(result or 0)
+    return base_cli.run_app(app, argv)
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -265,8 +259,8 @@ def run(ctx: base_cli.Context, dry_run: bool) -> int:
     ctx.log.info("Running example_cli.")
     if dry_run:
         print("[DRY-RUN] Would do the work.")
-        return 0
-    return 0
+        return base_cli.ExitCode.SUCCESS
+    return base_cli.ExitCode.SUCCESS
 ```
 
 Package entrypoints should provide `__main__.py`:
@@ -277,6 +271,11 @@ from .engine import main
 
 raise SystemExit(main())
 ```
+
+For standard options, `base_cli.ExitCode`, sensitive-option redaction, and the
+`--option value` syntax policy, use
+[`lib/python/base_cli/README.md`](lib/python/base_cli/README.md) as the
+canonical guide.
 
 ### 4.3 Logging And Output
 

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -151,6 +151,7 @@ These variables are involved in normal shell startup rather than the full
 | `BASE_ENABLE_BASH_DEFAULTS` | Base | Generated preference controlling optional Base Bash defaults. | Change with `basectl update-profile --defaults` or `--no-defaults`, not by editing files directly. |
 | `BASE_ENABLE_ZSH_DEFAULTS` | Base | Generated preference controlling optional Base Zsh defaults. | Change with `basectl update-profile --defaults` or `--no-defaults`, not by editing files directly. |
 | `BASE_DEBUG` | User | Enables debug traces in Base-managed shell startup snippets and the runtime Bash rcfile. | Safe to set in `~/.baserc` or as a one-off environment variable. |
+| `LOG_DEBUG` | Base wrapper compatibility | Internal debug signal exported by wrapper/debug paths before the full runtime exists. The Python config layer treats `1` or `true` as a fallback for `BASE_CLI_LOG_LEVEL=debug` when `BASE_CLI_LOG_LEVEL` is unset. | Do not set directly; use wrapper debug flags or `BASE_CLI_LOG_LEVEL=debug` for Python CLI logs. |
 
 The ordinary Bash/Zsh dotfile snippets derive `BASE_HOME` and add
 `$BASE_HOME/bin` to `PATH` so `basectl` is available in new terminals. When a

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -347,6 +347,10 @@ Environment variables currently recognized by the config layer:
 - `BASE_CLI_LOG_LEVEL`
 - `BASE_CLI_KEEP_TEMP`
 
+`LOG_DEBUG=1` or `LOG_DEBUG=true` is also accepted as an internal compatibility
+fallback for wrapper/debug paths when `BASE_CLI_LOG_LEVEL` is unset. Prefer
+`BASE_CLI_LOG_LEVEL=debug` for user-facing Python CLI debug logging.
+
 Command-line standard options are applied after config is loaded. For example,
 `--environment prod` overrides `environment: dev` from config.
 


### PR DESCRIPTION
## Summary
- modernize the STANDARDS Python CLI example around `base_cli.run_app` and `base_cli.ExitCode`
- document `LOG_DEBUG` as an internal wrapper compatibility alias beside `BASE_CLI_LOG_LEVEL`
- refresh `.ai-context/` Linux posture to match the active runtime/CI rollout

## Validation
- git diff --check
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_app_run.py -q
- rg -n "click_command\.main|import click|ClickException|Linux support is a future design target|Future platform direction|AI_CONTEXT\.md" STANDARDS.md .ai-context lib/python/base_cli/README.md docs/runtime-environment.md (expected no matches)

Fixes #1175
Fixes #1176
Fixes #1177