### PR TITLE
Harden setup process and config handling

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
-from base_cli.config import UserConfig, read_user_config
+from base_cli.config import UserConfig, UserIdeConfig
 from base_cli.paths import discover_manifest
 
 from .artifacts import check_artifact
@@ -152,6 +152,7 @@ def run_manifest_action(
             base_manifest,
             output_format=manifest_action.output_format,
             remote_network=manifest_action.remote_network,
+            user_config=ctx.user_config,
         )
     elif action == "precheck":
         status = check_pre_venv_manifest(
@@ -211,7 +212,7 @@ def reconcile_manifest(
 ) -> None:
     ctx.log.info("Reading Base manifest at '%s'.", manifest.path)
     ctx.log.info("Setting up project '%s'.", manifest.project_name)
-    user_config = read_user_config()
+    user_config = ctx.user_config
     log_ide_preference_warnings(ctx, ide_preference_warning_checks(manifest, user_config))
     effective_manifest = effective_manifest_with_user_config(manifest, user_config)
 
@@ -284,7 +285,12 @@ def check_manifest(
     output_format: str,
     remote_network: bool = False,
 ) -> int:
-    checks = manifest_checks(default_manifest, manifest, remote_network=remote_network)
+    checks = manifest_checks(
+        default_manifest,
+        manifest,
+        remote_network=remote_network,
+        user_config=ctx.user_config,
+    )
     if output_format == "json":
         print(json.dumps(checks_payload_to_json(checks, project=manifest.project_name), indent=2))
     elif output_format == "text":
@@ -330,8 +336,15 @@ def doctor_manifest(
     manifest: BaseManifest,
     output_format: str,
     remote_network: bool = False,
+    *,
+    user_config: UserConfig | None = None,
 ) -> int:
-    checks = manifest_checks(default_manifest, manifest, remote_network=remote_network)
+    checks = manifest_checks(
+        default_manifest,
+        manifest,
+        remote_network=remote_network,
+        user_config=user_config,
+    )
     if output_format == "json":
         print(json.dumps([check_to_json(check) for check in checks], indent=2))
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
@@ -384,16 +397,18 @@ def manifest_checks(
     default_manifest: BaseManifest,
     manifest: BaseManifest,
     remote_network: bool = False,
+    *,
+    user_config: UserConfig | None = None,
 ) -> tuple[ArtifactCheck, ...]:
     pre_venv_checks: list[ArtifactCheck] = []
     checks: list[ArtifactCheck] = []
-    user_config = read_user_config()
-    effective_manifest = effective_manifest_with_user_config(manifest, user_config)
+    active_user_config = user_config if user_config is not None else empty_user_config()
+    effective_manifest = effective_manifest_with_user_config(manifest, active_user_config)
     artifacts = setup_artifacts(default_manifest, effective_manifest)
     definitions = resolve_artifact_definitions(artifacts)
 
     pre_venv_checks.extend(pre_venv_manifest_checks(effective_manifest, remote_network=remote_network))
-    checks.extend(ide_preference_warning_checks(manifest, user_config))
+    checks.extend(ide_preference_warning_checks(manifest, active_user_config))
 
     if effective_manifest.brewfile is not None:
         checks.append(check_brewfile(effective_manifest))
@@ -426,6 +441,10 @@ def manifest_checks(
             )
         )
     return tuple(pre_venv_checks + checks)
+
+
+def empty_user_config() -> UserConfig:
+    return UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))
 
 
 def effective_manifest_with_user_config(manifest: BaseManifest, user_config: UserConfig) -> BaseManifest:

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -110,17 +110,17 @@ def run_command(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     ) as process:
-        assert process.stdout is not None
-        assert process.stderr is not None
+        stdout_pipe = _require_process_pipe(process.stdout, "stdout", command)
+        stderr_pipe = _require_process_pipe(process.stderr, "stderr", command)
         threads = (
             threading.Thread(
                 target=_tee_stream,
-                args=(ctx, process.stdout, sys.stdout, "stdout", stdout_recorder),
+                args=(ctx, stdout_pipe, sys.stdout, "stdout", stdout_recorder),
                 daemon=True,
             ),
             threading.Thread(
                 target=_tee_stream,
-                args=(ctx, process.stderr, sys.stderr, "stderr", stderr_recorder),
+                args=(ctx, stderr_pipe, sys.stderr, "stderr", stderr_recorder),
                 daemon=True,
             ),
         )
