### PR TITLE
Refresh command surface documentation

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -50,7 +50,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `update-profile`
 - `update`
 - `projects list`
-- `workspace status/check/doctor/clone/pull`
+- `workspace status/check/doctor/clone/pull/init/configure`
 - `version`
 - `help`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -590,10 +590,12 @@ basectl workspace check
 basectl workspace doctor
 basectl workspace clone
 basectl workspace pull
+basectl workspace init
+basectl workspace configure
 ```
 
-Workspace commands are read-first and mutate only through explicit clone or
-pull commands. `basectl workspace status` reports project manifest state,
+Workspace commands are read-first and mutate only through explicit init, clone,
+pull, or configure commands. `basectl workspace status` reports project manifest state,
 virtual environment state, and Git state across discovered projects, including
 invalid manifests without stopping the whole scan. With `workspace.manifest` or
 `--manifest <path>`, workspace commands also report missing required
@@ -601,10 +603,13 @@ repositories, missing optional repositories, and discovered Base-managed
 projects outside the expected repo set. `basectl workspace check` and `basectl
 workspace doctor` run project checks and diagnostics across discovered
 projects. `basectl workspace clone` materializes missing expected repositories
-only when invoked directly, and `basectl workspace pull` updates only the local
-workspace manifest after validating an explicit or configured source. JSON
-output is part of the status/check/doctor contract so automation and future CI
-smoke checks can use the same data.
+only when invoked directly. `basectl workspace pull` updates only the local
+workspace manifest after validating an explicit or configured source. `basectl
+workspace init` bootstraps a workspace from a workspace configuration repository
+and can materialize member repositories. `basectl workspace configure` applies
+the existing `repo configure` repair path across discovered Base-managed
+workspace repositories. JSON output is part of the status/check/doctor contract
+so automation and future CI smoke checks can use the same data.
 
 Future workspace commands should follow the same principles:
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -366,7 +366,7 @@ override.
 - richer YAML config merging
 - project manifest loading helpers
 - version discovery conventions
-- subcommand groups
+- nested command-group helpers beyond the current `App.subcommand()` API
 - better error formatting and exit code conventions
 
 ### V3

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -17,7 +17,7 @@ execution and are rejected by `basectl`.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv` |
+| `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv`, `--notify`, `--no-notify` |
 | `basectl update-profile` | Create or update Base-managed Bash and Zsh startup snippets. | `--defaults`, `--no-defaults`, `--dry-run` |
 | `basectl update [project]` | Update a Base-managed project checkout through Git, or update Base through Homebrew when Base is Homebrew-managed, then run setup for the selected project. | `--dry-run` |
 | `basectl onboard [project]` | Guide first-run setup by orchestrating check, setup, shell profile, doctor, and project discovery. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
@@ -76,10 +76,10 @@ inspect the resolved command contract first.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--copy-project-fields-from <title>`, `--no-project`, `--dry-run` |
+| `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--no-configure`, `--no-project`, `--dry-run` |
 | `basectl repo clone <name-or-owner/name>` | Clone one GitHub repository into the configured Base workspace, treating matching existing checkouts as already satisfied. | `--owner <owner>`, `--path <path>`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
-| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` to seed options and fill missing issue defaults when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--replace-project`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
+| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` to seed options and fill missing issue defaults when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--replace-project`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files, optionally through a draft PR. | `--repo <owner/name>`, `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--pr`, `--dry-run` |
 | `basectl repo installer-template [path]` | Write the maintained project installer starter script to a path, defaulting to `./install.sh`, optionally through a draft PR. | `--print`, `--repo <owner/name>`, `--pr`, `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -175,6 +175,10 @@ list is `basectl --help`; this list summarizes the shipped public surface:
 - `repo`
 - `release`
 - `logs`
+- `history`
+- `docs`
+- `export-context`
+- `prompt`
 - `workspace`
 - `onboard`
 - `gh`

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -260,16 +260,18 @@ Run everything locally with `basectl test base` or `bin/base-test`.
 
 ## Current Status
 
-Base **1.2.0** (June 2026) covers: first-mile `bootstrap.sh`
+Base **1.3.0** (June 2026) covers: first-mile `bootstrap.sh`
 installation, setup, check, doctor, project discovery, workspace
-status/check/doctor/clone/pull/configure, `basectl onboard`, project activation
+status/check/doctor/clone/pull/init/configure, `basectl onboard`, project activation
 (subshell), test execution, build targets, named commands, demo scripts,
 explicit `python.manager: uv` project support, standalone and source-checkout
 `base-bash-libs` consumption, repository baseline creation, guarded GitHub
 release publishing, AI context export, repo-owned prompt rendering, local
 command history, manifest-declared PR policy, Base-managed artifact
 declarations, `basectl ci` for non-interactive CI, IDE bootstrapping (VS
-Code/Cursor), and release readiness inspection.
+Code/Cursor), release readiness inspection, the `basectl docs` documentation
+shortcut, CI setup JSON output improvements, CI supply-chain policy enforcement,
+and pinned Homebrew installer variables for verified first-mile bootstrap.
 
 Linux support is a design target but not yet an implemented or tested contract.
 Windows is out of scope.


### PR DESCRIPTION
## Summary
- update current-status and command-surface docs for Base 1.3.0
- add shipped workspace init/configure and missing subcommands where docs drifted
- clarify the V2 base_cli roadmap and add missing quick-reference flags

## Verification
- git diff --check
- PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests/test_command_lint.py -q
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl --help

Closes #1257
Closes #1258
Closes #1263
Closes #1271
Closes #1272
Closes #1278