### PR TITLE
Handle export-context directory output

### DIFF
--- a/cli/python/base_export_context/engine.py
+++ b/cli/python/base_export_context/engine.py
@@ -130,9 +130,13 @@ def export_markdown_context(options: ExportContextOptions) -> int:
 
 
 def resolve_output_path(project_name: str, output_path: str | None, extension: str) -> Path:
+    default_filename = f"{project_name}-ai-context.{extension}"
     if output_path:
-        return Path(output_path).expanduser()
-    return Path.cwd() / f"{project_name}-ai-context.{extension}"
+        path = Path(output_path).expanduser()
+        if path.is_dir():
+            return path / default_filename
+        return path
+    return Path.cwd() / default_filename
 
 
 def ordered_context_files(project_name: str, project_root: Path, include_all: bool) -> tuple[ContextFile, ...]:
@@ -240,10 +244,13 @@ def write_text_file(destination: Path, content: str) -> None:
 
 
 def write_zip_file(destination: Path, files: tuple[ContextFile, ...]) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for context_file in files:
-            info = zipfile.ZipInfo(context_file.relative_path.as_posix(), ZIP_TIMESTAMP)
-            info.compress_type = zipfile.ZIP_DEFLATED
-            info.external_attr = 0o644 << 16
-            archive.writestr(info, context_file.path.read_bytes())
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for context_file in files:
+                info = zipfile.ZipInfo(context_file.relative_path.as_posix(), ZIP_TIMESTAMP)
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o644 << 16
+                archive.writestr(info, context_file.path.read_bytes())
+    except OSError as exc:
+        raise ExportContextError(f"Unable to write Zip AI context export to '{destination}': {exc}") from exc

--- a/cli/python/base_export_context/tests/test_engine.py
+++ b/cli/python/base_export_context/tests/test_engine.py
@@ -201,6 +201,65 @@ class ExportContextTests(unittest.TestCase):
                 for info in archive.infolist():
                     self.assertEqual(info.date_time, (1980, 1, 1, 0, 0, 0))
 
+    def test_zip_output_directory_uses_default_bundle_filename(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            output_dir = Path(tmpdir) / "exports"
+            project_root.mkdir()
+            output_dir.mkdir()
+            expected_zip = output_dir / "demo-ai-context.zip"
+            write_context_file(project_root, "PROJECT.md", "Project\n")
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "--project-name",
+                    "demo",
+                    "--project-root",
+                    str(project_root),
+                    "--format",
+                    "zip",
+                    "--output",
+                    str(output_dir),
+                ],
+                project_root,
+            )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(stderr, "")
+            self.assertEqual(stdout, f"Wrote Zip AI context export for project 'demo' to {expected_zip}\n")
+            self.assertTrue(expected_zip.is_file())
+            with zipfile.ZipFile(expected_zip) as archive:
+                self.assertEqual(archive.namelist(), ["PROJECT.md"])
+
+    def test_zip_output_invalid_destination_reports_error_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            parent_file = Path(tmpdir) / "not-a-directory"
+            project_root.mkdir()
+            parent_file.write_text("not a directory\n", encoding="utf-8")
+            output_path = parent_file / "bundle.zip"
+            write_context_file(project_root, "PROJECT.md", "Project\n")
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "--project-name",
+                    "demo",
+                    "--project-root",
+                    str(project_root),
+                    "--format",
+                    "zip",
+                    "--output",
+                    str(output_path),
+                ],
+                project_root,
+            )
+
+            self.assertEqual(status, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("Unable to write Zip AI context export", stderr)
+            self.assertIn(str(output_path), stderr)
+            self.assertNotIn("Traceback", stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
- Resolve existing directory `--output` values to the default export bundle filename before writing zip exports.
- Wrap zip write `OSError`s in `ExportContextError` so invalid destinations return a Base CLI error instead of a traceback.
- Add regressions for directory output and invalid destination handling.

Validation:
- Reproduced before fix: `basectl export-context --format zip --output /private/tmp/base-1305-export-dir/` raised `IsADirectoryError`.
- Red tests before fix: `test_zip_output_directory_uses_default_bundle_filename` and `test_zip_output_invalid_destination_reports_error_without_traceback` failed with traceback leaks.
- Focused tests: env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_export_context/tests/test_engine.py -q
- Smoke: env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1305 ./bin/basectl export-context --format zip --output /private/tmp/base-1305-export-dir
- Touched-file pylint: env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_export_context/engine.py cli/python/base_export_context/tests/test_engine.py
- git diff --check
- Full base-test: Python 722 passed, 1 skipped; Bats ok 1..567

Demo Impact: none

Fixes #1305
