### PR TITLE
docs: separate unscheduled observability work

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -205,15 +205,20 @@ should never upload the report.
 
 ## Implementation Split
 
-The commands should ship in separate, reviewable slices:
+The shipped first slice is:
 
 1. Add history recording and `basectl history`. **Shipped.**
-2. Add `basectl explain last-error` after history records exist.
-3. Add `basectl report` after history and explanation have stable local data.
-4. Extend `basectl clean` to compact or prune history records once the history
-   format is stable.
 
-This order keeps the data model and privacy boundary reviewable before Base
+### Unscheduled Future Work
+
+The following items remain tracked but are not scheduled:
+
+- Add `basectl explain last-error` after history records exist.
+- Add `basectl report` after history and explanation have stable local data.
+- Extend `basectl clean` to compact or prune history records once the history
+  format is stable.
+
+That sequence keeps the data model and privacy boundary reviewable before Base
 starts producing summaries or shareable diagnostic artifacts.
 
 ## First Slice Decisions

--- a/tests/test_observability_docs.py
+++ b/tests/test_observability_docs.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OBSERVABILITY_DOC = REPO_ROOT / "docs" / "observability.md"
+
+
+def implementation_split_section() -> str:
+    text = OBSERVABILITY_DOC.read_text(encoding="utf-8")
+    start = text.index("## Implementation Split")
+    end = text.index("## First Slice Decisions")
+    return text[start:end]
+
+
+def test_unscheduled_observability_work_is_not_numbered_as_active_steps() -> None:
+    section = implementation_split_section()
+
+    assert "Unscheduled Future Work" in section
+    assert "2. Add `basectl explain last-error`" not in section
+    assert "3. Add `basectl report`" not in section
+    assert "4. Extend `basectl clean`" not in section


### PR DESCRIPTION
## Summary
- reword the observability implementation split so only the shipped history slice is numbered
- move explain/report/cleanup follow-ups into an explicit unscheduled future-work section
- add a docs test that keeps unscheduled work from drifting back into active numbered steps

Fixes #1293

## Tests
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_observability_docs.py -q`
- `git diff --check`
