### PR TITLE
Centralize setup and check platform dispatch

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -356,6 +356,43 @@ setup_ci_runtime_only() {
     [[ "${BASE_CI:-false}" == true && "$OSTYPE" != darwin* ]]
 }
 
+setup_current_platform() {
+    local platform
+
+    if [[ -n "${BASE_SETUP_TEST_PLATFORM+x}" ]]; then
+        setup_reject_test_hook_if_disallowed BASE_SETUP_TEST_PLATFORM
+        platform="$BASE_SETUP_TEST_PLATFORM"
+    else
+        platform="${BASE_PLATFORM:-unsupported}"
+    fi
+    if [[ -z "$platform" ]]; then
+        platform=unsupported
+    fi
+    printf '%s\n' "$platform"
+}
+
+setup_platform_supported() {
+    local platform="${1:-}"
+
+    if [[ -z "$platform" ]]; then
+        platform="$(setup_current_platform)" || return 1
+    fi
+    case "$platform" in
+        macos)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+setup_unsupported_platform_message() {
+    local platform="$1"
+
+    printf "The setup/check platform path currently supports macOS only (BASE_PLATFORM='%s').\n" "$platform"
+}
+
 setup_allow_test_hooks() {
     [[ "${BASE_TEST_MODE:-false}" == true || "${CI:-false}" == true ]]
 }
@@ -1880,8 +1917,6 @@ setup_collect_macos_base_check_results() {
     local refresh_brew_failure_mode="${1:-warn}"
     local tmpdir
 
-    setup_clear_check_results
-    setup_require_macos
     click_package="$(setup_click_package)"
     pyyaml_package="$(setup_pyyaml_package)"
     setup_ensure_cached_paths
@@ -1916,6 +1951,20 @@ setup_collect_macos_base_check_results() {
     rm -rf "$tmpdir"
 
     return "$missing"
+}
+
+setup_collect_platform_base_check_results() {
+    local platform
+
+    platform="$(setup_current_platform)" || return 1
+    case "$platform" in
+        macos)
+            setup_collect_macos_base_check_results "$@"
+            ;;
+        *)
+            fatal_error "$(setup_unsupported_platform_message "$platform")"
+            ;;
+    esac
 }
 
 setup_collect_ci_runtime_check_results() {
@@ -1982,12 +2031,13 @@ setup_collect_ci_runtime_check_results() {
 }
 
 setup_collect_base_check_results() {
+    setup_clear_check_results
     if setup_ci_runtime_only; then
         setup_collect_ci_runtime_check_results
         return $?
     fi
 
-    setup_collect_macos_base_check_results "$@"
+    setup_collect_platform_base_check_results "$@"
 }
 
 setup_print_check_text_results() {
@@ -2153,13 +2203,7 @@ setup_run_ci_runtime_install() {
     fi
 }
 
-setup_run_install() {
-    if setup_ci_runtime_only; then
-        setup_run_ci_runtime_install
-        return $?
-    fi
-
-    setup_require_macos
+setup_run_macos_install() {
     setup_install_homebrew
     setup_install_xcode_tools
     setup_install_python
@@ -2181,4 +2225,27 @@ setup_run_install() {
     else
         log_info "Base CLI setup is complete."
     fi
+}
+
+setup_run_platform_install() {
+    local platform
+
+    platform="$(setup_current_platform)" || return 1
+    case "$platform" in
+        macos)
+            setup_run_macos_install
+            ;;
+        *)
+            fatal_error "$(setup_unsupported_platform_message "$platform")"
+            ;;
+    esac
+}
+
+setup_run_install() {
+    if setup_ci_runtime_only; then
+        setup_run_ci_runtime_install
+        return $?
+    fi
+
+    setup_run_platform_install
 }

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -71,6 +71,15 @@ load ./setup_helpers.bash
     [[ "$output" == *"Base CLI environment check passed."* ]]
 }
 
+@test "basectl check rejects unsupported BASE_PLATFORM before Homebrew probes" {
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-unknown check
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"supports macOS only"* ]]
+    [[ "$output" == *"BASE_PLATFORM='linux-unknown'"* ]]
+    [[ "$output" != *"Homebrew is not installed."* ]]
+}
+
 @test "basectl check preserves text order while base probes overlap" {
     local click_line homebrew_line python_line pyyaml_line venv_line xcode_line
     local venv_dir="$TEST_HOME/.base.d/base/.venv"

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -10,6 +10,26 @@ normalize_tty_output() {
     printf '%s' "$text"
 }
 
+create_doctor_uname_stub() {
+    local fake_bin="$1"
+
+    cat > "$fake_bin/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    ""|-s)
+        printf 'Darwin\n'
+        exit 0
+        ;;
+esac
+
+if [[ -x /usr/bin/uname ]]; then
+    exec /usr/bin/uname "$@"
+fi
+exec /bin/uname "$@"
+EOF
+    chmod +x "$fake_bin/uname"
+}
+
 run_tty_script() {
     local script_path="$1"
     local command
@@ -30,6 +50,7 @@ create_doctor_success_stubs() {
     local venv_python="$2"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    create_doctor_uname_stub "$fake_bin"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "list" ]]; then
@@ -198,6 +219,7 @@ EOF
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    create_doctor_uname_stub "$fake_bin"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "list" ]]; then
@@ -276,6 +298,7 @@ EOF
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    create_doctor_uname_stub "$fake_bin"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "list" ]]; then
@@ -339,6 +362,7 @@ EOF
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    create_doctor_uname_stub "$fake_bin"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "list" ]]; then
@@ -413,10 +437,12 @@ EOF
 }
 
 @test "basectl doctor reports errors with suggested fixes" {
+    create_doctor_uname_stub "$TEST_MOCKBIN"
+
     run env \
         HOME="$TEST_HOME" \
         OSTYPE="darwin24" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         BASE_SETUP_BREW_BIN="$TEST_TMPDIR/missing-brew" \
         BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/missing-xcode-tools" \
         "$BASE_REPO_ROOT/bin/basectl" doctor
@@ -429,10 +455,12 @@ EOF
 }
 
 @test "basectl doctor text uses shared base check recovery hints" {
+    create_doctor_uname_stub "$TEST_MOCKBIN"
+
     run env \
         HOME="$TEST_HOME" \
         OSTYPE="darwin24" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         BASE_SETUP_BREW_BIN="$TEST_TMPDIR/missing-brew" \
         BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/missing-xcode-tools" \
         "$BASE_REPO_ROOT/bin/basectl" doctor
@@ -449,6 +477,7 @@ EOF
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    create_doctor_uname_stub "$fake_bin"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "list" ]]; then
@@ -502,10 +531,12 @@ EOF
 }
 
 @test "basectl doctor --format json reports structured findings" {
+    create_doctor_uname_stub "$TEST_MOCKBIN"
+
     run --separate-stderr env \
         HOME="$TEST_HOME" \
         OSTYPE="darwin24" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         BASE_SETUP_BREW_BIN="$TEST_TMPDIR/missing-brew" \
         BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/missing-xcode-tools" \
         "$BASE_REPO_ROOT/bin/basectl" doctor --format json
@@ -531,6 +562,7 @@ EOF
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    create_doctor_uname_stub "$fake_bin"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "list" ]]; then
@@ -596,6 +628,7 @@ EOF
     local workspace="$TEST_TMPDIR/workspace"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$(dirname "$project_python")" "$workspace/demo"
