### PR TITLE
Harden contract runner composition

### DIFF
--- a/tests/contracts/run.sh
+++ b/tests/contracts/run.sh
@@ -30,7 +30,10 @@ run_step() {
     printf '\n==> '
     printf '%q ' "$@"
     printf '\n'
-    "$@"
+    (
+        cd "$REPO_ROOT"
+        "$@"
+    )
 }
 
 run_step "$PYTHON_BIN" -m pytest tests/test_github_workflows.py

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -77,6 +77,7 @@ def test_contract_runner_composes_existing_policy_checks() -> None:
     expected_commands = [
         "tests/test_github_workflows.py",
         "cli/python/base_projects/tests/test_workspace_manifest.py",
+        "cli/python/base_projects/tests/test_workspace_pull.py",
         "lib/python/base_cli/tests/test_logging.py",
         'bats --filter "project installer template"',
         "cli/bash/commands/basectl/tests/docs.bats",
@@ -91,6 +92,12 @@ def test_contract_runner_supports_base_worktree_library_layout() -> None:
     text = CONTRACT_RUNNER.read_text(encoding="utf-8")
 
     assert "../../base-bash-libs/lib/bash" in text
+
+
+def test_contract_runner_reenters_repo_root_for_each_step() -> None:
+    text = CONTRACT_RUNNER.read_text(encoding="utf-8")
+
+    assert '(\n        cd "$REPO_ROOT"\n        "$@"\n    )' in text
 
 
 def test_contract_runner_is_executable() -> None:


### PR DESCRIPTION
## Summary

- make each contract runner step re-enter the repository root
- assert that the contract runner includes `test_workspace_pull.py`

## Validation

- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest tests/test_contract_hardening.py -q`
- `tests/contracts/run.sh`
- `git diff --check`

Fixes #1219
Fixes #1228
