### PR TITLE
Fix release engine robustness gaps

### DIFF
--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -19,6 +19,7 @@ from base_setup.manifest import read_manifest
 
 app = base_cli.App(name="base_release")
 CHANGELOG_HEADER_RE = re.compile(r"^##\s+(?:\[(?P<bracket>[^\]]+)\]|(?P<plain>\S+))(?:\s+-.*)?$")
+GIT_INSPECTION_TIMEOUT_SECONDS = 10
 RELEASE_STEP_TIMEOUT_SECONDS = 120
 
 
@@ -27,7 +28,9 @@ class ReleaseUsageError(RuntimeError):
 
 
 class ReleaseError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, guidance: str = "") -> None:
+        super().__init__(message)
+        self.guidance = guidance
 
 
 @dataclass(frozen=True)
@@ -95,8 +98,17 @@ def run(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return base_cli.ExitCode.USAGE_ERROR
     except (ManifestError, ReleaseError) as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
+        print_error(exc)
         return base_cli.ExitCode.FAILURE
+
+
+def print_error(exc: ManifestError | ReleaseError) -> None:
+    print(f"ERROR: {exc}", file=sys.stderr)
+    guidance = getattr(exc, "guidance", "")
+    if guidance:
+        print("", file=sys.stderr)
+        print("Recovery guidance:", file=sys.stderr)
+        print(guidance, file=sys.stderr)
 
 
 def parse_release_args(arguments: tuple[str, ...]) -> ReleaseArguments:
@@ -282,7 +294,10 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
             cwd=project_root,
         )
     except ReleaseError as exc:
-        raise ReleaseError(f"{exc}\n\n{release_publish_recovery_guidance(ctx, title)}") from exc
+        raise ReleaseError(
+            str(exc),
+            guidance=release_publish_recovery_guidance(ctx, title),
+        ) from exc
     finally:
         notes_path.unlink(missing_ok=True)
 
@@ -372,7 +387,10 @@ def git_branch_finding(root: Path) -> ReleaseFinding:
 
 
 def local_tag_finding(root: Path, tag_name: str) -> ReleaseFinding:
-    if local_tag_exists(root, tag_name):
+    exists = local_tag_exists(root, tag_name)
+    if exists is None:
+        return ReleaseFinding("warn", "local_tag", f"Unable to inspect local tag {tag_name}.")
+    if exists:
         return ReleaseFinding("error", "local_tag", f"Local tag {tag_name} already exists.")
     return ReleaseFinding("ok", "local_tag", f"Local tag {tag_name} is available.")
 
@@ -425,28 +443,36 @@ def extract_changelog_section(path: Path, version: str) -> str:
 
 
 def git_status(root: Path) -> str | None:
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
-        cwd=root,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=GIT_INSPECTION_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     if result.returncode != 0:
         return None
     return result.stdout.strip()
 
 
 def current_git_branch(root: Path) -> str | None:
-    result = subprocess.run(
-        ["git", "branch", "--show-current"],
-        cwd=root,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=GIT_INSPECTION_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     if result.returncode != 0:
         return None
     return result.stdout.strip()
@@ -518,7 +544,7 @@ def require_interactive_publish_confirmation(ctx: ReleaseContext, title: str) ->
 
 
 def run_release_step(command: list[str], *, cwd: Path | None = None) -> None:
-    joined = " ".join(command)
+    joined = shlex.join(command)
     try:
         result = subprocess.run(
             command,
@@ -547,14 +573,18 @@ def write_temp_release_notes(notes: str) -> Path:
         return Path(notes_file.name)
 
 
-def local_tag_exists(root: Path, tag_name: str) -> bool:
-    result = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag_name}"],
-        cwd=root,
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+def local_tag_exists(root: Path, tag_name: str) -> bool | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag_name}"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=GIT_INSPECTION_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     return result.returncode == 0
 
 

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -270,32 +270,6 @@ class ReleaseEngineTests(unittest.TestCase):
         self.assertIn("Homebrew handoff required after GitHub release", stdout)
         run_step.assert_not_called()
 
