### PR TITLE
Bound workspace project command execution

### DIFF
--- a/cli/python/base_projects/command_helpers.py
+++ b/cli/python/base_projects/command_helpers.py
@@ -17,6 +17,9 @@ class ProjectCommandError(RuntimeError):
     pass
 
 
+PROJECT_COMMAND_TIMEOUT_SECONDS = 120
+
+
 @dataclass(frozen=True)
 class ProjectCommandResult:
     returncode: int
@@ -53,9 +56,26 @@ def format_project_command(command: list[str]) -> str:
     return shlex.join(redact_text_value(arg) for arg in command)
 
 
-def run_project_command(command: list[str], *, error_context: str) -> ProjectCommandResult:
+def run_project_command(
+    command: list[str],
+    *,
+    error_context: str,
+    timeout_seconds: int = PROJECT_COMMAND_TIMEOUT_SECONDS,
+) -> ProjectCommandResult:
     try:
-        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        timeout = exc.timeout if exc.timeout is not None else timeout_seconds
+        raise ProjectCommandError(
+            f"Timed out running {error_context} after {timeout} seconds. "
+            f"Command: {format_project_command(command)}"
+        ) from exc
     except OSError as exc:
         raise ProjectCommandError(
             f"Could not run {error_context}: {exc}. Command: {format_project_command(command)}"

--- a/cli/python/base_projects/tests/test_command_helpers.py
+++ b/cli/python/base_projects/tests/test_command_helpers.py
@@ -8,6 +8,7 @@ from base_github_projects import engine as github_engine
 from base_projects import engine as projects_engine
 from base_projects.command_helpers import ProjectCommandError
 from base_projects.command_helpers import ProjectUsageError
+from base_projects.command_helpers import PROJECT_COMMAND_TIMEOUT_SECONDS
 from base_projects.command_helpers import format_project_command
 from base_projects.command_helpers import github_repo_spec
 from base_projects.command_helpers import github_repo_spec_from_path
@@ -76,6 +77,7 @@ class ProjectCommandHelperTests(unittest.TestCase):
             check=False,
             capture_output=True,
             text=True,
+            timeout=PROJECT_COMMAND_TIMEOUT_SECONDS,
         )
         self.assertEqual(result.stdout, "cloned\n")
         self.assertEqual(result.stderr, "")
@@ -95,5 +97,26 @@ class ProjectCommandHelperTests(unittest.TestCase):
 
         message = str(exc.exception)
         self.assertIn("Could not run basectl repo clone", message)
+        self.assertIn("[REDACTED]", message)
+        self.assertNotIn("secret", message)
+
+    def test_run_project_command_reports_timeout_with_redacted_command(self) -> None:
+        command = [
+            "basectl",
+            "repo",
+            "clone",
+            "https://user:secret@github.com/basefoundry/base.git",
+        ]
+
+        with mock.patch(
+            "base_projects.command_helpers.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(command, timeout=PROJECT_COMMAND_TIMEOUT_SECONDS),
+        ):
+            with self.assertRaises(ProjectCommandError) as exc:
+                run_project_command(command, error_context="basectl repo clone")
+
+        message = str(exc.exception)
+        self.assertIn("Timed out running basectl repo clone", message)
+        self.assertIn(str(PROJECT_COMMAND_TIMEOUT_SECONDS), message)
         self.assertIn("[REDACTED]", message)
         self.assertNotIn("secret", message)


### PR DESCRIPTION
Summary:
- add a 120-second default timeout for workspace project subprocesses
- convert timeout failures into ProjectCommandError with redacted command details
- cover timeout and timeout propagation in command helper tests

Closes #1204

Verification:
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_command_helpers.py -q
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests -q
- git diff --check