### PR TITLE
Add contract hardening checks

### DIFF
--- a/.github/base-project.yml
+++ b/.github/base-project.yml
@@ -19,6 +19,7 @@ project:
     - pyproject/uv
     - v1.0 Readiness
     - Adoption Polish
+    - Contract Hardening
   issue_defaults:
     status: Backlog
     priority: P2

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,8 @@ reference. The filename should answer "what is this about?"
   pre-1.0.0 consumer upgrade proof and records rehearsal results.
 - [Testing](testing.md) explains Base's Python, BATS, and hermetic integration
   test layers.
+- [Base Contracts](contracts.md) maps documented behavior contracts to their
+  source of truth and executable enforcement checks.
 - [CI Supply Chain Policy](ci-supply-chain-policy.md) defines GitHub Action
   pinning, Python dependency auditing, and package-manager trust boundaries for
   repository workflows.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,0 +1,52 @@
+# Base Contracts
+
+Base contracts are documented promises that should fail loudly when behavior,
+docs, tests, generated guidance, or workflow policy drift apart. This registry
+maps the first high-value contracts to their source of truth and executable
+enforcement.
+
+Use this page during product reviews and large review-batch triage. If a
+finding says "the docs say X but the code does Y", add or update a contract row
+before treating the fix as complete.
+
+## Contract Registry
+
+| Contract | Source of truth | Enforced by | Failure mode | Area |
+| --- | --- | --- | --- | --- |
+| GitHub workflow policy | [GitHub Workflow](github-workflow.md), [CI Supply Chain Policy](ci-supply-chain-policy.md), `.github/workflows/*.yml` | `tests/test_github_workflows.py` | Workflow permissions, concurrency, timeout, token, supported Python, or generated-guidance policy drift | CI |
+| Workspace manifest repository URL policy | [Workspace Manifest](workspace-manifest.md), `cli/python/base_projects/workspace_manifest.py` | `cli/python/base_projects/tests/test_workspace_manifest.py` | A documented accepted URL form is rejected, or an insecure `http://` repository URL passes silently | Workspace |
+| Workspace manifest source policy | [Workspace Manifest](workspace-manifest.md), `cli/python/base_projects/workspace_pull.py` | `cli/python/base_projects/tests/test_workspace_pull.py` | `workspace.manifest_source` accepts cleartext HTTP or overwrites a local manifest after an invalid fetch | Workspace |
+| Project installer template integrity | [Project Installers](project-installers.md), `templates/project-install.sh` | `cli/bash/commands/basectl/tests/repo.bats` | The maintained installer template downloads and executes a Base installer without honoring configured SHA-256 verification | Security |
+| CLI docs, help, and completion drift | [Command Quick Reference](command-reference.md), `.ai-context/COMMANDS.md`, `bin/basectl`, shell completion scripts | `cli/bash/commands/basectl/tests/docs.bats`, `cli/bash/commands/basectl/tests/help.bats`, `cli/bash/commands/basectl/tests/completions.bats` | Public help, docs shortcut behavior, command reference, AI context, or completions no longer match the shipped command surface | CLI |
+| Project metadata defaults | `.github/base-project.yml`, [GitHub Workflow](github-workflow.md), [Repository Baseline](repo-baseline.md) | `cli/python/base_github_projects/tests/`, `cli/bash/commands/basectl/tests/gh.bats`, `cli/bash/commands/basectl/tests/repo.bats` | Issue defaults, Project field options, or repo-visible Project configuration drift from the Base Project schema | Product |
+
+## Contract Check Runner
+
+Run the first contract slice with:
+
+```bash
+tests/contracts/run.sh
+```
+
+The runner intentionally composes existing focused tests. It is not a
+replacement for the full suite. Use it when:
+
+- a review batch reports docs/implementation drift;
+- a change edits workflow policy, public command docs, generated guidance,
+  workspace manifest policy, or project installer behavior;
+- a PR needs a fast contract-focused signal before broader validation.
+
+## Review Finding Taxonomy
+
+Classify future review findings before opening issues:
+
+- `implementation bug`: shipped behavior is wrong even if docs are silent.
+- `docs/implementation drift`: docs and behavior disagree.
+- `missing regression test`: a fixed bug has no focused test.
+- `missing policy test`: a documented policy has no executable guard.
+- `duplicated helper/API drift`: parallel helpers disagree or invite inconsistent fixes.
+- `stale generated artifact`: generated guidance, completions, or exported context is out of date.
+
+This classification should appear in issue bodies for review-driven findings.
+It keeps future passes focused on the failure mode instead of producing another
+undifferentiated backlog.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -128,3 +128,20 @@ Run only integration tests with:
 BASE_INTEGRATION_PYTHON="$HOME/.base.d/base/.venv/bin/python" \
   bats tests/integration/base_workflows.bats
 ```
+
+## Contract Checks
+
+Contract checks are the narrow review-hardening layer for documented behavior
+that has drifted in past reviews: workflow policy, workspace manifest URL
+policy, project installer integrity, and CLI docs/help/completion alignment.
+They are mapped in [Base Contracts](contracts.md).
+
+Run the current contract slice with:
+
+```bash
+tests/contracts/run.sh
+```
+
+Use this runner before or during large review-batch triage, and for PRs that
+edit the mapped contract areas. It composes existing focused tests and should
+stay smaller than the full source-checkout suite.

--- a/tests/contracts/run.sh
+++ b/tests/contracts/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+
+cd "$REPO_ROOT"
+
+if [[ -z "${BASE_BASH_LIBS_DIR:-}" ]]; then
+    for candidate in "$REPO_ROOT/../base-bash-libs/lib/bash" "$REPO_ROOT/../../base-bash-libs/lib/bash"; do
+        if [[ -d "$candidate" ]]; then
+            export BASE_BASH_LIBS_DIR="$candidate"
+            break
+        fi
+    done
+fi
+
+if [[ -n "${PYTHON:-}" ]]; then
+    PYTHON_BIN="$PYTHON"
+elif [[ -x "$HOME/.base.d/base/.venv/bin/python" ]]; then
+    PYTHON_BIN="$HOME/.base.d/base/.venv/bin/python"
+else
+    PYTHON_BIN="python3"
+fi
+
+export PYTHONPATH="$REPO_ROOT/cli/python:$REPO_ROOT/lib/python${PYTHONPATH:+:$PYTHONPATH}"
+
+run_step() {
+    printf '\n==> '
+    printf '%q ' "$@"
+    printf '\n'
+    "$@"
+}
+
+run_step "$PYTHON_BIN" -m pytest tests/test_github_workflows.py
+run_step "$PYTHON_BIN" -m pytest cli/python/base_projects/tests/test_workspace_manifest.py
+run_step "$PYTHON_BIN" -m pytest cli/python/base_projects/tests/test_workspace_pull.py
+run_step bats --filter "project installer template" cli/bash/commands/basectl/tests/repo.bats
+run_step bats cli/bash/commands/basectl/tests/docs.bats
+run_step bats cli/bash/commands/basectl/tests/help.bats
+run_step bats cli/bash/commands/basectl/tests/completions.bats

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACTS_DOC = REPO_ROOT / "docs" / "contracts.md"
+CONTRACT_RUNNER = REPO_ROOT / "tests" / "contracts" / "run.sh"
+
+
+def test_contract_registry_maps_initial_review_contracts_to_enforcement() -> None:
+    text = CONTRACTS_DOC.read_text(encoding="utf-8")
+
+    expected_entries = {
+        "GitHub workflow policy": "tests/test_github_workflows.py",
+        "Workspace manifest repository URL policy": "cli/python/base_projects/tests/test_workspace_manifest.py",
+        "Project installer template integrity": "cli/bash/commands/basectl/tests/repo.bats",
+        "CLI docs, help, and completion drift": "cli/bash/commands/basectl/tests/completions.bats",
+    }
+    for contract, enforcement in expected_entries.items():
+        assert contract in text
+        assert enforcement in text
+
+    assert "Source of truth" in text
+    assert "Enforced by" in text
+    assert "Failure mode" in text
+
+
+def test_contract_runner_composes_existing_policy_checks() -> None:
+    text = CONTRACT_RUNNER.read_text(encoding="utf-8")
+
+    expected_commands = [
+        "tests/test_github_workflows.py",
+        "cli/python/base_projects/tests/test_workspace_manifest.py",
+        'bats --filter "project installer template"',
+        "cli/bash/commands/basectl/tests/docs.bats",
+        "cli/bash/commands/basectl/tests/help.bats",
+        "cli/bash/commands/basectl/tests/completions.bats",
+    ]
+    for command in expected_commands:
+        assert command in text
+
+
+def test_contract_runner_supports_base_worktree_library_layout() -> None:
+    text = CONTRACT_RUNNER.read_text(encoding="utf-8")
+
+    assert "../../base-bash-libs/lib/bash" in text
+
+
+def test_contract_runner_is_executable() -> None:
+    assert CONTRACT_RUNNER.exists()
+    assert CONTRACT_RUNNER.stat().st_mode & 0o111


### PR DESCRIPTION
## Summary
- add a Base contract registry mapping documented promises to source-of-truth docs and enforcement tests
- add `tests/contracts/run.sh` to compose the first workflow, workspace manifest, installer-template, docs/help, and completion contract checks
- document when to use the contract runner and seed the repo-visible `Contract Hardening` Project initiative

Closes #1192

## Verification
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_contract_hardening.py
- tests/contracts/run.sh
- shellcheck -S error tests/contracts/run.sh
- git diff --cached --check