-    def test_run_release_step_uses_bounded_timeout(self) -> None:
-        completed = subprocess.CompletedProcess(["git", "tag"], 0, stdout="")
-
-        with mock.patch("base_release.engine.subprocess.run", return_value=completed) as run:
-            engine.run_release_step(["git", "tag"], cwd=Path("/repo"))
-
-        self.assertEqual(run.call_args.kwargs["timeout"], engine.RELEASE_STEP_TIMEOUT_SECONDS)
-
-    def test_run_release_step_reports_timeout_as_release_error(self) -> None:
-        command = ["git", "push", "origin", "v1.2.3"]
-
-        with mock.patch(
-            "base_release.engine.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(command, timeout=30),
-        ):
-            with self.assertRaisesRegex(ReleaseError, "timed out"):
-                engine.run_release_step(command)
-
-    def test_run_release_step_reports_os_error_as_release_error(self) -> None:
-        command = ["gh", "release", "create", "v1.2.3"]
-
-        with mock.patch("base_release.engine.subprocess.run", side_effect=OSError("network unavailable")):
-            with self.assertRaisesRegex(ReleaseError, "Unable to run release command"):
-                engine.run_release_step(command)
-
-
     def test_publish_requires_yes_when_stdin_is_not_interactive(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -389,7 +363,12 @@ class ReleaseEngineTests(unittest.TestCase):
         self.assertEqual(stdout, "")
         self.assertEqual(commands[0][0], ["git", "tag", "-a", "v1.2.3", "-m", "Release v1.2.3"])
         self.assertEqual(commands[1][0], ["git", "push", "origin", "v1.2.3"])
-        self.assertIn("Release command failed: gh release create v1.2.3: network unavailable", stderr)
+        stderr_lines = stderr.splitlines()
+        self.assertEqual(
+            stderr_lines[0],
+            "ERROR: Release command failed: gh release create v1.2.3: network unavailable",
+        )
+        self.assertIn("Recovery guidance:", stderr_lines)
         self.assertIn("Release publish already created and pushed tag v1.2.3", stderr)
         self.assertIn("basectl release notes --version 1.2.3", stderr)
         self.assertIn("gh release create v1.2.3 --repo codeforester/demo", stderr)
@@ -562,3 +541,74 @@ class ReleaseEngineTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn("Remote tag v1.2.3 already exists on origin.", stdout)
         self.assertEqual(stderr, "")
+
+
+class ReleaseHelperTests(unittest.TestCase):
+    def test_run_release_step_uses_bounded_timeout(self) -> None:
+        completed = subprocess.CompletedProcess(["git", "tag"], 0, stdout="")
+
+        with mock.patch("base_release.engine.subprocess.run", return_value=completed) as run:
+            engine.run_release_step(["git", "tag"], cwd=Path("/repo"))
+
+        self.assertEqual(run.call_args.kwargs["timeout"], engine.RELEASE_STEP_TIMEOUT_SECONDS)
+
+    def test_run_release_step_reports_timeout_as_release_error(self) -> None:
+        command = ["git", "push", "origin", "v1.2.3"]
+
+        with mock.patch(
+            "base_release.engine.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(command, timeout=30),
+        ):
+            with self.assertRaisesRegex(ReleaseError, "timed out"):
+                engine.run_release_step(command)
+
+    def test_run_release_step_reports_os_error_as_release_error(self) -> None:
+        command = ["gh", "release", "create", "v1.2.3"]
+
+        with mock.patch("base_release.engine.subprocess.run", side_effect=OSError("network unavailable")):
+            with self.assertRaisesRegex(ReleaseError, "Unable to run release command"):
+                engine.run_release_step(command)
+
+    def test_run_release_step_quotes_spaced_arguments_in_errors(self) -> None:
+        command = ["gh", "release", "create", "v1.2.3", "--title", "Demo Release"]
+        completed = subprocess.CompletedProcess(command, 1, stdout="release failed\n")
+
+        with mock.patch("base_release.engine.subprocess.run", return_value=completed):
+            with self.assertRaisesRegex(
+                ReleaseError,
+                "gh release create v1.2.3 --title 'Demo Release'",
+            ):
+                engine.run_release_step(command)
+
+    def test_git_worktree_finding_warns_when_status_times_out(self) -> None:
+        with mock.patch(
+            "base_release.engine.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["git", "status", "--porcelain"], timeout=10),
+        ):
+            finding = engine.git_worktree_finding(Path("/repo"))
+
+        self.assertEqual(finding.status, "warn")
+        self.assertIn("Unable to inspect Git worktree status", finding.message)
+
+    def test_git_branch_finding_warns_when_branch_check_times_out(self) -> None:
+        with mock.patch(
+            "base_release.engine.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["git", "branch", "--show-current"], timeout=10),
+        ):
+            finding = engine.git_branch_finding(Path("/repo"))
+
+        self.assertEqual(finding.status, "warn")
+        self.assertIn("Unable to inspect current Git branch", finding.message)
+
+    def test_local_tag_finding_warns_when_tag_check_times_out(self) -> None:
+        with mock.patch(
+            "base_release.engine.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                ["git", "rev-parse", "--verify", "--quiet", "refs/tags/v1.2.3"],
+                timeout=10,
+            ),
+        ):
+            finding = engine.local_tag_finding(Path("/repo"), "v1.2.3")
+
+        self.assertEqual(finding.status, "warn")
+        self.assertIn("Unable to inspect local tag v1.2.3", finding.message)


### PR DESCRIPTION
## Summary

- add bounded Git inspection timeouts in the release engine
- quote release-step commands with `shlex.join()`
- render publish recovery guidance as a separate block after the primary error

## Validation

- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_release/tests/test_engine.py -q`
- `git diff --check`

Fixes #1221
Fixes #1222
Fixes #1229
