### PR TITLE
Make check and doctor Linux-aware for Ubuntu/Debian

### DIFF
--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -28,17 +28,16 @@ Profiles:
   ai  - AI coding assistant tooling.
 
 Purpose:
-  Verify the local Base CLI environment and, when provided, project artifacts on macOS without making changes.
+  Verify the local Base CLI environment and, when provided, project artifacts on supported platforms without making changes.
   Use check for a quick pass/fail result; use doctor for finding IDs and fix hints.
 
 See also:
   basectl doctor [project] [options]
 
 Check does:
-  1. Verify Homebrew is installed.
-  2. Verify Xcode Command Line Tools are installed and warn when Homebrew reports
-     them outdated or incomplete.
-  3. Verify Python 3.13 is installed via Homebrew.
+  1. Verify platform-specific runtime prerequisites.
+  2. On macOS, verify Homebrew, Xcode Command Line Tools, and Homebrew Python.
+  3. On Ubuntu/Debian Linux, verify system python3 is available.
   4. Verify ~/.base.d/base/.venv is healthy.
   5. Verify prerequisite profiles when --profile is passed.
   6. Verify project manifest artifacts when a project name is passed.

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -257,8 +257,6 @@ base_doctor_subcommand_main() {
         return $?
     fi
 
-    setup_require_macos
-
     if [[ "$output_format" == json ]]; then
         base_doctor_run_json "$project" "$remote_network"
         return $?

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -378,7 +378,7 @@ setup_platform_supported() {
         platform="$(setup_current_platform)" || return 1
     fi
     case "$platform" in
-        macos)
+        macos|linux-debian)
             return 0
             ;;
         *)
