### PR TITLE
Refresh repo and Project help docs

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -29,10 +29,10 @@ should start from a GitHub issue with one primary category label:
 Do not create new `type:*` labels.
 
 Issues created by automation should be assigned to `codeforester` when GitHub
-allows it. When an issue is tracked in the Base Roadmap Project, move its
-status through `In Progress`, `In Review`, and `Done` as the work advances.
-Base roadmap Project metadata uses five fields: `Status`, `Priority`, `Area`,
-`Size`, and `Initiative`.
+allows it. When an issue is tracked in the repo-named Project, move its status
+through `In Progress`, `In Review`, and `Done` as the work advances. Repo-named
+Project metadata uses five fields: `Status`, `Priority`, `Area`, `Size`, and
+`Initiative`.
 Use the smallest accurate `Size` when creating issues: `T` for tiny obvious
 work, `S` for normal small work or unknown scope, `M` for interacting changes,
 and `L` only for work that should probably be split. The default remains `S`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,10 @@ Before modifying files in this repository, classify the request.
 - Assign agent-created Base repository issues to `codeforester` when GitHub
   allows it; `.github/base-project.yml` carries this repo-local default for
   `basectl gh issue create`.
-- For issues tracked in Base Roadmap, set Project `Status` to `In Progress`
-  before implementation starts, move it to `In Review` when the PR opens, and
-  verify `Done` after merge/closure. If Project V2 access or item state
-  prevents an update, mention that in the work summary.
+- For issues tracked in the repo-named Project, set Project `Status` to
+  `In Progress` before implementation starts, move it to `In Review` when the
+  PR opens, and verify `Done` after merge/closure. If Project V2 access or item
+  state prevents an update, mention that in the work summary.
 - When creating issues, choose Project `Size` from actual scope: `T` for tiny
   obvious work, `S` for normal small work or unknown scope, `M` for interacting
   changes, and `L` only for work that should probably be split.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ for issue-backed work, validation, and design-only sessions.
    - `ci` for GitHub Actions, tests, release automation, or CI reliability.
    - `security` for security hardening, dependency pinning, static analysis, or
      permission tightening.
-3. When the issue is tracked in Base Roadmap, set its Project `Status` to
-   `In Progress` before branch or worktree work begins. Move it to `In Review`
-   when the PR opens, and verify it is `Done` after merge/closure.
+3. When the issue is tracked in the repo-named Project, set its Project
+   `Status` to `In Progress` before branch or worktree work begins. Move it to
+   `In Review` when the PR opens, and verify it is `Done` after merge/closure.
 4. Create a branch from the issue using this convention:
 
    ```text

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ behavior idempotent.
 Start a new Base-managed repository with:
 
 ```bash
