### PR TITLE
Route doctor findings to expected streams

### DIFF
--- a/cli/python/base_dev/checks.py
+++ b/cli/python/base_dev/checks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 
 
@@ -41,6 +42,7 @@ def doctor_status(check: DevCheck) -> str:
 
 
 def print_doctor_finding(status: str, finding_id: str, name: str, message: str, fix: str = "") -> None:
-    print(f"{status:<5}  {finding_id:<9}  {name:<26}  {message}")
+    stream = sys.stderr if status in {"error", "warn"} else sys.stdout
+    print(f"{status:<5}  {finding_id:<9}  {name:<26}  {message}", file=stream)
     if fix:
-        print(f"       Fix: {fix}")
+        print(f"       Fix: {fix}", file=stream)

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -139,7 +140,7 @@ def setup_profile_manifests(
             profile_manifest.definitions,
             dry_run=dry_run,
         )
-        if status != 0:
+        if status != base_cli.ExitCode.SUCCESS:
             return status
     return base_cli.ExitCode.SUCCESS
 
@@ -165,7 +166,7 @@ def setup_profiles(
                 profile_manifest.definitions,
                 dry_run=dry_run,
             )
-        if status != 0:
+        if status != base_cli.ExitCode.SUCCESS:
             return status
     return base_cli.ExitCode.SUCCESS
 
@@ -321,7 +322,7 @@ def print_doctor_results(checks: tuple[DevCheck, ...], output_format: str) -> in
         print(json.dumps([check_to_doctor_json(check) for check in checks], indent=2))
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
     if output_format != "text":
-        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.")
+        print(f"Unsupported doctor output format '{output_format}'. Expected text or json.", file=sys.stderr)
         return base_cli.ExitCode.USAGE_ERROR
 
     error_count = 0

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -766,12 +766,14 @@ class DevManifestTests(unittest.TestCase):
             mock.patch("base_dev.engine.run_check", return_value=False),
         ):
             stdout = io.StringIO()
-            with redirect_stdout(stdout):
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
                 status = engine.doctor_dev_artifacts(manifest.artifacts, definitions, output_format="text")
 
         self.assertEqual(status, 3)
-        self.assertIn("error", stdout.getvalue())
-        self.assertIn("Fix: basectl setup --profile dev", stdout.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("error", stderr.getvalue())
+        self.assertIn("Fix: basectl setup --profile dev", stderr.getvalue())
 
     def test_doctor_reports_invalid_github_auth(self) -> None:
         manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
@@ -801,13 +803,26 @@ class DevManifestTests(unittest.TestCase):
             mock.patch("base_setup.process.run_capture", return_value=current),
         ):
             stdout = io.StringIO()
-            with redirect_stdout(stdout):
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
                 status = engine.doctor_dev_artifacts(manifest.artifacts, definitions, output_format="text")
 
         self.assertEqual(status, 1)
-        self.assertIn("gh-auth", stdout.getvalue())
-        self.assertIn("GitHub CLI authentication is not ready.", stdout.getvalue())
-        self.assertIn("Fix: gh auth login -h github.com", stdout.getvalue())
+        self.assertIn("BASE-D104", stdout.getvalue())
+        self.assertNotIn("gh-auth", stdout.getvalue())
+        self.assertIn("gh-auth", stderr.getvalue())
+        self.assertIn("GitHub CLI authentication is not ready.", stderr.getvalue())
+        self.assertIn("Fix: gh auth login -h github.com", stderr.getvalue())
+
+    def test_doctor_reports_unsupported_text_format_to_stderr(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.doctor_dev_artifacts((), (), output_format="xml")
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Unsupported doctor output format 'xml'. Expected text or json.", stderr.getvalue())
 
     def test_doctor_supports_json_output(self) -> None:
         manifest = engine.read_manifest(Path(__file__).resolve().parents[4] / "lib" / "base" / "dev_manifest.yaml")
@@ -844,11 +859,18 @@ class DevManifestTests(unittest.TestCase):
         definitions = engine.resolve_artifact_definitions(manifest.artifacts)
         with mock.patch("base_dev.engine.check_homebrew_artifact", return_value=check):
             stdout = io.StringIO()
-            with redirect_stdout(stdout):
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
                 status = engine.doctor_dev_artifacts(manifest.artifacts, definitions, output_format="text")
 
         self.assertEqual(status, 0)
-        self.assertIn("warn", stdout.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("warn", stderr.getvalue())
+
+    def test_engine_uses_exit_code_constants_for_status_comparisons(self) -> None:
+        source = Path(engine.__file__).read_text(encoding="utf-8")
+
+        self.assertNotIn("status != 0", source)
 
 
 if __name__ == "__main__":

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -117,7 +117,6 @@ class WorkspaceCheckTests(unittest.TestCase):
             )
 
         self.assertEqual(status, 1)
-        self.assertEqual(stderr, "")
         self.assertIn(f"Workspace check: {workspace.resolve()} (5 repositories)", stdout)
         self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
         self.assertIn("Repository: base [ok]", stdout)
@@ -125,9 +124,8 @@ class WorkspaceCheckTests(unittest.TestCase):
         self.assertIn("Repository: api [error]", stdout)
         self.assertIn("Repository: optional-tool [warn]", stdout)
         self.assertIn("Repository: extra [warn]", stdout)
-        self.assertIn("BASE-W010", stdout)
-        self.assertIn("BASE-W011", stdout)
-        self.assertIn("BASE-W012", stdout)
+        self.assertIn("BASE-W010", stderr)
+        self.assertIn("BASE-W011", stderr)
         self.assertIn("Workspace has 1 error finding(s).", stdout)
 
     def test_workspace_check_manifest_supports_json_format(self) -> None:
@@ -207,9 +205,8 @@ class WorkspaceCheckTests(unittest.TestCase):
             )
 
         self.assertEqual(status, 1)
