### PR TITLE
Add timeouts to Python subprocess probes

### DIFF
--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -48,6 +48,8 @@ PROJECT_VALUE_OPTIONS = (
     "--initiative-option",
 )
 ISSUE_FIELD_OPTIONS = ("--status", "--priority", "--area", "--initiative", "--size")
+GIT_COMMAND_TIMEOUT_SECONDS = 10
+GITHUB_GRAPHQL_TIMEOUT_SECONDS = 60
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -476,12 +478,16 @@ def infer_owner_from_git() -> str | None:
 
 
 def infer_repo_from_git() -> str | None:
-    result = subprocess.run(
-        ["git", "config", "--get", "remote.origin.url"],
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=GIT_COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     if result.returncode != 0:
         return None
     return github_repo_spec(result.stdout)
@@ -489,13 +495,20 @@ def infer_repo_from_git() -> str | None:
 
 def run_graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
     payload = json.dumps({"query": query, "variables": variables})
-    result = subprocess.run(
-        ["gh", "api", "graphql", "--input", "-"],
-        input=payload,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "api", "graphql", "--input", "-"],
+            input=payload,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=GITHUB_GRAPHQL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        timeout = exc.timeout if exc.timeout is not None else GITHUB_GRAPHQL_TIMEOUT_SECONDS
+        raise ProjectError(f"Timed out running GitHub GraphQL request after {timeout} seconds.") from exc
+    except OSError as exc:
+        raise ProjectError(f"Could not run GitHub GraphQL request: {exc}") from exc
     if result.returncode != 0:
         message = (result.stderr or result.stdout).strip()
         if is_project_scope_error(message):

--- a/cli/python/base_github_projects/tests/test_subprocess_timeouts.py
+++ b/cli/python/base_github_projects/tests/test_subprocess_timeouts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from base_github_projects import engine
+
+
+def test_infer_repo_from_git_passes_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    completed = subprocess.CompletedProcess(
+        ["git", "config", "--get", "remote.origin.url"],
+        0,
+        stdout="git@github.com:basefoundry/base.git\n",
+        stderr="",
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["git", "config", "--get", "remote.origin.url"]
+        assert kwargs["timeout"] == engine.GIT_COMMAND_TIMEOUT_SECONDS
+        return completed
+
+    monkeypatch.setattr(engine.subprocess, "run", fake_run)
+
+    assert engine.infer_repo_from_git() == "basefoundry/base"
+
+
+def test_infer_repo_from_git_returns_none_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(engine.subprocess, "run", fake_run)
+
+    assert engine.infer_repo_from_git() is None
+
+
+def test_run_graphql_passes_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    completed = subprocess.CompletedProcess(
+        ["gh", "api", "graphql", "--input", "-"],
+        0,
+        stdout='{"data": {"viewer": {"login": "codeforester"}}}',
+        stderr="",
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["gh", "api", "graphql", "--input", "-"]
+        assert kwargs["timeout"] == engine.GITHUB_GRAPHQL_TIMEOUT_SECONDS
+        return completed
+
+    monkeypatch.setattr(engine.subprocess, "run", fake_run)
+
+    assert engine.run_graphql("query Viewer { viewer { login } }", {}) == {
+        "data": {"viewer": {"login": "codeforester"}}
+    }
+
+
+def test_run_graphql_reports_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(engine.subprocess, "run", fake_run)
+
+    with pytest.raises(engine.ProjectError) as excinfo:
+        engine.run_graphql("query Viewer { viewer { login } }", {})
+
+    assert "Timed out running GitHub GraphQL request after" in str(excinfo.value)

--- a/cli/python/base_projects/tests/test_workspace_configure.py
+++ b/cli/python/base_projects/tests/test_workspace_configure.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import io
 import os
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_projects import engine
+from base_projects import engine, workspace_configure
 
 
 def write_manifest(project_root: Path, name: str) -> None:
@@ -230,3 +231,76 @@ repos:
                     f"repo configure {(workspace / 'base').resolve()} --repo basefoundry/base --dry-run",
                 ],
             )
+
+    def test_configure_workspace_repo_passes_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            ctx = mock.Mock()
+            basectl = root / "base" / "bin" / "basectl"
+            target = workspace_configure.WorkspaceConfigureTarget(
+                name="base",
+                root=root / "base",
+                repo_spec="basefoundry/base",
+            )
+            completed = subprocess.CompletedProcess(
+                [str(basectl), "repo", "configure", str(target.root), "--repo", "basefoundry/base"],
+                0,
+                stdout="configured\n",
+                stderr="",
+            )
+
+            with mock.patch("base_projects.workspace_configure.subprocess.run", return_value=completed) as run:
+                status = workspace_configure.configure_workspace_repo(ctx, basectl, target, dry_run=False)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(run.call_args.kwargs["timeout"], workspace_configure.WORKSPACE_CONFIGURE_TIMEOUT_SECONDS)
+
+    def test_configure_workspace_repo_reports_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            ctx = mock.Mock()
+            basectl = root / "base" / "bin" / "basectl"
+            target = workspace_configure.WorkspaceConfigureTarget(
+                name="base",
+                root=root / "base",
+                repo_spec="basefoundry/base",
+            )
+            command = [str(basectl), "repo", "configure", str(target.root), "--repo", "basefoundry/base"]
+
+            with mock.patch(
+                "base_projects.workspace_configure.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(command, timeout=120),
+            ):
+                status = workspace_configure.configure_workspace_repo(ctx, basectl, target, dry_run=False)
+
+        self.assertEqual(status, 1)
+        ctx.log.error.assert_called_once()
+        self.assertIn("Timed out running basectl repo configure", ctx.log.error.call_args.args[0])
+
+    def test_github_origin_repo_spec_passes_timeout(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["git", "-C", "/repo", "config", "--get", "remote.origin.url"],
+            0,
+            stdout="https://github.com/basefoundry/base.git\n",
+            stderr="",
+        )
+
+        with mock.patch("base_projects.workspace_configure.subprocess.run", return_value=completed) as run:
+            repo_spec = workspace_configure.github_origin_repo_spec(Path("/repo"))
+
+        self.assertEqual(repo_spec, "basefoundry/base")
+        self.assertEqual(run.call_args.kwargs["timeout"], workspace_configure.GIT_CONFIG_TIMEOUT_SECONDS)
+
+    def test_github_origin_repo_spec_falls_back_to_config_file_on_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir) / "repo"
+            write_git_remote(repo, "git@github.com:basefoundry/base.git")
+            command = ["git", "-C", str(repo), "config", "--get", "remote.origin.url"]
+
+            with mock.patch(
+                "base_projects.workspace_configure.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(command, timeout=10),
+            ):
+                repo_spec = workspace_configure.github_origin_repo_spec(repo)
+
+        self.assertEqual(repo_spec, "basefoundry/base")

