### PR TITLE
Use public basectl names in Python usage

### DIFF
--- a/cli/bash/commands/basectl/subcommands/history.sh
+++ b/cli/bash/commands/basectl/subcommands/history.sh
@@ -57,5 +57,5 @@ base_history_subcommand_main() {
     done
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    "$wrapper" --project base base_history "${args[@]}"
+    BASE_CLI_DISPLAY_COMMAND="basectl history" "$wrapper" --project base base_history "${args[@]}"
 }

--- a/cli/bash/commands/basectl/subcommands/prompt.sh
+++ b/cli/bash/commands/basectl/subcommands/prompt.sh
@@ -67,5 +67,5 @@ base_prompt_subcommand_main() {
     ((debug)) && renderer_args+=(--debug)
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    "$wrapper" --project base base_prompt "${renderer_args[@]}" "${prompt_args[@]}"
+    BASE_CLI_DISPLAY_COMMAND="basectl prompt" "$wrapper" --project base base_prompt "${renderer_args[@]}" "${prompt_args[@]}"
 }

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -70,3 +70,27 @@ EOF
     [[ "$output" == *"ERROR: Option '--limit' requires an argument."* ]]
     [[ "$output" != *"FATAL"* ]]
 }
+
+@test "basectl history forwards public display command to Python wrapper" {
+    local base_home="$TEST_TMPDIR/base-home"
+
+    mkdir -p "$base_home/bin"
+    cat > "$base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'display=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$base_home/bin/base-wrapper"
+
+    run env \
+        BASE_HOME="$base_home" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/history.sh"
+            base_history_subcommand_main --limit 2
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"display=basectl history"* ]]
+    [[ "$output" == *"args=--project base base_history --limit 2"* ]]
+}

--- a/cli/bash/commands/basectl/tests/prompt.bats
+++ b/cli/bash/commands/basectl/tests/prompt.bats
@@ -92,3 +92,27 @@ EOF
     [[ "$output" == *"product-self-review"* ]]
     [[ "$output" == *"Periodic Base product self-review"* ]]
 }
+
+@test "basectl prompt forwards public display command to Python wrapper" {
+    local base_home="$TEST_TMPDIR/base-home"
+
+    mkdir -p "$base_home/bin"
+    cat > "$base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'display=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$base_home/bin/base-wrapper"
+
+    run env \
+        BASE_HOME="$base_home" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/prompt.sh"
+            base_prompt_subcommand_main list
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"display=basectl prompt"* ]]
+    [[ "$output" == *"args=--project base base_prompt list"* ]]
+}

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -45,10 +45,11 @@ def run(ctx: base_cli.Context, command: str | None, arguments: tuple[str, ...]) 
 
 
 def print_usage(file=sys.stdout) -> None:
+    command = base_cli.delegated_display_command("base_config")
     print(
-        """Usage:
-  base_config show
-  base_config doctor
+        f"""Usage:
+  {command} show
+  {command} doctor
 
 Purpose:
   Inspect Base's machine-local user config.

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -77,6 +77,23 @@ class BaseConfigCommandTests(unittest.TestCase):
             self.assertEqual(history_record["raw_command"], "base_config")
             self.assertEqual(history_record["status"], "ok")
 
+    def test_usage_errors_use_delegated_display_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stderr = io.StringIO()
+            env = {
+                "BASE_CLI_DISPLAY_COMMAND": "basectl config",
+                "BASE_CACHE_DIR": str(Path(tmpdir) / ".cache" / "base"),
+                "HOME": tmpdir,
+            }
+            with mock.patch.dict(os.environ, env):
+                with redirect_stderr(stderr):
+                    status = engine.main(["show", "extra"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("basectl config show", stderr.getvalue())
+        self.assertIn("basectl config doctor", stderr.getvalue())
+        self.assertNotIn("base_config", stderr.getvalue())
+
     def test_show_config_prints_parsed_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch.dict(os.environ, {"HOME": tmpdir}):

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -168,6 +168,21 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertEqual(format_status, 2)
         self.assertIn("Unsupported output format 'yaml'", format_stderr)
 
+    def test_click_usage_errors_use_delegated_display_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stderr = io.StringIO()
+            env = {
+                "BASE_CACHE_DIR": tmpdir,
+                "BASE_CLI_DISPLAY_COMMAND": "basectl history",
+            }
+            with mock.patch.dict(os.environ, env):
+                with redirect_stderr(stderr):
+                    status = engine.main(["unexpected"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("Usage: basectl history", stderr.getvalue())
+        self.assertNotIn("python -m base_history", stderr.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cli/python/base_prompt/engine.py
+++ b/cli/python/base_prompt/engine.py
@@ -62,10 +62,11 @@ def run(ctx: base_cli.Context, prompt_name: str | None) -> int:
 
 
 def print_usage(file=sys.stdout) -> None:
+    command = base_cli.delegated_display_command("base_prompt")
     print(
-        """Usage:
-  base_prompt list
-  base_prompt <name>
+        f"""Usage:
+  {command} list
+  {command} <name>
 
 Prompts:
   product-self-review  Periodic Base product self-review

--- a/cli/python/base_prompt/tests/test_engine.py
+++ b/cli/python/base_prompt/tests/test_engine.py
@@ -14,11 +14,12 @@ from base_prompt import engine
 BASE_HOME = Path(__file__).resolve().parents[4]
 
 
-def invoke(args: list[str]) -> tuple[int, str, str]:
+def invoke(args: list[str], env: dict[str, str] | None = None) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
     with tempfile.TemporaryDirectory() as home_dir:
-        with mock.patch.dict(os.environ, {"BASE_HOME": str(BASE_HOME), "HOME": home_dir}):
+        patched_env = {"BASE_HOME": str(BASE_HOME), "HOME": home_dir, **(env or {})}
+        with mock.patch.dict(os.environ, patched_env):
             with redirect_stdout(stdout), redirect_stderr(stderr):
                 status = engine.main(args)
     return status, stdout.getvalue(), stderr.getvalue()
@@ -56,6 +57,18 @@ class BasePromptTests(unittest.TestCase):
         self.assertEqual(stdout, "")
         self.assertIn("Usage:", stderr)
         self.assertIn("ERROR: Unknown prompt 'missing-prompt'.", stderr)
+
+    def test_usage_errors_use_delegated_display_command(self) -> None:
+        status, stdout, stderr = invoke(
+            ["missing-prompt"],
+            env={"BASE_CLI_DISPLAY_COMMAND": "basectl prompt"},
+        )
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("basectl prompt list", stderr)
+        self.assertIn("basectl prompt <name>", stderr)
+        self.assertNotIn("base_prompt", stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- pass public `basectl history` and `basectl prompt` display commands into Python wrappers
- make custom config and prompt usage render delegated public command names
- add Python, BATS, and smoke coverage for the user-facing error banners

Fixes #1286

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_config/tests/test_engine.py cli/python/base_prompt/tests/test_engine.py cli/python/base_history/tests/test_engine.py -q
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/config.bats cli/bash/commands/basectl/tests/history.bats cli/bash/commands/basectl/tests/prompt.bats
- real `basectl config show extra`, `basectl history unexpected`, and `basectl prompt unknown` smoke checks with BASE_CACHE_DIR=/private/tmp/base-1286-cache
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_config/engine.py cli/python/base_prompt/engine.py cli/python/base_config/tests/test_engine.py cli/python/base_prompt/tests/test_engine.py cli/python/base_history/tests/test_engine.py
- git diff --check
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test