-basectl repo init example --repo codeforester/example
+basectl repo init example --repo basefoundry/example
 ```
 
 This creates the local repository baseline: README, version, changelog,

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -16,7 +16,7 @@ Usage:
   basectl gh pr ready [gh options...]
   basectl gh pr merge [gh options...]
   basectl gh project doctor --project <title> [--owner <login>] [--schema base-project]
-  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-project] [--replace-project] [--initiative-option <name>] [--dry-run]
+  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-project] [--config <path>] [--copy-fields-from <title>] [--replace-project] [--initiative-option <name>] [--dry-run]
   basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [field options...]
   basectl gh branch stale [--days <days>]
   basectl gh branch prune [--dry-run] [--yes] [--remote]
@@ -111,7 +111,7 @@ base_gh_project_usage() {
     cat <<'EOF'
 Usage:
   basectl gh project doctor --project <title> [--owner <login>] [--schema base-project]
-  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-project] [--replace-project] [--initiative-option <name>] [--dry-run]
+  basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-project] [--config <path>] [--copy-fields-from <title>] [--replace-project] [--initiative-option <name>] [--dry-run]
   basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [field options...]
 
 Purpose:

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -159,7 +159,7 @@ Options:
 
 Examples:
   basectl repo configure . --repo codeforester/bankbuddy
-  basectl repo configure . --copy-project-fields-from "Base Roadmap"
+  basectl repo configure . --copy-project-fields-from "Legacy Roadmap"
 
 repo configure applies or repairs GitHub-side repository settings, labels,
 branch protection, Project metadata, and repo-visible Project intake support.

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -90,6 +90,15 @@ run_gh_subcommand() {
     [[ "$output" != *"basectl gh worktree prune"* ]]
 }
 
+@test "basectl gh project configure help lists delegated Python options" {
+    run_basectl gh project --help
+
+    [ "$status" -eq 0 ]
+    for flag in "--schema base-project" "--config <path>" "--copy-fields-from <title>" "--replace-project" "--initiative-option <name>" "--dry-run"; do
+        [[ "$output" == *"$flag"* ]]
+    done
+}
+
 @test "basectl gh project issue set-fields prints concrete help" {
     run_basectl gh project issue set-fields --help
 

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -180,6 +180,59 @@ load ./basectl_helpers.bash
     grep -Fqx -- "| \`basectl docs\` | Open the Base documentation home page on GitHub. | \`--show-url\` |" "$command_reference"
 }
 
+@test "command reference documents repo and Project configuration options" {
+    local command_reference="$BASE_REPO_ROOT/docs/command-reference.md"
+    local repo_init_row repo_configure_row project_configure_row
+
+    repo_init_row="$(grep -F '| `basectl repo init <name>` |' "$command_reference")"
+    run_basectl repo init --help
+
+    [ "$status" -eq 0 ]
+    for flag in \
+        "--description <text>" \
+        "--copyright-holder <name>" \
+        "--project <title>" \
+        "--project-owner <login>" \
+        "--project-schema <schema>" \
+        "--copy-project-fields-from <title>" \
+        "--initiative-option <name>" \
+        "--no-protect-default-branch"; do
+        [[ "$output" == *"$flag"* ]]
+        [[ "$repo_init_row" == *"$flag"* ]]
+    done
+
+    repo_configure_row="$(grep -F '| `basectl repo configure [path]` |' "$command_reference")"
+    run_basectl repo configure --help
+
+    [ "$status" -eq 0 ]
+    for flag in \
+        "--project <title>" \
+        "--project-owner <login>" \
+        "--project-schema <schema>" \
+        "--copy-project-fields-from <title>" \
+        "--initiative-option <name>" \
+        "--replace-project" \
+        "--no-protect-default-branch"; do
+        [[ "$output" == *"$flag"* ]]
+        [[ "$repo_configure_row" == *"$flag"* ]]
+    done
+
+    project_configure_row="$(grep -F '| `basectl gh project configure` |' "$command_reference")"
+    run_basectl gh project --help
+
+    [ "$status" -eq 0 ]
+    for flag in \
+        "--schema base-project" \
+        "--config <path>" \
+        "--copy-fields-from <title>" \
+        "--replace-project" \
+        "--initiative-option <name>" \
+        "--dry-run"; do
+        [[ "$output" == *"$flag"* ]]
+        [[ "$project_configure_row" == *"$flag"* ]]
+    done
+}
+
 @test "basectl config prints help" {
     run_basectl config --help
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -76,10 +76,10 @@ inspect the resolved command contract first.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--public`, `--private`, `--pr`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--no-configure`, `--no-project`, `--dry-run` |
+| `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. | `--path <path>`, `--repo <owner/name>`, `--description <text>`, `--copyright-holder <name>`, `--public`, `--private`, `--pr`, `--project <title>`, `--project-owner <login>`, `--project-schema <schema>`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--no-configure`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo clone <name-or-owner/name>` | Clone one GitHub repository into the configured Base workspace, treating matching existing checkouts as already satisfied. | `--owner <owner>`, `--path <path>`, `--dry-run` |
 | `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance` |
-| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` to seed options and fill missing issue defaults when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--replace-project`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
+| `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, branch protection, and repo Project metadata. Reads `.github/base-project.yml` to seed options and fill missing issue defaults when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--project-schema <schema>`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--replace-project`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files, optionally through a draft PR. | `--repo <owner/name>`, `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--pr`, `--dry-run` |
 | `basectl repo installer-template [path]` | Write the maintained project installer starter script to a path, defaulting to `./install.sh`, optionally through a draft PR. | `--print`, `--repo <owner/name>`, `--pr`, `--dry-run` |
 | `basectl gh issue list` | List GitHub issues through `gh`. | passes through `gh` options |
@@ -90,7 +90,7 @@ inspect the resolved command contract first.
 | `basectl gh branch prune` | Prune safe merged branches. | `--dry-run`, `--yes`, `--remote` |
 | `basectl gh worktree prune` | Prune stale merged worktrees. | `--dry-run`, `--yes` |
 | `basectl gh project doctor` | Inspect GitHub Project metadata against the Base Project schema. | `--project <title>`, `--owner <login>`, `--schema base-project` |
-| `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--config <path>`, `--copy-fields-from <title>`, `--replace-project`, `--dry-run` |
+| `basectl gh project configure` | Create or repair Base-managed Project metadata. | `--project <title>`, `--owner <login>`, `--repo <owner/name>`, `--schema base-project`, `--config <path>`, `--copy-fields-from <title>`, `--replace-project`, `--initiative-option <name>`, `--dry-run` |
 | `basectl gh project issue set-fields <number>` | Add an issue to the Project if needed and update metadata fields. | `--project <title>`, `--repo <owner/name>`, `--config <path>`, field options |
 
 ## Release And Context

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -86,8 +86,8 @@ of silently leaving the issue unassigned.
 
 ## Issue Project Metadata
 
-When an issue is tracked in the `Base Roadmap` Project, use the standard
-Base roadmap fields:
+When an issue is tracked in the repo-named Project, use the standard Base
+Project fields:
 
 - `Status`: `Triage`, `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`
 - `Priority`: `P0`, `P1`, `P2`, `P3`
@@ -152,7 +152,9 @@ schema repair, or issue field updates.
 When migrating from an existing shared Project, pass
 `--copy-project-fields-from <title>` to copy missing `Status`, `Priority`,
 `Area`, `Initiative`, and `Size` issue item values into the repo Project without
-overwriting values already set there.
+overwriting values already set there. Older Base issues may have been tracked in
+`Base Roadmap`; use that title only as the migration source when copying legacy
+field values into the current repo-named Project.
 
 ```bash
 basectl gh project doctor --project base --owner basefoundry

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -5,6 +5,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CONTRACTS_DOC = REPO_ROOT / "docs" / "contracts.md"
 CONTRACT_RUNNER = REPO_ROOT / "tests" / "contracts" / "run.sh"
 PYTEST_CONFIG = REPO_ROOT / "pytest.ini"
+ACTIVE_WORKFLOW_GUIDANCE_FILES = (
+    REPO_ROOT / ".ai-context" / "WORKFLOWS.md",
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "CONTRIBUTING.md",
+)
+GITHUB_WORKFLOW_DOC = REPO_ROOT / "docs" / "github-workflow.md"
 
 
 def contract_registry_rows() -> list[dict[str, str]]:
@@ -57,6 +63,20 @@ def pytest_testpaths() -> list[str]:
 
 def test_default_pytest_discovery_includes_top_level_contract_tests() -> None:
     assert "tests" in pytest_testpaths()
+
+
+def test_active_project_guidance_uses_repo_named_project_language() -> None:
+    for path in ACTIVE_WORKFLOW_GUIDANCE_FILES:
+        text = path.read_text(encoding="utf-8")
+        assert "Base Roadmap" not in text
+        assert "repo-named Project" in text
+
+    issue_metadata_section = GITHUB_WORKFLOW_DOC.read_text(encoding="utf-8").split(
+        "## Issue Project Metadata", maxsplit=1
+    )[1].split("\n## ", maxsplit=1)[0]
+    assert "When an issue is tracked in the `Base Roadmap` Project" not in issue_metadata_section
+    assert "repo-named Project" in issue_metadata_section
+    assert "use that title only as the migration source" in issue_metadata_section
 
 
 def test_contract_registry_maps_initial_review_contracts_to_enforcement() -> None:


### PR DESCRIPTION
Fixes #1287

## Summary
- Align `basectl gh project configure` shell help with the delegated Python option surface.
- Refresh command-reference rows for repo init/configure and Project configure flags.
- Update active workflow guidance to the current repo-named Project model and mark `Base Roadmap` as migration-only.

## Validation
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/repo.bats`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_contract_hardening.py -q`
- `BASE_CACHE_DIR=/private/tmp/base-1287-cache BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl gh project --help`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash env -u BASE_HOME ./bin/base-test`