### PR TITLE
Remove shell helper subprocesses

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -337,7 +337,10 @@ base_gh_issue_worktree_path() {
     repo_root="$(git rev-parse --show-toplevel)" || return 1
     repo_name="$(basename "$repo_root")"
     repo_parent="$(dirname "$repo_root")"
-    slug_short="$(printf '%s\n' "$slug" | cut -c1-40 | sed -E 's/-+$//')"
+    slug_short="${slug:0:40}"
+    while [[ "$slug_short" == *- ]]; do
+        slug_short="${slug_short%-}"
+    done
     [[ -n "$slug_short" ]] || slug_short="work"
 
     printf '%s/%s-worktrees/%s-%s\n' "$repo_parent" "$repo_name" "$issue" "$slug_short"
@@ -875,7 +878,7 @@ base_gh_issue_start() {
     fi
 
     slug="$(base_gh_slug "$title")"
-    today="$(date +%Y%m%d)"
+    printf -v today '%(%Y%m%d)T' -1
     branch="$category/$issue-$today-$slug"
     default_branch="$(base_gh_default_branch)"
     worktree_path="$(base_gh_issue_worktree_path "$issue" "$slug")" || return 1
@@ -963,7 +966,7 @@ base_gh_branch_stale() {
     }
     base_gh_require_git_repo || return 1
 
-    now="$(date +%s)"
+    printf -v now '%(%s)T' -1
     printf 'age_days\tlast_commit\tbranch\n'
     while read -r timestamp ref; do
         age=$(((now - timestamp) / 86400))

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -660,6 +660,72 @@ EOF
     [ "$(git -C "$repo" branch --show-current)" = "master" ]
 }
 
+@test "basectl gh issue start gets branch date without date command" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+
+    cat > "$TEST_MOCKBIN/date" <<'EOF'
+#!/usr/bin/env bash
+printf 'date should not run: %s\n' "$*" >&2
+exit 42
+EOF
+    chmod +x "$TEST_MOCKBIN/date"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue start 117 --category enhancement --title "Prune merged branches"
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "${lines[0]}" == "enhancement/117-"*"-prune-merged-branches" ]]
+    [[ "$output" != *"date should not run"* ]]
+}
+
+@test "basectl gh issue start truncates worktree slug without cut or sed" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+
+    for tool in cut sed; do
+        cat > "$TEST_MOCKBIN/$tool" <<'EOF'
+#!/usr/bin/env bash
+printf '%s should not run\n' "$(basename "$0")" >&2
+exit 42
+EOF
+        chmod +x "$TEST_MOCKBIN/$tool"
+    done
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main issue start 117 --category enhancement \
+                --title "Alpha beta gamma delta epsilon zeta eta theta iota kappa"
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/repo-worktrees/117-alpha-beta-gamma-delta-epsilon-zeta-eta origin/"* ]]
+    [[ "$output" != *"cut should not run"* ]]
+    [[ "$output" != *"sed should not run"* ]]
+}
+
 @test "basectl gh branch prune falls back to main when default branch is unknown" {
     local repo
 
@@ -850,6 +916,35 @@ if [[ "$*" == "+%s" ]]; then
     printf '2000000000\n'
     exit 0
 fi
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/date"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch stale --days 0
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\tunknown\tmaster'* ]]
+}
+
+@test "basectl gh branch stale gets current time without date command" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+
+cat > "$TEST_MOCKBIN/date" <<'EOF'
+#!/usr/bin/env bash
 exit 1
 EOF
     chmod +x "$TEST_MOCKBIN/date"

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -618,6 +618,14 @@ EOF
     fi
 }
 
+@test "Base shell defaults abbreviate detached HEAD without command substitution" {
+    run grep -F 'branch="$(printf' "$BASE_REPO_ROOT/lib/shell/bash_defaults.sh" "$BASE_REPO_ROOT/lib/shell/zsh_defaults.sh"
+    [ "$status" -eq 1 ]
+
+    grep -Fq 'branch="${head:0:7}"' "$BASE_REPO_ROOT/lib/shell/bash_defaults.sh"
+    grep -Fq 'branch="${head:0:7}"' "$BASE_REPO_ROOT/lib/shell/zsh_defaults.sh"
+}
+
 @test "basectl update-profile preserves an existing defaults preference" {
     run_base_command update-profile --defaults
     [ "$status" -eq 0 ]

--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -89,7 +89,7 @@ _base_bash_defaults_git_prompt() {
     case "$head" in
         "ref: refs/heads/"*) branch="${head#ref: refs/heads/}" ;;
         "ref: "*) branch="${head#ref: }"; branch="${branch##*/}" ;;
-        *) branch="$(printf '%.7s' "$head")" ;;
+        *) branch="${head:0:7}" ;;
     esac
     [[ -n "$branch" ]] || return 0
 

--- a/lib/shell/zsh_defaults.sh
+++ b/lib/shell/zsh_defaults.sh
@@ -91,7 +91,7 @@ _base_zsh_defaults_git_prompt() {
     case "$head" in
         "ref: refs/heads/"*) branch="${head#ref: refs/heads/}" ;;
         "ref: "*) branch="${head#ref: }"; branch="${branch##*/}" ;;
-        *) branch="$(printf '%.7s' "$head")" ;;
+        *) branch="${head:0:7}" ;;
     esac
     [[ -n "$branch" ]] || return 0
 


### PR DESCRIPTION
## Summary
- replace GitHub helper date/cut/sed subprocesses with Bash builtins
- abbreviate detached HEAD shell prompt values with parameter expansion
- add BATS coverage that mocks removed helper commands

Fixes #1223
Fixes #1224
Fixes #1225

## Tests
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/update-profile.bats
- git diff --check