@@ -145,6 +145,14 @@ def run_command(
         ctx.log.debug("Command succeeded in '%s': %s", cwd, format_command_for_logging(command))
     else:
         ctx.log.debug("Command succeeded: %s", format_command_for_logging(command))
+
+
+def _require_process_pipe(stream: BinaryIO | None, label: str, command: list[str]) -> BinaryIO:
+    if stream is None:
+        raise ArtifactError(
+            f"Command did not provide a {label} pipe: {format_command_for_logging(command)}"
+        )
+    return stream
 
 
 def dry_run_command(ctx: base_cli.Context, command: list[str], cwd: Path | None = None) -> None:

--- a/cli/python/base_setup/tests/helpers.py
+++ b/cli/python/base_setup/tests/helpers.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.config import UserConfig, UserIdeConfig
 from base_setup.engine import main
 
 
@@ -36,4 +37,5 @@ def run_engine(args: list[str]) -> tuple[int, str, str]:
 def fake_context() -> mock.Mock:
     ctx = mock.Mock()
     ctx.log = mock.Mock()
+    ctx.user_config = UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))
     return ctx

--- a/cli/python/base_setup/tests/test_process_redaction.py
+++ b/cli/python/base_setup/tests/test_process_redaction.py
@@ -30,6 +30,23 @@ class ProcessCommandRedactionTests(unittest.TestCase):
             timeout=7,
         )
 
+    def test_run_command_reports_missing_stdout_pipe_without_assert(self) -> None:
+        class MissingPipeProcess:
+            stdout = None
+            stderr = None
+
+            def __enter__(self) -> object:
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+        ctx = fake_context()
+
+        with unittest.mock.patch("base_setup.process.subprocess.Popen", return_value=MissingPipeProcess()):
+            with self.assertRaisesRegex(ArtifactError, "stdout pipe"):
+                process.run_command(ctx, ["installer"])
+
     def test_run_command_redacts_sensitive_command_arguments_from_failure(self) -> None:
         ctx = fake_context()
         stdout = io.StringIO()

--- a/cli/python/base_setup/tests/test_user_ide_preferences.py
+++ b/cli/python/base_setup/tests/test_user_ide_preferences.py
@@ -135,6 +135,58 @@ class UserIdePreferenceMergeTests(unittest.TestCase):
 
         self.assertEqual(ide.effective_ide_config(project_ide, user_config), {})
 
+    def test_reconcile_manifest_uses_context_user_config(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={"vscode": IdeConfig(install=True, extensions=("ms-python.python",), settings={})},
+        )
+        ctx = fake_context()
+        ctx.user_config = UserConfig(raw={}, ide=UserIdeConfig(enabled=False, preferences={}))
+
+        with (
+            mock.patch("base_setup.engine.reconcile_brewfile"),
+            mock.patch("base_setup.engine.reconcile_mise"),
+            mock.patch("base_setup.engine.reconcile_ide_installs") as reconcile_ide_installs,
+            mock.patch("base_setup.engine.reconcile_ide_extensions"),
+            mock.patch("base_setup.engine.reconcile_ide_settings"),
+            mock.patch("base_setup.engine.reconcile_uv_project"),
+        ):
+            engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=True)
+
+        effective_manifest = reconcile_ide_installs.call_args.args[1]
+        self.assertEqual(effective_manifest.ide, {})
+
+    def test_manifest_checks_accepts_injected_user_config(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={"vscode": IdeConfig(install=True, extensions=("ms-python.python",), settings={})},
+        )
+        user_config = UserConfig(raw={}, ide=UserIdeConfig(enabled=False, preferences={}))
+
+        checks = engine.manifest_checks(default_manifest, manifest, user_config=user_config)
+
+        self.assertEqual(len(checks), 1)
+        self.assertEqual(checks[0].name, "user IDE config")
+        self.assertIn("disables", checks[0].message)
+
 
 
     def test_effective_ide_config_can_disable_one_ide(self) -> None:


### PR DESCRIPTION
## Summary

- replace assert-only stdout/stderr pipe guards in setup process execution with deterministic `ArtifactError` checks
- route setup/check/doctor manifest logic through the already-loaded context user config
- add focused regression coverage for missing process pipes and injected setup user config

Fixes #1164
Fixes #1166

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_process_redaction.py::ProcessCommandRedactionTests::test_run_command_reports_missing_stdout_pipe_without_assert cli/python/base_setup/tests/test_user_ide_preferences.py::UserIdePreferenceMergeTests::test_reconcile_manifest_uses_context_user_config cli/python/base_setup/tests/test_user_ide_preferences.py::UserIdePreferenceMergeTests::test_manifest_checks_accepts_injected_user_config -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests lib/python/base_cli/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/engine.py cli/python/base_setup/process.py cli/python/base_setup/tests/helpers.py cli/python/base_setup/tests/test_process_redaction.py cli/python/base_setup/tests/test_user_ide_preferences.py`
- `git diff --check`
- `rg -n "assert process\\.(stdout|stderr)|read_user_config" cli/python/base_setup/process.py cli/python/base_setup/engine.py cli/python/base_setup/tests` (expected no matches)
