### PR TITLE
Consolidate history and log display helpers

### DIFF
--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -8,6 +8,10 @@ from typing import Any
 
 import base_cli
 from base_cli.history import HISTORY_PATH
+from base_cli.history import optional_int
+from base_cli.history import optional_string
+from base_cli.history import parse_finished_history_record_line
+from base_cli.history import parse_positive_int
 from base_cli.paths import base_cache_root
 
 
@@ -102,15 +106,6 @@ def normalize_format(value: str) -> str:
     return normalized
 
 
-def parse_positive_int(option: str, value: str) -> int:
-    if not value.isdigit():
-        raise ValueError(f"Option '{option}' must be a positive integer.")
-    amount = int(value)
-    if amount <= 0:
-        raise ValueError(f"Option '{option}' must be greater than zero.")
-    return amount
-
-
 def recent_history(
     cache_root: Path,
     options: HistoryOptions | None = None,
@@ -143,13 +138,8 @@ def read_history_records(cache_root: Path, logger: Any | None = None) -> list[Hi
 
 
 def parse_history_line(line: str) -> HistoryRecord | None:
-    try:
-        payload = json.loads(line)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
-        return None
-    if payload.get("event") != "finished":
+    payload = parse_finished_history_record_line(line)
+    if payload is None:
         return None
 
     run_id = optional_string(payload.get("run_id"))
@@ -170,14 +160,6 @@ def parse_history_line(line: str) -> HistoryRecord | None:
         sort_time=parse_timestamp(ended_at),
         log_path=optional_string(payload.get("log_path")),
     )
-
-
-def optional_string(value: Any) -> str | None:
-    return value if isinstance(value, str) and value else None
-
-
-def optional_int(value: Any) -> int | None:
-    return value if isinstance(value, int) else None
 
 
 def parse_timestamp(value: str) -> datetime:

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 import re
 import shlex
@@ -10,10 +9,15 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 import base_cli
 from base_cli.history import HISTORY_PATH
+from base_cli.history import compact_path
+from base_cli.history import display_command
+from base_cli.history import optional_int
+from base_cli.history import optional_string
+from base_cli.history import parse_finished_history_record_line
+from base_cli.history import parse_positive_int
 from base_cli.paths import base_cache_root
 
 
@@ -47,6 +51,7 @@ class LogCommandOptions:
 class HistoryLogStatus:
     status: str
     exit_code: int | None
+    command: str | None
 
 
 @dataclass(frozen=True)
@@ -104,15 +109,6 @@ def run(
     return run_with_entries(entries, options)
 
 
-def parse_positive_int(option: str, value: str) -> int:
-    if not value.isdigit():
-        raise ValueError(f"Option '{option}' must be a positive integer.")
-    amount = int(value)
-    if amount <= 0:
-        raise ValueError(f"Option '{option}' must be greater than zero.")
-    return amount
-
-
 def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandOptions) -> int:
     if options.path_only or options.tail or options.open_file:
         ctx.log.error("No Base CLI logs found.")
@@ -165,7 +161,9 @@ def discover_log_entries(cache_root: Path) -> list[LogEntry]:
             history_status = history_status_for_log(history_statuses, run_id=path.stem, path=path)
             entries.append(
                 LogEntry(
-                    command=infer_display_command(raw_command, path),
+                    command=history_status.command
+                    if history_status is not None and history_status.command is not None
+                    else infer_display_command(raw_command, path),
                     raw_command=raw_command,
                     run_id=path.stem,
                     path=path,
@@ -196,13 +194,8 @@ def read_history_log_statuses(cache_root: Path) -> HistoryLogStatusIndex:
 
 
 def parse_history_log_status_line(line: str) -> tuple[str, str | None, HistoryLogStatus] | None:
-    try:
-        payload = json.loads(line)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
-        return None
-    if payload.get("event") != "finished":
+    payload = parse_finished_history_record_line(line)
+    if payload is None:
         return None
 
     run_id = optional_string(payload.get("run_id"))
@@ -213,16 +206,12 @@ def parse_history_log_status_line(line: str) -> tuple[str, str | None, HistoryLo
     return (
         run_id,
         optional_string(payload.get("log_path")),
-        HistoryLogStatus(status=status, exit_code=optional_int(payload.get("exit_code"))),
+        HistoryLogStatus(
+            status=status,
+            exit_code=optional_int(payload.get("exit_code")),
+            command=optional_string(payload.get("command")),
+        ),
     )
-
-
-def optional_string(value: Any) -> str | None:
-    return value if isinstance(value, str) and value else None
-
-
-def optional_int(value: Any) -> int | None:
-    return value if isinstance(value, int) else None
 
 
 def history_status_for_log(index: HistoryLogStatusIndex, run_id: str, path: Path) -> HistoryLogStatus | None:
@@ -236,10 +225,8 @@ def normalize_history_log_path(value: str) -> str:
 def infer_display_command(raw_command: str, path: Path) -> str:
     if raw_command == "base_setup":
         action = infer_base_setup_action(path)
-        return action or "setup"
-    if raw_command.startswith("base_"):
-        return raw_command.removeprefix("base_").replace("_", "-")
-    return raw_command.replace("_", "-")
+        return action or display_command(raw_command, [])
+    return display_command(raw_command, [])
 
 
 def infer_base_setup_action(path: Path) -> str | None:
@@ -312,13 +299,6 @@ def print_log_table(entries: list[LogEntry]) -> None:
             f"{entry.status:<6}  "
             f"{compact_path(entry.path)}"
         )
-
-
-def compact_path(path: Path) -> str:
-    try:
-        return f"~/{path.expanduser().resolve().relative_to(Path.home().resolve())}"
-    except ValueError:
-        return str(path)
 
 
 def tail_log(path: Path, lines: int) -> int:

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -149,6 +149,37 @@ class BaseLogsTests(unittest.TestCase):
         self.assertEqual([entry.path for entry in display_filtered], [log_path])
         self.assertEqual([entry.path for entry in raw_filtered], [log_path])
 
+    def test_history_command_overrides_base_setup_log_action_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            run_id = "20260601T010000_aaaaaaaa"
+            log_path = write_log(
+                cache_root,
+                "base_setup",
+                run_id,
+                "2026-06-01 01:00:00 DEBUG argv=['base_setup']\n",
+            )
+            write_history_line(
+                cache_root,
+                {
+                    "schema_version": 1,
+                    "run_id": run_id,
+                    "event": "finished",
+                    "command": "check",
+                    "raw_command": "base_setup",
+                    "ended_at": "2026-06-01T01:00:02Z",
+                    "exit_code": 0,
+                    "status": "ok",
+                    "log_path": str(log_path),
+                },
+            )
+
+            entries = engine.recent_logs(cache_root)
+            filtered = engine.recent_logs(cache_root, command_filter="check")
+
+        self.assertEqual(entries[0].command, "check")
+        self.assertEqual([entry.path for entry in filtered], [log_path])
+
     def test_history_status_can_match_by_log_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -98,6 +98,35 @@ def display_command(cli_name: str, argv: list[str]) -> str:
     return cli_name.replace("_", "-")
 
 
+def parse_positive_int(option: str, value: str) -> int:
+    if not value.isdigit():
+        raise ValueError(f"Option '{option}' must be a positive integer.")
+    amount = int(value)
+    if amount <= 0:
+        raise ValueError(f"Option '{option}' must be greater than zero.")
+    return amount
+
+
+def parse_finished_history_record_line(line: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+        return None
+    if payload.get("event") != "finished":
+        return None
+    return payload
+
+
+def optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def optional_int(value: Any) -> int | None:
+    return value if isinstance(value, int) else None
+
+
 def base_setup_action(argv: list[str]) -> str | None:
     for index, arg in enumerate(argv):
         if arg == "--action" and index + 1 < len(argv):

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest import mock
 
 import base_cli
+from base_cli import history as history_helpers
 
 
 def read_history_records(cache_root: Path) -> list[dict]:
@@ -19,6 +20,38 @@ def read_history_records(cache_root: Path) -> list[dict]:
 
 
 class BaseCliHistoryTests(unittest.TestCase):
+    def test_shared_history_helpers_parse_records_and_display_paths(self) -> None:
+        payload = {
+            "schema_version": 1,
+            "event": "finished",
+            "run_id": "run-1",
+            "command": "check",
+            "status": "ok",
+            "exit_code": 0,
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            inside_home = home / "logs" / "run.log"
+            outside_home = Path(tmpdir) / "outside" / "run.log"
+            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+                self.assertEqual(
+                    history_helpers.parse_finished_history_record_line(json.dumps(payload)),
+                    payload,
+                )
+                self.assertIsNone(history_helpers.parse_finished_history_record_line("{not json"))
+                self.assertIsNone(
+                    history_helpers.parse_finished_history_record_line(
+                        json.dumps({**payload, "event": "started"})
+                    )
+                )
+                self.assertEqual(history_helpers.display_command("base_setup", ["--action", "check"]), "check")
+                self.assertEqual(history_helpers.compact_path(inside_home), "~/logs/run.log")
+                self.assertEqual(
+                    history_helpers.compact_path(outside_home),
+                    str(outside_home.expanduser().resolve(strict=False)),
+                )
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_records_successful_command_history_with_redacted_metadata(self) -> None:
         app = base_cli.App(name="history-demo", version="0.1.0")


### PR DESCRIPTION
## Summary

- move shared history JSONL parsing, scalar parsing, positive-int parsing, and path compaction helpers into `base_cli.history`
- switch `base_history` and `base_logs` to use the shared history helpers
- make `base_logs` prefer the parsed history record command when matching a log, so logs/history agree on `base_setup --action` display

Fixes #1169

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_history.py::BaseCliHistoryTests::test_shared_history_helpers_parse_records_and_display_paths cli/python/base_logs/tests/test_engine.py::BaseLogsTests::test_history_command_overrides_base_setup_log_action_fallback -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_history.py cli/python/base_logs/tests/test_engine.py cli/python/base_history/tests/test_engine.py -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests cli/python/base_logs/tests cli/python/base_history/tests -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint lib/python/base_cli/history.py lib/python/base_cli/tests/test_history.py cli/python/base_logs/engine.py cli/python/base_logs/tests/test_engine.py cli/python/base_history/engine.py cli/python/base_history/tests/test_engine.py`
- `git diff --check`
- `rg -n "def parse_positive_int|def optional_string|def optional_int|def compact_path|def infer_display_command|def parse_finished_history_record_line" lib/python/base_cli/history.py cli/python/base_logs/engine.py cli/python/base_history/engine.py`
