### PR TITLE
Surface default Homebrew installer trust policy

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -163,6 +163,11 @@ bootstrap_homebrew_installer_sha256() {
     fi
 }
 
+bootstrap_log_homebrew_mutable_policy() {
+    bootstrap_log "Homebrew installer trust policy: using Homebrew's official mutable installer without checksum verification."
+    bootstrap_log "Set BASE_HOMEBREW_INSTALLER_URL and BASE_HOMEBREW_INSTALLER_SHA256 to use a pinned verified installer."
+}
+
 bootstrap_fetch_homebrew_installer() {
     local installer_url="$1"
     local target="$2"
@@ -242,6 +247,7 @@ bootstrap_install_homebrew() {
         return 0
     fi
 
+    bootstrap_log_homebrew_mutable_policy
     if [[ "${BASE_BOOTSTRAP_DRY_RUN:-false}" == "true" ]]; then
         bootstrap_log "[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from $installer_url>"
         printf -v "$result_var" '%s' brew

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -545,6 +545,11 @@ setup_homebrew_installer_sha256() {
     fi
 }
 
+setup_log_homebrew_mutable_policy() {
+    log_info "Homebrew installer trust policy: using Homebrew's official mutable installer without checksum verification."
+    log_info "Set BASE_HOMEBREW_INSTALLER_URL and BASE_HOMEBREW_INSTALLER_SHA256 to use a pinned verified installer."
+}
+
 setup_fetch_homebrew_installer() {
     local installer_url="$1"
     local target="$2"
@@ -637,6 +642,7 @@ setup_install_homebrew() {
         return 0
     fi
 
+    setup_log_homebrew_mutable_policy
     if setup_is_dry_run; then
         log_info "[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from $installer_url>"
         return 0

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -865,6 +865,7 @@ EOF
     run_base_command setup --dry-run
 
     [ "$status" -eq 0 ]
+    [[ "$output" == *"Homebrew installer trust policy: using Homebrew's official mutable installer without checksum verification."* ]]
     [[ "$output" == *"[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh>"* ]]
     [[ "$output" == *"[DRY-RUN] Would install Xcode Command Line Tools and wait for installation to complete."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python formula 'python@3.13' via Homebrew."* ]]

--- a/docs/remote-installer-policy.md
+++ b/docs/remote-installer-policy.md
@@ -26,8 +26,11 @@ non-interactive setup stays deterministic.
 ## Managed Workstations And Pinned Installers
 
 Base intentionally follows Homebrew's official mutable installer entry point
-instead of pinning a reviewed commit by default. Teams that require pinned,
-mirrored, or managed Homebrew installer content can opt in by setting both a
+instead of pinning a reviewed commit by default. When Base uses that default
+path, it prints the trust policy before downloading or running the installer.
+
+Teams that require pinned, mirrored, or managed Homebrew installer content can
+opt in by setting both a
 Homebrew installer location and its expected SHA-256 before running Base:
 
 - all Homebrew entry points: `BASE_HOMEBREW_INSTALLER_URL` and

--- a/install.sh
+++ b/install.sh
@@ -142,6 +142,11 @@ install_homebrew_installer_sha256() {
     fi
 }
 
+install_log_homebrew_mutable_policy() {
+    install_log "Homebrew installer trust policy: using Homebrew's official mutable installer without checksum verification."
+    install_log "Set BASE_HOMEBREW_INSTALLER_URL and BASE_HOMEBREW_INSTALLER_SHA256 to use a pinned verified installer."
+}
+
 install_fetch_homebrew_installer() {
     local installer_url="$1"
     local target="$2"
@@ -219,6 +224,7 @@ install_homebrew() {
         return 0
     fi
 
+    install_log_homebrew_mutable_policy
     if [[ "${BASE_INSTALL_DRY_RUN:-false}" == "true" ]]; then
         install_log "[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from $installer_url>"
         return 0

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -155,6 +155,7 @@ sha256_file() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Base bootstrap"* ]]
     [[ "$output" == *"Installing Homebrew."* ]]
+    [[ "$output" == *"Homebrew installer trust policy: using Homebrew's official mutable installer without checksum verification."* ]]
     [[ "$output" == *"[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh>"* ]]
     [[ "$output" == *"Installing Git through Homebrew."* ]]
     [[ "$output" == *"[DRY-RUN] Would run: brew install git"* ]]

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -163,6 +163,7 @@ assert_base_init_loads() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"A supported Bash was not found; bootstrapping Homebrew Bash before running basectl."* ]]
     [[ "$output" == *"Installing Homebrew."* ]]
+    [[ "$output" == *"Homebrew installer trust policy: using Homebrew's official mutable installer without checksum verification."* ]]
     [[ "$output" == *"[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh>"* ]]
     [[ "$output" == *"[DRY-RUN] Would run: brew install bash"* ]]
     [[ "$output" == *"[DRY-RUN] Would run: /opt/homebrew/bin/bash $TEST_HOME/work/base/bin/basectl setup"* ]]


### PR DESCRIPTION
Summary:
- keep the official mutable Homebrew installer as the v1.4.0 default
- print the trust policy on the default unverified Homebrew installer path in bootstrap.sh, install.sh, and basectl setup
- document that default-path visibility and preserve pinned fail-closed behavior

Closes #1203

Verification:
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "installer bootstraps Homebrew Bash" tests/install.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "bootstrap source dry-run" tests/bootstrap.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "basectl setup supports dry-run" cli/bash/commands/basectl/tests/setup.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/install.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/bootstrap.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats
- shellcheck -S error bootstrap.sh install.sh cli/bash/commands/basectl/subcommands/setup_common.sh
- git diff --check