### PR TITLE
Raise explicit IDE diagnostic snapshot errors

### DIFF
--- a/cli/python/base_setup/ide.py
+++ b/cli/python/base_setup/ide.py
@@ -139,7 +139,8 @@ class IdeDiagnosticSnapshot:
                 self._extension_error = exc
         if self._extension_error is not None:
             raise self._extension_error
-        assert self._installed_extensions is not None
+        if self._installed_extensions is None:
+            raise RuntimeError(f"{self.definition.label} installed extensions snapshot is unavailable.")
         return self._installed_extensions
 
     def settings_file(self) -> Path:
@@ -155,7 +156,8 @@ class IdeDiagnosticSnapshot:
                 self._settings_error = exc
         if self._settings_error is not None:
             raise self._settings_error
-        assert self._current_settings is not None
+        if self._current_settings is None:
+            raise RuntimeError(f"{self.definition.label} settings snapshot is unavailable.")
         return self._current_settings
 
 

--- a/cli/python/base_setup/tests/test_ide_extensions.py
+++ b/cli/python/base_setup/tests/test_ide_extensions.py
@@ -157,6 +157,13 @@ class IdeExtensionTests(unittest.TestCase):
             with self.assertRaisesRegex(ArtifactError, "timed out"):
                 ide.list_ide_extensions(definition)
 
+    def test_diagnostic_snapshot_reports_missing_extension_probe_result_explicitly(self) -> None:
+        snapshot = ide.IdeDiagnosticSnapshot(ide.IDE_DEFINITIONS["vscode"])
+
+        with mock.patch("base_setup.ide.list_ide_extensions", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "installed extensions"):
+                snapshot.installed_extensions()
+
 
 
     def test_check_ide_extensions_reuses_probe_for_all_extensions_in_ide(self) -> None:

--- a/cli/python/base_setup/tests/test_ide_settings.py
+++ b/cli/python/base_setup/tests/test_ide_settings.py
@@ -304,3 +304,10 @@ class IdeSettingsTests(unittest.TestCase):
             ["VS Code setting: editor.formatOnSave", "VS Code setting: editor.rulers"],
         )
         self.assertTrue(all(check.ok for check in checks))
+
+    def test_diagnostic_snapshot_reports_missing_settings_probe_result_explicitly(self) -> None:
+        snapshot = ide.IdeDiagnosticSnapshot(ide.IDE_DEFINITIONS["vscode"])
+
+        with mock.patch("base_setup.ide.read_ide_settings", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "settings"):
+                snapshot.current_settings()


### PR DESCRIPTION
## Summary
- replace IDE diagnostic snapshot asserts with explicit RuntimeError guards
- add regression coverage for missing extension and settings probe results

## Tests
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests/test_ide_extensions.py cli/python/base_setup/tests/test_ide_settings.py -q
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint cli/python/base_setup/ide.py cli/python/base_setup/tests/test_ide_extensions.py cli/python/base_setup/tests/test_ide_settings.py
- git diff --check

Closes #1266