### PR TITLE
Fix base_cli testing package export

### DIFF
--- a/lib/python/base_cli/__init__.py
+++ b/lib/python/base_cli/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from . import history
+from . import history, testing
 from .app import App, argument, command, delegated_display_command, option, run_app
 from .context import Context, get_current_context
 from .exit_codes import ExitCode
@@ -11,6 +11,7 @@ __all__ = [
     "Context",
     "ExitCode",
     "history",
+    "testing",
     "argument",
     "command",
     "configure_logger",

--- a/lib/python/base_cli/tests/test_testing.py
+++ b/lib/python/base_cli/tests/test_testing.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
+import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,6 +12,33 @@ from unittest import mock
 
 import base_cli
 from base_cli.testing import invoke
+
+
+class PackageExportTests(unittest.TestCase):
+    def test_package_exports_testing_module_for_documented_access(self) -> None:
+        env = os.environ.copy()
+        pythonpath = str(Path(__file__).resolve().parents[2])
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            pythonpath
+            if not existing_pythonpath
+            else f"{pythonpath}{os.pathsep}{existing_pythonpath}"
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import base_cli; assert base_cli.testing.invoke",
+            ],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")


### PR DESCRIPTION
## Summary
- export `base_cli.testing` from the package initializer
- add a fresh-interpreter regression test for the documented `base_cli.testing.invoke(...)` access pattern

Fixes #1314

## Tests
- `PYTHONPATH=lib/python python3 -m unittest lib/python/base_cli/tests/test_testing.py -k test_package_exports_testing_module_for_documented_access`
- `PYTHONPATH=lib/python python3 -m unittest lib/python/base_cli/tests/test_testing.py`
