### PR TITLE
Clarify GitHub Projects engine return values

### DIFF
--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -50,6 +50,7 @@ PROJECT_VALUE_OPTIONS = (
 ISSUE_FIELD_OPTIONS = ("--status", "--priority", "--area", "--initiative", "--size")
 GIT_COMMAND_TIMEOUT_SECONDS = 10
 GITHUB_GRAPHQL_TIMEOUT_SECONDS = 60
+PROJECT_AUTH_EXIT_CODE = 3
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -79,7 +80,7 @@ def run(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
     except ProjectAuthError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         print("Run `gh auth refresh -h github.com -s project` and retry.", file=sys.stderr)
-        return 3
+        return PROJECT_AUTH_EXIT_CODE
     except ProjectError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return base_cli.ExitCode.FAILURE
@@ -193,14 +194,15 @@ def parse_project_options(remaining: list[str], *, allow_fields: bool, allow_iss
 
 
 def apply_spaced_option(state: OptionState, remaining: list[str], index: int, *, allow_fields: bool) -> int:
+    """Apply a spaced option and return the number of consumed tokens."""
     option = remaining[index]
     if option in PROJECT_VALUE_OPTIONS:
         apply_project_option(state, option, option_value(remaining, index))
-        return base_cli.ExitCode.USAGE_ERROR
+        return 2
     if allow_fields and option in ISSUE_FIELD_OPTIONS:
         state.field_values[option[2:]] = option_value(remaining, index)
-        return base_cli.ExitCode.USAGE_ERROR
-    return base_cli.ExitCode.SUCCESS
+        return 2
+    return 0
 
 
 def option_value(remaining: list[str], index: int) -> str:

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 
 import pytest
@@ -107,6 +108,24 @@ def test_parse_project_configure_accepts_copy_fields_from_project() -> None:
     )
 
     assert args.copy_fields_from_project == "Base Roadmap"
+
+
+def test_project_auth_exit_code_is_named() -> None:
+    assert engine.PROJECT_AUTH_EXIT_CODE == 3
+    assert "return 3" not in inspect.getsource(engine.run)
+    assert "PROJECT_AUTH_EXIT_CODE" in inspect.getsource(engine.run)
+
+
+def test_apply_spaced_option_returns_token_counts_not_exit_codes() -> None:
+    source = inspect.getsource(engine.apply_spaced_option)
+    state = engine.OptionState(initiative_options=[], field_values={})
+
+    consumed = engine.apply_spaced_option(state, ["--project", "base"], 0, allow_fields=False)
+    skipped = engine.apply_spaced_option(state, ["--unknown"], 0, allow_fields=False)
+
+    assert consumed == 2
+    assert skipped == 0
+    assert "ExitCode" not in source
 
 
 def test_read_project_config_loads_repo_taxonomy(tmp_path: Path) -> None:

--- a/lib/python/base_cli/tests/test_exit_code_adoption.py
+++ b/lib/python/base_cli/tests/test_exit_code_adoption.py
@@ -7,6 +7,9 @@ from pathlib import Path
 STANDARD_EXIT_VALUES = {0, 1, 2}
 STANDARD_ERROR_EXIT_VALUES = {1, 2}
 EXIT_STATUS_VARIABLES = {"exit_code", "status"}
+NON_EXIT_STATUS_RETURN_FUNCTIONS = {
+    ("cli/python/base_github_projects/engine.py", "apply_spaced_option"),
+}
 
 
 def repository_root() -> Path:
@@ -25,20 +28,40 @@ def iter_production_python_files() -> list[Path]:
 
 def raw_standard_exit_returns(path: Path) -> list[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    relative_path = str(path.relative_to(repository_root()))
+    allowed_functions = {
+        function_name
+        for allowed_path, function_name in NON_EXIT_STATUS_RETURN_FUNCTIONS
+        if allowed_path == relative_path
+    }
     findings: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Return):
-            continue
-        values: tuple[ast.expr | None, ...]
-        if isinstance(node.value, ast.IfExp):
-            values = (node.value.body, node.value.orelse)
-        else:
-            values = (node.value,)
-        for value in values:
-            if not isinstance(value, ast.Constant) or isinstance(value.value, bool):
-                continue
-            if isinstance(value.value, int) and value.value in STANDARD_EXIT_VALUES:
-                findings.append(f"{path.relative_to(repository_root())}:{node.lineno}: return {value.value}")
+
+    class ReturnVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.function_stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.function_stack.append(node.name)
+            self.generic_visit(node)
+            self.function_stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_Return(self, node: ast.Return) -> None:
+            if self.function_stack and self.function_stack[-1] in allowed_functions:
+                return
+            values: tuple[ast.expr | None, ...]
+            if isinstance(node.value, ast.IfExp):
+                values = (node.value.body, node.value.orelse)
+            else:
+                values = (node.value,)
+            for value in values:
+                if not isinstance(value, ast.Constant) or isinstance(value.value, bool):
+                    continue
+                if isinstance(value.value, int) and value.value in STANDARD_EXIT_VALUES:
+                    findings.append(f"{relative_path}:{node.lineno}: return {value.value}")
+
+    ReturnVisitor().visit(tree)
     return findings
 
 


### PR DESCRIPTION
## Summary
- name the GitHub Projects auth-error exit code
- make spaced option parsing return token counts instead of ExitCode constants
- keep the exit-code adoption scanner strict with a narrow parser-helper exemption

## Tests
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_github_projects/tests/test_engine.py lib/python/base_cli/tests/test_exit_code_adoption.py -q
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pylint cli/python/base_github_projects/engine.py cli/python/base_github_projects/tests/test_engine.py lib/python/base_cli/tests/test_exit_code_adoption.py
- git diff --check

Closes #1265
Closes #1267