### PR TITLE
Verify project installer template downloads

### DIFF
--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -26,6 +26,71 @@ EOF
     chmod +x "$TEST_MOCKBIN/gh"
 }
 
+write_project_installer_template_mocks() {
+    local real_bash="$1"
+    local installer_body="$2"
+
+    cat > "$TEST_MOCKBIN/curl" <<EOF
+#!$real_bash
+output=""
+while ((\$#)); do
+    case "\$1" in
+        -o)
+            output="\$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+[[ -n "\$output" ]] || exit 1
+cat > "\$output" <<'INSTALLER'
+$installer_body
+INSTALLER
+EOF
+    chmod +x "$TEST_MOCKBIN/curl"
+
+    cat > "$TEST_MOCKBIN/git" <<EOF
+#!$real_bash
+case "\${1:-}" in
+    clone)
+        target="\${@: -1}"
+        mkdir -p "\$target/.git"
+        printf 'project:\n  name: demo\nartifacts: []\n' > "\$target/base_manifest.yaml"
+        ;;
+    *)
+        ;;
+esac
+EOF
+    chmod +x "$TEST_MOCKBIN/git"
+
+    cat > "$TEST_MOCKBIN/bash" <<EOF
+#!$real_bash
+printf 'bash %s\n' "\$*" >> "\${BASE_REPO_TEST_STATE_DIR:?}/bash.log"
+base_dir=""
+while ((\$#)); do
+    case "\$1" in
+        --dir)
+            base_dir="\$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+[[ -n "\$base_dir" ]] || exit 1
+mkdir -p "\$base_dir/.git" "\$base_dir/bin"
+cat > "\$base_dir/bin/basectl" <<'BASECTL'
+#!$real_bash
+printf 'basectl %s\n' "\$*" >> "\${BASE_REPO_TEST_STATE_DIR:?}/basectl.log"
+BASECTL
+chmod +x "\$base_dir/bin/basectl"
+EOF
+    chmod +x "$TEST_MOCKBIN/bash"
+}
+
 run_repo_command_with_mocks() {
     run env \
         HOME="$TEST_HOME" \
@@ -405,10 +470,56 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *'PROJECT_NAME="${PROJECT_NAME:-example-project}"'* ]]
     [[ "$output" == *'PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/example/example-project.git}"'* ]]
+    [[ "$output" == *'BASE_INSTALL_SHA256="${BASE_INSTALL_SHA256:-}"'* ]]
     [[ "$output" == *'basectl" setup --manifest "$PROJECT_DIR/base_manifest.yaml" "$PROJECT_NAME"'* ]]
     [[ "$output" == *"Explicit error handling is used instead of set -e"* ]]
     [[ "$output" == *'run git -C "$BASE_DIR" pull --ff-only || die'* ]]
     [[ "$output" != *"set -euo pipefail"* ]]
+}
+
+@test "project installer template rejects mismatched Base installer checksum before execution" {
+    local real_bash
+    local installer_body='printf "installer should not run\n"'
+
+    real_bash="$(command -v bash)"
+    write_project_installer_template_mocks "$real_bash" "$installer_body"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_INSTALL_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
+        WORKSPACE_DIR="$TEST_TMPDIR/workspace" \
+        PROJECT_NAME="demo" \
+        "$real_bash" "$BASE_REPO_ROOT/templates/project-install.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Base installer checksum mismatch"* ]]
+    [ ! -f "$TEST_STATE_DIR/bash.log" ]
+}
+
+@test "project installer template verifies matching Base installer checksum" {
+    local real_bash
+    local installer_body='printf "installer ok\n"'
+    local checksum
+
+    real_bash="$(command -v bash)"
+    checksum="$(printf '%s\n' "$installer_body" | shasum -a 256)"
+    checksum="${checksum%% *}"
+    write_project_installer_template_mocks "$real_bash" "$installer_body"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_INSTALL_SHA256="$checksum" \
+        WORKSPACE_DIR="$TEST_TMPDIR/workspace" \
+        PROJECT_NAME="demo" \
+        "$real_bash" "$BASE_REPO_ROOT/templates/project-install.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Verified Base installer SHA-256 $checksum."* ]]
+    [ -f "$TEST_STATE_DIR/bash.log" ]
 }
 
 @test "basectl repo installer-template writes install.sh by default" {

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -77,7 +77,20 @@ PROJECT_REPO_URL="${PROJECT_REPO_URL:-https://github.com/basefoundry/banyanlabs.
 WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/work}"
 BASE_DIR="${BASE_DIR:-$WORKSPACE_DIR/base}"
 PROJECT_DIR="${PROJECT_DIR:-$WORKSPACE_DIR/$PROJECT_NAME}"
