### PR TITLE
Fix self-demo BATS fixture path portability

### DIFF
--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -180,13 +180,15 @@ EOF
 }
 
 @test "Base self-demo pause reads from terminal fd when stdin is redirected" {
+    local bash_libs_dir
     local tty_input="$TEST_TMPDIR/demo-tty"
 
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
     printf '\n' > "$tty_input"
 
     run env \
         BASE_HOME="$BASE_REPO_ROOT" \
-        BASE_BASH_LIBS_DIR="${BASE_BASH_LIBS_DIR:-/Users/rameshhp/work/base-bash-libs/lib/bash}" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
         BASE_DEMO_TTY_FD=9 \
         bash -c '
             source "$BASE_HOME/demo/demo.sh"

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -140,6 +140,12 @@ def test_contract_runner_supports_base_worktree_library_layout() -> None:
     assert "../../base-bash-libs/lib/bash" in text
 
 
+def test_bats_tests_do_not_embed_personal_base_bash_libs_path() -> None:
+    demo_bats = REPO_ROOT / "cli" / "bash" / "commands" / "basectl" / "tests" / "demo.bats"
+
+    assert "/Users/rameshhp/work/base-bash-libs" not in demo_bats.read_text(encoding="utf-8")
+
+
 def test_contract_runner_reenters_repo_root_for_each_step() -> None:
     text = CONTRACT_RUNNER.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Replace the hard-coded personal `base-bash-libs` path in the self-demo BATS pause test with the existing portable fixture resolver.
- Add a contract check that prevents that personal path from returning to the BATS test.

## Root Cause
The self-demo pause test used `/Users/rameshhp/work/base-bash-libs/lib/bash` as a fallback `BASE_BASH_LIBS_DIR`. That works on the primary macOS checkout but fails on fresh Ubuntu source checkouts, so the test exits before exercising the terminal-fd pause behavior.

## Validation
- `PYTHONPATH=/Users/rameshhp/work/base/lib/python:/Users/rameshhp/work/base/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_contract_hardening.py -q`
- `bats cli/bash/commands/basectl/tests/demo.bats`
- `git diff --check`
- Prior full local gate after this patch: `env -u BASE_HOME ./bin/base-test` -> Python `731 passed, 1 skipped`; BATS `569 ok`

Fixes #1322