### PR TITLE
Keep Project Intake gh stderr out of JSON output

### DIFF
--- a/.github/workflows/project-intake.yml
+++ b/.github/workflows/project-intake.yml
@@ -96,42 +96,68 @@ jobs:
             local operation="$1"
             shift
             local output
+            local error_output
+            local diagnostic_output
+            local stderr_file
             local status
             local retry_delay
 
-            if output="$("$@" 2>&1)"; then
+            stderr_file="$(mktemp)"
+            if output="$("$@" 2>"$stderr_file")"; then
+              error_output="$(cat "$stderr_file")"
+              rm -f "$stderr_file"
+              [[ -z "$error_output" ]] || printf '%s\n' "$error_output" >&2
               [[ -z "$output" ]] || printf '%s\n' "$output"
               return 0
             else
               status=$?
+              error_output="$(cat "$stderr_file")"
+              rm -f "$stderr_file"
             fi
 
-            if project_intake_is_auth_failure "$output"; then
+            diagnostic_output="$output"
+            if [[ -n "$error_output" ]]; then
+              [[ -z "$diagnostic_output" ]] || diagnostic_output+=$'\n'
+              diagnostic_output+="$error_output"
+            fi
+
+            if project_intake_is_auth_failure "$diagnostic_output"; then
               echo "::error::GitHub authentication failed during Project Intake: $operation" >&2
               echo "::error::Rotate BASE_PROJECT_TOKEN and rerun this workflow_dispatch for issue #${issue_number:-unknown}." >&2
               echo "::error::Fix: gh auth token | gh secret set BASE_PROJECT_TOKEN --repo $GITHUB_REPOSITORY" >&2
-              printf '%s\n' "$output" >&2
+              printf '%s\n' "$diagnostic_output" >&2
               return "$status"
             fi
 
-            if project_intake_is_retryable_api_failure "$output"; then
-              retry_delay="$(project_intake_retry_delay_seconds "$output")"
+            if project_intake_is_retryable_api_failure "$diagnostic_output"; then
+              retry_delay="$(project_intake_retry_delay_seconds "$diagnostic_output")"
               echo "::warning::GitHub API pressure during Project Intake: $operation" >&2
               echo "::warning::Waiting ${retry_delay}s and retrying once." >&2
               sleep "$retry_delay"
-              if output="$("$@" 2>&1)"; then
+              stderr_file="$(mktemp)"
+              if output="$("$@" 2>"$stderr_file")"; then
+                error_output="$(cat "$stderr_file")"
+                rm -f "$stderr_file"
+                [[ -z "$error_output" ]] || printf '%s\n' "$error_output" >&2
                 [[ -z "$output" ]] || printf '%s\n' "$output"
                 return 0
               else
                 status=$?
+                error_output="$(cat "$stderr_file")"
+                rm -f "$stderr_file"
+              fi
+              diagnostic_output="$output"
+              if [[ -n "$error_output" ]]; then
+                [[ -z "$diagnostic_output" ]] || diagnostic_output+=$'\n'
+                diagnostic_output+="$error_output"
               fi
               echo "::error::GitHub API retry failed during Project Intake: $operation" >&2
-              printf '%s\n' "$output" >&2
+              printf '%s\n' "$diagnostic_output" >&2
               return "$status"
             fi
 
             echo "::error::GitHub API command failed during Project Intake: $operation" >&2
-            printf '%s\n' "$output" >&2
+            printf '%s\n' "$diagnostic_output" >&2
             return "$status"
           }
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -99,6 +99,10 @@ case "${1:-} ${2:-}" in
       exit 1
     fi
 
+    if [[ "${PROJECT_INTAKE_WARN_ON_SUCCESS:-}" == "1" ]]; then
+      printf 'warning: gh emitted a non-fatal notice\\n' >&2
+    fi
+
     printf '{"state":"OPEN","url":"https://github.com/basefoundry/base/issues/1311"}\\n'
     ;;
   "project list")
@@ -316,6 +320,15 @@ def test_project_intake_retries_rate_limited_operations_once(tmp_path: Path) -> 
     assert "retrying once" in result.stderr
     assert (tmp_path / "sleep.log").read_text(encoding="utf-8") == "7\n"
     assert (tmp_path / "issue-view-count").read_text(encoding="utf-8") == "2\n"
+    assert "Synced issue #1311 into Project base." in result.stdout
+
+
+def test_project_intake_keeps_success_stderr_out_of_json_stdout(tmp_path: Path) -> None:
+    result = run_project_intake_script(tmp_path, PROJECT_INTAKE_WARN_ON_SUCCESS="1")
+
+    assert result.returncode == 0, result.stderr
+    assert "warning: gh emitted a non-fatal notice" in result.stderr
+    assert "warning: gh emitted a non-fatal notice" not in result.stdout
     assert "Synced issue #1311 into Project base." in result.stdout
 
 


### PR DESCRIPTION
## Summary
- capture `project_intake_gh` stdout and stderr separately
- replay successful stderr notices on stderr without contaminating JSON stdout
- keep auth and retry diagnostics using combined failure output
- add a regression test for non-fatal `gh` stderr with valid JSON stdout

Fixes #1317

## Tests
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py::test_project_intake_keeps_success_stderr_out_of_json_stdout -q`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py -q`
- `git diff --check`