--- a/cli/python/base_projects/workspace_configure.py
+++ b/cli/python/base_projects/workspace_configure.py
@@ -16,6 +16,9 @@ from base_projects.workspace_reports import ProjectDiscoveryError
 from base_projects.workspace_reports import resolve_workspace_manifest
 from base_projects.workspace_reports import workspace_manifest_entries
 
+GIT_CONFIG_TIMEOUT_SECONDS = 10
+WORKSPACE_CONFIGURE_TIMEOUT_SECONDS = 120
+
 
 @dataclass(frozen=True)
 class WorkspaceConfigureTarget:
@@ -143,7 +146,7 @@ def configure_workspace_target(
 
     print(f"CONFIGURE repository '{target.name}' at '{target.root}' for '{target.repo_spec}'.")
     status = configure_workspace_repo(ctx, basectl, target, dry_run=dry_run)
-    if status == 0:
+    if status == base_cli.ExitCode.SUCCESS:
         return WorkspaceConfigureCounts(counts.configured + 1, counts.skipped, counts.failed)
     return WorkspaceConfigureCounts(counts.configured, counts.skipped, counts.failed + 1)
 
@@ -160,7 +163,21 @@ def configure_workspace_repo(
         command.append("--dry-run")
 
     try:
-        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=WORKSPACE_CONFIGURE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        timeout = exc.timeout if exc.timeout is not None else WORKSPACE_CONFIGURE_TIMEOUT_SECONDS
+        ctx.log.error(
+            "Timed out running basectl repo configure for repository '%s' after %s seconds.",
+            target.name,
+            timeout,
+        )
+        return base_cli.ExitCode.FAILURE
     except OSError as exc:
         ctx.log.error("Could not run basectl repo configure for repository '%s': %s", target.name, exc)
         return base_cli.ExitCode.FAILURE
@@ -221,8 +238,9 @@ def github_origin_repo_spec(root: Path) -> str | None:
             check=False,
             capture_output=True,
             text=True,
+            timeout=GIT_CONFIG_TIMEOUT_SECONDS,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         origin_url = git_config_origin_url(root)
         return github_repo_spec(origin_url) if origin_url else None
     if result.returncode != 0:

--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -22,6 +22,7 @@ from .python_policy import version_label
 from .registry import ArtifactDefinition, get_artifact_definition
 
 PIP_INSTALL_COMMAND_PREFIX = ("-m", "pip", "install", "--disable-pip-version-check")
+PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS = process.DIAGNOSTIC_TIMEOUT_SECONDS
 
 
 @dataclass(frozen=True)
@@ -539,7 +540,17 @@ def python_artifact_installed(python_bin: Path, package: str, version: str) -> b
     if not python_bin.exists():
         return False
     command = [str(python_bin), "-m", "pip", "show", package]
-    completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
+    try:
+        completed = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
     if completed.returncode:
         return False
     if version == "latest":

--- a/cli/python/base_setup/tests/test_artifact_probe_timeouts.py
+++ b/cli/python/base_setup/tests/test_artifact_probe_timeouts.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+from base_setup import artifacts
+
+
+def test_python_artifact_installed_passes_timeout_to_pip_show(tmp_path: Path) -> None:
+    python_bin = tmp_path / "python"
+    python_bin.write_text("", encoding="utf-8")
+    completed = subprocess.CompletedProcess(
+        [str(python_bin), "-m", "pip", "show", "requests"],
+        0,
+        stdout="Name: requests\nVersion: 2.32.4\n",
+        stderr="",
+    )
+
+    with mock.patch("base_setup.artifacts.subprocess.run", return_value=completed) as run:
+        assert artifacts.python_artifact_installed(python_bin, "requests", "2.32.4")
+
+    assert run.call_args.kwargs["timeout"] == artifacts.PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS
+
+
+def test_python_artifact_installed_returns_false_on_timeout(tmp_path: Path) -> None:
+    python_bin = tmp_path / "python"
+    python_bin.write_text("", encoding="utf-8")
+    command = [str(python_bin), "-m", "pip", "show", "requests"]
+
+    with mock.patch(
+        "base_setup.artifacts.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(command, timeout=10),
+    ):
+        assert not artifacts.python_artifact_installed(python_bin, "requests", "latest")

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -526,7 +526,6 @@ class ArtifactReconcileTests(unittest.TestCase):
             timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
         )
 
-
     def test_python_artifact_honors_project_venv_dir_override(self) -> None:
         definition = get_artifact_definition("python-package", "requests")
         self.assertIsNotNone(definition)


### PR DESCRIPTION
## Summary
- add bounded timeouts to Git repo inference, GitHub GraphQL, workspace configure, and pip show probes
- handle timeout/OSError paths with each caller's existing failure semantics
- add regression coverage for timeout propagation and handling

Closes #1243

## Verification
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_github_projects/tests/test_engine.py cli/python/base_github_projects/tests/test_subprocess_timeouts.py cli/python/base_projects/tests/test_workspace_configure.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_artifact_probe_timeouts.py -q
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint cli/python/base_github_projects/engine.py cli/python/base_github_projects/tests/test_engine.py cli/python/base_github_projects/tests/test_subprocess_timeouts.py cli/python/base_projects/workspace_configure.py cli/python/base_projects/tests/test_workspace_configure.py cli/python/base_setup/artifacts.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_artifact_probe_timeouts.py
- git diff --check