### PR TITLE
Warn in basectl check when CLT is outdated

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -20,7 +20,7 @@ options.
 - `basectl setup [project]` - install and bootstrap the local Base CLI
   environment and optional project artifacts.
 - `basectl check [project]` - verify local Base and optional project artifacts
-  without making changes.
+  without making changes, warning on non-blocking readiness issues.
 - `basectl doctor [project]` - diagnose Base or project readiness and explain
   fixes.
 - `basectl test [project]` - run a project's declared test command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Made `basectl check` warn when Homebrew reports installed Xcode Command Line
+  Tools are outdated or incomplete, matching the existing `basectl doctor`
+  finding while keeping the check non-blocking.
+
 ## [1.3.0] - 2026-06-28
 
 ### Added

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -36,7 +36,8 @@ See also:
 
 Check does:
   1. Verify Homebrew is installed.
-  2. Verify Xcode Command Line Tools are installed.
+  2. Verify Xcode Command Line Tools are installed and warn when Homebrew reports
+     them outdated or incomplete.
   3. Verify Python 3.13 is installed via Homebrew.
   4. Verify ~/.base.d/base/.venv is healthy.
   5. Verify prerequisite profiles when --profile is passed.
@@ -127,8 +128,8 @@ base_check_subcommand_main() {
     export BASE_SETUP_REMOTE_NETWORK
     log_debug "Running 'basectl check'."
     if [[ "$output_format" == json ]]; then
-        setup_run_check_json "$remote_network"
+        BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true setup_run_check_json "$remote_network"
     else
-        setup_run_check
+        BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true setup_run_check
     fi
 }

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -50,6 +50,27 @@ load ./setup_helpers.bash
     [ "$(grep -c '^click$' "$TEST_STATE_DIR/pip-show.log")" -eq 1 ]
 }
 
+@test "basectl check warns when Homebrew reports outdated Xcode Command Line Tools" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    touch "$TEST_STATE_DIR/xcode-outdated"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command check
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete."* ]]
+    [[ "$output" == *"Update Xcode Command Line Tools from Software Update, or reinstall them with 'xcode-select --install'."* ]]
+    [[ "$output" == *"Base CLI environment check passed."* ]]
+}
+
 @test "basectl check preserves text order while base probes overlap" {
     local click_line homebrew_line python_line pyyaml_line venv_line xcode_line
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
@@ -592,6 +613,30 @@ load ./setup_helpers.bash
     [[ "$output" != *'"ok":'* ]]
     [[ "$output" == *"Virtual environment Python is broken because home path '$missing_home' no longer provides Python."* ]]
     [[ "$output" == *"Run 'basectl setup demo --recreate-venv' to back up and recreate the project virtual environment."* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl check --format json warns when Homebrew reports outdated Xcode Command Line Tools" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    touch "$TEST_STATE_DIR/xcode-outdated"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command_separate_stderr check --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"id":"BASE-D002","status":"warn","name":"xcode_command_line_tools"'* ]]
+    [[ "$output" == *"Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete."* ]]
+    [[ "$output" == *"Update Xcode Command Line Tools from Software Update, or reinstall them with 'xcode-select --install'."* ]]
+    [[ "$output" != *'"ok":'* ]]
     [ "${stderr:-}" = "" ]
 }
 

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -333,6 +333,15 @@ PYEOF
         fi
         exit 1
         ;;
+    doctor)
+        if [[ -f "$state_dir/xcode-outdated" ]]; then
+            printf 'Warning: Your Command Line Tools are too outdated.\n'
+            printf 'Update them from Software Update in System Settings.\n'
+            exit 1
+        fi
+        printf 'Your system is ready to brew.\n'
+        exit 0
+        ;;
     *)
         printf 'unexpected brew args: %s\n' "$*" >&2
         exit 1

--- a/docs/check-parallelism.md
+++ b/docs/check-parallelism.md
@@ -14,7 +14,7 @@ the existing deterministic order.
 The shipped macOS base probes run concurrently for:
 
 - Homebrew presence and path discovery
-- Xcode Command Line Tools presence
+- Xcode Command Line Tools presence and Homebrew-reported freshness
 - Homebrew Python formula presence
 - Base virtual environment integrity
 - Base bootstrap Python package checks


### PR DESCRIPTION
## Summary
- Enable the existing Homebrew CLT freshness diagnostic during `basectl check` text and JSON runs.
- Keep installed-but-outdated CLT non-blocking while surfacing the warning and recovery hint.
- Add focused BATS coverage plus changelog, docs, and AI-context updates for the visible check behavior.

## Root Cause
`basectl doctor` set `BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true` before collecting base check results, but `basectl check` did not. The shared Xcode probe already knew how to emit a warning when Homebrew reports outdated or incomplete Command Line Tools; the normal check path simply left that probe disabled.

## Validation
- RED: `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/check.bats --filter "outdated Xcode Command Line Tools"` failed before the production change.
- GREEN: same focused BATS filter passed after the fix.
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/check.bats` passed, 29 tests.
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/doctor.bats` passed, 18 tests.
- `shellcheck cli/bash/commands/basectl/subcommands/check.sh cli/bash/commands/basectl/tests/setup_helpers.bash` passed.
- `git diff --check` passed.
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test` passed: Python 667 passed, 1 skipped; BATS 557 passed.

## Project Metadata
Issue Project field update was attempted before implementation, but GitHub returned `API rate limit already exceeded for user ID 22363102` on the Project/GraphQL path. The issue and PR are linked; Project fields still need a retry after the GraphQL limit resets.

Fixes #1230