### PR TITLE
Reduce shell prompt and profile subprocess work

### DIFF
--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -65,10 +65,29 @@ base_update_profile_source_line() {
 
 base_update_profile_file_ends_with_newline() {
     local target_file="$1"
-    local last_byte
+    local line=""
 
-    last_byte="$(tail -c 1 "$target_file" 2>/dev/null || true)"
-    [[ -z "$last_byte" ]]
+    [[ -r "$target_file" && -s "$target_file" ]] || return 0
+    while IFS= read -r line; do
+        line=""
+    done < "$target_file" 2>/dev/null || return 0
+
+    [[ -z "$line" ]]
+}
+
+base_update_profile_file_last_line_is_empty() {
+    local target_file="$1"
+    local last_line=""
+    local line=""
+
+    [[ -r "$target_file" && -s "$target_file" ]] || return 0
+    while IFS= read -r line; do
+        last_line="$line"
+        line=""
+    done < "$target_file" 2>/dev/null || return 0
+    [[ -z "$line" ]] || last_line="$line"
+
+    [[ -z "$last_line" ]]
 }
 
 base_update_profile_section_lines() {
@@ -83,8 +102,6 @@ base_update_profile_section_lines() {
 base_update_profile_prepare_section_spacing() {
     local target_file="$1"
     local start_marker="$2"
-    local last_line=""
-
     [[ -s "$target_file" ]] || return 0
     grep -qF -- "$start_marker" "$target_file" && return 0
 
@@ -93,8 +110,7 @@ base_update_profile_prepare_section_spacing() {
         return 0
     fi
 
-    last_line="$(tail -n 1 "$target_file" 2>/dev/null || true)"
-    [[ -z "$last_line" ]] && return 0
+    base_update_profile_file_last_line_is_empty "$target_file" && return 0
 
     printf '\n' >> "$target_file"
 }

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -119,6 +119,15 @@ EOF
     chmod +x "$TEST_MOCKBIN/wc"
 }
 
+create_tail_failure_stub() {
+    cat > "$TEST_MOCKBIN/tail" <<'EOF'
+#!/usr/bin/env bash
+printf 'tail should not run\n' >&2
+exit 99
+EOF
+    chmod +x "$TEST_MOCKBIN/tail"
+}
+
 create_curl_failure_stub() {
     cat > "$TEST_MOCKBIN/curl" <<'EOF'
 #!/usr/bin/env bash

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -101,12 +101,16 @@ EOF
     [[ "$(cat "$TEST_HOME/.bashrc")" != *"/Cellar/base/0.4.0"* ]]
 }
 
-@test "update-profile spacing helper checks trailing newline without wc" {
+@test "update-profile spacing helper checks trailing newline without wc or tail" {
     local bash_libs_dir
 
     bash_libs_dir="$(base_bash_libs_fixture_dir)"
     create_wc_failure_stub
+    create_tail_failure_stub
     printf 'export CUSTOM=1' > "$TEST_HOME/.bashrc"
+    printf 'export CUSTOM=1\n' > "$TEST_HOME/.bash_profile"
+    printf 'export CUSTOM=1\n\n' > "$TEST_HOME/.zshrc"
+    : > "$TEST_HOME/.zprofile"
 
     run env \
         HOME="$TEST_HOME" \
@@ -117,11 +121,18 @@ EOF
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update_profile.sh"
             base_update_profile_prepare_section_spacing "$HOME/.bashrc" "# >>> base: bashrc managed >>>"
+            base_update_profile_prepare_section_spacing "$HOME/.bash_profile" "# >>> base: bash_profile managed >>>"
+            base_update_profile_prepare_section_spacing "$HOME/.zshrc" "# >>> base: zshrc managed >>>"
+            base_update_profile_prepare_section_spacing "$HOME/.zprofile" "# >>> base: zprofile managed >>>"
         '
 
     [ "$status" -eq 0 ]
     [[ "$output" != *"wc should not run"* ]]
+    [[ "$output" != *"tail should not run"* ]]
     [[ "$(cat "$TEST_HOME/.bashrc"; printf marker)" == $'export CUSTOM=1\n\nmarker' ]]
+    [[ "$(cat "$TEST_HOME/.bash_profile"; printf marker)" == $'export CUSTOM=1\n\nmarker' ]]
+    [[ "$(cat "$TEST_HOME/.zshrc"; printf marker)" == $'export CUSTOM=1\n\nmarker' ]]
+    [[ "$(cat "$TEST_HOME/.zprofile"; printf marker)" == "marker" ]]
 }
 
 @test "basectl update-profile explains BASE_HOME mismatch recovery" {

--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -47,22 +47,50 @@ readonly _base_bash_defaults_sourced
 
 set -o vi
 
+_base_bash_defaults_git_dir() {
+    local current="${PWD:-}"
+    local git_dir
+    local git_file
+    local parent
+
+    while [[ -n "$current" ]]; do
+        if [[ -d "$current/.git" ]]; then
+            printf '%s\n' "$current/.git"
+            return 0
+        fi
+        if [[ -f "$current/.git" ]]; then
+            IFS= read -r git_file < "$current/.git" || return 1
+            [[ "$git_file" == gitdir:\ * ]] || return 1
+            git_dir="${git_file#gitdir: }"
+            case "$git_dir" in
+                /*) ;;
+                *) git_dir="$current/$git_dir" ;;
+            esac
+            printf '%s\n' "$git_dir"
+            return 0
+        fi
+
+        [[ "$current" == "/" ]] && return 1
+        parent="${current%/*}"
+        [[ -n "$parent" && "$parent" != "$current" ]] || parent="/"
+        current="$parent"
+    done
+
+    return 1
+}
+
 _base_bash_defaults_git_prompt() {
     local branch
-    local git_state
-    local inside
+    local git_dir
+    local head
 
-    command -v git >/dev/null 2>&1 || return 0
-
-    git_state="$(git rev-parse --is-inside-work-tree --abbrev-ref HEAD 2>/dev/null)" || return 0
-    [[ "$git_state" == *$'\n'* ]] || return 0
-    inside="${git_state%%$'\n'*}"
-    branch="${git_state#*$'\n'}"
-    branch="${branch%%$'\n'*}"
-    [[ "$inside" == "true" ]] || return 0
-    if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
-        branch="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
-    fi
+    git_dir="$(_base_bash_defaults_git_dir)" || return 0
+    IFS= read -r head < "$git_dir/HEAD" || return 0
+    case "$head" in
+        "ref: refs/heads/"*) branch="${head#ref: refs/heads/}" ;;
+        "ref: "*) branch="${head#ref: }"; branch="${branch##*/}" ;;
+        *) branch="$(printf '%.7s' "$head")" ;;
+    esac
     [[ -n "$branch" ]] || return 0
 
     printf '(%s) ' "$branch"

--- a/lib/shell/zsh_defaults.sh
+++ b/lib/shell/zsh_defaults.sh
@@ -49,22 +49,50 @@ bindkey -v
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
 zstyle ':completion:*' menu select
 
+_base_zsh_defaults_git_dir() {
+    local current="${PWD:-}"
+    local git_dir
+    local git_file
+    local parent
+
+    while [[ -n "$current" ]]; do
+        if [[ -d "$current/.git" ]]; then
+            printf '%s\n' "$current/.git"
+            return 0
+        fi
+        if [[ -f "$current/.git" ]]; then
+            IFS= read -r git_file < "$current/.git" || return 1
+            [[ "$git_file" == gitdir:\ * ]] || return 1
+            git_dir="${git_file#gitdir: }"
+            case "$git_dir" in
+                /*) ;;
+                *) git_dir="$current/$git_dir" ;;
+            esac
+            printf '%s\n' "$git_dir"
+            return 0
+        fi
+
+        [[ "$current" == "/" ]] && return 1
+        parent="${current%/*}"
+        [[ -n "$parent" && "$parent" != "$current" ]] || parent="/"
+        current="$parent"
+    done
+
+    return 1
+}
+
 _base_zsh_defaults_git_prompt() {
     local branch
-    local git_state
-    local inside
+    local git_dir
+    local head
 
-    command -v git >/dev/null 2>&1 || return 0
-
-    git_state="$(git rev-parse --is-inside-work-tree --abbrev-ref HEAD 2>/dev/null)" || return 0
-    [[ "$git_state" == *$'\n'* ]] || return 0
-    inside="${git_state%%$'\n'*}"
-    branch="${git_state#*$'\n'}"
-    branch="${branch%%$'\n'*}"
-    [[ "$inside" == "true" ]] || return 0
-    if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
-        branch="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
-    fi
+    git_dir="$(_base_zsh_defaults_git_dir)" || return 0
+    IFS= read -r head < "$git_dir/HEAD" || return 0
+    case "$head" in
+        "ref: refs/heads/"*) branch="${head#ref: refs/heads/}" ;;
+        "ref: "*) branch="${head#ref: }"; branch="${branch##*/}" ;;
+        *) branch="$(printf '%.7s' "$head")" ;;
+    esac
     [[ -n "$branch" ]] || return 0
 
     printf '(%s) ' "$branch"

--- a/tests/source_guards.bats
+++ b/tests/source_guards.bats
@@ -42,6 +42,14 @@ EOF
     chmod +x "$TEST_MOCKBIN/git"
 }
 
+write_prompt_git_head() {
+    local repo_dir="$1"
+    local head_value="$2"
+
+    mkdir -p "$repo_dir/.git"
+    printf '%s\n' "$head_value" > "$repo_dir/.git/HEAD"
+}
+
 @test "Bash source guard examples use explicit success returns" {
     grep -F '[[ -n "${_base_example_lib_sourced:-}" ]] && return 0' "$BASE_REPO_ROOT/STANDARDS.md"
 }
@@ -128,16 +136,22 @@ EOF
     [[ "$output" == *"declare -r _base_defaults_sourced=\"1\""* ]]
 }
 
-@test "Bash defaults git prompt uses one Git process per branch prompt render" {
+@test "Bash defaults git prompt reads branch metadata without Git subprocesses" {
+    local repo_dir="$TEST_TMPDIR/bash-repo"
+
     write_prompt_git_stub
+    write_prompt_git_head "$repo_dir" "ref: refs/heads/main"
 
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
         BASE_TEST_GIT_ARGS="$TEST_TMPDIR/bash-git-args" \
+        BASE_TEST_REPO="$repo_dir" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash -i -c '
+            : > "$BASE_TEST_GIT_ARGS"
             source "$BASE_HOME/lib/shell/bash_defaults.sh"
+            cd "$BASE_TEST_REPO"
             printf "first=%s\n" "$(_base_bash_defaults_git_prompt)"
             printf "second=%s\n" "$(_base_bash_defaults_git_prompt)"
             printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
@@ -147,8 +161,33 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"first=(main) "* ]]
     [[ "$output" == *"second=(main) "* ]]
-    [[ "$output" == *"git_calls=2"* ]]
-    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
+    [[ "$output" == *"git_calls=0"* ]]
+    [[ "$output" == *"git_args="* ]]
+}
+
+@test "Bash defaults git prompt reads detached HEAD metadata without Git subprocesses" {
+    local repo_dir="$TEST_TMPDIR/bash-detached-repo"
+
+    write_prompt_git_stub
+    write_prompt_git_head "$repo_dir" "abc1234567890"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_GIT_ARGS="$TEST_TMPDIR/bash-detached-git-args" \
+        BASE_TEST_REPO="$repo_dir" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -i -c '
+            : > "$BASE_TEST_GIT_ARGS"
+            source "$BASE_HOME/lib/shell/bash_defaults.sh"
+            cd "$BASE_TEST_REPO"
+            printf "prompt=%s\n" "$(_base_bash_defaults_git_prompt)"
+            printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"prompt=(abc1234) "* ]]
+    [[ "$output" == *"git_calls=0"* ]]
 }
 
 @test "Bash defaults git prompt keeps non-Git directories quiet with one probe" {
@@ -161,6 +200,7 @@ EOF
         BASE_TEST_GIT_MODE="non-git" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash -i -c '
+            : > "$BASE_TEST_GIT_ARGS"
             source "$BASE_HOME/lib/shell/bash_defaults.sh"
             printf "prompt=%s\n" "$(_base_bash_defaults_git_prompt)"
             printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
@@ -169,8 +209,8 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"prompt="* ]]
-    [[ "$output" == *"git_calls=1"* ]]
-    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
+    [[ "$output" == *"git_calls=0"* ]]
+    [[ "$output" == *"git_args="* ]]
 }
 
 @test "Zsh defaults re-sourcing preserves local overrides" {
@@ -197,17 +237,23 @@ EOF
     [[ "$output" == *"typeset -r _base_defaults_sourced=1"* ]]
 }
 
