### PR TITLE
Extract workspace init from base_projects engine

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-# pylint: disable=too-many-lines
-
 import json
 import shlex
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import urlparse
 
 import base_cli
-from base_cli.config import load_user_config
-from base_cli.config import user_config_path
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
 from base_projects.command_helpers import ProjectCommandError as ProjectRunnerError
@@ -29,6 +24,7 @@ from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_configure import workspace_configure_from_options
+from base_projects.workspace_init import workspace_init_command
 from base_projects.workspace_pull import pull_workspace_manifest
 from base_projects.workspace_reports import ProjectDiscoveryError
 from base_projects.workspace_reports import dumps_json
@@ -61,14 +57,6 @@ class WorkspaceCommandOptions:
     workspace_owner: str | None = None
     include_optional: bool = False
     dry_run: bool = False
-
-
-@dataclass(frozen=True)
-class WorkspaceInitSource:
-    display: str
-    repo_spec: str | None = None
-    repo_name: str | None = None
-    local_path: Path | None = None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -284,7 +272,12 @@ def workspace_init_from_args(
     options: WorkspaceCommandOptions,
 ) -> int:
     require_argument_count("init", arguments, 1, 1)
-    return workspace_init_command(ctx, arguments[0], options)
+    return workspace_init_command(
+        ctx,
+        arguments[0],
+        options,
+        workspace_clone_command=workspace_clone_command,
+    )
 
 
 def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