-        self.assertEqual(stderr, "")
         self.assertIn("Repository: broken [error]", stdout)
-        self.assertIn("BASE-P002", stdout)
+        self.assertIn("BASE-P002", stderr)
 
     def test_workspace_check_reports_project_findings_and_invalid_manifests(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -230,13 +227,12 @@ class WorkspaceCheckTests(unittest.TestCase):
             status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
 
         self.assertEqual(status, 1)
-        self.assertEqual(stderr, "")
         self.assertIn(f"Workspace check: {workspace.resolve()} (2 projects)", stdout)
         self.assertIn("Project: demo [ok]", stdout)
         self.assertIn("BASE-P050", stdout)
         self.assertIn("BASE-P001", stdout)
         self.assertIn("Project: broken [error]", stdout)
-        self.assertIn("BASE-P002", stdout)
+        self.assertIn("BASE-P002", stderr)
         self.assertIn("Workspace has 1 error finding(s).", stdout)
 
     def test_workspace_check_uses_uv_project_venv_without_base_project_venv(self) -> None:

--- a/cli/python/base_setup/checks.py
+++ b/cli/python/base_setup/checks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterable
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -58,6 +59,7 @@ def doctor_status(check: ArtifactCheck) -> str:
 
 
 def print_doctor_finding(status: str, finding_id: str, name: str, message: str, fix: str = "") -> None:
-    print(f"{status:<5}  {finding_id:<9}  {name:<26}  {message}")
+    stream = sys.stderr if status in {"error", "warn"} else sys.stdout
+    print(f"{status:<5}  {finding_id:<9}  {name:<26}  {message}", file=stream)
     if fix:
-        print(f"       Fix: {fix}")
+        print(f"       Fix: {fix}", file=stream)

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -18,6 +18,7 @@ from .build import check_build
 from .checks import ArtifactCheck
 from .checks import check_to_json
 from .checks import checks_payload_to_json
+from .checks import checks_status
 from .checks import doctor_status
 from .checks import print_doctor_finding
 from .command_lint import check_manifest_commands
@@ -359,7 +360,8 @@ def doctor_manifest(
         return min(sum(1 for check in checks if doctor_status(check) == "error"), 125)
 
     error_count = 0
-    print(f"\nProject doctor: {manifest.project_name}\n")
+    output_stream = sys.stderr if checks_status(checks) != "ok" else sys.stdout
+    print(f"\nProject doctor: {manifest.project_name}\n", file=output_stream)
     for check in checks:
         status = doctor_status(check)
         if status == "error":

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -123,12 +123,13 @@ class ProjectCheckTests(unittest.TestCase):
             artifacts=(ArtifactRequest(artifact_type="python-package", name="requests", version="latest"),),
         )
 
-        with redirect_stdout(io.StringIO()) as stdout:
+        with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr:
             status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
 
         self.assertEqual(status, 1)
-        self.assertIn("Project doctor: demo", stdout.getvalue())
-        self.assertIn("Fix: basectl setup demo", stdout.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Project doctor: demo", stderr.getvalue())
+        self.assertIn("Fix: basectl setup demo", stderr.getvalue())
 
 
 
@@ -198,9 +199,9 @@ class ProjectCheckTests(unittest.TestCase):
                 status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
 
         self.assertEqual(status, 1)
-        self.assertEqual(stderr.getvalue(), "")
-        self.assertIn("error", stdout.getvalue())
-        self.assertIn("BASE-P040", stdout.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("error", stderr.getvalue())
+        self.assertIn("BASE-P040", stderr.getvalue())
 
 
 
@@ -232,11 +233,13 @@ class ProjectCheckTests(unittest.TestCase):
         )
         with mock.patch("base_setup.engine.manifest_checks", return_value=(check,)):
             stdout = io.StringIO()
-            with redirect_stdout(stdout):
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
                 status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
 
         self.assertEqual(status, 0)
-        self.assertIn("warn", stdout.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("warn", stderr.getvalue())
 
     def test_artifact_check_requires_explicit_finding_id(self) -> None:
         kwargs = {
@@ -436,19 +439,21 @@ class ProjectCheckTests(unittest.TestCase):
 
         with mock.patch.dict(os.environ, {"BASE_TEST_DOCTOR_PRESENT": "another-secret-value"}, clear=False):
             os.environ.pop("BASE_TEST_DOCTOR_MISSING", None)
-            with redirect_stdout(io.StringIO()) as stdout:
+            with redirect_stdout(io.StringIO()) as stdout, redirect_stderr(io.StringIO()) as stderr:
                 status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
 
         output = stdout.getvalue()
+        error_output = stderr.getvalue()
         self.assertEqual(status, 1)
         self.assertIn("ok", output)
         self.assertIn("BASE_TEST_DOCTOR_PRESENT", output)
         self.assertIn("Environment variable 'BASE_TEST_DOCTOR_PRESENT' is set.", output)
-        self.assertIn("error", output)
-        self.assertIn("BASE_TEST_DOCTOR_MISSING", output)
-        self.assertIn("Environment variable 'BASE_TEST_DOCTOR_MISSING' is not set or is empty.", output)
-        self.assertIn("Fix: Set BASE_TEST_DOCTOR_MISSING in your shell, .env, or secrets manager.", output)
+        self.assertIn("error", error_output)
+        self.assertIn("BASE_TEST_DOCTOR_MISSING", error_output)
+        self.assertIn("Environment variable 'BASE_TEST_DOCTOR_MISSING' is not set or is empty.", error_output)
+        self.assertIn("Fix: Set BASE_TEST_DOCTOR_MISSING in your shell, .env, or secrets manager.", error_output)
         self.assertNotIn("another-secret-value", output)
+        self.assertNotIn("another-secret-value", error_output)
 
 
     def test_doctor_manifest_reports_required_ports_with_finding_ids(self) -> None:
@@ -763,13 +768,16 @@ class IdeDiagnosticsTests(unittest.TestCase):
                 return_value=False,
             ):
                 stdout = io.StringIO()
-                with redirect_stdout(stdout):
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
                     status = engine.doctor_manifest(default_manifest, manifest, output_format="text")
 
         output = stdout.getvalue()
+        error_output = stderr.getvalue()
         self.assertGreater(status, 0)
-        self.assertIn("Project doctor: demo", output)
-        self.assertIn("Cursor app", output)
-        self.assertIn("github.copilot", output)
-        self.assertIn("Cursor setting: editor.formatOnSave", output)
-        self.assertIn("Fix:", output)
+        self.assertEqual(output, "")
+        self.assertIn("Project doctor: demo", error_output)
+        self.assertIn("Cursor app", error_output)
+        self.assertIn("github.copilot", error_output)
+        self.assertIn("Cursor setting: editor.formatOnSave", error_output)
+        self.assertIn("Fix:", error_output)


### PR DESCRIPTION
## Summary
- route setup/dev doctor error and warning findings to stderr
- keep ok doctor rows on stdout and JSON output unchanged
- send base_dev unsupported doctor format errors to stderr and use ExitCode.SUCCESS comparisons

Fixes #1242
Fixes #1249

## Tests
- PYTHONPATH=lib/python:cli/python "/Users/rameshhp/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests/test_diagnostics.py cli/python/base_dev/tests/test_engine.py lib/python/base_cli/tests/test_exit_code_adoption.py -q
- PYTHONPATH=lib/python:cli/python "/Users/rameshhp/.base.d/base/.venv/bin/python" -m pylint --rcfile=.pylintrc cli/python/base_setup/checks.py cli/python/base_setup/engine.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_dev/checks.py cli/python/base_dev/engine.py cli/python/base_dev/tests/test_engine.py
- git diff --check