### PR TITLE
Refresh contributor setup documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,14 @@ Follow [STANDARDS.md](STANDARDS.md). In particular:
 Base's curated tool artifact registry lives in:
 
 ```text
+lib/base/artifact-registry.yaml
 cli/python/base_setup/registry.py
 ```
+
+`lib/base/artifact-registry.yaml` is the registry data file where built-in tool
+artifact definitions are declared. `cli/python/base_setup/registry.py` is the
+Python loader that validates and exposes that YAML data to setup and check
+code.
 
 Python package artifacts are pass-through PyPI package names; they do not need
 registry entries unless Base needs special handling for them.

--- a/docs/basectl-ci.md
+++ b/docs/basectl-ci.md
@@ -103,6 +103,11 @@ Full Linux bootstrap can come later through the Linux support plan.
   run: ./bin/basectl ci check base --format json
 ```
 
+This example is a minimal starter for source-checkout CI. Workflows that install
+Python packages or third-party Actions should also follow the
+[CI Supply Chain Policy](ci-supply-chain-policy.md), including pinned
+`requirements-dev.txt` installs for Base-managed CI dependencies.
+
 The Homebrew formula bundles Base's Python runtime environment. A source
 checkout CI job that prepares `~/.base.d/base/.venv` manually must install the
 same bootstrap packages that Base uses to read manifests and run Python command

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -68,14 +68,17 @@ Contributors should prefer source mode:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source
+git clone https://github.com/basefoundry/base-bash-libs.git ~/work/base-bash-libs
 ~/work/base/bin/basectl setup --profile dev
 ~/work/base/bin/basectl update-profile
 exec "$SHELL" -l
 ```
 
-The `dev` profile installs contributor prerequisites such as BATS, the GitHub
-CLI, and ShellCheck. After that, use `basectl test base` for the dogfood test
-contract.
+The sibling `base-bash-libs` checkout gives the source-tree BATS suite the
+reusable Bash libraries it validates against. If that checkout already exists,
+update it before running the full contributor test contract. The `dev` profile
+installs contributor prerequisites such as BATS, the GitHub CLI, and ShellCheck.
+After that, use `basectl test base` for the dogfood test contract.
 
 Named profiles compose when a contributor also wants site-reliability tools:
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -515,20 +515,24 @@ own its labels, required sections, path-triggered sections, and review policy.
 
 ## Milestones
 
-Milestones represent release intent, not workflow state.
+Milestones represent release intent, not workflow state. Active 1.x release
+planning should live in the repository's
+[GitHub Milestones](https://github.com/basefoundry/base/milestones); the
+examples below are shipped historical milestones kept as a product-roadmap
+record.
 
-Suggested Base milestones:
+Historical shipped Base milestones:
 
-- `v0.1.0 - Public baseline`
+- `SHIPPED - v0.1.0 - Public baseline`
   Current public baseline for Base's first installable product shape.
-- `v0.2.0 - Adoption polish`
+- `SHIPPED - v0.2.0 - Adoption polish`
   Installer, Homebrew, README, changelog, issue templates, and workflow polish.
-- `v0.3.0 - Project orchestration`
+- `SHIPPED - v0.3.0 - Project orchestration`
   Project test execution, mise integration, manifest refinement, and a real
   Base-managed demo project.
-- `v0.4.0 - CI and Linux foundation`
+- `SHIPPED - v0.4.0 - CI and Linux foundation`
   Linux runtime support and CI-oriented `basectl ci` behavior.
-- `v1.0.0 - Stable public release`
+- `SHIPPED - v1.0.0 - Stable public release`
   Stable manifest contracts, compatibility expectations, and upgrade policy.
 
 Every issue does not need a milestone. Use milestones when the issue contributes

--- a/docs/homebrew-upgrade-rehearsal.md
+++ b/docs/homebrew-upgrade-rehearsal.md
@@ -1,10 +1,12 @@
 # Homebrew Upgrade Rehearsal
 
-Use this checklist before Base 1.0.0 to prove the consumer upgrade path from an
-existing Homebrew install to a release candidate or equivalent test formula.
-This is separate from the tap update checklist: the tap checklist proves the
-formula can be published, while this rehearsal proves an existing user can
-upgrade without losing local Base state.
+Use this checklist to prove the consumer upgrade path from an existing Homebrew
+install to a release candidate or equivalent test formula. It remains the
+durable rehearsal for future releases after Base 1.0.0; the historical run
+records below preserve pre-1.0 rehearsal evidence for reference. This is
+separate from the tap update checklist: the tap checklist proves the formula can
+be published, while this rehearsal proves an existing user can upgrade without
+losing local Base state.
 
 ## Preconditions
 
@@ -74,7 +76,7 @@ brew update
 brew upgrade --no-ask basefoundry/base/base
 ```
 
-For a pre-1.0.0 release candidate, use the candidate formula or tap branch that
+For an unreleased candidate, use the candidate formula or tap branch that
 will become the published formula. Record the exact command, tap ref, formula
 path, and archive checksum used for the rehearsal.
 
@@ -126,8 +128,8 @@ Accept the rehearsal only when:
 - `basectl setup`, `check`, `doctor`, and `test` pass for the scratch project.
 
 If any Base-specific breakage appears, fix it or file a blocking follow-up
-before 1.0.0. If a host prerequisite blocks the run, record it and rerun on a
-qualified host; do not close the rehearsal issue.
+before shipping the target release. If a host prerequisite blocks the run,
+record it and rerun on a qualified host; do not close the rehearsal issue.
 
 ## Historical Run Record Notes
 

--- a/docs/project-demo-workflow.md
+++ b/docs/project-demo-workflow.md
@@ -144,10 +144,12 @@ The public reference repository is
 It is not primarily a test harness. Its tests prove that the walkthrough stays
 executable, but its product role is onboarding and inspection.
 
-Clone it next to Base:
+Assuming Base is already checked out, clone `base-demo` next to that existing
+Base checkout. If your Base checkout is not under `~/work`, use its parent
+directory instead:
 
 ```bash
-git clone https://github.com/basefoundry/base.git
+cd ~/work
 git clone https://github.com/basefoundry/base-demo.git
 ```
 


### PR DESCRIPTION
## Summary
- add the source contributor base-bash-libs checkout step
- clarify artifact registry data vs loader ownership
- mark shipped milestones as historical and link active GitHub Milestones
- cross-link CI supply-chain policy from the CI starter example
- remove redundant Base clone guidance from the demo workflow
- reframe the Homebrew upgrade rehearsal as durable post-1.0 guidance

## Verification
- git diff --check
- targeted searches confirmed stale phrases and redundant clone URL were removed from the affected docs

Closes #1259
Closes #1268
Closes #1269
Closes #1270
Closes #1274
Closes #1279