### PR TITLE
Polish shell subprocess guards and exit-code adoption

### DIFF
--- a/cli/bash/commands/basectl/subcommands/ci.sh
+++ b/cli/bash/commands/basectl/subcommands/ci.sh
@@ -203,6 +203,7 @@ base_ci_run_setup_json() {
     base_setup_subcommand_main "${args[@]}" > "$stdout_file" 2> "$stderr_file"
     exit_code=$?
 
+    # Keep JSON as stdout-only; replay setup logs to stderr for CI visibility.
     if [[ -s "$stdout_file" ]]; then
         cat "$stdout_file" >&2
     fi

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -980,9 +980,12 @@ base_gh_branch_stale() {
 
 base_gh_format_unix_date() {
     local timestamp="$1"
+    local formatted
 
-    date -r "$timestamp" +%Y-%m-%d 2>/dev/null && return 0
-    date -d "@$timestamp" +%Y-%m-%d 2>/dev/null && return 0
+    if printf -v formatted '%(%Y-%m-%d)T' "$timestamp" 2>/dev/null; then
+        printf '%s\n' "$formatted"
+        return 0
+    fi
     printf 'unknown\n'
 }
 

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -510,7 +510,10 @@ base_repo_clone_url() {
 }
 
 base_repo_baseline_year() {
-    date +%Y
+    local year
+
+    printf -v year '%(%Y)T' -1 || return 1
+    printf '%s\n' "$year"
 }
 
 base_repo_create_directory() {

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -84,17 +84,20 @@ base_update_is_homebrew_install() {
 
 base_update_homebrew_prefix() {
     local package="$1"
+    local candidate
+    local candidates=("base")
     local prefix
 
-    if prefix="$(brew --prefix base 2>/dev/null)" && [[ -n "$prefix" ]]; then
-        printf '%s\n' "$prefix"
-        return 0
+    if [[ -n "$package" && "$package" != "base" ]]; then
+        candidates+=("$package")
     fi
 
-    if prefix="$(brew --prefix "$package" 2>/dev/null)" && [[ -n "$prefix" ]]; then
-        printf '%s\n' "$prefix"
-        return 0
-    fi
+    for candidate in "${candidates[@]}"; do
+        if prefix="$(brew --prefix "$candidate" 2>/dev/null)" && [[ -n "$prefix" ]]; then
+            printf '%s\n' "$prefix"
+            return 0
+        fi
+    done
 
     return 1
 }

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -902,39 +902,6 @@ EOF
     ! git -C "$repo" show-ref --verify --quiet refs/remotes/origin/stale-branch
 }
 
-@test "basectl gh branch stale prints fallback date when date formatting is unavailable" {
-    local repo
-
-    repo="$TEST_TMPDIR/repo"
-    init_git_repo "$repo"
-    printf 'hello\n' > "$repo/README.md"
-    commit_all "$repo" "Initial commit"
-
-    cat > "$TEST_MOCKBIN/date" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$*" == "+%s" ]]; then
-    printf '2000000000\n'
-    exit 0
-fi
-exit 1
-EOF
-    chmod +x "$TEST_MOCKBIN/date"
-
-    run env \
-        HOME="$TEST_HOME" \
-        BASE_HOME="$BASE_REPO_ROOT" \
-        PATH="$TEST_MOCKBIN:$PATH" \
-        bash -c '
-            cd "$1"
-            source "$BASE_HOME/base_init.sh"
-            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            base_gh_subcommand_main branch stale --days 0
-        ' bash "$repo"
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == *$'\tunknown\tmaster'* ]]
-}
-
 @test "basectl gh branch stale gets current time without date command" {
     local repo
 
@@ -961,7 +928,29 @@ EOF
         ' bash "$repo"
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *$'\tunknown\tmaster'* ]]
+    [[ "$output" != *$'\tunknown\tmaster'* ]]
+    [[ "$output" == *$'\tmaster'* ]]
+}
+
+@test "base_gh_format_unix_date formats timestamps without date command" {
+    cat > "$TEST_MOCKBIN/date" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/date"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_format_unix_date 1704110400
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "2024-01-01" ]
 }
 
 @test "basectl gh branch prune --remote previews safe GitHub branch deletion" {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -1128,6 +1128,27 @@ EOF
     grep -Fq "GNU Affero General Public License as published by" "$repo_dir/LICENSE"
 }
 