+    create_doctor_uname_stub "$fake_bin"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
@@ -683,6 +716,7 @@ EOF
     local workspace="$TEST_TMPDIR/workspace"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$(dirname "$project_python")" "$workspace/demo"
+    create_doctor_uname_stub "$fake_bin"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
@@ -768,6 +802,7 @@ EOF
     local workspace="$TEST_TMPDIR/workspace"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$(dirname "$project_python")" "$workspace/demo"
+    create_doctor_uname_stub "$fake_bin"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash
@@ -859,6 +894,7 @@ EOF
     local workspace="$TEST_TMPDIR/workspace"
 
     mkdir -p "$fake_bin" "$(dirname "$venv_python")" "$(dirname "$project_python")" "$workspace/demo"
+    create_doctor_uname_stub "$fake_bin"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     cat > "$fake_bin/brew" <<'EOF'
 #!/usr/bin/env bash

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -9,6 +9,7 @@ run_setup_common_script() {
     bash_libs_dir="$(base_bash_libs_fixture_dir)"
     run env \
         HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         BASE_HOME="$BASE_REPO_ROOT" \
         BASE_BASH_LIBS_DIR="$bash_libs_dir" \
         PYTHONPATH="${BASE_SETUP_TEST_PYTHONPATH:-}" \
@@ -52,4 +53,28 @@ run_setup_common_script() {
     [[ "$output" == *"homebrew=BASE-D001/Homebrew"* ]]
     [[ "$output" == *"venv=BASE-D004/Base virtualenv"* ]]
     [[ "$output" == *"unknown=BASE-D000/unexpected"* ]]
+}
+
+@test "setup_common exposes centralized platform policy helpers" {
+    run_setup_common_script '
+        for helper in \
+            setup_current_platform \
+            setup_platform_supported \
+            setup_collect_platform_base_check_results \
+            setup_run_platform_install; do
+            declare -F "$helper" >/dev/null || {
+                printf "missing helper: %s\n" "$helper" >&2
+                exit 10
+            }
+        done
+        printf "platform=%s\n" "$(setup_current_platform)"
+        setup_platform_supported macos || exit 11
+        if setup_platform_supported linux-unknown; then
+            printf "linux-unknown should not be supported yet\n" >&2
+            exit 12
+        fi
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"platform=macos"* ]]
 }

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -86,12 +86,11 @@ load ./setup_helpers.bash
 }
 
 @test "basectl setup fails on unsupported operating systems" {
-    OSTYPE_OVERRIDE="linux-gnu"
-
-    run_base_command setup
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-unknown setup
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"supports macOS only"* ]]
+    [[ "$output" == *"BASE_PLATFORM='linux-unknown'"* ]]
 }
 
 @test "basectl setup is idempotent when brew, xcode tools, python, and the venv already exist" {

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -13,6 +13,25 @@ setup() {
     unset OSTYPE_OVERRIDE
 
     mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
+    create_uname_stub
+}
+
+create_uname_stub() {
+    cat > "$TEST_MOCKBIN/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    ""|-s)
+        printf 'Darwin\n'
+        exit 0
+        ;;
+esac
+
+if [[ -x /usr/bin/uname ]]; then
+    exec /usr/bin/uname "$@"
+fi
+exec /bin/uname "$@"
+EOF
+    chmod +x "$TEST_MOCKBIN/uname"
 }
 
 create_xcode_stubs() {

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -57,6 +57,22 @@ create_base_runtime() {
 }
 
 create_fake_platform_tools() {
+    cat > "$TEST_MOCKBIN/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    ""|-s)
+        printf 'Darwin\n'
+        exit 0
+        ;;
+esac
+
+if [[ -x /usr/bin/uname ]]; then
+    exec /usr/bin/uname "$@"
+fi
+exec /bin/uname "$@"
+EOF
+    chmod +x "$TEST_MOCKBIN/uname"
+
     cat > "$TEST_MOCKBIN/brew" <<'EOF'
 #!/usr/bin/env bash
 case "${1:-}" in
@@ -141,6 +157,7 @@ run_basectl() {
         HOME="$TEST_HOME" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         OSTYPE=darwin24 \
+        BASE_TEST_MODE=true \
         BASE_INTEGRATION_BREW_PREFIX="$TEST_TMPDIR/homebrew-prefix" \
         BASE_INTEGRATION_STATE_DIR="$TEST_STATE_DIR" \
         BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
@@ -155,6 +172,7 @@ run_basectl_separate_stderr() {
         HOME="$TEST_HOME" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         OSTYPE=darwin24 \
+        BASE_TEST_MODE=true \
         BASE_INTEGRATION_BREW_PREFIX="$TEST_TMPDIR/homebrew-prefix" \
         BASE_INTEGRATION_STATE_DIR="$TEST_STATE_DIR" \
         BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \


### PR DESCRIPTION
## Summary

- Add centralized setup platform helpers around `BASE_PLATFORM`.
- Route `basectl setup` and `basectl check` through explicit platform dispatch while preserving the current macOS implementation.
- Keep the CI runtime-only path ahead of platform dispatch so Linux CI checks continue to work before apt-backed setup exists.

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure --filter "setup_common exposes centralized platform policy helpers" cli/bash/commands/basectl/tests/setup-common.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure --filter "basectl setup fails on unsupported operating systems" cli/bash/commands/basectl/tests/setup.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure --filter "basectl check rejects unsupported BASE_PLATFORM before Homebrew probes" cli/bash/commands/basectl/tests/check.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure cli/bash/commands/basectl/tests/setup-common.bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/ci.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure cli/bash/commands/basectl/tests/doctor.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure cli/bash/commands/basectl/tests/*.bats lib/bash/runtime/tests/runtime_bashrc.bats lib/bash/version/tests/lib_version.bats lib/shell/completions/tests/completions.bats tests/base_test.bats tests/base_init.bats tests/bootstrap.bats tests/install.bats tests/source_guards.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure tests/integration/base_workflows.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/setup_common.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-1333-base-test BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-1333-base-test-2 BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-1333-base-test-3 BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Fixes #1333.
Part of #562.
