### PR TITLE
Cover workspace configure integration flow

### DIFF
--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -255,3 +255,28 @@ run_basectl_separate_stderr() {
     [[ "$output" == *$'base\t'"$TEST_BASE_HOME"* ]]
     [[ "$output" == *$'demo\t'"$TEST_PROJECT_ROOT"* ]]
 }
+
+@test "basectl workspace configure dry-run follows manifest without mutating missing repositories" {
+    local manifest_path="$TEST_TMPDIR/workspace.yaml"
+
+    manifest_path="$(cd "$TEST_TMPDIR" && pwd -P)/workspace.yaml"
+    cat > "$manifest_path" <<'EOF'
+schema_version: 1
+workspace:
+  name: integration-suite
+repos:
+  - name: demo
+    url: git@github.com:basefoundry/demo.git
+  - name: missing
+    url: git@github.com:basefoundry/missing.git
+EOF
+
+    run_basectl workspace configure --workspace "$TEST_WORKSPACE" --manifest "$manifest_path" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Workspace configure: $TEST_WORKSPACE (2 manifest repos)"* ]]
+    [[ "$output" == *"Workspace manifest: $manifest_path (integration-suite)"* ]]
+    [[ "$output" == *"CONFIGURE repository 'demo' at '$TEST_PROJECT_ROOT' for 'basefoundry/demo'."* ]]
+    [[ "$output" == *"SKIP repository 'missing' is missing at '$TEST_WORKSPACE/missing'."* ]]
+    [[ "$output" == *"[DRY-RUN] No repositories were modified."* ]]
+    [[ "$output" == *"Workspace configure completed: configured=1 skipped=1 failed=0."* ]]
+}


### PR DESCRIPTION
## Summary

- add a hermetic integration scenario for `basectl workspace configure --dry-run`
- cover manifest-driven configure behavior across one present Base-managed repo and one missing repo
- verify the dry-run path reports configured/skipped counts without mutating missing repositories

Fixes #1234

## Validation

- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_INTEGRATION_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bats --filter "workspace configure dry-run" tests/integration/base_workflows.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_INTEGRATION_PYTHON=/Users/rameshhp/.base.d/base/.venv/bin/python bats tests/integration/base_workflows.bats`
- `git diff --check`

## Deferred follow-up candidates

- `workspace init`, `workspace clone`, and `workspace pull` remain good candidates for additional hermetic scenarios.
- Prompt/export-context flows remain useful next coverage targets if their output contracts keep changing.
- Release/packaging preflight coverage should be handled as a separate focused issue if it needs live Homebrew or release-state simulation.