+@test "base_repo_baseline_year uses bash time formatting without date command" {
+    cat > "$TEST_MOCKBIN/date" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/date"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/repo.sh"
+            base_repo_baseline_year
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9]{4}$ ]]
+}
+
 @test "basectl repo init leaves existing files unchanged" {
     local repo_dir="$TEST_TMPDIR/custom"
 

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -214,6 +214,37 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "base_update_homebrew_prefix does not repeat identical base prefix probes" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local brew_log="$TEST_TMPDIR/brew.log"
+
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/brew" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$brew_log"
+exit 1
+EOF
+    chmod +x "$fake_bin/brew"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -c '
+            log_debug() { :; }
+            log_error() { printf "ERROR: %s\n" "$*"; }
+            log_info() { printf "INFO: %s\n" "$*"; }
+            log_warn() { printf "WARN: %s\n" "$*"; }
+            print_error() { printf "ERROR: %s\n" "$*"; }
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_homebrew_prefix base
+        '
+
+    [ "$status" -eq 1 ]
+    [ "$(cat "$brew_log")" = "--prefix base" ]
+}
+
 @test "basectl update runs exact Homebrew package upgrade and clears Base env for setup" {
     local fake_bin="$TEST_TMPDIR/bin"
     local fake_base="$TEST_TMPDIR/homebrew/opt/base/libexec"

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 
 from .config import load_config, read_user_config
 from .context import Context, reset_current_context, set_current_context
+from .exit_codes import ExitCode
 from .history import utc_now, write_finished_record
 from .logging import configure_logger, log_invocation
 from .paths import (
@@ -135,7 +136,7 @@ class App:
                 raise click.ClickException(str(exc)) from exc
             token = set_current_context(context)
             started_at = utc_now()
-            exit_code = 0
+            exit_code = ExitCode.SUCCESS
             invocation_argv = _current_invocation_argv()
             try:
                 log_invocation(context.log, invocation_argv, sensitive_options)
@@ -144,10 +145,10 @@ class App:
                 if context.manifest_path is not None:
                     context.log.debug("manifest_path=%s", context.manifest_path)
                 result = func(context, **kwargs)
-                exit_code = int(result or 0)
+                exit_code = int(result or ExitCode.SUCCESS)
                 return result
             except Exception:
-                exit_code = 1
+                exit_code = ExitCode.FAILURE
                 raise
             finally:
                 write_finished_record(context, invocation_argv, sensitive_options, started_at, exit_code)
@@ -241,7 +242,7 @@ def run_app(app: App, argv: list[str] | None = None) -> int:
         click = _require_click()
     except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
+        return ExitCode.FAILURE
 
     explicit_argv = argv is not None
     args = list(sys.argv[1:] if argv is None else argv)

--- a/lib/python/base_cli/tests/test_exit_code_adoption.py
+++ b/lib/python/base_cli/tests/test_exit_code_adoption.py
@@ -13,12 +13,13 @@ def repository_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
-def iter_production_cli_python_files() -> list[Path]:
-    cli_root = repository_root() / "cli" / "python"
+def iter_production_python_files() -> list[Path]:
+    roots = (repository_root() / "cli" / "python", repository_root() / "lib" / "python")
     return sorted(
         path
-        for path in cli_root.rglob("*.py")
-        if "tests" not in path.relative_to(cli_root).parts
+        for root in roots
+        for path in root.rglob("*.py")
+        if "tests" not in path.relative_to(root).parts
     )
 
 
@@ -75,7 +76,7 @@ def raw_standard_exit_assignments(path: Path) -> list[str]:
 
 def test_production_cli_code_uses_exit_code_constants_for_standard_returns() -> None:
     findings: list[str] = []
-    for path in iter_production_cli_python_files():
+    for path in iter_production_python_files():
         findings.extend(raw_standard_exit_returns(path))
 
     assert not findings, "\n".join(findings)
@@ -83,7 +84,7 @@ def test_production_cli_code_uses_exit_code_constants_for_standard_returns() -> 
 
 def test_production_cli_code_uses_exit_code_constants_for_standard_status_assignments() -> None:
     findings: list[str] = []
-    for path in iter_production_cli_python_files():
+    for path in iter_production_python_files():
         findings.extend(raw_standard_exit_assignments(path))
 
     assert not findings, "\n".join(findings)


### PR DESCRIPTION
## Summary
- replace shell date formatting forks with Bash time formatting helpers
- avoid duplicate Homebrew prefix probes in the update helper
- document why CI setup JSON replays setup logs to stderr
- expand exit-code adoption coverage to lib/python and use ExitCode constants in base_cli/app.py

Closes #1244
Closes #1245
Closes #1246
Closes #1251

## Verification
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest lib/python/base_cli/tests/test_exit_code_adoption.py -q
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -f 'date command|base_gh_format' cli/bash/commands/basectl/tests/gh.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -f 'base_repo_baseline_year' cli/bash/commands/basectl/tests/repo.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -f 'base_update_homebrew_prefix' cli/bash/commands/basectl/tests/update.bats
- env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -f 'ci setup json output' cli/bash/commands/basectl/tests/ci.bats
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint lib/python/base_cli/app.py lib/python/base_cli/tests/test_exit_code_adoption.py
- bash -n cli/bash/commands/basectl/subcommands/gh.sh cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/ci.sh cli/bash/commands/basectl/subcommands/update.sh
- git diff --check main...HEAD