### PR TITLE
Warn when project installer skips checksum verification

### DIFF
--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -498,6 +498,26 @@ EOF
     [ ! -f "$TEST_STATE_DIR/bash.log" ]
 }
 
+@test "project installer template warns when Base installer checksum is not configured" {
+    local real_bash
+    local installer_body='printf "installer ok\n"'
+
+    real_bash="$(command -v bash)"
+    write_project_installer_template_mocks "$real_bash" "$installer_body"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        WORKSPACE_DIR="$TEST_TMPDIR/workspace" \
+        PROJECT_NAME="demo" \
+        "$real_bash" "$BASE_REPO_ROOT/templates/project-install.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING: BASE_INSTALL_SHA256 is empty; downloaded Base installer checksum verification was skipped."* ]]
+    [ -f "$TEST_STATE_DIR/bash.log" ]
+}
+
 @test "project installer template verifies matching Base installer checksum" {
     local real_bash
     local installer_body='printf "installer ok\n"'

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -83,8 +83,12 @@ RUN_UPDATE_PROFILE="${RUN_UPDATE_PROFILE:-true}"
 ```
 
 `BASE_INSTALL_SHA256` is empty by default because the maintained template points
-at Base's mutable `HEAD/install.sh`. When a project pins `BASE_INSTALL_URL` to a
-tag, commit, or project-owned copy, set `BASE_INSTALL_SHA256` to that installer's
+at Base's mutable `HEAD/install.sh`. That path is convenient for starter
+templates, but it is intentionally visible at runtime: when the value is empty,
+the template warns that downloaded installer checksum verification was skipped.
+
+For project-owned installers, prefer pinning `BASE_INSTALL_URL` to a tag, commit,
+or project-owned copy and setting `BASE_INSTALL_SHA256` to that installer's
 SHA-256 digest. The template verifies the downloaded installer before executing
 it and stops immediately on a mismatch. Update the digest whenever the pinned
 installer content changes:

--- a/templates/project-install.sh
+++ b/templates/project-install.sh
@@ -19,6 +19,10 @@ log() {
     printf '%s\n' "$*"
 }
 
+warn() {
+    printf 'WARNING: %s\n' "$*" >&2
+}
+
 die() {
     printf 'ERROR: %s\n' "$*" >&2
     exit 1
@@ -47,6 +51,7 @@ verify_base_installer() {
     local checksum_output
 
     if [[ -z "$BASE_INSTALL_SHA256" ]]; then
+        warn "BASE_INSTALL_SHA256 is empty; downloaded Base installer checksum verification was skipped."
         return 0
     fi
 


### PR DESCRIPTION
Summary:
- warn when the maintained project installer template runs without BASE_INSTALL_SHA256
- document the mutable default URL and the preferred pinned project-owned path
- cover empty, matching, and mismatched checksum behavior in BATS

Closes #1207

Verification:
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "project installer template" cli/bash/commands/basectl/tests/repo.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats
- shellcheck -S error templates/project-install.sh
- git diff --check