### PR TITLE
Consolidate project workspace helpers

### DIFF
--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import base_cli
 import click
+from base_projects.command_helpers import ProjectUsageError, github_repo_spec
 
 from . import graphql_queries as queries
 from .project_configure import standard_template_view_errors
@@ -21,10 +22,6 @@ from .project_model import SelectFieldSpec, SelectOption
 from .project_config import ProjectConfig, ProjectConfigError
 from .project_config import read_project_config as _read_project_config
 from .project_errors import missing_issue_field_option_message
-
-
-class ProjectUsageError(RuntimeError):
-    pass
 
 
 class ProjectError(RuntimeError):
@@ -487,15 +484,7 @@ def infer_repo_from_git() -> str | None:
     )
     if result.returncode != 0:
         return None
-    remote = result.stdout.strip()
-    if remote.startswith("git@github.com:"):
-        remote = remote.removeprefix("git@github.com:")
-    elif remote.startswith("https://github.com/"):
-        remote = remote.removeprefix("https://github.com/")
-    else:
-        return None
-    remote = remote.removesuffix(".git")
-    return remote if "/" in remote else None
+    return github_repo_spec(result.stdout)
 
 
 def run_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:

--- a/cli/python/base_projects/command_helpers.py
+++ b/cli/python/base_projects/command_helpers.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from base_cli.redaction import redact_text_value
+
+
+class ProjectUsageError(RuntimeError):
+    pass
+
+
+class ProjectCommandError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProjectCommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def github_repo_spec(url: str, *, allow_path: bool = False) -> str | None:
+    normalized_url = url.strip()
+    parsed = urlparse(normalized_url)
+    if parsed.scheme and parsed.hostname == "github.com":
+        return github_repo_spec_from_path(parsed.path)
+
+    git_ssh_prefix = "git@github.com:"
+    if normalized_url.startswith(git_ssh_prefix):
+        return github_repo_spec_from_path(normalized_url[len(git_ssh_prefix) :])
+
+    if allow_path and "/" in normalized_url and not parsed.scheme:
+        return github_repo_spec_from_path(normalized_url)
+    return None
+
+
+def github_repo_spec_from_path(path: str) -> str | None:
+    normalized = path.strip().lstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    parts = normalized.split("/")
+    if len(parts) != 2 or not all(parts):
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def format_project_command(command: list[str]) -> str:
+    return shlex.join(redact_text_value(arg) for arg in command)
+
+
+def run_project_command(command: list[str], *, error_context: str) -> ProjectCommandResult:
+    try:
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+    except OSError as exc:
+        raise ProjectCommandError(
+            f"Could not run {error_context}: {exc}. Command: {format_project_command(command)}"
+        ) from exc
+    return ProjectCommandResult(
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def write_project_command_output(result: ProjectCommandResult) -> None:
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 # pylint: disable=too-many-lines
 
 import json
-import subprocess
 import shlex
-import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +14,11 @@ from base_cli.config import load_user_config
 from base_cli.config import user_config_path
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
+from base_projects.command_helpers import ProjectCommandError as ProjectRunnerError
+from base_projects.command_helpers import ProjectUsageError
+from base_projects.command_helpers import github_repo_spec
+from base_projects.command_helpers import run_project_command
+from base_projects.command_helpers import write_project_command_output
 from base_projects.project_discovery import Project
 from base_projects.project_discovery import discover_projects_cached
 from base_projects.project_discovery import find_project_in_projects
@@ -193,10 +196,6 @@ def dispatch_projects_command(
         command,
     )
     return 2
-
-
-class ProjectUsageError(RuntimeError):
-    pass
 
 
 def require_argument_count(command: str, arguments: tuple[str, ...], minimum: int, maximum: int) -> None:
@@ -572,17 +571,7 @@ def is_workspace_init_path_source(workspace_source: str) -> bool:
 
 
 def workspace_init_github_repo_spec(workspace_source: str) -> str | None:
-    parsed = urlparse(workspace_source)
-    if parsed.scheme and parsed.hostname == "github.com":
-        return github_repo_spec_from_path(parsed.path)
-
-    git_ssh_prefix = "git@github.com:"
-    if workspace_source.startswith(git_ssh_prefix):
-        return github_repo_spec_from_path(workspace_source[len(git_ssh_prefix) :])
-
-    if "/" in workspace_source and not parsed.scheme:
-        return github_repo_spec_from_path(workspace_source)
-    return None
+    return github_repo_spec(workspace_source, allow_path=True)
 
 
 def resolve_workspace_config_repo_path(
@@ -628,15 +617,13 @@ def clone_workspace_config_repo(ctx: base_cli.Context, repo_spec: str, target: P
     if dry_run:
         command.append("--dry-run")
     try:
-        result = subprocess.run(command, check=False, capture_output=True, text=True)
-    except OSError as exc:
-        raise WorkspaceManifestError(
-            f"Could not run basectl repo clone for workspace source '{repo_spec}': {exc}"
-        ) from exc
-    if result.stdout:
-        print(result.stdout, end="")
-    if result.stderr:
-        print(result.stderr, end="", file=sys.stderr)
+        result = run_project_command(
+            command,
+            error_context=f"basectl repo clone for workspace source '{repo_spec}'",
+        )
+    except ProjectRunnerError as exc:
+        raise WorkspaceManifestError(str(exc)) from exc
+    write_project_command_output(result)
     if result.returncode != 0:
         raise WorkspaceManifestError(f"Workspace source clone failed for '{repo_spec}'.")
 
@@ -769,15 +756,15 @@ def clone_workspace_repo(
         command.append("--dry-run")
 
     try:
-        result = subprocess.run(command, check=False, capture_output=True, text=True)
-    except OSError as exc:
-        ctx.log.error("Could not run basectl repo clone for repository '%s': %s", repo.name, exc)
+        result = run_project_command(
+            command,
+            error_context=f"basectl repo clone for repository '{repo.name}'",
+        )
+    except ProjectRunnerError as exc:
+        ctx.log.error(str(exc))
         return 1
 
-    if result.stdout:
-        print(result.stdout, end="")
-    if result.stderr:
-        print(result.stderr, end="", file=sys.stderr)
+    write_project_command_output(result)
     if result.returncode == 0:
         return 0
 
@@ -789,26 +776,7 @@ def workspace_clone_repo_spec(repo: WorkspaceManifestRepo) -> str | None:
     if repo.url is None:
         return repo.name
 
-    url = repo.url
-    parsed = urlparse(url)
-    if parsed.scheme and parsed.hostname == "github.com":
-        return github_repo_spec_from_path(parsed.path)
-
-    git_ssh_prefix = "git@github.com:"
-    if url.startswith(git_ssh_prefix):
-        return github_repo_spec_from_path(url[len(git_ssh_prefix) :])
-
-    return None
-
-
-def github_repo_spec_from_path(path: str) -> str | None:
-    normalized = path.strip().lstrip("/")
-    if normalized.endswith(".git"):
-        normalized = normalized[:-4]
-    parts = normalized.split("/")
-    if len(parts) != 2 or not all(parts):
-        return None
-    return f"{parts[0]}/{parts[1]}"
+    return github_repo_spec(repo.url)
 
 
 def resolve_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:

--- a/cli/python/base_projects/tests/test_command_helpers.py
+++ b/cli/python/base_projects/tests/test_command_helpers.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest import mock
+
+from base_github_projects import engine as github_engine
+from base_projects import engine as projects_engine
+from base_projects.command_helpers import ProjectCommandError
+from base_projects.command_helpers import ProjectUsageError
+from base_projects.command_helpers import format_project_command
+from base_projects.command_helpers import github_repo_spec
+from base_projects.command_helpers import github_repo_spec_from_path
+from base_projects.command_helpers import run_project_command
+
+
+class ProjectCommandHelperTests(unittest.TestCase):
+    def test_project_usage_error_is_shared_across_project_commands(self) -> None:
+        self.assertIs(projects_engine.ProjectUsageError, ProjectUsageError)
+        self.assertIs(github_engine.ProjectUsageError, ProjectUsageError)
+
+    def test_github_repo_spec_from_path_normalizes_owner_repo_paths(self) -> None:
+        cases = {
+            "basefoundry/base": "basefoundry/base",
+            "/basefoundry/base.git": "basefoundry/base",
+            " basefoundry/base.git ": "basefoundry/base",
+        }
+
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(github_repo_spec_from_path(value), expected)
+
+    def test_github_repo_spec_normalizes_github_urls(self) -> None:
+        cases = {
+            "https://github.com/basefoundry/base.git": "basefoundry/base",
+            "git@github.com:basefoundry/base.git": "basefoundry/base",
+            " basefoundry/base.git ": "basefoundry/base",
+        }
+
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(github_repo_spec(value, allow_path=True), expected)
+
+    def test_github_repo_spec_rejects_non_github_urls(self) -> None:
+        self.assertIsNone(github_repo_spec("https://gitlab.com/basefoundry/base.git"))
+
+    def test_format_project_command_redacts_url_credentials(self) -> None:
+        formatted = format_project_command(
+            [
+                "basectl",
+                "repo",
+                "clone",
+                "https://user:secret@github.com/basefoundry/base.git",
+            ]
+        )
+
+        self.assertNotIn("secret", formatted)
+        self.assertIn("[REDACTED]", formatted)
+
+    def test_run_project_command_captures_text_output(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["basectl", "repo", "clone"],
+            0,
+            stdout="cloned\n",
+            stderr="",
+        )
+
+        with mock.patch("base_projects.command_helpers.subprocess.run", return_value=completed) as run:
+            result = run_project_command(
+                ["basectl", "repo", "clone"],
+                error_context="basectl repo clone for repository 'base'",
+            )
+
+        run.assert_called_once_with(
+            ["basectl", "repo", "clone"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout, "cloned\n")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.returncode, 0)
+
+    def test_run_project_command_reports_os_error_with_redacted_command(self) -> None:
+        command = [
+            "basectl",
+            "repo",
+            "clone",
+            "https://user:secret@github.com/basefoundry/base.git",
+        ]
+
+        with mock.patch("base_projects.command_helpers.subprocess.run", side_effect=OSError("missing basectl")):
+            with self.assertRaises(ProjectCommandError) as exc:
+                run_project_command(command, error_context="basectl repo clone")
+
+        message = str(exc.exception)
+        self.assertIn("Could not run basectl repo clone", message)
+        self.assertIn("[REDACTED]", message)
+        self.assertNotIn("secret", message)

--- a/cli/python/base_projects/workspace_configure.py
+++ b/cli/python/base_projects/workspace_configure.py
@@ -6,9 +6,9 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import base_cli
+from base_projects.command_helpers import github_repo_spec
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_manifest import WorkspaceManifestRepo
@@ -244,25 +244,3 @@ def git_config_origin_url(root: Path) -> str | None:
     if not parser.has_option(section, "url"):
         return None
     return parser.get(section, "url").strip()
-
-
-def github_repo_spec(url: str) -> str | None:
-    parsed = urlparse(url)
-    if parsed.scheme and parsed.hostname == "github.com":
-        return github_repo_spec_from_path(parsed.path)
-
-    git_ssh_prefix = "git@github.com:"
-    if url.startswith(git_ssh_prefix):
-        return github_repo_spec_from_path(url[len(git_ssh_prefix) :])
-
-    return None
-
-
-def github_repo_spec_from_path(path: str) -> str | None:
-    normalized = path.strip("/")
-    if normalized.endswith(".git"):
-        normalized = normalized[:-4]
-    parts = normalized.split("/")
-    if len(parts) != 2 or not all(parts):
-        return None
-    return f"{parts[0]}/{parts[1]}"


### PR DESCRIPTION
## Summary

- add `base_projects.command_helpers` for shared project usage errors, GitHub repo-spec parsing, command formatting/redaction, and command execution
- route workspace init/clone/configure and GitHub Project repo inference through the shared parser
- route workspace clone subprocess handling through the shared runner while preserving stdout/stderr forwarding and user-facing clone failures

Fixes #1167
Fixes #1168

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_command_helpers.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_command_helpers.py cli/python/base_projects/tests/test_workspace_clone.py cli/python/base_projects/tests/test_workspace_configure.py cli/python/base_projects/tests/test_engine.py cli/python/base_github_projects/tests/test_engine.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests cli/python/base_github_projects/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_projects/command_helpers.py cli/python/base_projects/engine.py cli/python/base_projects/workspace_configure.py cli/python/base_github_projects/engine.py cli/python/base_projects/tests/test_command_helpers.py`
- `git diff --check`
- `rg -n "class ProjectUsageError|def github_repo_spec_from_path" cli/python/base_projects cli/python/base_github_projects`
