### PR TITLE
Harden contract and workflow policy tests

### DIFF
--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -6,6 +6,33 @@ CONTRACTS_DOC = REPO_ROOT / "docs" / "contracts.md"
 CONTRACT_RUNNER = REPO_ROOT / "tests" / "contracts" / "run.sh"
 
 
+def contract_registry_rows() -> list[dict[str, str]]:
+    text = CONTRACTS_DOC.read_text(encoding="utf-8")
+    headers: list[str] = []
+    rows: list[dict[str, str]] = []
+    in_registry = False
+
+    for line in text.splitlines():
+        if line == "## Contract Registry":
+            in_registry = True
+            continue
+        if in_registry and line.startswith("## ") and rows:
+            break
+        if not in_registry or not line.startswith("|"):
+            continue
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if not headers:
+            headers = cells
+            continue
+        if all(set(cell) <= {"-"} for cell in cells):
+            continue
+        if len(cells) == len(headers):
+            rows.append(dict(zip(headers, cells)))
+
+    return rows
+
+
 def test_contract_registry_maps_initial_review_contracts_to_enforcement() -> None:
     text = CONTRACTS_DOC.read_text(encoding="utf-8")
 
@@ -23,6 +50,25 @@ def test_contract_registry_maps_initial_review_contracts_to_enforcement() -> Non
     assert "Source of truth" in text
     assert "Enforced by" in text
     assert "Failure mode" in text
+
+
+def test_contract_registry_rows_have_complete_enforcement_metadata() -> None:
+    rows = contract_registry_rows()
+
+    assert {row["Contract"] for row in rows} == {
+        "GitHub workflow policy",
+        "Workspace manifest repository URL policy",
+        "Workspace manifest source policy",
+        "Project installer template integrity",
+        "CLI local log file privacy",
+        "CLI docs, help, and completion drift",
+        "Project metadata defaults",
+    }
+    for row in rows:
+        assert row["Source of truth"], row
+        assert row["Enforced by"], row
+        assert row["Failure mode"], row
+        assert row["Area"], row
 
 
 def test_contract_runner_composes_existing_policy_checks() -> None:

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import yaml
@@ -5,6 +6,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+FULL_COMMIT_SHA_ACTION_REF = re.compile(r"^[^@]+@[0-9a-f]{40}$")
 
 
 def workflow_files() -> list[Path]:
@@ -15,6 +17,44 @@ def load_workflow(path: Path) -> dict:
     payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert isinstance(payload, dict), f"{path} did not parse as a YAML mapping"
     return payload
+
+
+def workflow_steps(path: Path) -> list[tuple[str, int, dict]]:
+    workflow = load_workflow(path)
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), f"{path} jobs did not parse as a YAML mapping"
+
+    steps: list[tuple[str, int, dict]] = []
+    for job_name, job in jobs.items():
+        assert isinstance(job, dict), f"{path} job {job_name} did not parse as a YAML mapping"
+        job_steps = job.get("steps", [])
+        assert isinstance(job_steps, list), f"{path} job {job_name} steps did not parse as a list"
+        steps.extend(
+            (job_name, index, step)
+            for index, step in enumerate(job_steps)
+            if isinstance(step, dict)
+        )
+    return steps
+
+
+def workflow_action_references_without_full_sha() -> list[str]:
+    unpinned: list[str] = []
+    for path in workflow_files():
+        for job_name, index, step in workflow_steps(path):
+            uses = step.get("uses")
+            if not isinstance(uses, str) or uses.startswith("./"):
+                continue
+            if not FULL_COMMIT_SHA_ACTION_REF.match(uses):
+                unpinned.append(f"{path.name}:{job_name}:steps[{index}] uses {uses}")
+    return unpinned
+
+
+def workflow_step_by_name(job: dict, name: str) -> dict:
+    steps = job.get("steps", [])
+    assert isinstance(steps, list)
+    matches = [step for step in steps if isinstance(step, dict) and step.get("name") == name]
+    assert len(matches) == 1, f"Expected exactly one workflow step named {name!r}, found {len(matches)}."
+    return matches[0]
 
 
 def test_all_workflows_cancel_superseded_runs() -> None:
@@ -34,6 +74,12 @@ def test_all_workflow_jobs_have_timeouts() -> None:
                 missing.append(f"{path.name}:{job_name}")
 
     assert not missing, missing
+
+
+def test_all_workflow_action_uses_are_pinned_to_full_commit_sha() -> None:
+    unpinned = workflow_action_references_without_full_sha()
+
+    assert not unpinned, unpinned
 
 
 def test_python_tests_run_on_supported_minor_versions() -> None:
@@ -73,7 +119,8 @@ def test_macos_smoke_tests_cover_shell_compatibility_surfaces() -> None:
 def test_project_intake_requires_base_project_token() -> None:
     workflow = load_workflow(WORKFLOW_DIR / "project-intake.yml")
     sync_job = workflow["jobs"]["sync"]
-    run_command = sync_job["steps"][0]["run"]
+    reconcile_step = workflow_step_by_name(sync_job, "Reconcile Project item")
+    run_command = reconcile_step["run"]
 
     assert sync_job["env"]["GH_TOKEN"] == "${{ secrets.BASE_PROJECT_TOKEN }}"
     assert "github.token" not in run_command


### PR DESCRIPTION
## Summary
- parse every contract registry row and require complete enforcement metadata
- enforce full 40-character SHA pins for external GitHub Actions references
- find the Project Intake reconciliation step by name instead of step index

Closes #1205
Closes #1206

## Verification
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_contract_hardening.py tests/test_github_workflows.py -q
- tests/contracts/run.sh
- git diff --check