### PR TITLE
Make command history appends concurrency-safe

### DIFF
--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -7,6 +7,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - fcntl is unavailable on Windows.
+    _fcntl = None  # type: ignore[assignment]
+
 from .config import load_yaml_file
 from .context import Context
 from .paths import base_cache_root
@@ -75,10 +80,39 @@ def build_finished_record(
 def write_history_record(record: dict[str, Any]) -> None:
     path = base_cache_root() / HISTORY_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, sort_keys=True))
-        handle.write("\n")
+    append_history_line(path, f"{json.dumps(record, sort_keys=True)}\n")
     path.chmod(0o600)
+
+
+def append_history_line(path: Path, line: str) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        lock_history_file(fd)
+        try:
+            write_all(fd, line.encode("utf-8"))
+        finally:
+            unlock_history_file(fd)
+    finally:
+        os.close(fd)
+
+
+def lock_history_file(fd: int) -> None:
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_EX)
+
+
+def unlock_history_file(fd: int) -> None:
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_UN)
+
+
+def write_all(fd: int, data: bytes) -> None:
+    remaining = data
+    while remaining:
+        written = os.write(fd, remaining)
+        if written == 0:
+            raise OSError("history append wrote zero bytes")
+        remaining = remaining[written:]
 
 
 def format_timestamp(value: datetime) -> str:

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -52,6 +52,41 @@ class BaseCliHistoryTests(unittest.TestCase):
                     str(outside_home.expanduser().resolve(strict=False)),
                 )
 
+    def test_write_history_record_uses_locked_append_payload(self) -> None:
+        record = {
+            "schema_version": 1,
+            "event": "finished",
+            "run_id": "run-1",
+            "command": "check",
+            "status": "ok",
+            "exit_code": 0,
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache"
+            real_os_write = os.write
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                with mock.patch("base_cli.history._fcntl") as fcntl_module:
+                    fcntl_module.LOCK_EX = 1
+                    fcntl_module.LOCK_UN = 8
+                    with mock.patch("base_cli.history.os.write", wraps=real_os_write) as os_write:
+                        history_helpers.write_history_record(record)
+
+            history_path = cache_root / "history" / "runs.jsonl"
+            payloads = [call.args[1] for call in os_write.call_args_list]
+            history_mode = history_path.stat().st_mode & 0o777
+
+        fcntl_module.flock.assert_has_calls(
+            [
+                mock.call(mock.ANY, fcntl_module.LOCK_EX),
+                mock.call(mock.ANY, fcntl_module.LOCK_UN),
+            ]
+        )
+        self.assertEqual(len(payloads), 1)
+        self.assertTrue(payloads[0].endswith(b"\n"))
+        self.assertEqual(json.loads(payloads[0]), record)
+        self.assertEqual(history_mode, 0o600)
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_records_successful_command_history_with_redacted_metadata(self) -> None:
         app = base_cli.App(name="history-demo", version="0.1.0")


### PR DESCRIPTION
Summary:
- write history records through an O_APPEND file descriptor with advisory flock locking when available
- emit each JSONL record as one newline-terminated payload and preserve 0600 permissions
- add a deterministic locking/append-path regression test

Closes #1200

Verification:
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_history.py -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_history.py cli/python/base_history/tests/test_engine.py cli/python/base_logs/tests/test_engine.py cli/python/base_config/tests/test_engine.py -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint lib/python/base_cli/history.py lib/python/base_cli/tests/test_history.py
- git diff --check