### PR TITLE
Align setup doctor output streams

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -339,6 +340,10 @@ def doctor_manifest(
     *,
     user_config: UserConfig | None = None,
 ) -> int:
+    if output_format not in {"json", "text"}:
+        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.", file=sys.stderr)
+        return 2
+
     checks = manifest_checks(
         default_manifest,
         manifest,
@@ -348,9 +353,6 @@ def doctor_manifest(
     if output_format == "json":
         print(json.dumps([check_to_json(check) for check in checks], indent=2))
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
-    if output_format != "text":
-        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
-        return 2
 
     error_count = 0
     print(f"\nProject doctor: {manifest.project_name}\n")
@@ -369,13 +371,14 @@ def doctor_pre_venv_manifest(
     output_format: str,
     remote_network: bool = False,
 ) -> int:
+    if output_format not in {"json", "text"}:
+        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.", file=sys.stderr)
+        return 2
+
     checks = pre_venv_manifest_checks(manifest, remote_network=remote_network)
     if output_format == "json":
         print(json.dumps([check_to_json(check) for check in checks], separators=(",", ":")))
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
-    if output_format != "text":
-        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
-        return 2
 
     error_count = 0
     for check in checks:

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -8,7 +8,7 @@ import socket
 import subprocess
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -146,14 +146,61 @@ class ProjectCheckTests(unittest.TestCase):
             artifacts=(ArtifactRequest(artifact_type="python-package", name="requests", version="latest"),),
         )
 
-        with redirect_stdout(io.StringIO()) as stdout:
+        with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr:
             status = engine.doctor_manifest(default_manifest, manifest, output_format="json")
 
         findings = json.loads(stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
         self.assertEqual(status, 1)
         self.assertEqual(findings[0]["id"], "BASE-P040")
         self.assertEqual(findings[0]["status"], "error")
         self.assertEqual(findings[0]["fix"], "basectl setup demo")
+
+    def test_doctor_stream_contract_separates_output_from_usage_errors(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+
+        with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr:
+            status = engine.doctor_manifest(default_manifest, manifest, output_format="xml")
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Unsupported doctor output format 'xml'. Expected text or json.", stderr.getvalue())
+
+        with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr:
+            status = engine.doctor_pre_venv_manifest(manifest, output_format="yaml")
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Unsupported doctor output format 'yaml'. Expected text or json.", stderr.getvalue())
+
+        check = setup_checks.ArtifactCheck(
+            name="required-artifact",
+            ok=False,
+            message="Required project artifact is not installed.",
+            fix="basectl setup demo",
+            finding_id="BASE-P040",
+        )
+        with mock.patch("base_setup.engine.manifest_checks", return_value=(check,)):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertIn("error", stdout.getvalue())
+        self.assertIn("BASE-P040", stdout.getvalue())
 
 
 

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -17,6 +17,11 @@ Doctor findings should be specific, actionable, and non-alarming. Text output
 is for humans who need a safe next step; JSON output is for automation that
 needs stable IDs, statuses, names, messages, and fix guidance.
 
+Text and JSON doctor findings are primary command output and are written to
+stdout. Usage and validation errors, including unsupported `--format` values,
+are diagnostics and must be written to stderr so scripts can safely parse
+machine-readable stdout.
+
 `basectl doctor` should not mutate local state. A future fix path must be
 explicit, reviewable, and paired with dry-run behavior before Base offers it as
 part of the doctor workflow.


### PR DESCRIPTION
## Summary
- route unsupported setup doctor output-format usage errors to stderr
- codify that text and JSON doctor findings are primary stdout output
- document the doctor stdout/stderr stream contract

Closes #1196

## Verification
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest base_setup.tests.test_diagnostics.ProjectCheckTests.test_doctor_stream_contract_separates_output_from_usage_errors base_setup.tests.test_diagnostics.ProjectCheckTests.test_doctor_manifest_supports_json_output
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests -p 'test_*.py'
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_setup/engine.py cli/python/base_setup/tests/test_diagnostics.py
- git diff --check