### PR TITLE
Document diagnostics helper CLI boundary

### DIFF
--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -1,3 +1,13 @@
+"""Internal pre-CLI JSON renderer for setup/check/doctor shell orchestration.
+
+This module intentionally does not expose a public ``base_cli.App`` command.
+``setup_common.sh`` calls it while collecting host diagnostics, including cases
+where Click, PyYAML, or the normal Base CLI runtime may be missing or unhealthy.
+It therefore accepts only its argparse subcommands, writes structured payloads
+to stdout or explicit output files, and does not provide base_cli.App debug,
+log-file, history, run-id, or standard-option behavior.
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/cli/python/base_setup/tests/test_diagnostics_payloads.py
+++ b/cli/python/base_setup/tests/test_diagnostics_payloads.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import io
 import json
+import os
+import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
 
+from base_setup import diagnostics
 from base_setup.diagnostics import DiagnosticCheck
 from base_setup.diagnostics import render_base_check_payload
 from base_setup.diagnostics import render_base_doctor_payload
@@ -12,6 +19,70 @@ from base_setup.diagnostics import render_project_venv_doctor_payload
 
 
 class DiagnosticsPayloadTests(unittest.TestCase):
+    def test_module_documents_internal_pre_cli_boundary(self) -> None:
+        module_doc = diagnostics.__doc__ or ""
+
+        self.assertIn("internal", module_doc.lower())
+        self.assertIn("pre-CLI", module_doc)
+        self.assertIn("base_cli.App", module_doc)
+
+    def test_main_rejects_base_cli_standard_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "check.json"
+            stderr = io.StringIO()
+            with self.assertRaises(SystemExit) as raised:
+                with redirect_stderr(stderr):
+                    diagnostics.main(
+                        [
+                            "--debug",
+                            "record-check",
+                            "--project",
+                            "demo",
+                            "--status",
+                            "ok",
+                            "--checked-at",
+                            "2026-06-28T12:00:00Z",
+                            "--output-path",
+                            str(output_path),
+                        ]
+                    )
+
+            self.assertEqual(raised.exception.code, 2)
+            self.assertIn("--debug", stderr.getvalue())
+            self.assertFalse(output_path.exists())
+
+    def test_main_does_not_create_base_cli_runtime_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output_path = root / "check.json"
+            cache_root = root / "cache"
+            home = root / "home"
+            home.mkdir()
+            env = {
+                "BASE_CACHE_DIR": str(cache_root),
+                "HOME": str(home),
+                "BASE_HOME": os.environ.get("BASE_HOME", str(root / "base")),
+            }
+
+            with mock.patch.dict(os.environ, env), redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                status = diagnostics.main(
+                    [
+                        "record-check",
+                        "--project",
+                        "demo",
+                        "--status",
+                        "ok",
+                        "--checked-at",
+                        "2026-06-28T12:00:00Z",
+                        "--output-path",
+                        str(output_path),
+                    ]
+                )
+
+            self.assertEqual(status, 0)
+            self.assertTrue(output_path.exists())
+            self.assertFalse((cache_root / "cli" / "base_setup.diagnostics").exists())
+
     def test_render_base_check_payload_merges_embedded_statuses(self) -> None:
         payload_text = render_base_check_payload(
             checks=(

--- a/docs/setup-common-ownership.md
+++ b/docs/setup-common-ownership.md
@@ -72,6 +72,14 @@ serialization to `base_setup.diagnostics`, but it still owns top-level
 diagnostic status merging, check argument assembly, and Base/profile/project
 payload splicing before calling the Python formatter.
 
+`base_setup.diagnostics` is intentionally an internal pre-CLI helper rather
+than a public `base_cli.App` command. `setup_common.sh` can call it while
+diagnosing whether Click, PyYAML, or the normal Base CLI runtime is present, so
+the helper accepts only its documented argparse subcommands. It does not support
+Base CLI standard flags such as `--debug`, `--log-file`, `--keep-temp`, or
+history/run-id behavior; outer setup/check/doctor orchestration owns user-facing
+logging and status handling.
+
 Python already has diagnostic payload helpers in `base_setup.checks`, and JSON
 serialization is a better Python responsibility. Bash can continue to collect
 host probe results and call a Python formatter for structured output.


### PR DESCRIPTION
## Summary
- document `base_setup.diagnostics` as an internal pre-CLI JSON renderer instead of a public `base_cli.App` command
- add tests that codify unsupported Base CLI standard flags and absence of Base CLI runtime state creation
- preserve existing diagnostics payload schemas and exit behavior

Closes #1195

## Verification
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest base_setup.tests.test_diagnostics_payloads.DiagnosticsPayloadTests.test_module_documents_internal_pre_cli_boundary base_setup.tests.test_diagnostics_payloads.DiagnosticsPayloadTests.test_main_rejects_base_cli_standard_flags base_setup.tests.test_diagnostics_payloads.DiagnosticsPayloadTests.test_main_does_not_create_base_cli_runtime_state
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_setup/tests -p 'test_*.py'
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q
- PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc $(git ls-files '*.py')
- git diff --check