### PR TITLE
Reject HTTP workspace repo URLs

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_manifest.py
@@ -58,8 +58,12 @@ repos:
     url: https://github.com/codeforester/base.git
   - name: ssh-repo
     url: ssh://git@github.com/codeforester/base.git
+  - name: git-protocol-repo
+    url: git://github.com/codeforester/base.git
   - name: scp-repo
     url: git@github.com:codeforester/base.git
+  - name: file-repo
+    url: file:///opt/repos/base.git
   - name: local-repo
     url: {local_repo}
 """,
@@ -72,10 +76,33 @@ repos:
             [
                 "https://github.com/codeforester/base.git",
                 "ssh://git@github.com/codeforester/base.git",
+                "git://github.com/codeforester/base.git",
                 "git@github.com:codeforester/base.git",
+                "file:///opt/repos/base.git",
                 str(local_repo),
             ],
         )
+
+    def test_rejects_cleartext_http_repo_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "workspace.yaml"
+            write_workspace_manifest(
+                path,
+                """
+schema_version: 1
+workspace:
+  name: demo-workspace
+repos:
+  - name: base
+    url: http://github.com/codeforester/base.git
+""",
+            )
+
+            with self.assertRaisesRegex(
+                WorkspaceManifestError,
+                "repos\\[1\\]\\.url uses insecure cleartext HTTP",
+            ):
+                read_workspace_manifest(path)
 
     def test_rejects_repo_url_without_git_url_form(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/workspace_manifest.py
+++ b/cli/python/base_projects/workspace_manifest.py
@@ -161,7 +161,12 @@ def _read_optional_string(path: Path, field: str, value: Any) -> str | None:
 
 
 def _validate_repo_url(path: Path, index: int, url: str) -> None:
-    if url.startswith(("https://", "http://", "git://", "ssh://", "file://")):
+    if url.startswith("http://"):
+        raise WorkspaceManifestError(
+            f"{path}: repos[{index}].url uses insecure cleartext HTTP. "
+            "Use HTTPS, SSH, file://, or an absolute local path."
+        )
+    if url.startswith(("https://", "git://", "ssh://", "file://")):
         return
     if re.match(r"^[^@\s]+@[^:\s]+:.+$", url):
         return

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -130,9 +130,11 @@ guidance.
 stable identifier used in reports.
 
 `repos[].url` is optional v1 metadata for a Git clone URL. The
-`basectl workspace clone` command supports common `github.com` SSH and HTTPS
-repository URLs and otherwise falls back to `repos[].name` when no URL is
-provided. Base does not parse credentials or manage authentication.
+`basectl workspace clone` command supports HTTPS, SSH, Git protocol,
+SCP-style SSH, `file://`, and absolute local path repository sources. It
+otherwise falls back to `repos[].name` when no URL is provided. Cleartext
+`http://` repository URLs are rejected by default. Base does not parse
+credentials or manage authentication.
 
 `repos[].default_branch` is advisory metadata for reports and future clone
 validation. It should default to the remote's default branch when omitted, but


### PR DESCRIPTION
## Summary
- reject cleartext http:// repository URLs in workspace manifests before clone planning
- preserve supported HTTPS, SSH, Git protocol, SCP-style SSH, file://, and absolute local path repo URL forms
- document the repo URL policy beside repos[].url

Closes #1179

## Verification
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_workspace_manifest.py
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests
- git diff --check