### PR TITLE
Replace Python runtime asserts and clean IDE temp files

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_init.py
+++ b/cli/python/base_projects/tests/test_workspace_init.py
@@ -7,9 +7,10 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
-from base_projects import engine
+from base_projects import engine, workspace_init as workspace_init_module
 
 
 def write_workspace_manifest(path: Path) -> None:
@@ -288,3 +289,17 @@ class WorkspaceInitTests(unittest.TestCase):
             state_lines,
             [f"repo clone codeforester/base-workspace --path {source.resolve()} --dry-run"],
         )
+
+    def test_resolve_workspace_config_repo_path_uses_explicit_repo_name_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_root = Path(tmpdir) / "workspace"
+            ctx = SimpleNamespace(workspace_root=workspace_root, base_home=None)
+            source = workspace_init_module.WorkspaceInitSource(
+                display="codeforester/base-workspace",
+                repo_spec="codeforester/base-workspace",
+                repo_name=None,
+            )
+            options = SimpleNamespace(workspace=None, workspace_config_path=None)
+
+            with self.assertRaisesRegex(ValueError, "repo_name"):
+                workspace_init_module.resolve_workspace_config_repo_path(ctx, source, options)

--- a/cli/python/base_projects/workspace_init.py
+++ b/cli/python/base_projects/workspace_init.py
@@ -159,7 +159,8 @@ def resolve_workspace_config_repo_path(
     if source.local_path is not None:
         return source.local_path
     workspace_root = resolve_workspace_init_root(ctx, options.workspace, None)
-    assert source.repo_name is not None
+    if source.repo_name is None:
+        raise ValueError("Workspace init source must include repo_name when resolving a repo path.")
     return (workspace_root / source.repo_name).resolve(strict=False)
 
 

--- a/cli/python/base_setup/ide.py
+++ b/cli/python/base_setup/ide.py
@@ -398,11 +398,16 @@ def merge_ide_settings(
 
 
 def write_json_atomic(path: Path, data: dict[str, object]) -> None:
-    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp_file:
-        json.dump(data, tmp_file, indent=2, sort_keys=True)
-        tmp_file.write("\n")
-        tmp_path = Path(tmp_file.name)
-    tmp_path.replace(path)
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp_file:
+            tmp_path = Path(tmp_file.name)
+            json.dump(data, tmp_file, indent=2, sort_keys=True)
+            tmp_file.write("\n")
+        tmp_path.replace(path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
 
 
 def check_ide_settings(manifest: BaseManifest) -> list[ArtifactCheck]:

--- a/cli/python/base_setup/python_policy.py
+++ b/cli/python/base_setup/python_policy.py
@@ -52,7 +52,7 @@ ResolvePythonInterpreter = Callable[[tuple[int, int]], PythonInterpreter | None]
 
 def python_requirement_checks(
     manifest: BaseManifest,
-    resolve_interpreter: ResolvePythonInterpreter = None,
+    resolve_interpreter: ResolvePythonInterpreter | None = None,
 ) -> tuple[ArtifactCheck, ...]:
     policy_check = python_requirement_policy_check(manifest)
     if policy_check is None:
@@ -104,7 +104,7 @@ def python_requirement_policy_check(manifest: BaseManifest) -> ArtifactCheck | N
 
 def python_interpreter_availability_check(
     manifest: BaseManifest,
-    resolve_interpreter: ResolvePythonInterpreter = None,
+    resolve_interpreter: ResolvePythonInterpreter | None = None,
 ) -> ArtifactCheck | None:
     requested = manifest.python.requires_python
     if requested is None:
@@ -115,7 +115,8 @@ def python_interpreter_availability_check(
         return None
 
     selected_version = policy.selected_version
-    assert selected_version is not None
+    if selected_version is None:
+        raise ValueError("Python requirement policy is ok without a selected Python version.")
     selected_label = version_label(selected_version)
     if resolve_interpreter is None:
         resolve_interpreter = resolve_python_interpreter

--- a/cli/python/base_setup/tests/test_ide_settings.py
+++ b/cli/python/base_setup/tests/test_ide_settings.py
@@ -94,6 +94,28 @@ class IdeSettingsTests(unittest.TestCase):
 
         self.assertEqual(settings, {"editor.formatOnSave": True})
 
+    def test_write_json_atomic_removes_temp_file_when_dump_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_dir = Path(tmpdir)
+            settings_file = settings_dir / "settings.json"
+
+            with mock.patch("base_setup.ide.json.dump", side_effect=OSError("disk full")):
+                with self.assertRaises(OSError):
+                    ide.write_json_atomic(settings_file, {"editor.formatOnSave": True})
+
+            self.assertEqual(list(settings_dir.iterdir()), [])
+
+    def test_write_json_atomic_removes_temp_file_when_replace_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_dir = Path(tmpdir)
+            settings_file = settings_dir / "settings.json"
+
+            with mock.patch.object(Path, "replace", side_effect=OSError("replace failed")):
+                with self.assertRaises(OSError):
+                    ide.write_json_atomic(settings_file, {"editor.formatOnSave": True})
+
+            self.assertEqual(list(settings_dir.iterdir()), [])
+
 
 
     def test_merge_ide_settings_preserves_existing_user_value(self) -> None:

--- a/cli/python/base_setup/tests/test_python_policy.py
+++ b/cli/python/base_setup/tests/test_python_policy.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from typing import get_type_hints
+from unittest import mock
 
+from base_setup import python_policy
 from base_setup.manifest import BaseManifest
 from base_setup.manifest import PythonConfig
 from base_setup.python_policy import PythonInterpreter
@@ -108,6 +112,26 @@ class PythonPolicyTests(unittest.TestCase):
         self.assertEqual(check.finding_id, "BASE-P171")
         self.assertEqual(check.details["python"], str(python_path))
         self.assertEqual(check.details["selected_version"], "3.11")
+
+    def test_resolve_interpreter_annotations_allow_none_default(self) -> None:
+        requirement_hints = get_type_hints(python_policy.python_requirement_checks)
+        availability_hints = get_type_hints(python_policy.python_interpreter_availability_check)
+
+        self.assertEqual(
+            requirement_hints["resolve_interpreter"],
+            python_policy.ResolvePythonInterpreter | None,
+        )
+        self.assertEqual(
+            availability_hints["resolve_interpreter"],
+            python_policy.ResolvePythonInterpreter | None,
+        )
+
+    def test_interpreter_availability_uses_explicit_guard_for_missing_selected_version(self) -> None:
+        policy = SimpleNamespace(ok=True, selected_version=None)
+
+        with mock.patch("base_setup.python_policy.evaluate_python_requirement", return_value=policy):
+            with self.assertRaisesRegex(ValueError, "selected Python version"):
+                python_interpreter_availability_check(manifest_with_python_requirement("3.12"))
 
     def test_python_requirement_checks_include_policy_and_interpreter_availability(self) -> None:
         checks = python_requirement_checks(


### PR DESCRIPTION
## Summary
- replace runtime `assert` guards in Python requirement and workspace init paths with explicit `ValueError`s
- correct optional `resolve_interpreter` annotations to include `None`
- clean up temporary IDE settings files when atomic JSON writes fail

Closes #1248
Closes #1250

## Verification
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests/test_python_policy.py cli/python/base_projects/tests/test_workspace_init.py cli/python/base_setup/tests/test_ide_settings.py -q
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint cli/python/base_setup/python_policy.py cli/python/base_setup/tests/test_python_policy.py cli/python/base_projects/workspace_init.py cli/python/base_projects/tests/test_workspace_init.py cli/python/base_setup/ide.py cli/python/base_setup/tests/test_ide_settings.py
- git diff --check