+BASE_INSTALL_URL="${BASE_INSTALL_URL:-https://raw.githubusercontent.com/basefoundry/base/HEAD/install.sh}"
+BASE_INSTALL_SHA256="${BASE_INSTALL_SHA256:-}"
 RUN_UPDATE_PROFILE="${RUN_UPDATE_PROFILE:-true}"
+```
+
+`BASE_INSTALL_SHA256` is empty by default because the maintained template points
+at Base's mutable `HEAD/install.sh`. When a project pins `BASE_INSTALL_URL` to a
+tag, commit, or project-owned copy, set `BASE_INSTALL_SHA256` to that installer's
+SHA-256 digest. The template verifies the downloaded installer before executing
+it and stops immediately on a mismatch. Update the digest whenever the pinned
+installer content changes:
+
+```bash
+curl -fsSL "$BASE_INSTALL_URL" | shasum -a 256
 ```
 
 It should also replace the generic success text with project-specific next

--- a/templates/project-install.sh
+++ b/templates/project-install.sh
@@ -10,6 +10,7 @@ WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/work}"
 BASE_DIR="${BASE_DIR:-$WORKSPACE_DIR/base}"
 PROJECT_DIR="${PROJECT_DIR:-$WORKSPACE_DIR/$PROJECT_NAME}"
 BASE_INSTALL_URL="${BASE_INSTALL_URL:-https://raw.githubusercontent.com/basefoundry/base/HEAD/install.sh}"
+BASE_INSTALL_SHA256="${BASE_INSTALL_SHA256:-}"
 RUN_UPDATE_PROFILE="${RUN_UPDATE_PROFILE:-true}"
 
 INSTALLER_TMP=""
@@ -41,6 +42,26 @@ require_command() {
     command -v "$1" >/dev/null 2>&1 || die "Required command '$1' was not found."
 }
 
+verify_base_installer() {
+    local actual_sha256
+    local checksum_output
+
+    if [[ -z "$BASE_INSTALL_SHA256" ]]; then
+        return 0
+    fi
+
+    require_command shasum
+    [[ "$BASE_INSTALL_SHA256" =~ ^[0-9a-fA-F]{64}$ ]] || die "BASE_INSTALL_SHA256 must be a 64-character SHA-256 hex digest."
+
+    checksum_output="$(shasum -a 256 "$INSTALLER_TMP")" || die "Failed to compute Base installer checksum."
+    actual_sha256="${checksum_output%% *}"
+    if [[ "$actual_sha256" != "$BASE_INSTALL_SHA256" ]]; then
+        die "Base installer checksum mismatch (expected $BASE_INSTALL_SHA256, got $actual_sha256)."
+    fi
+
+    log "Verified Base installer SHA-256 $BASE_INSTALL_SHA256."
+}
+
 ensure_workspace() {
     run mkdir -p "$WORKSPACE_DIR" || die "Failed to create workspace directory '$WORKSPACE_DIR'."
 }
@@ -62,6 +83,7 @@ install_or_update_base() {
     INSTALLER_TMP="$(mktemp "${TMPDIR:-/tmp}/base-install.XXXXXX")" || die "Failed to create installer temp file."
     log "Installing Base into '$BASE_DIR'."
     run curl -fsSL -o "$INSTALLER_TMP" "$BASE_INSTALL_URL" || die "Failed to download Base installer."
+    verify_base_installer || die "Base installer verification failed."
     run bash "$INSTALLER_TMP" --dir "$BASE_DIR" --no-profile || die "Failed to install Base into '$BASE_DIR'."
 }
 


### PR DESCRIPTION
## Summary
- add opt-in SHA-256 verification for downloaded Base installers in the maintained project installer template
- stop before executing the downloaded installer when the configured digest does not match
- document how projects should pin BASE_INSTALL_URL and BASE_INSTALL_SHA256 together

Closes #1178

## Verification
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "project installer template" cli/bash/commands/basectl/tests/repo.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "installer-template" cli/bash/commands/basectl/tests/repo.bats
- shellcheck -S error templates/project-install.sh cli/bash/commands/basectl/tests/repo.bats
- git diff --check
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats