### PR TITLE
ci: declare workflow permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -63,6 +63,12 @@ def test_all_workflows_cancel_superseded_runs() -> None:
     assert not missing, missing
 
 
+def test_all_workflows_declare_top_level_permissions() -> None:
+    missing = [path.name for path in workflow_files() if "permissions" not in load_workflow(path)]
+
+    assert not missing, missing
+
+
 def test_all_workflow_jobs_have_timeouts() -> None:
     missing: list[str] = []
     for path in workflow_files():


### PR DESCRIPTION
## Summary
- declare explicit `contents: read` permissions for tests and pylint workflows
- add a workflow policy test requiring every workflow to declare top-level permissions

Fixes #1290

## Tests
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py::test_all_workflows_declare_top_level_permissions -q`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py cli/python/base_setup/tests/test_ci_supply_chain_policy.py -q`
- `git diff --check`