@@ -471,184 +464,6 @@ def workspace_pull_command(ctx: base_cli.Context, options: WorkspaceCommandOptio
 
     print(f"Updated workspace manifest: {result.target}")
     return base_cli.ExitCode.SUCCESS
-
-
-def workspace_init_command(ctx: base_cli.Context, workspace_source: str, options: WorkspaceCommandOptions) -> int:
-    if options.output_format != "text":
-        raise ProjectUsageError(f"Unsupported output format '{options.output_format}'. Expected: text.")
-
-    try:
-        source = resolve_workspace_init_source(ctx, workspace_source, options.workspace_owner)
-        config_repo = resolve_workspace_config_repo_path(ctx, source, options)
-        workspace_root = resolve_workspace_init_root(ctx, options.workspace, config_repo)
-    except ProjectDiscoveryError as exc:
-        ctx.log.error(str(exc))
-        return base_cli.ExitCode.FAILURE
-
-    print("Workspace init")
-    print(f"Workspace source: {source.display}")
-    print(f"Workspace config repo: {config_repo}")
-    print(f"Workspace root: {workspace_root}")
-
-    try:
-        if source.repo_spec is not None:
-            clone_workspace_config_repo(ctx, source.repo_spec, config_repo, dry_run=options.dry_run)
-        manifest_path = resolve_workspace_init_manifest_path(config_repo, options.workspace_manifest)
-        if options.dry_run and source.repo_spec is not None and not manifest_path.is_file():
-            print(f"[DRY-RUN] Would read workspace manifest: {manifest_path}")
-            print("[DRY-RUN] Would update user config:")
-            print(f"  workspace.root: {workspace_root}")
-            print(f"  workspace.manifest: {manifest_path}")
-            print("[DRY-RUN] Skipping member repository plan because the workspace config repo is not present.")
-            return base_cli.ExitCode.SUCCESS
-        manifest = resolve_workspace_manifest(str(manifest_path))
-        if manifest is None:
-            raise WorkspaceManifestError(f"{manifest_path}: workspace manifest is required.")
-    except WorkspaceManifestError as exc:
-        ctx.log.error(str(exc))
-        return base_cli.ExitCode.FAILURE
-
-    print(f"Workspace manifest: {manifest.path} ({manifest.name})")
-
-    if options.dry_run:
-        print("[DRY-RUN] Would update user config:")
-        print(f"  workspace.root: {workspace_root}")
-        print(f"  workspace.manifest: {manifest.path}")
-    else:
-        write_workspace_init_user_config(workspace_root, manifest.path)
-        print(f"Updated user config: {user_config_path()}")
-
-    clone_options = WorkspaceCommandOptions(
-        workspace=str(workspace_root),
-        output_format="text",
-        workspace_manifest=str(manifest.path),
-        include_optional=options.include_optional,
-        dry_run=options.dry_run,
-    )
-    return workspace_clone_command(ctx, clone_options)
-
-
-def resolve_workspace_init_source(
-    ctx: base_cli.Context,
-    workspace_source: str,
-    owner: str | None,
-) -> WorkspaceInitSource:
-    source_path = Path(workspace_source).expanduser()
-    if workspace_source.startswith("file://"):
-        parsed = urlparse(workspace_source)
-        return WorkspaceInitSource(
-            display=workspace_source,
-            local_path=Path(parsed.path).expanduser().resolve(strict=False),
-        )
-    if is_workspace_init_path_source(workspace_source) or source_path.exists():
-        return WorkspaceInitSource(
-            display=workspace_source,
-            local_path=source_path.resolve(strict=False),
-        )
-
-    repo_spec = workspace_init_github_repo_spec(workspace_source)
-    if repo_spec is not None:
-        return WorkspaceInitSource(
-            display=repo_spec,
-            repo_spec=repo_spec,
-            repo_name=repo_spec.split("/", 1)[1],
-        )
-
-    if "/" in workspace_source:
-        raise ProjectUsageError(
-            "Workspace source must be a local path, GitHub URL, "
-            "'<owner>/<repo>', or short repo name."
-        )
-
-    effective_owner = owner or ctx.user_config.github.default_owner
-    if effective_owner is None:
-        raise ProjectUsageError(
-            "Workspace source owner is required for short repo names. "
-            "Pass --owner <owner> or set github.default_owner in ~/.base.d/config.yaml."
-        )
-    repo_spec = f"{effective_owner}/{workspace_source}"
-    return WorkspaceInitSource(display=repo_spec, repo_spec=repo_spec, repo_name=workspace_source)
-
-
-def is_workspace_init_path_source(workspace_source: str) -> bool:
-    return workspace_source.startswith(("/", "./", "../", "~"))
-
-
-def workspace_init_github_repo_spec(workspace_source: str) -> str | None:
-    return github_repo_spec(workspace_source, allow_path=True)
-
-
-def resolve_workspace_config_repo_path(
-    ctx: base_cli.Context,
-    source: WorkspaceInitSource,
-    options: WorkspaceCommandOptions,
-) -> Path:
-    if options.workspace_config_path is not None:
-        return Path(options.workspace_config_path).expanduser().resolve(strict=False)
-    if source.local_path is not None:
-        return source.local_path
-    workspace_root = resolve_workspace_init_root(ctx, options.workspace, None)
-    assert source.repo_name is not None
-    return (workspace_root / source.repo_name).resolve(strict=False)
-
-
-def resolve_workspace_init_manifest_path(config_repo: Path, workspace_manifest: str | None) -> Path:
-    if workspace_manifest is None:
-        return (config_repo / "workspace.yaml").resolve(strict=False)
-    manifest_path = Path(workspace_manifest).expanduser()
-    if manifest_path.is_absolute():
-        return manifest_path.resolve(strict=False)
-    return (config_repo / manifest_path).resolve(strict=False)
-
-
-def resolve_workspace_init_root(ctx: base_cli.Context, workspace: str | None, config_repo: Path | None) -> Path:
-    if workspace is not None:
-        return Path(workspace).expanduser().resolve(strict=False)
-    if ctx.workspace_root is not None:
-        return ctx.workspace_root
-    if config_repo is None:
-        if ctx.base_home is None:
-            raise ProjectDiscoveryError("BASE_HOME is required to resolve the default workspace root.")
-        return ctx.base_home.parent.resolve(strict=False)
-    return config_repo.parent.resolve(strict=False)
-
-
-def clone_workspace_config_repo(ctx: base_cli.Context, repo_spec: str, target: Path, *, dry_run: bool) -> None:
-    if ctx.base_home is None:
-        raise WorkspaceManifestError("BASE_HOME is required to clone the workspace configuration repository.")
-    basectl = ctx.base_home / "bin" / "basectl"
-    command = [str(basectl), "repo", "clone", repo_spec, "--path", str(target)]
-    if dry_run:
-        command.append("--dry-run")
-    try:
-        result = run_project_command(
-            command,
-            error_context=f"basectl repo clone for workspace source '{repo_spec}'",
-        )
-    except ProjectRunnerError as exc:
-        raise WorkspaceManifestError(str(exc)) from exc
-    write_project_command_output(result)
-    if result.returncode != 0:
-        raise WorkspaceManifestError(f"Workspace source clone failed for '{repo_spec}'.")
-
-
-def write_workspace_init_user_config(workspace_root: Path, manifest_path: Path) -> None:
-    try:
-        import yaml
-    except ImportError as exc:
-        raise WorkspaceManifestError(
-            "PyYAML is required to update ~/.base.d/config.yaml. "
-            "Run 'basectl setup' to install Base Python bootstrap dependencies."
-        ) from exc
-
-    config_path = user_config_path()
-    raw_config = load_user_config()
-    workspace_config = dict(raw_config.get("workspace") or {})
-    workspace_config["root"] = str(workspace_root)
-    workspace_config["manifest"] = str(manifest_path)
-    raw_config["workspace"] = workspace_config
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(yaml.safe_dump(raw_config, sort_keys=False), encoding="utf-8")
 
 
 def effective_workspace_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> str | None:

--- a/cli/python/base_projects/tests/test_workspace_init.py
+++ b/cli/python/base_projects/tests/test_workspace_init.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import importlib
 import os
 import tempfile
 import unittest
@@ -89,6 +90,14 @@ def invoke_engine(
 
 
 class WorkspaceInitTests(unittest.TestCase):
+    def test_workspace_init_command_is_extracted_from_engine(self) -> None:
+        workspace_init = importlib.import_module("base_projects.workspace_init")
+
+        self.assertIs(
+            engine.workspace_init_from_args.__globals__["workspace_init_command"],
+            workspace_init.workspace_init_command,
+        )
+
     def test_workspace_init_dry_run_uses_local_source_without_writing_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/workspace_init.py
+++ b/cli/python/base_projects/workspace_init.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+import base_cli
+from base_cli.config import load_user_config
+from base_cli.config import user_config_path
+from base_projects.command_helpers import ProjectCommandError as ProjectRunnerError
+from base_projects.command_helpers import ProjectUsageError
+from base_projects.command_helpers import github_repo_spec
+from base_projects.command_helpers import run_project_command
+from base_projects.command_helpers import write_project_command_output
+from base_projects.workspace_manifest import WorkspaceManifestError
+from base_projects.workspace_reports import ProjectDiscoveryError
+from base_projects.workspace_reports import resolve_workspace_manifest
+
+
+class WorkspaceInitOptions(Protocol):
+    workspace: str | None
+    output_format: str
+    workspace_manifest: str | None
+    workspace_config_path: str | None
+    workspace_owner: str | None
+    include_optional: bool
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class WorkspaceInitSource:
+    display: str
+    repo_spec: str | None = None
+    repo_name: str | None = None
+    local_path: Path | None = None
+
+
+def workspace_init_command(
+    ctx: base_cli.Context,
+    workspace_source: str,
+    options: WorkspaceInitOptions,
+    *,
+    workspace_clone_command: Callable[[base_cli.Context, Any], int],
+) -> int:
+    if options.output_format != "text":
+        raise ProjectUsageError(f"Unsupported output format '{options.output_format}'. Expected: text.")
+
+    try:
+        source = resolve_workspace_init_source(ctx, workspace_source, options.workspace_owner)
+        config_repo = resolve_workspace_config_repo_path(ctx, source, options)
+        workspace_root = resolve_workspace_init_root(ctx, options.workspace, config_repo)
+    except ProjectDiscoveryError as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    print("Workspace init")
+    print(f"Workspace source: {source.display}")
+    print(f"Workspace config repo: {config_repo}")
+    print(f"Workspace root: {workspace_root}")
+
+    try:
+        if source.repo_spec is not None:
+            clone_workspace_config_repo(ctx, source.repo_spec, config_repo, dry_run=options.dry_run)
+        manifest_path = resolve_workspace_init_manifest_path(config_repo, options.workspace_manifest)
+        if options.dry_run and source.repo_spec is not None and not manifest_path.is_file():
+            print(f"[DRY-RUN] Would read workspace manifest: {manifest_path}")
+            print("[DRY-RUN] Would update user config:")
+            print(f"  workspace.root: {workspace_root}")
+            print(f"  workspace.manifest: {manifest_path}")
+            print("[DRY-RUN] Skipping member repository plan because the workspace config repo is not present.")
+            return base_cli.ExitCode.SUCCESS
+        manifest = resolve_workspace_manifest(str(manifest_path))
+        if manifest is None:
+            raise WorkspaceManifestError(f"{manifest_path}: workspace manifest is required.")
+    except WorkspaceManifestError as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    print(f"Workspace manifest: {manifest.path} ({manifest.name})")
+
+    if options.dry_run:
+        print("[DRY-RUN] Would update user config:")
+        print(f"  workspace.root: {workspace_root}")
+        print(f"  workspace.manifest: {manifest.path}")
+    else:
+        write_workspace_init_user_config(workspace_root, manifest.path)
+        print(f"Updated user config: {user_config_path()}")
+
+    clone_options = replace(
+        options,
+        workspace=str(workspace_root),
+        output_format="text",
+        workspace_manifest=str(manifest.path),
+        include_optional=options.include_optional,
+        dry_run=options.dry_run,
+    )
+    return workspace_clone_command(ctx, clone_options)
+
+
+def resolve_workspace_init_source(
+    ctx: base_cli.Context,
+    workspace_source: str,
+    owner: str | None,
+) -> WorkspaceInitSource:
+    source_path = Path(workspace_source).expanduser()
+    if workspace_source.startswith("file://"):
+        parsed = urlparse(workspace_source)
+        return WorkspaceInitSource(
+            display=workspace_source,
+            local_path=Path(parsed.path).expanduser().resolve(strict=False),
+        )
+    if is_workspace_init_path_source(workspace_source) or source_path.exists():
+        return WorkspaceInitSource(
+            display=workspace_source,
+            local_path=source_path.resolve(strict=False),
+        )
+
+    repo_spec = workspace_init_github_repo_spec(workspace_source)
+    if repo_spec is not None:
+        return WorkspaceInitSource(
+            display=repo_spec,
+            repo_spec=repo_spec,
+            repo_name=repo_spec.split("/", 1)[1],
+        )
+
+    if "/" in workspace_source:
+        raise ProjectUsageError(
+            "Workspace source must be a local path, GitHub URL, "
+            "'<owner>/<repo>', or short repo name."
+        )
+
+    effective_owner = owner or ctx.user_config.github.default_owner
+    if effective_owner is None:
+        raise ProjectUsageError(
+            "Workspace source owner is required for short repo names. "
+            "Pass --owner <owner> or set github.default_owner in ~/.base.d/config.yaml."
+        )
+    repo_spec = f"{effective_owner}/{workspace_source}"
+    return WorkspaceInitSource(display=repo_spec, repo_spec=repo_spec, repo_name=workspace_source)
+
+
+def is_workspace_init_path_source(workspace_source: str) -> bool:
+    return workspace_source.startswith(("/", "./", "../", "~"))
+
+
+def workspace_init_github_repo_spec(workspace_source: str) -> str | None:
+    return github_repo_spec(workspace_source, allow_path=True)
+
+
+def resolve_workspace_config_repo_path(
+    ctx: base_cli.Context,
+    source: WorkspaceInitSource,
+    options: WorkspaceInitOptions,
+) -> Path:
+    if options.workspace_config_path is not None:
+        return Path(options.workspace_config_path).expanduser().resolve(strict=False)
+    if source.local_path is not None:
+        return source.local_path
+    workspace_root = resolve_workspace_init_root(ctx, options.workspace, None)
+    assert source.repo_name is not None
+    return (workspace_root / source.repo_name).resolve(strict=False)
+
+
+def resolve_workspace_init_manifest_path(config_repo: Path, workspace_manifest: str | None) -> Path:
+    if workspace_manifest is None:
+        return (config_repo / "workspace.yaml").resolve(strict=False)
+    manifest_path = Path(workspace_manifest).expanduser()
+    if manifest_path.is_absolute():
+        return manifest_path.resolve(strict=False)
+    return (config_repo / manifest_path).resolve(strict=False)
+
+
+def resolve_workspace_init_root(ctx: base_cli.Context, workspace: str | None, config_repo: Path | None) -> Path:
+    if workspace is not None:
+        return Path(workspace).expanduser().resolve(strict=False)
+    if ctx.workspace_root is not None:
+        return ctx.workspace_root
+    if config_repo is None:
+        if ctx.base_home is None:
+            raise ProjectDiscoveryError("BASE_HOME is required to resolve the default workspace root.")
+        return ctx.base_home.parent.resolve(strict=False)
+    return config_repo.parent.resolve(strict=False)
+
+
+def clone_workspace_config_repo(ctx: base_cli.Context, repo_spec: str, target: Path, *, dry_run: bool) -> None:
+    if ctx.base_home is None:
+        raise WorkspaceManifestError("BASE_HOME is required to clone the workspace configuration repository.")
+    basectl = ctx.base_home / "bin" / "basectl"
+    command = [str(basectl), "repo", "clone", repo_spec, "--path", str(target)]
+    if dry_run:
+        command.append("--dry-run")
+    try:
+        result = run_project_command(
+            command,
+            error_context=f"basectl repo clone for workspace source '{repo_spec}'",
+        )
+    except ProjectRunnerError as exc:
+        raise WorkspaceManifestError(str(exc)) from exc
+    write_project_command_output(result)
+    if result.returncode != 0:
+        raise WorkspaceManifestError(f"Workspace source clone failed for '{repo_spec}'.")
+
+
+def write_workspace_init_user_config(workspace_root: Path, manifest_path: Path) -> None:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise WorkspaceManifestError(
+            "PyYAML is required to update ~/.base.d/config.yaml. "
+            "Run 'basectl setup' to install Base Python bootstrap dependencies."
+        ) from exc
+
+    config_path = user_config_path()
+    raw_config = load_user_config()
+    workspace_config = dict(raw_config.get("workspace") or {})
+    workspace_config["root"] = str(workspace_root)
+    workspace_config["manifest"] = str(manifest_path)
+    raw_config["workspace"] = workspace_config
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.safe_dump(raw_config, sort_keys=False), encoding="utf-8")


### PR DESCRIPTION
## Summary
- move workspace init implementation and helpers into `base_projects.workspace_init`
- keep `base_projects.engine` as the dispatcher and remove its broad `too-many-lines` suppression
- add a boundary test that verifies workspace init delegates to the extracted module

Closes #1198

## Verification
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest base_projects.tests.test_workspace_init
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_projects/tests -p 'test_*.py'
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py') cli/python/base_projects/workspace_init.py
- git diff --check