### PR TITLE
Adopt ExitCode constants in Python CLI engines

### DIFF
--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -33,7 +33,7 @@ def main(argv: list[str] | None = None) -> int:
 def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dry_run: bool) -> int:
     if not older_than and not keep_last:
         ctx.log.error("One of '--older-than' or '--keep-last' is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     cache_root = base_cache_root()
     ctx.log.debug("Scanning Base cache root '%s'.", cache_root)
@@ -44,7 +44,7 @@ def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dr
             threshold_seconds = parse_age(older_than)
         except ValueError as exc:
             ctx.log.error(str(exc))
-            return 2
+            return base_cli.ExitCode.USAGE_ERROR
         cutoff = time.time() - threshold_seconds
         candidates.extend(find_clean_candidates(cache_root, cutoff, ctx.log))
 
@@ -53,14 +53,14 @@ def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dr
             keep_count = parse_keep_last(keep_last)
         except ValueError as exc:
             ctx.log.error(str(exc))
-            return 2
+            return base_cli.ExitCode.USAGE_ERROR
         candidates.extend(find_log_retention_candidates(cache_root, keep_count, ctx.log))
 
     unique_candidates = tuple(deduplicate_candidates(candidates))
 
     if not unique_candidates:
         ctx.log.info("No Base runtime artifacts matched the clean criteria.")
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     for candidate in unique_candidates:
         action = "Would remove" if dry_run else "Removing"
@@ -73,7 +73,7 @@ def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dr
         "Would remove" if dry_run else "Removed",
         len(unique_candidates),
     )
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def parse_age(value: str) -> int:

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -30,18 +30,18 @@ def run(ctx: base_cli.Context, command: str | None, arguments: tuple[str, ...]) 
         if arguments:
             print_usage(file=sys.stderr)
             print("ERROR: config show does not accept arguments.", file=sys.stderr)
-            return 2
+            return base_cli.ExitCode.USAGE_ERROR
         return show_config_command()
     if command == "doctor":
         if arguments:
             print_usage(file=sys.stderr)
             print("ERROR: config doctor does not accept arguments.", file=sys.stderr)
-            return 2
+            return base_cli.ExitCode.USAGE_ERROR
         return doctor_config_command()
 
     print_usage(file=sys.stderr)
     print(f"ERROR: Unknown config command '{command}'. Supported commands: show, doctor.", file=sys.stderr)
-    return 2
+    return base_cli.ExitCode.USAGE_ERROR
 
 
 def print_usage(file=sys.stdout) -> None:
@@ -64,10 +64,10 @@ def show_config_command() -> int:
         config = load_user_config()
     except (RuntimeError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print(json.dumps(redact_config(config), indent=2, sort_keys=True))
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def redact_config(value: Any, key: str | None = None) -> Any:
@@ -91,18 +91,18 @@ def doctor_config_command() -> int:
             print_finding("ok", "symlink", f"Config path is a symlink to '{safe_resolve(path)}'.")
         else:
             print_finding("warn", "symlink", f"Config path is a broken symlink to '{safe_resolve(path)}'.")
-            return 0
+            return base_cli.ExitCode.SUCCESS
     elif path.exists():
         print_finding("ok", "file", "Config file exists.")
     else:
         print_finding("warn", "file", "Config file is missing; Base will use an empty user config.")
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     try:
         config = load_user_config()
     except (RuntimeError, ValueError) as exc:
         print_finding("error", "yaml", str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print_finding("ok", "yaml", "Config YAML is valid.")
     print_finding("ok", "mapping", f"Config contains {len(config)} top-level key(s).")
@@ -110,11 +110,11 @@ def doctor_config_command() -> int:
         user_config = read_user_config()
     except (RuntimeError, ValueError) as exc:
         print_finding("error", "schema", str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print_workspace_findings(user_config)
     print_github_findings(user_config)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def print_workspace_findings(user_config: UserConfig) -> None:

--- a/cli/python/base_dev/ai_tools.py
+++ b/cli/python/base_dev/ai_tools.py
@@ -59,10 +59,10 @@ def setup_ai_tools(ctx: base_cli.Context, dry_run: bool) -> int:
                 run_command(ctx, list(installer_command))
     except ArtifactError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     ctx.log.info("Base 'ai' prerequisite setup is complete.")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def ai_remote_installer_urls() -> tuple[str, ...]:

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -57,10 +57,10 @@ def run(ctx: base_cli.Context, action: str, dry_run: bool, output_format: str, p
         profile_manifests = read_profile_manifests(ctx, normalized_profiles)
     except (ManifestError, ArtifactError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
     except ProfileError as exc:
         ctx.log.error(str(exc))
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     if action == "setup":
         return setup_profiles(ctx, normalized_profiles, profile_manifests, dry_run=dry_run)
@@ -70,7 +70,7 @@ def run(ctx: base_cli.Context, action: str, dry_run: bool, output_format: str, p
         return doctor_profiles(normalized_profiles, profile_manifests, output_format=output_format)
 
     ctx.log.error("Unsupported base_dev action '%s'. Expected setup, check, or doctor.", action)
-    return 2
+    return base_cli.ExitCode.USAGE_ERROR
 
 
 def normalize_profiles(profiles: tuple[str, ...]) -> tuple[str, ...]:
@@ -141,7 +141,7 @@ def setup_profile_manifests(
         )
         if status != 0:
             return status
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def setup_profiles(
@@ -167,7 +167,7 @@ def setup_profiles(
             )
         if status != 0:
             return status
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def setup_dev_artifacts(
@@ -198,13 +198,13 @@ def setup_profile_artifacts(
             reconcile_artifact(ctx, definition, artifact.version, manifest.project_name, dry_run=dry_run)
     except ArtifactError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if profile == "dev":
         ctx.log.info("Base developer prerequisite setup is complete.")
     else:
         ctx.log.info("Base '%s' prerequisite setup is complete.", profile)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def check_profile_manifests(
@@ -275,9 +275,11 @@ def print_check_results(
                 ctx.log.warning(check.message)
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
-    return 0 if all(doctor_status(check) != "error" for check in checks) else 1
+    if all(doctor_status(check) != "error" for check in checks):
+        return base_cli.ExitCode.SUCCESS
+    return base_cli.ExitCode.FAILURE
 
 
 def doctor_profile_manifests(
@@ -320,7 +322,7 @@ def print_doctor_results(checks: tuple[DevCheck, ...], output_format: str) -> in
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
     if output_format != "text":
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     error_count = 0
     for check in checks:

--- a/cli/python/base_export_context/engine.py
+++ b/cli/python/base_export_context/engine.py
@@ -75,13 +75,13 @@ def run(
     validation_error = validate_options(options, raw_output_format=output_format)
     if validation_error is not None:
         ctx.log.error(validation_error)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         return export_context(options)
     except ExportContextError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
 
 def validate_options(options: ExportContextOptions, raw_output_format: str) -> str | None:
@@ -105,7 +105,7 @@ def export_context(options: ExportContextOptions) -> int:
         )
         for context_file in files:
             print(context_file.display_path)
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     if options.output_format == MARKDOWN_FORMAT:
         return export_markdown_context(options)
@@ -114,7 +114,7 @@ def export_context(options: ExportContextOptions) -> int:
     destination = resolve_output_path(options.project_name, options.output_path, "zip")
     write_zip_file(destination, files)
     print(f"Wrote Zip AI context export for project '{options.project_name}' to {destination}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def export_markdown_context(options: ExportContextOptions) -> int:
@@ -122,11 +122,11 @@ def export_markdown_context(options: ExportContextOptions) -> int:
     content = render_markdown_bundle(options.project_name, files)
     if options.print_bundle:
         print(content, end="")
-        return 0
+        return base_cli.ExitCode.SUCCESS
     destination = resolve_output_path(options.project_name, options.output_path, "md")
     write_text_file(destination, content)
     print(f"Wrote Markdown AI context export for project '{options.project_name}' to {destination}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def resolve_output_path(project_name: str, output_path: str | None, extension: str) -> Path:

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -73,14 +73,14 @@ def run(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
     except ProjectUsageError as exc:
         print_usage(file=sys.stderr)
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     except ProjectAuthError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         print("Run `gh auth refresh -h github.com -s project` and retry.", file=sys.stderr)
         return 3
     except ProjectError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
+        return base_cli.ExitCode.FAILURE
 
 
 def print_usage(file=sys.stdout) -> None:
@@ -194,11 +194,11 @@ def apply_spaced_option(state: OptionState, remaining: list[str], index: int, *,
     option = remaining[index]
     if option in PROJECT_VALUE_OPTIONS:
         apply_project_option(state, option, option_value(remaining, index))
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     if allow_fields and option in ISSUE_FIELD_OPTIONS:
         state.field_values[option[2:]] = option_value(remaining, index)
-        return 2
-    return 0
+        return base_cli.ExitCode.USAGE_ERROR
+    return base_cli.ExitCode.SUCCESS
 
 
 def option_value(remaining: list[str], index: int) -> str:
@@ -294,7 +294,7 @@ def issue_defaults_command(args: ProjectArguments) -> int:
         value = config.issue_defaults.get(key)
         if value:
             print(f"{key}\t{value}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def project_field_defaults_for_config(config: ProjectConfig) -> dict[str, str]:

--- a/cli/python/base_github_projects/project_configure_command.py
+++ b/cli/python/base_github_projects/project_configure_command.py
@@ -4,6 +4,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
+import base_cli
+
 from .project_configure import ConfigureDryRunPlan, ProjectReplacement
 from .project_configure import legacy_project_title, render_dry_run_configure, standard_template_view_errors
 
@@ -37,7 +39,7 @@ def configure_command(args: Any, ops: Any) -> int:
     if errors:
         for action in errors:
             print(f"ERROR   {action.name}  {action.message}", file=sys.stderr)
-        return 1
+        return base_cli.ExitCode.FAILURE
     if args.dry_run:
         render_dry_run_configure(
             args,
@@ -48,7 +50,7 @@ def configure_command(args: Any, ops: Any) -> int:
                 project_config=project_config,
             ),
         )
-        return 0
+        return base_cli.ExitCode.SUCCESS
     project = prepare_configure_project(
         ConfigureExecution(
             owner=owner,
@@ -68,7 +70,7 @@ def configure_command(args: Any, ops: Any) -> int:
     apply_project_config_defaults(project.project_id, fields, project_config, ops)
     close_replacement_project(replacement, ops)
     print(f"✓ Configured GitHub Project {args.project_title}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def replacement_plan_for_args(

--- a/cli/python/base_github_projects/project_doctor_command.py
+++ b/cli/python/base_github_projects/project_doctor_command.py
@@ -2,18 +2,20 @@ from __future__ import annotations
 
 from typing import Any
 
+import base_cli
+
 
 def doctor_command(args: Any, ops: Any) -> int:
     owner = ops.require_owner(args)
     owner_info = ops.find_owner_and_project(owner, args.project_title or "")
     if owner_info.project is None:
         print(f"MISSING Project {args.project_title}")
-        return 1
+        return base_cli.ExitCode.FAILURE
     fields = ops.fetch_project_fields(owner_info.project.project_id)
     findings = ops.compare_schema(fields, ops.schema_for_args(args))
     if not findings:
         print(f"OK      Project {args.project_title}")
-        return 0
+        return base_cli.ExitCode.SUCCESS
     for finding in findings:
         print(f"{finding.status.upper():<8}{finding.name}  {finding.message}")
-    return 1
+    return base_cli.ExitCode.FAILURE

--- a/cli/python/base_github_projects/project_issue_fields_command.py
+++ b/cli/python/base_github_projects/project_issue_fields_command.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import base_cli
+
 
 def issue_set_fields_command(args: Any, ops: Any) -> int:
     owner = ops.require_owner(args)
@@ -25,10 +27,10 @@ def issue_set_fields_command(args: Any, ops: Any) -> int:
         print(f"[DRY-RUN] Would add issue #{args.issue_number} to Project '{args.project_title}' if needed.")
         for update in updates:
             print(f"[DRY-RUN] Would set {update.field_name} to {update.option_name}.")
-        return 0
+        return base_cli.ExitCode.SUCCESS
     if item_id is None:
         item_id = ops.add_project_item(project.project_id, issue_id)
     for update in updates:
         ops.update_item_field(project.project_id, item_id, update)
     print(f"✓ Updated Project metadata for issue #{args.issue_number}")
-    return 0
+    return base_cli.ExitCode.SUCCESS

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -80,17 +80,17 @@ def run(
         )
     except ValueError as exc:
         ctx.log.error(str(exc))
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     records = recent_history(base_cache_root(), options=options, logger=ctx.log)
     if options.output_format == "json":
         print(json.dumps([record.to_json() for record in records], indent=2))
-        return 0
+        return base_cli.ExitCode.SUCCESS
     if not records:
         print(f"No Base command history found under {base_cache_root() / HISTORY_PATH}.")
-        return 0
+        return base_cli.ExitCode.SUCCESS
     print_history_table(records)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def normalize_optional_filter(value: str | None) -> str | None:

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -86,7 +86,7 @@ def run(
         line_count = parse_positive_int("--lines", lines)
     except ValueError as exc:
         ctx.log.error(str(exc))
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     options = LogCommandOptions(
         command_filter=command_filter,
@@ -99,7 +99,7 @@ def run(
     selected_actions = sum(1 for selected in (path_only, tail, open_file) if selected)
     if selected_actions > 1:
         ctx.log.error("Choose only one of --path, --tail, or --open.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     cache_root = base_cache_root()
     ctx.log.debug("Scanning Base cache root '%s'.", cache_root)
@@ -112,23 +112,23 @@ def run(
 def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandOptions) -> int:
     if options.path_only or options.tail or options.open_file:
         ctx.log.error("No Base CLI logs found.")
-        return 1
+        return base_cli.ExitCode.FAILURE
     print(f"No Base CLI logs found under {cache_root / 'cli'}.")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def run_with_entries(entries: list[LogEntry], options: LogCommandOptions) -> int:
     newest = entries[0]
     if options.path_only:
         print(newest.path)
-        return 0
+        return base_cli.ExitCode.SUCCESS
     if options.tail:
         return tail_log(newest.path, options.lines)
     if options.open_file:
         return open_log(newest.path)
 
     print_log_table(entries[: options.limit])
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def recent_logs(cache_root: Path, command_filter: str | None = None) -> list[LogEntry]:
@@ -305,22 +305,22 @@ def tail_log(path: Path, lines: int) -> int:
     tail = shutil.which("tail")
     if tail is None:
         print(f"ERROR: tail was not found on PATH. Log path: {path}", file=sys.stderr)
-        return 1
+        return base_cli.ExitCode.FAILURE
     os.execv(tail, [tail, "-n", str(lines), "-f", str(path)])
-    return 1
+    return base_cli.ExitCode.FAILURE
 
 
 def open_log(path: Path) -> int:
     command = os.environ.get("PAGER") or os.environ.get("EDITOR")
     if not command:
         print(path)
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     args = shlex.split(command)
     if not args:
         print(path)
-        return 0
+        return base_cli.ExitCode.SUCCESS
     if shutil.which(args[0]) is None:
         print(f"ERROR: {args[0]} was not found on PATH. Log path: {path}", file=sys.stderr)
-        return 1
+        return base_cli.ExitCode.FAILURE
     return subprocess.call([*args, str(path)])

--- a/cli/python/base_pr_policy/engine.py
+++ b/cli/python/base_pr_policy/engine.py
@@ -119,11 +119,11 @@ def run(
 ) -> int:
     if command != "body":
         ctx.log.error("Expected command 'body'.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     manifest_path = Path(manifest).expanduser().resolve() if manifest else discover_manifest(Path.cwd())
     if manifest_path is None:
         ctx.log.error("No base_manifest.yaml found from the current directory upward.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     try:
         body = body_from_manifest(
             manifest_path,
@@ -133,9 +133,9 @@ def run(
         )
     except (ManifestError, PrPolicyError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
     sys.stdout.write(body)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def _template_body(policy: GithubPrConfig, inputs: PrPolicyInputs) -> str:

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -30,7 +30,7 @@ def build_targets_project_from_args(
 ) -> int:
     if len(arguments) < 1:
         ctx.log.error("Command 'build-targets' requires at least 1 argument (project name); got %d.", len(arguments))
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     return build_targets_project_command(ctx, arguments[0], arguments[1:], workspace, resolve_project)
 
 
@@ -42,7 +42,7 @@ def list_build_targets_from_args(
 ) -> int:
     if len(arguments) != 1:
         ctx.log.error("Command 'build-target-list' requires exactly 1 argument (project name); got %d.", len(arguments))
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     return list_build_targets_command(ctx, arguments[0], workspace, resolve_project)
 
 
@@ -55,7 +55,7 @@ def build_targets_project_command(
 ) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         project = resolve_project(ctx, project_name, workspace)
@@ -63,11 +63,11 @@ def build_targets_project_command(
         targets = selected_build_targets(project, manifest, target_names)
     except (RuntimeError, ManifestError, BuildTargetError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     for target_name, target_config, working_dir in targets:
         print_build_target(project, manifest, target_name, target_config, working_dir)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def list_build_targets_command(
@@ -78,7 +78,7 @@ def list_build_targets_command(
 ) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         project = resolve_project(ctx, project_name, workspace)
@@ -86,11 +86,11 @@ def list_build_targets_command(
         targets = all_build_targets(project, manifest)
     except (RuntimeError, ManifestError, BuildTargetError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     for target_name, target_config, working_dir in targets:
         print_build_target(project, manifest, target_name, target_config, working_dir)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def print_build_target(

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -122,7 +122,7 @@ def run(
         )
     except ProjectUsageError as exc:
         ctx.log.error(str(exc))
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
 
 def dispatch_projects_command(
@@ -195,7 +195,7 @@ def dispatch_projects_command(
         "run-commands, build-targets, build-target-list, pull.",
         command,
     )
-    return 2
+    return base_cli.ExitCode.USAGE_ERROR
 
 
 def require_argument_count(command: str, arguments: tuple[str, ...], minimum: int, maximum: int) -> None:
@@ -290,14 +290,14 @@ def workspace_init_from_args(
 def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
     if output_format not in ("text", "json"):
         ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
         projects = discover_projects_cached(ctx, workspace_root)
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if output_format == "json":
         print(
@@ -306,11 +306,11 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_f
                 separators=(",", ":"),
             )
         )
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     for project in projects:
         print(f"{project.name}\t{project.root}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def workspace_status_command(
@@ -321,7 +321,7 @@ def workspace_status_command(
 ) -> int:
     if output_format not in ("text", "json"):
         ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
@@ -331,14 +331,16 @@ def workspace_status_command(
         statuses = workspace_project_statuses(workspace_root, manifest)
     except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if output_format == "json":
         print(dumps_json(workspace_status_to_json(workspace_root, statuses, manifest)))
     else:
         print_workspace_status(workspace_root, statuses, manifest)
 
-    return 1 if any(project.status == "error" for project in statuses) else 0
+    if any(project.status == "error" for project in statuses):
+        return base_cli.ExitCode.FAILURE
+    return base_cli.ExitCode.SUCCESS
 
 
 def workspace_check_command(
@@ -349,7 +351,7 @@ def workspace_check_command(
 ) -> int:
     if output_format not in ("text", "json"):
         ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
@@ -357,14 +359,16 @@ def workspace_check_command(
         results = workspace_project_check_results(ctx, workspace_root, manifest)
     except (ProjectDiscoveryError, ManifestError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if output_format == "json":
         print(dumps_json(workspace_check_to_json(workspace_root, results, manifest)))
     else:
         print_workspace_check(workspace_root, results, manifest)
 
-    return 1 if any(result.status == "error" for result in results) else 0
+    if any(result.status == "error" for result in results):
+        return base_cli.ExitCode.FAILURE
+    return base_cli.ExitCode.SUCCESS
 
 
 def workspace_doctor_command(
@@ -375,7 +379,7 @@ def workspace_doctor_command(
 ) -> int:
     if output_format not in ("text", "json"):
         ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
@@ -383,7 +387,7 @@ def workspace_doctor_command(
         results = workspace_project_check_results(ctx, workspace_root, manifest)
     except (ProjectDiscoveryError, ManifestError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if output_format == "json":
         print(dumps_json(workspace_doctor_to_json(workspace_root, results, manifest)))
@@ -402,11 +406,11 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCommandOpti
         manifest = require_workspace_clone_manifest(ctx, options.workspace_manifest)
     except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if ctx.base_home is None:
         ctx.log.error("BASE_HOME is required to clone workspace repositories.")
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     basectl = ctx.base_home / "bin" / "basectl"
     print(f"Workspace clone: {workspace_root} ({len(manifest.repos)} repositories)")
@@ -427,10 +431,10 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCommandOpti
 
     if errors:
         print(f"Workspace clone completed with {errors} error(s).")
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print("Workspace clone completed.")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def workspace_pull_command(ctx: base_cli.Context, options: WorkspaceCommandOptions) -> int:
@@ -449,7 +453,7 @@ def workspace_pull_command(ctx: base_cli.Context, options: WorkspaceCommandOptio
         result = pull_workspace_manifest(source, target, dry_run=options.dry_run)
     except WorkspaceManifestError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print("Workspace manifest pull")
     print(f"Source: {result.source}")
@@ -459,14 +463,14 @@ def workspace_pull_command(ctx: base_cli.Context, options: WorkspaceCommandOptio
 
     if options.dry_run:
         print("[DRY-RUN] No files changed.")
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     if not result.changed:
         print("Workspace manifest already up to date.")
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     print(f"Updated workspace manifest: {result.target}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def workspace_init_command(ctx: base_cli.Context, workspace_source: str, options: WorkspaceCommandOptions) -> int:
@@ -479,7 +483,7 @@ def workspace_init_command(ctx: base_cli.Context, workspace_source: str, options
         workspace_root = resolve_workspace_init_root(ctx, options.workspace, config_repo)
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print("Workspace init")
     print(f"Workspace source: {source.display}")
@@ -496,13 +500,13 @@ def workspace_init_command(ctx: base_cli.Context, workspace_source: str, options
             print(f"  workspace.root: {workspace_root}")
             print(f"  workspace.manifest: {manifest_path}")
             print("[DRY-RUN] Skipping member repository plan because the workspace config repo is not present.")
-            return 0
+            return base_cli.ExitCode.SUCCESS
         manifest = resolve_workspace_manifest(str(manifest_path))
         if manifest is None:
             raise WorkspaceManifestError(f"{manifest_path}: workspace manifest is required.")
     except WorkspaceManifestError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print(f"Workspace manifest: {manifest.path} ({manifest.name})")
 
@@ -749,7 +753,7 @@ def clone_workspace_repo(
             repo.name,
             repo.url,
         )
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     command = [str(basectl), "repo", "clone", repo_spec, "--path", str(target)]
     if dry_run:
@@ -762,14 +766,14 @@ def clone_workspace_repo(
         )
     except ProjectRunnerError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     write_project_command_output(result)
     if result.returncode == 0:
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     ctx.log.error("Clone failed for repository '%s'.", repo.name)
-    return 1
+    return base_cli.ExitCode.FAILURE
 
 
 def workspace_clone_repo_spec(repo: WorkspaceManifestRepo) -> str | None:
@@ -782,17 +786,17 @@ def workspace_clone_repo_spec(repo: WorkspaceManifestRepo) -> str | None:
 def resolve_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         project = resolve_named_project(ctx, project_name, workspace)
         manifest = read_manifest(project.manifest_path)
     except (ProjectDiscoveryError, ManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print(_project_output(project.name, project.root, project.manifest_path, manifest))
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def test_command_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
@@ -804,7 +808,7 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
         manifest = read_manifest(project.manifest_path)
     except (ProjectDiscoveryError, ManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if manifest.test is None:
         ctx.log.error(
@@ -812,11 +816,11 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
             project.name,
             project.manifest_path,
         )
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     command_config = test_command(manifest.test)
     print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def demo_script_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
@@ -832,20 +836,20 @@ def demo_script_project_command(ctx: base_cli.Context, project_name: str | None,
                 project.name,
                 project.manifest_path,
             )
-            return 1
+            return base_cli.ExitCode.FAILURE
         demo_script = resolve_demo_script_path(manifest)
     except (ProjectDiscoveryError, ManifestError, ArtifactError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print(_demo_output(project.name, project.root, project.manifest_path, demo_script, manifest))
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def activation_sources_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         project = resolve_named_project(ctx, project_name, workspace)
@@ -853,11 +857,11 @@ def activation_sources_project_command(ctx: base_cli.Context, project_name: str 
         sources = activation_source_paths(project, manifest.activate.source)
     except (ProjectDiscoveryError, ManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     for source in sources:
         print(source)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def run_command_project_command(
@@ -868,10 +872,10 @@ def run_command_project_command(
 ) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     if not command_name:
         ctx.log.error("Command name is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         project = resolve_named_project(ctx, project_name, workspace)
@@ -879,10 +883,10 @@ def run_command_project_command(
         command_config = project_command(manifest, command_name)
     except (ProjectDiscoveryError, ManifestError, ProjectCommandError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def list_run_commands_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
@@ -894,16 +898,16 @@ def list_run_commands_command(ctx: base_cli.Context, project_name: str | None, w
         manifest = read_manifest(project.manifest_path)
     except (ProjectDiscoveryError, ManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     commands = project_commands(manifest)
     if not commands:
         ctx.log.error("Project '%s' does not declare runnable commands in '%s'.", project.name, project.manifest_path)
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     for command_name, command_config in commands.items():
         print(_named_command_output(project.name, project.root, project.manifest_path, command_name, command_config))
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def current_project_command(ctx: base_cli.Context) -> int:
@@ -911,10 +915,10 @@ def current_project_command(ctx: base_cli.Context) -> int:
         project = current_project()
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print(f"{project.name}\t{project.root}\t{project.manifest_path}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def test_command(test_config: TestConfig) -> CommandConfig:
@@ -1039,16 +1043,16 @@ def resolve_activation_source_path(project: Project, source_path: str, index: in
 def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:
     if not manifest:
         ctx.log.error("Manifest path is required.")
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         project = read_project(Path(manifest).expanduser().resolve())
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     print(f"{project.name}\t{project.root}\t{project.manifest_path}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path:

--- a/cli/python/base_projects/workspace_configure.py
+++ b/cli/python/base_projects/workspace_configure.py
@@ -38,14 +38,14 @@ def workspace_configure_from_options(
 ) -> int:
     if options.output_format != "text":
         ctx.log.error("Unsupported output format '%s'. Expected: text.", options.output_format)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     try:
         workspace_root = resolve_workspace_root(ctx, options.workspace)
         manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, options.workspace_manifest))
     except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     return workspace_configure_command(ctx, workspace_root, manifest, dry_run=options.dry_run)
 
@@ -59,7 +59,7 @@ def workspace_configure_command(
 ) -> int:
     if ctx.base_home is None:
         ctx.log.error("BASE_HOME is required to configure workspace repositories.")
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     basectl = ctx.base_home / "bin" / "basectl"
     targets = workspace_configure_targets(workspace_root, workspace_manifest)
@@ -76,7 +76,7 @@ def workspace_configure_command(
         "Workspace configure completed: "
         f"configured={counts.configured} skipped={counts.skipped} failed={counts.failed}."
     )
-    return 1 if counts.failed else 0
+    return base_cli.ExitCode.FAILURE if counts.failed else base_cli.ExitCode.SUCCESS
 
 
 def workspace_configure_targets(
@@ -163,17 +163,17 @@ def configure_workspace_repo(
         result = subprocess.run(command, check=False, capture_output=True, text=True)
     except OSError as exc:
         ctx.log.error("Could not run basectl repo configure for repository '%s': %s", target.name, exc)
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     if result.stdout:
         print(result.stdout, end="")
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
     if result.returncode == 0:
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     ctx.log.error("Configure failed for repository '%s'.", target.name)
-    return 1
+    return base_cli.ExitCode.FAILURE
 
 
 def print_workspace_configure_header(

--- a/cli/python/base_prompt/engine.py
+++ b/cli/python/base_prompt/engine.py
@@ -51,14 +51,14 @@ def run(ctx: base_cli.Context, prompt_name: str | None) -> int:
             raise PromptUsageError("The 'prompt' command requires 'list' or a prompt name.")
         prompt = prompt_definition(prompt_name)
         print(render_prompt(ctx.base_home, prompt), end="")
-        return 0
+        return base_cli.ExitCode.SUCCESS
     except PromptUsageError as exc:
         print_usage(file=sys.stderr)
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     except PromptError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
+        return base_cli.ExitCode.FAILURE
 
 
 def print_usage(file=sys.stdout) -> None:
@@ -80,7 +80,7 @@ Purpose:
 def list_prompts() -> int:
     for prompt in PROMPTS:
         print(f"{prompt.name}\t{prompt.description}")
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def prompt_definition(name: str) -> PromptDefinition:

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -93,10 +93,10 @@ def run(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
     except ReleaseUsageError as exc:
         print_usage(file=sys.stderr)
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
     except (ManifestError, ReleaseError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
+        return base_cli.ExitCode.FAILURE
 
 
 def parse_release_args(arguments: tuple[str, ...]) -> ReleaseArguments:
@@ -208,8 +208,8 @@ def release_check_command(ctx: ReleaseContext) -> int:
     for finding in findings:
         print(f"{finding.status:<5}  {finding.name:<14}  {finding.message}")
     if any(finding.status == "error" for finding in findings):
-        return 1
-    return 0
+        return base_cli.ExitCode.FAILURE
+    return base_cli.ExitCode.SUCCESS
 
 
 def release_plan_command(ctx: ReleaseContext) -> int:
@@ -223,12 +223,12 @@ def release_plan_command(ctx: ReleaseContext) -> int:
     print(f"GitHub release title: {title}")
     print("")
     print_homebrew_handoff(ctx, after_publish=False)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def release_notes_command(ctx: ReleaseContext) -> int:
     print(extract_changelog_section(ctx.changelog, ctx.version))
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
@@ -241,7 +241,7 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
     if blockers:
         print(f"\nRelease publish blocked by readiness findings for {ctx.manifest.project_name} v{ctx.version}\n")
         print_findings(blockers)
-        return 1
+        return base_cli.ExitCode.FAILURE
 
     notes = extract_changelog_section(ctx.changelog, ctx.version)
 
@@ -255,7 +255,7 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
         print(f"GitHub Release URL: {github_release_url(ctx.release.github.repository, ctx.tag_name)}")
         print("")
         print_homebrew_handoff(ctx, after_publish=True)
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     if not args.yes:
         require_interactive_publish_confirmation(ctx, title)
@@ -290,7 +290,7 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
     print(f"Tag URL: {github_tag_url(ctx.release.github.repository, ctx.tag_name)}")
     print("")
     print_homebrew_handoff(ctx, after_publish=True)
-    return 0
+    return base_cli.ExitCode.SUCCESS
 
 
 def release_publish_recovery_guidance(ctx: ReleaseContext, title: str) -> str:

--- a/cli/python/base_setup/ci_json.py
+++ b/cli/python/base_setup/ci_json.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import base_cli
+
 
 LOG_LINE_RE = re.compile(
     r"^\d{4}-\d{2}-\d{2}\s+"
@@ -106,10 +108,9 @@ def main(argv: list[str] | None = None) -> int:
                 stderr_file=args.stderr_file,
             )
         )
-        return 0
-    return 2
+        return base_cli.ExitCode.SUCCESS
+    return base_cli.ExitCode.USAGE_ERROR
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import base_cli
+
 from .checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 
 
@@ -269,17 +271,17 @@ def main(argv: list[str] | None = None) -> int:
         status = payload_status(json.loads(payload))
         if args.record_path and args.project and args.checked_at:
             write_check_record(Path(args.record_path), args.project, status, args.checked_at)
-        return 0 if status != "error" else 1
+        return base_cli.ExitCode.SUCCESS if status != "error" else base_cli.ExitCode.FAILURE
     if args.command == "doctor-json":
         checks = tuple(parse_check(finding) for finding in args.finding)
         embedded_payloads = tuple((key, payload) for key, payload in args.embedded_payload)
         payload = render_base_doctor_payload(checks, project=args.project, embedded_payloads=embedded_payloads)
         print(payload, end="")
         status = payload_status(json.loads(payload))
-        return 0 if status != "error" else 1
+        return base_cli.ExitCode.SUCCESS if status != "error" else base_cli.ExitCode.FAILURE
     if args.command == "record-check":
         write_check_record(Path(args.output_path), args.project, args.status, args.checked_at)
-        return 0
+        return base_cli.ExitCode.SUCCESS
     if args.command == "project-venv-check-json":
         print(
             render_project_venv_check_payload(
@@ -291,7 +293,7 @@ def main(argv: list[str] | None = None) -> int:
             ),
             end="",
         )
-        return 0 if args.status != "error" else 1
+        return base_cli.ExitCode.SUCCESS if args.status != "error" else base_cli.ExitCode.FAILURE
     if args.command == "project-venv-doctor-json":
         print(
             render_project_venv_doctor_payload(
@@ -302,9 +304,9 @@ def main(argv: list[str] | None = None) -> int:
             ),
             end="",
         )
-        return 0 if args.status != "error" else 1
+        return base_cli.ExitCode.SUCCESS if args.status != "error" else base_cli.ExitCode.FAILURE
     parser.error(f"Unsupported diagnostics command '{args.command}'.")
-    return 2
+    return base_cli.ExitCode.USAGE_ERROR
 
 
 if __name__ == "__main__":

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -96,9 +96,9 @@ def run(
     if manifest_path is None:
         if project:
             ctx.log.error("No base_manifest.yaml found for project '%s'.", project)
-            return 1
+            return base_cli.ExitCode.FAILURE
         ctx.log.info("No base_manifest.yaml found; skipping project artifact work.")
-        return 0
+        return base_cli.ExitCode.SUCCESS
 
     try:
         base_manifest = read_manifest(manifest_path)
@@ -187,8 +187,8 @@ def route_manifest(
         print(route_to_text(route_for_manifest(manifest), manifest_action.output_format))
     except ValueError as exc:
         ctx.log.error(str(exc))
-        return 2
-    return 0
+        return base_cli.ExitCode.USAGE_ERROR
+    return base_cli.ExitCode.SUCCESS
 
 
 def validate_project_name(manifest: BaseManifest, expected_project: str | None) -> None:
@@ -305,8 +305,10 @@ def check_manifest(
                     ctx.log.warning("Fix: %s", check.fix)
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
-        return 2
-    return 0 if all(check.ok or doctor_status(check) == "warn" for check in checks) else 1
+        return base_cli.ExitCode.USAGE_ERROR
+    if all(check.ok or doctor_status(check) == "warn" for check in checks):
+        return base_cli.ExitCode.SUCCESS
+    return base_cli.ExitCode.FAILURE
 
 
 def check_pre_venv_manifest(
@@ -328,8 +330,10 @@ def check_pre_venv_manifest(
                     ctx.log.warning("Fix: %s", check.fix)
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
-        return 2
-    return 0 if all(check.ok or doctor_status(check) == "warn" for check in checks) else 1
+        return base_cli.ExitCode.USAGE_ERROR
+    if all(check.ok or doctor_status(check) == "warn" for check in checks):
+        return base_cli.ExitCode.SUCCESS
+    return base_cli.ExitCode.FAILURE
 
 
 def doctor_manifest(
@@ -342,7 +346,7 @@ def doctor_manifest(
 ) -> int:
     if output_format not in {"json", "text"}:
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.", file=sys.stderr)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     checks = manifest_checks(
         default_manifest,
@@ -373,7 +377,7 @@ def doctor_pre_venv_manifest(
 ) -> int:
     if output_format not in {"json", "text"}:
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.", file=sys.stderr)
-        return 2
+        return base_cli.ExitCode.USAGE_ERROR
 
     checks = pre_venv_manifest_checks(manifest, remote_network=remote_network)
     if output_format == "json":

--- a/lib/python/base_cli/tests/test_exit_code_adoption.py
+++ b/lib/python/base_cli/tests/test_exit_code_adoption.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+STANDARD_EXIT_VALUES = {0, 1, 2}
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def iter_production_cli_python_files() -> list[Path]:
+    cli_root = repository_root() / "cli" / "python"
+    return sorted(
+        path
+        for path in cli_root.rglob("*.py")
+        if "tests" not in path.relative_to(cli_root).parts
+    )
+
+
+def raw_standard_exit_returns(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    findings: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Return):
+            continue
+        values: tuple[ast.expr | None, ...]
+        if isinstance(node.value, ast.IfExp):
+            values = (node.value.body, node.value.orelse)
+        else:
+            values = (node.value,)
+        for value in values:
+            if not isinstance(value, ast.Constant) or isinstance(value.value, bool):
+                continue
+            if isinstance(value.value, int) and value.value in STANDARD_EXIT_VALUES:
+                findings.append(f"{path.relative_to(repository_root())}:{node.lineno}: return {value.value}")
+    return findings
+
+
+def test_production_cli_code_uses_exit_code_constants_for_standard_returns() -> None:
+    findings: list[str] = []
+    for path in iter_production_cli_python_files():
+        findings.extend(raw_standard_exit_returns(path))
+
+    assert not findings, "\n".join(findings)


### PR DESCRIPTION
## Summary
- replace standard raw Python CLI returns with `base_cli.ExitCode` constants
- add an AST guard test to keep production CLI modules from reintroducing raw standard return codes
- preserve dynamic and capped non-standard return expressions

Closes #1197

## Verification
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')
- git diff --check
- production Python line-length scan