-@test "Zsh defaults git prompt uses one Git process per branch prompt render" {
+@test "Zsh defaults git prompt reads branch metadata without Git subprocesses" {
     command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+    local repo_dir="$TEST_TMPDIR/zsh-repo"
+
     write_prompt_git_stub
+    write_prompt_git_head "$repo_dir" "ref: refs/heads/main"
 
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
         BASE_TEST_GIT_ARGS="$TEST_TMPDIR/zsh-git-args" \
+        BASE_TEST_REPO="$repo_dir" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         zsh -f -i -c '
+            : > "$BASE_TEST_GIT_ARGS"
             source "$BASE_HOME/lib/shell/zsh_defaults.sh"
+            cd "$BASE_TEST_REPO"
             printf "first=%s\n" "$(_base_zsh_defaults_git_prompt)"
             printf "second=%s\n" "$(_base_zsh_defaults_git_prompt)"
             printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
@@ -217,8 +263,34 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"first=(main) "* ]]
     [[ "$output" == *"second=(main) "* ]]
-    [[ "$output" == *"git_calls=2"* ]]
-    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
+    [[ "$output" == *"git_calls=0"* ]]
+    [[ "$output" == *"git_args="* ]]
+}
+
+@test "Zsh defaults git prompt reads detached HEAD metadata without Git subprocesses" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+    local repo_dir="$TEST_TMPDIR/zsh-detached-repo"
+
+    write_prompt_git_stub
+    write_prompt_git_head "$repo_dir" "abc1234567890"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_GIT_ARGS="$TEST_TMPDIR/zsh-detached-git-args" \
+        BASE_TEST_REPO="$repo_dir" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        zsh -f -i -c '
+            : > "$BASE_TEST_GIT_ARGS"
+            source "$BASE_HOME/lib/shell/zsh_defaults.sh"
+            cd "$BASE_TEST_REPO"
+            printf "prompt=%s\n" "$(_base_zsh_defaults_git_prompt)"
+            printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"prompt=(abc1234) "* ]]
+    [[ "$output" == *"git_calls=0"* ]]
 }
 
 @test "Zsh defaults git prompt keeps non-Git directories quiet with one probe" {
@@ -232,6 +304,7 @@ EOF
         BASE_TEST_GIT_MODE="non-git" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         zsh -f -i -c '
+            : > "$BASE_TEST_GIT_ARGS"
             source "$BASE_HOME/lib/shell/zsh_defaults.sh"
             printf "prompt=%s\n" "$(_base_zsh_defaults_git_prompt)"
             printf "git_calls=%s\n" "$(wc -l < "$BASE_TEST_GIT_ARGS" | tr -d "[:space:]")"
@@ -240,6 +313,6 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"prompt="* ]]
-    [[ "$output" == *"git_calls=1"* ]]
-    [[ "$output" == *"git_args=rev-parse --is-inside-work-tree --abbrev-ref HEAD|"* ]]
+    [[ "$output" == *"git_calls=0"* ]]
+    [[ "$output" == *"git_args="* ]]
 }


### PR DESCRIPTION
Summary:
- read Bash/Zsh prompt branch and detached HEAD metadata directly from .git/HEAD instead of shelling out to git
- cover branch, detached HEAD, and non-Git prompt behavior with zero Git subprocess calls
- replace update-profile trailing newline and last-line checks with Bash read loops instead of wc/tail subprocesses
- cover empty, newline-terminated, newline-less, and blank-final-line spacing cases

Closes #1199
Closes #1202

Verification:
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "git prompt" tests/source_guards.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "spacing helper" cli/bash/commands/basectl/tests/update-profile.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/source_guards.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/update-profile.bats
- shellcheck -S error lib/shell/bash_defaults.sh lib/shell/zsh_defaults.sh cli/bash/commands/basectl/subcommands/update_profile.sh cli/bash/commands/basectl/tests/setup_helpers.bash
- git diff --check