### PR TITLE
Add bounded release publish timeouts

### DIFF
--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TextIO
 
 import base_cli
 from base_setup.manifest import BaseManifest
@@ -18,6 +19,7 @@ from base_setup.manifest import read_manifest
 
 app = base_cli.App(name="base_release")
 CHANGELOG_HEADER_RE = re.compile(r"^##\s+(?:\[(?P<bracket>[^\]]+)\]|(?P<plain>\S+))(?:\s+-.*)?$")
+RELEASE_STEP_TIMEOUT_SECONDS = 120
 
 
 class ReleaseUsageError(RuntimeError):
@@ -162,7 +164,7 @@ def require_publish_option(command: str, option_name: str) -> None:
         raise ReleaseUsageError(f"Option '{option_name}' is only supported by release publish.")
 
 
-def print_usage(file=sys.stdout) -> None:
+def print_usage(file: TextIO = sys.stdout) -> None:
     command = base_cli.delegated_display_command("base_release")
     print(
         f"""Usage:
@@ -516,17 +518,23 @@ def require_interactive_publish_confirmation(ctx: ReleaseContext, title: str) ->
 
 
 def run_release_step(command: list[str], *, cwd: Path | None = None) -> None:
-    result = subprocess.run(
-        command,
-        cwd=cwd,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
+    joined = " ".join(command)
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=RELEASE_STEP_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ReleaseError(f"Release command timed out after {exc.timeout} seconds: {joined}") from exc
+    except OSError as exc:
+        raise ReleaseError(f"Unable to run release command: {joined}: {exc}") from exc
     if result.returncode != 0:
         detail = last_non_empty_line(result.stdout)
-        joined = " ".join(command)
         if detail:
             raise ReleaseError(f"Release command failed: {joined}: {detail}")
         raise ReleaseError(f"Release command failed: {joined}")

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -11,6 +11,7 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_release import engine
 from base_release.engine import ReleaseError
 from base_release.engine import ReleaseFinding
 from base_release.engine import main
@@ -268,6 +269,31 @@ class ReleaseEngineTests(unittest.TestCase):
         self.assertIn("Would create GitHub Release: Demo v1.2.3", stdout)
         self.assertIn("Homebrew handoff required after GitHub release", stdout)
         run_step.assert_not_called()
+
+    def test_run_release_step_uses_bounded_timeout(self) -> None:
+        completed = subprocess.CompletedProcess(["git", "tag"], 0, stdout="")
+
+        with mock.patch("base_release.engine.subprocess.run", return_value=completed) as run:
+            engine.run_release_step(["git", "tag"], cwd=Path("/repo"))
+
+        self.assertEqual(run.call_args.kwargs["timeout"], engine.RELEASE_STEP_TIMEOUT_SECONDS)
+
+    def test_run_release_step_reports_timeout_as_release_error(self) -> None:
+        command = ["git", "push", "origin", "v1.2.3"]
+
+        with mock.patch(
+            "base_release.engine.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(command, timeout=30),
+        ):
+            with self.assertRaisesRegex(ReleaseError, "timed out"):
+                engine.run_release_step(command)
+
+    def test_run_release_step_reports_os_error_as_release_error(self) -> None:
+        command = ["gh", "release", "create", "v1.2.3"]
+
+        with mock.patch("base_release.engine.subprocess.run", side_effect=OSError("network unavailable")):
+            with self.assertRaisesRegex(ReleaseError, "Unable to run release command"):
+                engine.run_release_step(command)
 
 
     def test_publish_requires_yes_when_stdin_is_not_interactive(self) -> None:


### PR DESCRIPTION
## Summary

- add a bounded timeout to irreversible release publish subprocesses
- convert publish-step `TimeoutExpired` and `OSError` failures into clear `ReleaseError` messages
- type the release usage output stream while touching the helper

Fixes #1165

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_release/tests/test_engine.py::ReleaseEngineTests::test_run_release_step_uses_bounded_timeout cli/python/base_release/tests/test_engine.py::ReleaseEngineTests::test_run_release_step_reports_timeout_as_release_error cli/python/base_release/tests/test_engine.py::ReleaseEngineTests::test_run_release_step_reports_os_error_as_release_error -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_release/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_release/engine.py cli/python/base_release/tests/test_engine.py`
- `git diff --check`
