### PR TITLE
Polish Python CLI helper coverage

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -116,13 +116,13 @@ def run(
             )
     except ManifestError as exc:
         ctx.log.error(str(exc))
-        status = 1
+        status = base_cli.ExitCode.FAILURE
     except ValueError as exc:
         ctx.log.error(str(exc))
-        status = 1
+        status = base_cli.ExitCode.FAILURE
     except ArtifactError as exc:
         ctx.log.error(str(exc))
-        status = 1
+        status = base_cli.ExitCode.FAILURE
     return status
 
 
@@ -174,7 +174,7 @@ def run_manifest_action(
             "route, precheck, or predoctor.",
             action,
         )
-        status = 2
+        status = base_cli.ExitCode.USAGE_ERROR
     return status
 
 

--- a/lib/python/base_cli/testing.py
+++ b/lib/python/base_cli/testing.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import inspect
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .paths import use_working_dir
+
+if TYPE_CHECKING:
+    from click.testing import Result
 
 
 # pylint: disable=too-many-arguments
@@ -17,7 +20,7 @@ def invoke(
     env: dict[str, str] | None = None,
     *,
     manifest: Mapping[str, Any] | None = None,
-):
+) -> Result:
     cwd_path = Path(cwd).expanduser().resolve() if cwd is not None else None
     if manifest is not None:
         if cwd_path is None:

--- a/lib/python/base_cli/tests/test_exit_code_adoption.py
+++ b/lib/python/base_cli/tests/test_exit_code_adoption.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 
 STANDARD_EXIT_VALUES = {0, 1, 2}
+STANDARD_ERROR_EXIT_VALUES = {1, 2}
+EXIT_STATUS_VARIABLES = {"exit_code", "status"}
 
 
 def repository_root() -> Path:
@@ -39,9 +41,49 @@ def raw_standard_exit_returns(path: Path) -> list[str]:
     return findings
 
 
+def target_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def raw_standard_exit_assignments(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    findings: list[str] = []
+    for node in ast.walk(tree):
+        assignments: tuple[tuple[ast.expr, ast.expr | None], ...]
+        if isinstance(node, ast.Assign):
+            assignments = tuple((target, node.value) for target in node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            assignments = ((node.target, node.value),)
+        else:
+            continue
+        for target, value in assignments:
+            if target_name(target) not in EXIT_STATUS_VARIABLES:
+                continue
+            if not isinstance(value, ast.Constant) or isinstance(value.value, bool):
+                continue
+            if isinstance(value.value, int) and value.value in STANDARD_ERROR_EXIT_VALUES:
+                findings.append(
+                    f"{path.relative_to(repository_root())}:{node.lineno}: "
+                    f"{target_name(target)} = {value.value}"
+                )
+    return findings
+
+
 def test_production_cli_code_uses_exit_code_constants_for_standard_returns() -> None:
     findings: list[str] = []
     for path in iter_production_cli_python_files():
         findings.extend(raw_standard_exit_returns(path))
+
+    assert not findings, "\n".join(findings)
+
+
+def test_production_cli_code_uses_exit_code_constants_for_standard_status_assignments() -> None:
+    findings: list[str] = []
+    for path in iter_production_cli_python_files():
+        findings.extend(raw_standard_exit_assignments(path))
 
     assert not findings, "\n".join(findings)

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -87,6 +87,28 @@ class BaseCliHistoryTests(unittest.TestCase):
         self.assertEqual(json.loads(payloads[0]), record)
         self.assertEqual(history_mode, 0o600)
 
+    def test_write_history_record_appends_without_fcntl(self) -> None:
+        record = {
+            "schema_version": 1,
+            "event": "finished",
+            "run_id": "run-1",
+            "command": "check",
+            "status": "ok",
+            "exit_code": 0,
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache"
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                with mock.patch("base_cli.history._fcntl", None):
+                    history_helpers.write_history_record(record)
+
+            history_mode = (cache_root / "history" / "runs.jsonl").stat().st_mode & 0o777
+            records = read_history_records(cache_root)
+
+        self.assertEqual(records, [record])
+        self.assertEqual(history_mode, 0o600)
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_records_successful_command_history_with_redacted_metadata(self) -> None:
         app = base_cli.App(name="history-demo", version="0.1.0")

--- a/lib/python/base_cli/tests/test_testing.py
+++ b/lib/python/base_cli/tests/test_testing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,6 +13,12 @@ from base_cli.testing import invoke
 
 @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
 class InvokeTests(unittest.TestCase):
+    def test_invoke_declares_click_result_return_type(self) -> None:
+        return_annotation = inspect.signature(invoke).return_annotation
+
+        self.assertNotEqual(return_annotation, inspect.Signature.empty)
+        self.assertIn("Result", str(return_annotation))
+
     def test_invoke_writes_manifest_fixture_into_cwd(self) -> None:
         app = base_cli.App(name="testing-manifest", log_to_file=False)
         seen: dict[str, Path | None] = {}


### PR DESCRIPTION
## Summary
- replace raw setup-engine error status assignments with base_cli.ExitCode constants
- add an explicit click Result return annotation to base_cli.testing.invoke
- cover history append behavior when fcntl is unavailable

Fixes #1220
Fixes #1226
Fixes #1227

## Tests
- PYTHONPATH=lib/python:cli/python "/Users/rameshhp/.base.d/base/.venv/bin/python" -m pytest lib/python/base_cli/tests/test_exit_code_adoption.py lib/python/base_cli/tests/test_testing.py lib/python/base_cli/tests/test_history.py -q
- PYTHONPATH=lib/python:cli/python "/Users/rameshhp/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests -q
- PYTHONPATH=lib/python:cli/python "/Users/rameshhp/.base.d/base/.venv/bin/python" -m pylint --rcfile=.pylintrc cli/python/base_setup/engine.py lib/python/base_cli/testing.py lib/python/base_cli/history.py lib/python/base_cli/tests/test_exit_code_adoption.py lib/python/base_cli/tests/test_testing.py lib/python/base_cli/tests/test_history.py
- git diff --check