@@ -390,7 +390,13 @@ setup_platform_supported() {
 setup_unsupported_platform_message() {
     local platform="$1"
 
-    printf "The setup/check platform path currently supports macOS only (BASE_PLATFORM='%s').\n" "$platform"
+    printf "The setup/check platform path currently supports macOS and Ubuntu/Debian Linux only (BASE_PLATFORM='%s').\n" "$platform"
+}
+
+setup_unsupported_install_platform_message() {
+    local platform="$1"
+
+    printf "The setup platform path currently supports macOS only (BASE_PLATFORM='%s').\n" "$platform"
 }
 
 setup_allow_test_hooks() {
@@ -438,6 +444,10 @@ setup_recovery_base_bash_libraries() {
 
 setup_recovery_ci_python() {
     printf "%s\n" "Install Python 3.13 or set BASE_SETUP_PYTHON_BIN, then rerun 'basectl ci'."
+}
+
+setup_recovery_linux_python() {
+    printf "%s\n" "Install python3 and python3-venv, or set BASE_SETUP_PYTHON_BIN, then rerun 'basectl check'."
 }
 
 setup_recovery_project_layer() {
@@ -822,6 +832,22 @@ setup_find_python_bin() {
     fi
 
     if setup_allow_system_python && command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+
+    return 1
+}
+
+setup_find_linux_python_bin() {
+    if [[ -n "${BASE_SETUP_PYTHON_BIN:-}" ]]; then
+        setup_reject_test_hook_if_disallowed BASE_SETUP_PYTHON_BIN
+        [[ -x "${BASE_SETUP_PYTHON_BIN}" ]] || return 1
+        printf '%s\n' "${BASE_SETUP_PYTHON_BIN}"
+        return 0
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
         command -v python3
         return 0
     fi
@@ -1953,6 +1979,70 @@ setup_collect_macos_base_check_results() {
     return "$missing"
 }
 
+setup_collect_linux_debian_base_check_results() {
+    local click_package
+    local missing=0
+    local pyyaml_package
+    local python_bin
+
+    click_package="$(setup_click_package)"
+    pyyaml_package="$(setup_pyyaml_package)"
+    setup_ensure_cached_paths
+
+    setup_add_base_bash_libraries_check_result
+
+    if python_bin="$(setup_find_linux_python_bin)"; then
+        setup_add_check_result \
+            "python" \
+            true \
+            "Python is available for Ubuntu/Debian runtime checks." \
+            "" \
+            "Resolved Python binary: $python_bin"
+    else
+        setup_add_check_result \
+            "python" \
+            false \
+            "Python is not available for Ubuntu/Debian runtime checks." \
+            "$(setup_recovery_linux_python)"
+        missing=1
+    fi
+
+    if setup_virtualenv_healthy; then
+        setup_add_check_result "base_virtualenv" true "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+    else
+        setup_add_check_result \
+            "base_virtualenv" \
+            false \
+            "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
+            "$(setup_recovery_venv)"
+        missing=1
+    fi
+
+    if setup_base_python_package_installed "$pyyaml_package"; then
+        setup_add_check_result "pyyaml" true "$(setup_base_python_package_check_message "$pyyaml_package" true)"
+    else
+        setup_add_check_result \
+            "pyyaml" \
+            false \
+            "$(setup_base_python_package_check_message "$pyyaml_package" false)" \
+            "$(setup_recovery_base_python_package)"
+        missing=1
+    fi
+
+    if setup_base_python_package_installed "$click_package"; then
+        setup_add_check_result "click" true "$(setup_base_python_package_check_message "$click_package" true)"
+    else
+        setup_add_check_result \
+            "click" \
+            false \
+            "$(setup_base_python_package_check_message "$click_package" false)" \
+            "$(setup_recovery_base_python_package)"
+        missing=1
+    fi
+
+    return "$missing"
+}
+
 setup_collect_platform_base_check_results() {
     local platform
 
@@ -1960,6 +2050,9 @@ setup_collect_platform_base_check_results() {
     case "$platform" in
         macos)
             setup_collect_macos_base_check_results "$@"
+            ;;
+        linux-debian)
+            setup_collect_linux_debian_base_check_results "$@"
             ;;
         *)
             fatal_error "$(setup_unsupported_platform_message "$platform")"
@@ -2236,7 +2329,7 @@ setup_run_platform_install() {
             setup_run_macos_install
             ;;
         *)
-            fatal_error "$(setup_unsupported_platform_message "$platform")"
+            fatal_error "$(setup_unsupported_install_platform_message "$platform")"
             ;;
     esac
 }

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -16,7 +16,7 @@ load ./setup_helpers.bash
     [[ "$output" == *"sre - production/SRE prerequisite tooling."* ]]
     [[ "$output" == *"ai  - AI coding assistant tooling."* ]]
     [[ "$output" == *"--remote-network"* ]]
-    [[ "$output" == *"Verify the local Base CLI environment and, when provided, project artifacts on macOS without making changes."* ]]
+    [[ "$output" == *"Verify the local Base CLI environment and, when provided, project artifacts on supported platforms without making changes."* ]]
     [[ "$output" == *"Use check for a quick pass/fail result; use doctor for finding IDs and fix hints."* ]]
     [[ "$output" == *"See also:"* ]]
     [[ "$output" == *"basectl doctor [project] [options]"* ]]
@@ -75,9 +75,29 @@ load ./setup_helpers.bash
     run_base_command BASE_SETUP_TEST_PLATFORM=linux-unknown check
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"supports macOS only"* ]]
+    [[ "$output" == *"supports macOS and Ubuntu/Debian Linux only"* ]]
     [[ "$output" == *"BASE_PLATFORM='linux-unknown'"* ]]
     [[ "$output" != *"Homebrew is not installed."* ]]
+}
+
+@test "basectl check supports linux-debian without Homebrew or Xcode probes" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_system_python3_stub
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian check
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Python is available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Virtual environment is healthy at '$venv_dir'."* ]]
+    [[ "$output" == *"Python package 'PyYAML' is installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Python package 'click' is installed in the Base virtual environment."* ]]
+    [[ "$output" == *"Base CLI environment check passed."* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
 }
 
 @test "basectl check preserves text order while base probes overlap" {
@@ -308,7 +328,10 @@ load ./setup_helpers.bash
     grep -Fq '"project": "demo"' "$record_path"
     grep -Fq '"command": "basectl check"' "$record_path"
     grep -Fq '"status": "error"' "$record_path"
-    ! grep -Fq '"status": "ok"' "$record_path"
+    if grep -Fq '"status": "ok"' "$record_path"; then
+        printf 'unexpected ok status in failed check record\n' >&2
+        return 1
+    fi
     [[ "$output" == *"Virtual environment is missing at '$TEST_HOME/.base.d/demo/.venv'."* ]]
 }
 
@@ -399,6 +422,29 @@ load ./setup_helpers.bash
     click_line="$(printf '%s\n' "$output" | grep -n '"name":"click"' | cut -d: -f1)"
     [ "$venv_line" -lt "$pyyaml_line" ]
     [ "$pyyaml_line" -lt "$click_line" ]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl check --format json supports linux-debian readiness findings" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_system_python3_stub
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command_separate_stderr BASE_SETUP_TEST_PLATFORM=linux-debian check --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    assert_base_check_json_status_for_readiness "$output"
+    [[ "$output" == *'"id":"BASE-D003","status":"ok","name":"python","message":"Python is available for Ubuntu/Debian runtime checks."'* ]]
+    [[ "$output" == *'"id":"BASE-D004","status":"ok","name":"base_virtualenv"'* ]]
+    [[ "$output" == *'"id":"BASE-D005","status":"ok","name":"pyyaml"'* ]]
+    [[ "$output" == *'"id":"BASE-D006","status":"ok","name":"click"'* ]]
+    assert_base_bash_libraries_json_finding "$output"
+    [[ "$output" != *'"name":"homebrew"'* ]]
+    [[ "$output" != *'"name":"xcode_command_line_tools"'* ]]
     [ "${stderr:-}" = "" ]
 }
 

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -102,6 +102,36 @@ EOF
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
 }
 
