### PR TITLE
Harden AI installer command construction

### DIFF
--- a/cli/python/base_dev/ai_tools.py
+++ b/cli/python/base_dev/ai_tools.py
@@ -79,7 +79,7 @@ def validate_ai_remote_installer(tool: AITool) -> None:
 
 def ai_tool_installer_command(tool: AITool) -> tuple[str, ...]:
     validate_ai_remote_installer(tool)
-    return ("sh", "-c", f"curl -fsSL {tool.installer_url} | {tool.installer_shell}")
+    return ("sh", "-c", 'curl -fsSL "$1" | "$2"', "--", tool.installer_url, tool.installer_shell)
 
 
 def log_ai_remote_installer_policy(ctx: base_cli.Context, tool: AITool) -> None:

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -111,10 +111,30 @@ class DevManifestTests(unittest.TestCase):
         self.assertEqual(
             [ai_tools.ai_tool_installer_command(tool) for tool in ai_tools.AI_TOOLS],
             [
-                ("sh", "-c", "curl -fsSL https://chatgpt.com/codex/install.sh | sh"),
-                ("sh", "-c", "curl -fsSL https://claude.ai/install.sh | bash"),
+                (
+                    "sh",
+                    "-c",
+                    'curl -fsSL "$1" | "$2"',
+                    "--",
+                    "https://chatgpt.com/codex/install.sh",
+                    "sh",
+                ),
+                (
+                    "sh",
+                    "-c",
+                    'curl -fsSL "$1" | "$2"',
+                    "--",
+                    "https://claude.ai/install.sh",
+                    "bash",
+                ),
             ],
         )
+
+    def test_ai_installer_command_does_not_interpolate_url_into_shell_source(self) -> None:
+        command = ai_tools.ai_tool_installer_command(ai_tools.AI_TOOLS[0])
+
+        self.assertNotIn(ai_tools.AI_TOOLS[0].installer_url, command[2])
+        self.assertEqual(command[3:], ("--", ai_tools.AI_TOOLS[0].installer_url, "sh"))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_setup_profile_sre_uses_sre_manifest(self) -> None:
@@ -147,11 +167,13 @@ class DevManifestTests(unittest.TestCase):
             stderr,
         )
         self.assertIn(
-            "[DRY-RUN] Would run: sh -c 'curl -fsSL https://chatgpt.com/codex/install.sh | sh'",
+            "[DRY-RUN] Would run: sh -c 'curl -fsSL \"$1\" | \"$2\"' -- "
+            "https://chatgpt.com/codex/install.sh sh",
             stderr,
         )
         self.assertIn(
-            "[DRY-RUN] Would run: sh -c 'curl -fsSL https://claude.ai/install.sh | bash'",
+            "[DRY-RUN] Would run: sh -c 'curl -fsSL \"$1\" | \"$2\"' -- "
+            "https://claude.ai/install.sh bash",
             stderr,
         )
 
@@ -217,8 +239,8 @@ class DevManifestTests(unittest.TestCase):
         self.assertEqual(
             [call.args[1] for call in run_command.call_args_list],
             [
-                ["sh", "-c", "curl -fsSL https://chatgpt.com/codex/install.sh | sh"],
-                ["sh", "-c", "curl -fsSL https://claude.ai/install.sh | bash"],
+                ["sh", "-c", 'curl -fsSL "$1" | "$2"', "--", "https://chatgpt.com/codex/install.sh", "sh"],
+                ["sh", "-c", 'curl -fsSL "$1" | "$2"', "--", "https://claude.ai/install.sh", "bash"],
             ],
         )
 


### PR DESCRIPTION
## Summary
- pass AI installer URL and shell as positional args to sh -c
- keep the AI remote installer allowlist in front of command construction
- update tests and dry-run expectations for the safer command shape

Fixes #1247

## Tests
- PYTHONPATH=lib/python:cli/python "/Users/rameshhp/.base.d/base/.venv/bin/python" -m pytest cli/python/base_dev/tests/test_engine.py -q
- PYTHONPATH=lib/python:cli/python "/Users/rameshhp/.base.d/base/.venv/bin/python" -m pylint --rcfile=.pylintrc cli/python/base_dev/ai_tools.py cli/python/base_dev/tests/test_engine.py
- git diff --check