### PR TITLE
Automate safe macOS install validation checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,28 @@ jobs:
           brew install bash bats-core
           echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
 
+      - name: Run bootstrap dry-run install-route checks
+        run: |
+          require_output() {
+            case "$1" in
+              *"$2"*) ;;
+              *)
+                printf "Expected bootstrap output to include: %s\n" "$2" >&2
+                return 1
+                ;;
+            esac
+          }
+
+          brew_output="$(./bootstrap.sh --dry-run --brew)"
+          printf '%s\n' "$brew_output"
+          require_output "$brew_output" "basectl setup"
+          require_output "$brew_output" "basectl update-profile"
+
+          source_output="$(./bootstrap.sh --dry-run --source --install-dir "$GITHUB_WORKSPACE")"
+          printf '%s\n' "$source_output"
+          require_output "$source_output" "basectl setup"
+          require_output "$source_output" "basectl update-profile"
+
       - name: Run Base setup and check smoke tests
         run: |
           ./bin/basectl ci setup base --format json

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -38,13 +38,18 @@ installs.
 
 | Check | Where it belongs | Notes |
 | --- | --- | --- |
-| `git diff --check` | CI and local PR validation | Required for documentation-only updates to this checklist. |
-| `bin/base-test` | CI and local source checkout validation | Exercises the hermetic test contract without installing real Homebrew packages. |
-| `bootstrap.sh --dry-run` | CI or local source checkout validation | Confirms the planned first-mile route without mutating the machine. |
-| Real Homebrew install or upgrade | Manual macOS validation | Requires the real package manager, network access, and user-owned install state. |
+| `git diff --check` | Automated CI and local PR validation | Required for documentation-only updates to this checklist. |
+| `bin/base-test` | Automated CI and local source checkout validation | Exercises the hermetic test contract without installing real Homebrew packages. |
+| `bootstrap.sh --dry-run --brew` and `bootstrap.sh --dry-run --source` | Automated macOS smoke, CI, and local source checkout validation | Confirms the planned first-mile install routes and setup/profile handoff commands without mutating the machine. |
+| Real Homebrew install or upgrade | Manual or dedicated macOS validation only | Requires the real package manager, network access, and user-owned install state. |
 | Real shell profile update and terminal restart | Manual macOS validation | Requires the user's interactive shell startup files and a fresh login shell. |
 | Real project activation | Manual macOS validation | Requires an interactive runtime shell; record the observed environment contract and exit cleanly. |
 | Reference project setup, test, and demo | Manual today unless a focused automation issue exists | Use `base-demo` as the neutral project smoke test outside a source checkout. |
+
+In this table, "Automated CI" means ordinary pull request or local source
+checkout validation can run the check safely. "Manual" means ordinary CI must
+not run the step because it mutates user-owned package, shell, project, or
+terminal state.
 
 Do not run mutating Homebrew, shell profile, or user-project checks in ordinary
 CI unless the runner is explicitly dedicated to this purpose.

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -116,6 +116,18 @@ def test_macos_smoke_tests_cover_shell_compatibility_surfaces() -> None:
     assert "lib/shell/completions/tests/completions.bats" in run_commands
 
 
+def test_macos_smoke_tests_cover_bootstrap_dry_run_routes() -> None:
+    workflow = load_workflow(WORKFLOW_DIR / "tests.yml")
+    macos_job = workflow["jobs"]["macos"]
+    bootstrap_step = workflow_step_by_name(macos_job, "Run bootstrap dry-run install-route checks")
+    run_command = bootstrap_step["run"]
+
+    assert "./bootstrap.sh --dry-run --brew" in run_command
+    assert './bootstrap.sh --dry-run --source --install-dir "$GITHUB_WORKSPACE"' in run_command
+    assert "basectl setup" in run_command
+    assert "basectl update-profile" in run_command
+
+
 def test_project_intake_requires_base_project_token() -> None:
     workflow = load_workflow(WORKFLOW_DIR / "project-intake.yml")
     sync_job = workflow["jobs"]["sync"]


### PR DESCRIPTION
## Summary

- add a macOS smoke workflow step for non-mutating `bootstrap.sh --dry-run --brew` and `--source`
- assert the dry-run output still includes setup/profile handoff commands
- update the clean macOS install checklist to distinguish automated CI checks from manual-only validation

Fixes #1233

## Validation

- RED: `uv run --with pytest==9.0.3 --with PyYAML==6.0.3 python -m pytest tests/test_github_workflows.py -q` failed before the workflow step existed
- GREEN: `uv run --with pytest==9.0.3 --with PyYAML==6.0.3 python -m pytest tests/test_github_workflows.py -q`
- `./bootstrap.sh --dry-run --brew`
- `./bootstrap.sh --dry-run --source`
- `tests/contracts/run.sh`
- `git diff --check`
