### PR TITLE
Add Ubuntu source-checkout CI validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,6 +197,53 @@ jobs:
         run: |
           bats tests/integration/base_workflows.bats
 
+  ubuntu-source-checkout:
+    name: Ubuntu source-checkout suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-bash-libs
+          ref: 34a71d08decf715f5767ab064197f7e63f418448
+          path: .dependencies/base-bash-libs
+
+      - name: Expose reusable Bash library checkout as sibling
+        run: |
+          ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"
+
+      - name: Install Ubuntu source-checkout prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            git \
+            curl \
+            build-essential \
+            ca-certificates \
+            python3-venv \
+            python3-pip \
+            bats \
+            shellcheck \
+            jq \
+            golang-go
+
+      - name: Prepare Base test virtual environment
+        run: |
+          mkdir -p "$HOME/.base.d/base"
+          python3 -m venv "$HOME/.base.d/base/.venv"
+          "$HOME/.base.d/base/.venv/bin/python" -m pip install --upgrade pip
+          "$HOME/.base.d/base/.venv/bin/python" -m pip install -r requirements-dev.txt
+
+      - name: Run Ubuntu source-checkout validation
+        run: |
+          ./bin/basectl ci check base --format json
+          env -u BASE_HOME ./bin/base-test
+
   security:
     name: Security scanners
     runs-on: ubuntu-latest

--- a/cli/python/base_setup/tests/test_ci_supply_chain_policy.py
+++ b/cli/python/base_setup/tests/test_ci_supply_chain_policy.py
@@ -94,6 +94,51 @@ def test_ci_bats_job_covers_base_test_source_suite() -> None:
         assert test_path in bats_command
 
 
+def test_ci_includes_ubuntu_source_checkout_base_test_job() -> None:
+    tests_workflow = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+    workflow = load_workflow(tests_workflow)
+    ubuntu_job = workflow["jobs"].get("ubuntu-source-checkout")
+
+    assert ubuntu_job is not None, "tests.yml must include an Ubuntu source-checkout job."
+    assert ubuntu_job["runs-on"] == "ubuntu-latest"
+
+    bash_libs_checkouts = [
+        step
+        for step in ubuntu_job["steps"]
+        if step.get("with", {}).get("repository") == "basefoundry/base-bash-libs"
+    ]
+    assert bash_libs_checkouts, "Ubuntu source-checkout CI must fetch base-bash-libs."
+    assert bash_libs_checkouts[0]["with"]["path"] == ".dependencies/base-bash-libs"
+
+    steps = {step.get("name"): step for step in ubuntu_job["steps"]}
+    sibling_command = steps["Expose reusable Bash library checkout as sibling"].get("run", "")
+    assert ".dependencies/base-bash-libs" in sibling_command
+    assert "../base-bash-libs" in sibling_command
+
+    install_command = steps["Install Ubuntu source-checkout prerequisites"].get("run", "")
+    for package in (
+        "git",
+        "curl",
+        "build-essential",
+        "ca-certificates",
+        "python3-venv",
+        "python3-pip",
+        "bats",
+        "shellcheck",
+        "jq",
+        "golang-go",
+    ):
+        assert package in install_command
+
+    venv_command = steps["Prepare Base test virtual environment"].get("run", "")
+    assert "$HOME/.base.d/base/.venv" in venv_command
+    assert "-r requirements-dev.txt" in venv_command
+
+    validation_command = steps["Run Ubuntu source-checkout validation"].get("run", "")
+    assert "./bin/basectl ci check base --format json" in validation_command
+    assert "env -u BASE_HOME ./bin/base-test" in validation_command
+
+
 def test_shellcheck_covers_runtime_bashrc() -> None:
     tests_workflow = REPO_ROOT / ".github" / "workflows" / "tests.yml"
     for step_name in ("Run ShellCheck", "Run ShellCheck warnings"):

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -79,11 +79,15 @@ Linux support should make GitHub Actions a first-class validation target:
 ```bash
 basectl ci check base --format json
 basectl ci doctor base --format json
+env -u BASE_HOME ./bin/base-test
 ```
 
 The first CI-compatible milestone is live: workflows install their own
 prerequisites before invoking Base, and `basectl ci` runs non-interactive
-runtime checks without requiring Homebrew or Xcode on Linux.
+runtime checks without requiring Homebrew or Xcode on Linux. The
+`ubuntu-source-checkout` job also runs the full source-checkout suite through
+`bin/base-test` after preparing the Base-managed test virtual environment and
+the sibling `base-bash-libs` checkout expected by source tests.
 
 ## Implementation Phases
 
@@ -92,7 +96,7 @@ runtime checks without requiring Homebrew or Xcode on Linux.
 | 1. Split macOS-only setup checks from portable runtime checks. | Done | Initial support exists through the live `basectl ci` entry point. |
 | 2. Add platform detection and explicit unsupported-platform messages. | Done for macOS setup boundaries | `basectl setup` fails clearly outside the supported macOS setup contract. Linux runtime support remains narrower than setup support. |
 | 3. Make `basectl check` and `doctor` report Linux prerequisite status without requiring Homebrew or Xcode. | Future | `basectl ci` is the current Linux-friendly read-only path; broader Linux prerequisite reporting still needs implementation. |
-| 4. Add Ubuntu CI coverage for read-only commands. | Future | Add once the runtime checks are stable enough to gate every PR. |
+| 4. Add Ubuntu CI coverage for read-only commands and the source-checkout suite. | Done for source-checkout validation | The `ubuntu-source-checkout` job installs hosted-runner prerequisites, runs `basectl ci check base --format json`, and runs `env -u BASE_HOME ./bin/base-test`. |
 | 5. Add apt-backed setup for simple prerequisites. | Future | Keep setup conservative until the first supported Linux distribution contract is finalized. |
 | 6. Revisit Python installation once the desired Linux Python distribution strategy is clear. | Future | Do not silently fall back to arbitrary system Python. |
 


### PR DESCRIPTION
## Summary

- Add an `ubuntu-source-checkout` GitHub Actions job for the v1.5.0 Ubuntu milestone.
- Install the hosted Ubuntu prerequisites used by the manual Parallels smoke test, prepare `~/.base.d/base/.venv`, and run both `basectl ci check` and the full `bin/base-test` source-checkout suite.
- Add a workflow contract test and update `docs/linux-support.md` to record the new hosted Ubuntu validation lane.

## Validation

- `PYTHONPATH=lib/python:cli/python "$HOME/.base.d/base/.venv/bin/python" -m pytest cli/python/base_setup/tests/test_ci_supply_chain_policy.py -q`
- `git diff --check`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-1328-base-test ./bin/base-test`

## Notes

- Part of #562.
- Local `./bin/basectl ci check base --format json` on this macOS sandbox is not useful evidence for the Ubuntu job: the sandbox blocks writes under `~/.base.d`, and this machine is missing the Homebrew `python@3.13` formula expected by the macOS check path. The full source-checkout runner passed with a writable `BASE_CACHE_DIR`.

Fixes #1328.
