### PR TITLE
Document Base platform policy boundary

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -31,7 +31,21 @@ layer boundaries rather than placing logic wherever it is easiest to call.
 | Persistent Base state such as config and project venvs | `~/.base.d` |
 | Ephemeral logs, temp files, and cache | Base cache root, normally `~/Library/Caches/base` on macOS |
 
-### 1.2 Public Command Surface
+### 1.2 Host Platform Policy
+
+Host platform detection belongs to `base_init.sh`; installer, package-manager,
+and diagnostic policy belong behind explicit platform boundary helpers in the
+owning layer. Normal command, runtime, setup, check, doctor, and artifact code
+should not branch directly on `BASE_PLATFORM` unless it is itself part of that
+platform boundary.
+
+Keep platform-specific leaf helpers narrow and named for their platform, such
+as `setup_collect_macos_base_check_results` or
+`setup_collect_linux_debian_base_check_results`. Route platform choice through
+central dispatch helpers so Homebrew, apt, and future platform providers do not
+become scattered call-site decisions.
+
+### 1.3 Public Command Surface
 
 `$BASE_HOME/bin` is the only public command surface that should be added to
 `PATH`.
@@ -64,7 +78,7 @@ exec "$(dirname "$0")/base-wrapper" --project "${BASE_PROJECT:-base}" example_cl
 This keeps direct CLI execution aligned with the same venv and `PYTHONPATH`
 rules that `basectl` uses internally.
 
-### 1.3 `basectl` And `base-wrapper`
+### 1.4 `basectl` And `base-wrapper`
 
 `bin/basectl` is the control plane. It decides whether the user asked to:
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -43,6 +43,40 @@ selection need them. Distribution ID and CPU architecture are separate axes:
 `BASE_PLATFORM` answers "which supported platform family is this?", while a
 future `BASE_ARCH` would answer "which binary/package architecture is this?".
 
+## Platform Policy Boundary
+
+`BASE_PLATFORM` is an input to centralized platform policy, not a general
+branch condition for feature code. `base_init.sh` owns detection and exports
+`BASE_OS` / `BASE_PLATFORM`; it must not decide installer, package-manager, or
+diagnostic behavior.
+
+Setup and check behavior should inspect `BASE_PLATFORM` only through explicit
+platform boundary helpers. The intended shell setup/check shape is:
+
+- `setup_current_platform` resolves the supported platform name from the
+  runtime contract.
+- `setup_platform_supported` reports whether the current platform has a
+  supported setup/check path.
+- `setup_collect_platform_base_check_results` dispatches Base environment
+  checks to platform-specific collectors.
+- `setup_run_platform_install` dispatches setup/install behavior to
+  platform-specific installers.
+
+Leaf helpers should stay platform-specific rather than internally branching on
+every platform. Prefer names such as `setup_collect_macos_base_check_results`,
+`setup_collect_linux_debian_base_check_results`, `setup_run_macos_install`, and
+`setup_run_linux_debian_install`.
+
+Package-manager selection belongs behind this boundary. macOS setup can use
+Homebrew-specific helpers, and Ubuntu/Debian setup can later use apt-specific
+helpers, but ordinary command, diagnostic, and artifact code should call the
+platform boundary instead of checking `BASE_PLATFORM` directly.
+
+Python project artifact management has a separate future seam. If system
+packages become project artifacts on Linux, the Python artifact registry should
+learn platform-aware providers instead of inheriting the shell setup/check
+dispatch directly.
+
 ## Package Manager Mapping
 
 Initial Ubuntu/Debian mappings:


### PR DESCRIPTION
## Summary

- Documents `BASE_PLATFORM` as an input to centralized platform policy, not a broad call-site branch condition.
- Adds the intended setup/check helper shape for platform dispatch before Ubuntu-specific behavior grows.
- Adds a standards rule keeping platform-specific decisions behind explicit boundary helpers.

Fixes #1332.
Part of #562.

## Validation

- `git diff --check`
- `rg -n "^### 1\\." STANDARDS.md`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash PYTHONPATH=/Users/rameshhp/work/base/lib/python:/Users/rameshhp/work/base/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_base_cli_docs.py tests/test_observability_docs.py`