+create_doctor_linux_success_stubs() {
+    local fake_bin="$1"
+    local venv_python="$2"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    cat > "$fake_bin/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+exit 1
+EOF
+    chmod +x "$fake_bin/python3" "$venv_python"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+}
+
 write_doctor_tty_script() {
     local script_path="$1"
     local fake_bin="$2"
@@ -293,6 +323,30 @@ EOF
     [[ "$output" == *"Base doctor found no blocking issues."* ]]
 }
 
+@test "basectl doctor supports linux-debian without Homebrew or Xcode probes" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    create_doctor_linux_success_stubs "$fake_bin" "$venv_python"
+
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="linux-gnu" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_MODE=true \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base doctor"* ]]
+    [[ "$output" == *"ok"*"BASE-D003"*"Python"*"Python is available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"ok"*"BASE-D004"*"Base virtualenv"*"Virtual environment is healthy at"* ]]
+    [[ "$output" == *"Base doctor found no blocking issues."* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
+}
+
 @test "basectl doctor warns when Homebrew reports outdated Xcode Command Line Tools" {
     local fake_bin="$TEST_TMPDIR/bin"
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
@@ -454,6 +508,22 @@ EOF
     [[ "$output" == *"Base doctor found"*"blocking issue(s)."* ]]
 }
 
+@test "basectl doctor rejects unsupported BASE_PLATFORM before Homebrew probes" {
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="linux-gnu" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_MODE=true \
+        BASE_SETUP_TEST_PLATFORM=linux-unknown \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"supports macOS and Ubuntu/Debian Linux only"* ]]
+    [[ "$output" == *"BASE_PLATFORM='linux-unknown'"* ]]
+    [[ "$output" != *"Homebrew is not installed."* ]]
+    [[ "$output" != *"Xcode Command Line Tools are not installed."* ]]
+}
+
 @test "basectl doctor text uses shared base check recovery hints" {
     create_doctor_uname_stub "$TEST_MOCKBIN"
 
@@ -554,6 +624,35 @@ EOF
     [[ "$output" == *'"id":"BASE-D005","status":"error","name":"pyyaml"'* ]]
     [[ "$output" == *'"id":"BASE-D006","status":"error","name":"click"'* ]]
     [[ "$output" != *"Base doctor"* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl doctor --format json supports linux-debian readiness findings" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    create_doctor_linux_success_stubs "$fake_bin" "$venv_python"
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        OSTYPE="linux-gnu" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_MODE=true \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "ok"'* || "$output" == *'"status": "warn"'* ]]
+    [[ "$output" == *'"findings":'* ]]
+    [[ "$output" == *'"id":"BASE-D003","status":"ok","name":"python","message":"Python is available for Ubuntu/Debian runtime checks."'* ]]
+    [[ "$output" == *'"id":"BASE-D004","status":"ok","name":"base_virtualenv"'* ]]
+    [[ "$output" == *'"id":"BASE-D005","status":"ok","name":"pyyaml"'* ]]
+    [[ "$output" == *'"id":"BASE-D006","status":"ok","name":"click"'* ]]
+    assert_base_bash_libraries_json_finding "$output"
+    [[ "$output" != *'"name":"homebrew"'* ]]
+    [[ "$output" != *'"name":"xcode_command_line_tools"'* ]]
     [ "${stderr:-}" = "" ]
 }
 

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -69,9 +69,10 @@ run_setup_common_script() {
         done
         printf "platform=%s\n" "$(setup_current_platform)"
         setup_platform_supported macos || exit 11
+        setup_platform_supported linux-debian || exit 12
         if setup_platform_supported linux-unknown; then
             printf "linux-unknown should not be supported yet\n" >&2
-            exit 12
+            exit 13
         fi
     '
 


### PR DESCRIPTION
## Summary

- Route `BASE_PLATFORM=linux-debian` through a dedicated check/doctor collector.
- Avoid Homebrew and Xcode findings on Ubuntu/Debian while preserving macOS behavior.
- Keep `linux-unknown` explicit with unsupported-platform guidance and leave setup/install macOS-only for the next apt-backed slice.
- Update `basectl check --help` and add text/JSON BATS coverage for Linux check and doctor output.

## Validation

- `bats cli/bash/commands/basectl/tests/check.bats`
- `bats cli/bash/commands/basectl/tests/doctor.bats`
- `bats cli/bash/commands/basectl/tests/setup-common.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/doctor.sh cli/bash/commands/basectl/subcommands/check.sh cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats cli/bash/commands/basectl/tests/setup-common.bats`
- `git diff --check`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-1334-base-test BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Fixes #1334
Part of #562
