### PR TITLE
chore: document interactive log pager blocking

### DIFF
--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -323,4 +323,5 @@ def open_log(path: Path) -> int:
     if shutil.which(args[0]) is None:
         print(f"ERROR: {args[0]} was not found on PATH. Log path: {path}", file=sys.stderr)
         return base_cli.ExitCode.FAILURE
+    # Interactive pager/editor path: intentionally block until the user exits.
     return subprocess.call([*args, str(path)])


### PR DESCRIPTION
## Summary
- document why `base_logs.open_log()` intentionally uses a blocking pager/editor subprocess without a timeout
- keep the existing interactive log-opening behavior unchanged

Fixes #1289

## Tests
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_logs/tests/test_engine.py`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_logs/engine.py`
- `git diff --check`
