### PR TITLE
Document base_cli Context fields

### DIFF
--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -127,6 +127,7 @@ ctx.run_id         # str
 ctx.base_home      # Path | None
 ctx.project_root   # Path | None
 ctx.manifest_path  # Path | None
+ctx.workspace_root # configured workspace root, or None
 ctx.state_dir      # Base cache root / cli / <cli-name>
 ctx.log_dir        # state_dir/logs
 ctx.cache_dir      # state_dir/cache
@@ -138,6 +139,7 @@ ctx.environment    # str
 ctx.debug          # bool
 ctx.dry_run        # bool
 ctx.keep_temp      # bool
+ctx.quiet          # bool
 ctx.log            # logging.Logger
 ```
 

--- a/tests/test_base_cli_docs.py
+++ b/tests/test_base_cli_docs.py
@@ -1,0 +1,24 @@
+import re
+from dataclasses import fields
+from pathlib import Path
+
+from base_cli.context import Context
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASE_CLI_DOC = REPO_ROOT / "docs" / "base-cli.md"
+INTERNAL_CONTEXT_FIELDS = {"cleanup_hooks"}
+
+
+def context_section() -> str:
+    text = BASE_CLI_DOC.read_text(encoding="utf-8")
+    start = text.index("## Context")
+    end = text.index("## State Directories")
+    return text[start:end]
+
+
+def test_base_cli_context_docs_list_public_context_fields() -> None:
+    documented_fields = set(re.findall(r"ctx\.([a-z_]+)", context_section()))
+    public_context_fields = {field.name for field in fields(Context)} - INTERNAL_CONTEXT_FIELDS
+
+    assert public_context_fields <= documented_fields


### PR DESCRIPTION
## Summary
- document `ctx.workspace_root` and `ctx.quiet` in the base_cli Context API reference
- add a docs contract test that keeps public Context dataclass fields represented in `docs/base-cli.md`

Fixes #1315

## Tests
- `PYTHONPATH=lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_base_cli_docs.py -q`
- `git diff --check`
