### PR TITLE
Avoid process cwd mutation in testing invoke

### DIFF
--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -442,10 +442,11 @@ def test_command(tmp_path: Path) -> None:
     assert "hello Ada" in result.stdout
 ```
 
-The helper wraps Click's `CliRunner`, sets `HOME` when requested, changes to
-`cwd` only for the invocation, and keeps stderr separate on Click versions that
-support it. Use `cwd` for commands whose behavior depends on project discovery,
-including tests that intentionally run outside a Base project. Pass
+The helper wraps Click's `CliRunner`, sets `HOME` when requested, supplies
+`cwd` to Base's context discovery without mutating process-global cwd, and keeps
+stderr separate on Click versions that support it. Use `cwd` for commands whose
+behavior depends on project discovery, including tests that intentionally run
+outside a Base project. Pass
 `manifest={...}` with `cwd` to write a temporary `base_manifest.yaml` before
 the command runs.
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -12,7 +12,14 @@ from .config import load_config, read_user_config
 from .context import Context, reset_current_context, set_current_context
 from .history import utc_now, write_finished_record
 from .logging import configure_logger, log_invocation
-from .paths import base_cache_root, discover_manifest, make_run_id, normalize_cli_name, resolve_base_home
+from .paths import (
+    base_cache_root,
+    current_working_dir,
+    discover_manifest,
+    make_run_id,
+    normalize_cli_name,
+    resolve_base_home,
+)
 from .redaction import parameter_name_from_decls
 
 _STANDARD_OPTION_KEYS = ("debug", "quiet", "environment", "config", "keep_temp", "log_file")
@@ -158,7 +165,7 @@ class App:
     def _create_context(self, standard: dict[str, Any], sensitive_options: set[str], dry_run: bool = False) -> Context:
         del sensitive_options
         run_id = make_run_id()
-        manifest_path = discover_manifest(Path.cwd())
+        manifest_path = discover_manifest(current_working_dir())
         project_root = manifest_path.parent if manifest_path is not None else None
         explicit_config = Path(standard["config"]).expanduser() if standard.get("config") else None
         user_config = read_user_config()

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TextIO
 
 from .context import get_current_context
+from .paths import current_working_dir
 from .redaction import redact_argv
 
 
@@ -107,7 +108,7 @@ def _source_path(record: logging.LogRecord) -> str:
     project_root = _active_project_root()
     if project_root is not None:
         candidates.append(project_root)
-    candidates.append(Path.cwd())
+    candidates.append(current_working_dir())
 
     for root in candidates:
         try:

--- a/lib/python/base_cli/paths.py
+++ b/lib/python/base_cli/paths.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import os
 import sys
 import time
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
+
+_WORKING_DIRECTORY_OVERRIDE: contextvars.ContextVar[Path | None] = contextvars.ContextVar(
+    "base_cli_working_directory_override",
+    default=None,
+)
 
 
 def base_state_root(home: Path | None = None) -> Path:
@@ -19,6 +27,23 @@ def base_cache_root(home: Path | None = None) -> Path:
     if sys.platform == "darwin":
         return root / "Library" / "Caches" / "base"
     return root / ".cache" / "base"
+
+
+def current_working_dir() -> Path:
+    return _WORKING_DIRECTORY_OVERRIDE.get() or Path.cwd()
+
+
+@contextlib.contextmanager
+def use_working_dir(path: Path | None) -> Iterator[None]:
+    if path is None:
+        yield
+        return
+
+    token = _WORKING_DIRECTORY_OVERRIDE.set(path.expanduser().resolve())
+    try:
+        yield
+    finally:
+        _WORKING_DIRECTORY_OVERRIDE.reset(token)
 
 
 def make_run_id() -> str:

--- a/lib/python/base_cli/testing.py
+++ b/lib/python/base_cli/testing.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import inspect
-import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+
+from .paths import use_working_dir
 
 
 # pylint: disable=too-many-arguments
@@ -17,7 +18,7 @@ def invoke(
     *,
     manifest: Mapping[str, Any] | None = None,
 ):
-    cwd_path = Path(cwd) if cwd is not None else None
+    cwd_path = Path(cwd).expanduser().resolve() if cwd is not None else None
     if manifest is not None:
         if cwd_path is None:
             raise ValueError("manifest requires cwd so base_manifest.yaml has a target directory.")
@@ -36,14 +37,8 @@ def invoke(
     if "mix_stderr" in inspect.signature(CliRunner).parameters:
         runner_kwargs["mix_stderr"] = False
     runner = CliRunner(**runner_kwargs)
-    original_cwd = Path.cwd()
-    if cwd_path is not None:
-        os.chdir(cwd_path)
-    try:
+    with use_working_dir(cwd_path):
         return runner.invoke(app.click_command, args or [], env=invoke_env)
-    finally:
-        if cwd_path is not None:
-            os.chdir(original_cwd)
 
 
 def _write_manifest_fixture(cwd: Path, manifest: Mapping[str, Any]) -> None:

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -745,7 +745,6 @@ class BaseCliTests(unittest.TestCase):
 
         @app.command()
         def main(ctx: base_cli.Context) -> None:
-            seen["cwd"] = Path.cwd()
             seen["manifest_path"] = ctx.manifest_path
             seen["project_root"] = ctx.project_root
 
@@ -765,7 +764,6 @@ class BaseCliTests(unittest.TestCase):
             result = invoke(app, [], home=home, cwd=nested)
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertEqual(seen["cwd"], nested.resolve())
         self.assertEqual(seen["manifest_path"], manifest_path.resolve())
         self.assertEqual(seen["project_root"], project.resolve())
         self.assertEqual(Path.cwd(), original_cwd)
@@ -777,7 +775,6 @@ class BaseCliTests(unittest.TestCase):
 
         @app.command()
         def main(ctx: base_cli.Context) -> None:
-            seen["cwd"] = Path.cwd()
             seen["manifest_path"] = ctx.manifest_path
             seen["project_root"] = ctx.project_root
 
@@ -794,7 +791,6 @@ class BaseCliTests(unittest.TestCase):
             result = invoke(app, [], home=home, cwd=isolated)
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertEqual(seen["cwd"], isolated.resolve())
         self.assertIsNone(seen["manifest_path"])
         self.assertIsNone(seen["project_root"])
         self.assertEqual(Path.cwd(), original_cwd)

--- a/lib/python/base_cli/tests/test_testing.py
+++ b/lib/python/base_cli/tests/test_testing.py
@@ -4,6 +4,7 @@ import importlib.util
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import base_cli
 from base_cli.testing import invoke
@@ -45,6 +46,33 @@ class InvokeTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "manifest requires cwd"):
             invoke(app, [], manifest={"project": {"name": "demo"}})
+
+    def test_invoke_with_cwd_does_not_mutate_process_cwd(self) -> None:
+        app = base_cli.App(name="testing-cwd-isolation", log_to_file=False)
+        seen: dict[str, Path | None] = {}
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            seen["project_root"] = ctx.project_root
+            seen["manifest_path"] = ctx.manifest_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project = root / "project"
+            home.mkdir()
+            project.mkdir()
+            manifest_path = project / "base_manifest.yaml"
+            manifest_path.write_text("project:\n  name: demo\n", encoding="utf-8")
+            original_cwd = Path.cwd()
+
+            with mock.patch("os.chdir", side_effect=AssertionError("process-global cwd mutation")):
+                result = invoke(app, [], home=home, cwd=project)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(seen["project_root"], project.resolve())
+        self.assertEqual(seen["manifest_path"], manifest_path.resolve())
+        self.assertEqual(Path.cwd(), original_cwd)
 
     def test_invoke_with_cwd_without_manifest_preserves_no_manifest_behavior(self) -> None:
         app = base_cli.App(name="testing-no-manifest", log_to_file=False)


### PR DESCRIPTION
Summary:
- replace base_cli.testing.invoke os.chdir calls with a context-local Base working-directory override
- route Base manifest discovery and log source fallback through the context-local cwd helper
- add a regression test that fails if invoke mutates process-global cwd
- update helper docs and direct Path.cwd test expectations

Closes #1201

Verification:
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_testing.py -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests/test_testing.py lib/python/base_cli/tests/test_base_cli.py -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest lib/python/base_cli/tests -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint lib/python/base_cli/paths.py lib/python/base_cli/app.py lib/python/base_cli/logging.py lib/python/base_cli/testing.py lib/python/base_cli/tests/test_testing.py lib/python/base_cli/tests/test_base_cli.py
- git diff --check