### PR TITLE
docs: include profiles in doctor JSON example

### DIFF
--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -50,6 +50,7 @@ Check commands that return an object include an aggregate `status` and a
 {
   "schema_version": 1,
   "status": "ok",
+  "profiles": [],
   "checks": []
 }
 ```

--- a/tests/test_doctor_findings_docs.py
+++ b/tests/test_doctor_findings_docs.py
@@ -1,0 +1,26 @@
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCTOR_FINDINGS_DOC = REPO_ROOT / "docs" / "doctor-findings.md"
+
+
+def json_examples() -> list[dict]:
+    text = DOCTOR_FINDINGS_DOC.read_text(encoding="utf-8")
+    examples: list[dict] = []
+    for match in re.finditer(r"```json\n(.*?)\n```", text, re.DOTALL):
+        examples.append(json.loads(match.group(1)))
+    return examples
+
+
+def test_top_level_diagnostic_json_example_includes_profiles() -> None:
+    example = json_examples()[0]
+
+    assert example == {
+        "schema_version": 1,
+        "status": "ok",
+        "profiles": [],
+        "checks": [],
+    }


### PR DESCRIPTION
## Summary
- add `profiles: []` to the top-level diagnostic JSON example in `docs/doctor-findings.md`
- add a docs-contract test that parses the example and checks the emitted top-level fields

Fixes #1291

## Tests
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_doctor_findings_docs.py -q`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_dev/tests/test_engine.py -q`
- `git diff --check`
