### PR TITLE
Run contract checks in default pytest

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -23,7 +23,11 @@ before treating the fix as complete.
 
 ## Contract Check Runner
 
-Run the first contract slice with:
+Default Python validation includes the top-level Python contract tests. That
+means `python -m pytest` in CI and `./bin/base-test` in a source checkout fail
+when GitHub workflow policy or the contract registry drifts.
+
+Run the focused cross-surface contract slice with:
 
 ```bash
 tests/contracts/run.sh

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ addopts = --import-mode=importlib
 testpaths =
     cli/python
     lib/python
+    tests

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -4,6 +4,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CONTRACTS_DOC = REPO_ROOT / "docs" / "contracts.md"
 CONTRACT_RUNNER = REPO_ROOT / "tests" / "contracts" / "run.sh"
+PYTEST_CONFIG = REPO_ROOT / "pytest.ini"
 
 
 def contract_registry_rows() -> list[dict[str, str]]:
@@ -31,6 +32,31 @@ def contract_registry_rows() -> list[dict[str, str]]:
             rows.append(dict(zip(headers, cells)))
 
     return rows
+
+
+def pytest_testpaths() -> list[str]:
+    lines = PYTEST_CONFIG.read_text(encoding="utf-8").splitlines()
+    testpaths: list[str] = []
+    in_testpaths = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "testpaths =":
+            in_testpaths = True
+            continue
+        if not in_testpaths:
+            continue
+        if line.startswith((" ", "\t")) and stripped:
+            testpaths.append(stripped)
+            continue
+        if stripped:
+            break
+
+    return testpaths
+
+
+def test_default_pytest_discovery_includes_top_level_contract_tests() -> None:
+    assert "tests" in pytest_testpaths()
 
 
 def test_contract_registry_maps_initial_review_contracts_to_enforcement() -> None:


### PR DESCRIPTION
## Summary
- include top-level `tests` in default pytest discovery so Python contract checks run in CI and `base-test`
- add a contract hardening test that protects the default discovery path
- document the default contract validation behavior

Fixes #1285

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_contract_hardening.py -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py -q
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q
- tests/contracts/run.sh
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test