### PR TITLE
Add Ubuntu prerequisite diagnostics and fix hints

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -450,6 +450,17 @@ setup_recovery_linux_python() {
     printf "%s\n" "Install python3 and python3-venv, or set BASE_SETUP_PYTHON_BIN, then rerun 'basectl check'."
 }
 
+setup_recovery_linux_apt_package() {
+    local display_name="$1"
+    local package_name="$2"
+
+    printf "Install %s with 'sudo apt-get install %s', then rerun 'basectl check'.\n" "$display_name" "$package_name"
+}
+
+setup_recovery_linux_github_cli() {
+    printf "%s\n" "Install GitHub CLI 'gh' from the official GitHub CLI apt repository, or install apt package 'gh' if that repository is already configured, then rerun 'basectl check'."
+}
+
 setup_recovery_project_layer() {
     printf "%s\n" "Review the Python error above, then rerun 'basectl setup -v' for more detail."
 }
@@ -855,6 +866,43 @@ setup_find_linux_python_bin() {
     return 1
 }
 
+setup_test_linux_tool_forced_missing() {
+    local missing_tools="${BASE_SETUP_TEST_MISSING_LINUX_TOOLS:-}"
+    local tool="$1"
+
+    [[ -n "${BASE_SETUP_TEST_MISSING_LINUX_TOOLS+x}" ]] || return 1
+    setup_reject_test_hook_if_disallowed BASE_SETUP_TEST_MISSING_LINUX_TOOLS
+    case ",$missing_tools," in
+        *,"$tool",*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+setup_linux_command_path() {
+    local command_name="$1"
+
+    setup_test_linux_tool_forced_missing "$command_name" && return 1
+    command -v "$command_name" 2>/dev/null
+}
+
+setup_linux_python_venv_available() {
+    local python_bin="$1"
+
+    [[ -n "$python_bin" ]] || return 1
+    "$python_bin" -m venv --help >/dev/null 2>&1
+}
+
+setup_linux_bash_version_supported() {
+    local major="${BASH_VERSINFO[0]:-0}"
+    local minor="${BASH_VERSINFO[1]:-0}"
+
+    ((major > 4 || (major == 4 && minor >= 2)))
+}
+
 setup_create_virtualenv() {
     local venv_dir python_bin
 
@@ -1015,6 +1063,30 @@ setup_base_check_finding_id() {
         base_bash_libraries)
             printf '%s\n' "BASE-D007"
             ;;
+        bash)
+            printf '%s\n' "BASE-D008"
+            ;;
+        python_venv)
+            printf '%s\n' "BASE-D009"
+            ;;
+        git)
+            printf '%s\n' "BASE-D010"
+            ;;
+        gh)
+            printf '%s\n' "BASE-D011"
+            ;;
+        bats)
+            printf '%s\n' "BASE-D012"
+            ;;
+        shellcheck)
+            printf '%s\n' "BASE-D013"
+            ;;
+        jq)
+            printf '%s\n' "BASE-D014"
+            ;;
+        go)
+            printf '%s\n' "BASE-D015"
+            ;;
         *)
             printf '%s\n' "BASE-D000"
             ;;
@@ -1043,6 +1115,30 @@ setup_base_check_display_name() {
             ;;
         base_bash_libraries)
             printf '%s\n' "Base Bash libraries"
+            ;;
+        bash)
+            printf '%s\n' "Bash"
+            ;;
+        python_venv)
+            printf '%s\n' "Python venv support"
+            ;;
+        git)
+            printf '%s\n' "Git"
+            ;;
+        gh)
+            printf '%s\n' "GitHub CLI"
+            ;;
+        bats)
+            printf '%s\n' "BATS"
+            ;;
+        shellcheck)
+            printf '%s\n' "ShellCheck"
+            ;;
+        jq)
+            printf '%s\n' "jq"
+            ;;
+        go)
+            printf '%s\n' "Go"
             ;;
         *)
             printf '%s\n' "$1"
@@ -1979,6 +2075,66 @@ setup_collect_macos_base_check_results() {
     return "$missing"
 }
 
+setup_add_linux_bash_check_result() {
+    if setup_linux_bash_version_supported; then
+        setup_add_check_result \
+            "bash" \
+            true \
+            "Bash 4.2+ is available for Base shell runtime." \
+            "" \
+            "Resolved Bash version: ${BASH_VERSION:-unknown}"
+    else
+        setup_add_check_result \
+            "bash" \
+            false \
+            "Bash 4.2+ is not available for Base shell runtime." \
+            "$(setup_recovery_linux_apt_package Bash bash)"
+        return 1
+    fi
+}
+
+setup_add_linux_python_venv_check_result() {
+    local python_bin="$1"
+
+    if setup_linux_python_venv_available "$python_bin"; then
+        setup_add_check_result \
+            "python_venv" \
+            true \
+            "Python venv support is available for Ubuntu/Debian runtime checks."
+    else
+        setup_add_check_result \
+            "python_venv" \
+            false \
+            "Python venv support is not available for Ubuntu/Debian runtime checks." \
+            "$(setup_recovery_linux_apt_package python3-venv python3-venv)"
+        return 1
+    fi
+}
+
+setup_add_linux_command_check_result() {
+    local command_name="$1"
+    local finding_name="$2"
+    local display_name="$3"
+    local recovery="$4"
+    local command_path
+
+    if command_path="$(setup_linux_command_path "$command_name")"; then
+        setup_add_check_result \
+            "$finding_name" \
+            true \
+            "$display_name is available for Ubuntu/Debian runtime checks." \
+            "" \
+            "Resolved $display_name binary: $command_path"
+    else
+        setup_add_check_result \
+            "$finding_name" \
+            false \
+            "$display_name is not available for Ubuntu/Debian runtime checks." \
+            "$recovery"
+        return 1
+    fi
+}
+
 setup_collect_linux_debian_base_check_results() {
     local click_package
     local missing=0
@@ -1989,6 +2145,7 @@ setup_collect_linux_debian_base_check_results() {
     pyyaml_package="$(setup_pyyaml_package)"
     setup_ensure_cached_paths
 
+    setup_add_linux_bash_check_result || missing=1
     setup_add_base_bash_libraries_check_result
 
     if python_bin="$(setup_find_linux_python_bin)"; then
@@ -2006,6 +2163,7 @@ setup_collect_linux_debian_base_check_results() {
             "$(setup_recovery_linux_python)"
         missing=1
     fi
+    setup_add_linux_python_venv_check_result "$python_bin" || missing=1
 
     if setup_virtualenv_healthy; then
         setup_add_check_result "base_virtualenv" true "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
@@ -2039,6 +2197,37 @@ setup_collect_linux_debian_base_check_results() {
             "$(setup_recovery_base_python_package)"
         missing=1
     fi
+
+    setup_add_linux_command_check_result \
+        "git" \
+        "git" \
+        "Git" \
+        "$(setup_recovery_linux_apt_package git git)" || missing=1
+    setup_add_linux_command_check_result \
+        "gh" \
+        "gh" \
+        "GitHub CLI 'gh'" \
+        "$(setup_recovery_linux_github_cli)" || missing=1
+    setup_add_linux_command_check_result \
+        "bats" \
+        "bats" \
+        "BATS" \
+        "$(setup_recovery_linux_apt_package bats bats)" || missing=1
+    setup_add_linux_command_check_result \
+        "shellcheck" \
+        "shellcheck" \
+        "ShellCheck" \
+        "$(setup_recovery_linux_apt_package shellcheck shellcheck)" || missing=1
+    setup_add_linux_command_check_result \
+        "jq" \
+        "jq" \
+        "jq" \
+        "$(setup_recovery_linux_apt_package jq jq)" || missing=1
+    setup_add_linux_command_check_result \
+        "go" \
+        "go" \
+        "Go" \
+        "$(setup_recovery_linux_apt_package Go golang-go)" || missing=1
 
     return "$missing"
 }

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -84,6 +84,7 @@ load ./setup_helpers.bash
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_system_python3_stub
+    create_linux_prerequisite_stubs
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
     create_base_venv_stub "$venv_dir"
@@ -96,6 +97,49 @@ load ./setup_helpers.bash
     [[ "$output" == *"Python package 'PyYAML' is installed in the Base virtual environment."* ]]
     [[ "$output" == *"Python package 'click' is installed in the Base virtual environment."* ]]
     [[ "$output" == *"Base CLI environment check passed."* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl check linux-debian reports missing prerequisite apt hints" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    cat > "$TEST_MOCKBIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && "${3:-}" == "--help" ]]; then
+    exit 1
+fi
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/python3"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_LINUX_TOOLS=git,gh,bats,shellcheck,jq,go \
+        check
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Python venv support is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Install python3-venv with 'sudo apt-get install python3-venv', then rerun 'basectl check'."* ]]
+    [[ "$output" == *"Git is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Install git with 'sudo apt-get install git', then rerun 'basectl check'."* ]]
+    [[ "$output" == *"GitHub CLI 'gh' is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Install GitHub CLI 'gh' from the official GitHub CLI apt repository"* ]]
+    [[ "$output" == *"BATS is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Install bats with 'sudo apt-get install bats', then rerun 'basectl check'."* ]]
+    [[ "$output" == *"ShellCheck is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Install shellcheck with 'sudo apt-get install shellcheck', then rerun 'basectl check'."* ]]
+    [[ "$output" == *"jq is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Install jq with 'sudo apt-get install jq', then rerun 'basectl check'."* ]]
+    [[ "$output" == *"Go is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Install Go with 'sudo apt-get install golang-go', then rerun 'basectl check'."* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
 }
@@ -429,6 +473,7 @@ load ./setup_helpers.bash
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_system_python3_stub
+    create_linux_prerequisite_stubs
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
     create_base_venv_stub "$venv_dir"
@@ -442,6 +487,14 @@ load ./setup_helpers.bash
     [[ "$output" == *'"id":"BASE-D004","status":"ok","name":"base_virtualenv"'* ]]
     [[ "$output" == *'"id":"BASE-D005","status":"ok","name":"pyyaml"'* ]]
     [[ "$output" == *'"id":"BASE-D006","status":"ok","name":"click"'* ]]
+    [[ "$output" == *'"id":"BASE-D008","status":"ok","name":"bash"'* ]]
+    [[ "$output" == *'"id":"BASE-D009","status":"ok","name":"python_venv"'* ]]
+    [[ "$output" == *'"id":"BASE-D010","status":"ok","name":"git"'* ]]
+    [[ "$output" == *'"id":"BASE-D011","status":"ok","name":"gh"'* ]]
+    [[ "$output" == *'"id":"BASE-D012","status":"ok","name":"bats"'* ]]
+    [[ "$output" == *'"id":"BASE-D013","status":"ok","name":"shellcheck"'* ]]
+    [[ "$output" == *'"id":"BASE-D014","status":"ok","name":"jq"'* ]]
+    [[ "$output" == *'"id":"BASE-D015","status":"ok","name":"go"'* ]]
     assert_base_bash_libraries_json_finding "$output"
     [[ "$output" != *'"name":"homebrew"'* ]]
     [[ "$output" != *'"name":"xcode_command_line_tools"'* ]]

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -113,6 +113,10 @@ if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && "${3:-}" == "--help" ]]; then
+    printf 'usage: python3 -m venv ENV_DIR\n'
+    exit 0
+fi
 exit 1
 EOF
     cat > "$venv_python" <<'EOF'
@@ -129,6 +133,13 @@ fi
 exit 1
 EOF
     chmod +x "$fake_bin/python3" "$venv_python"
+    for tool in git gh bats shellcheck jq go; do
+        cat > "$fake_bin/$tool" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+        chmod +x "$fake_bin/$tool"
+    done
     touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
 }
 
@@ -342,7 +353,64 @@ EOF
     [[ "$output" == *"Base doctor"* ]]
     [[ "$output" == *"ok"*"BASE-D003"*"Python"*"Python is available for Ubuntu/Debian runtime checks."* ]]
     [[ "$output" == *"ok"*"BASE-D004"*"Base virtualenv"*"Virtual environment is healthy at"* ]]
+    [[ "$output" == *"ok"*"BASE-D010"*"Git"*"Git is available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"ok"*"BASE-D015"*"Go"*"Go is available for Ubuntu/Debian runtime checks."* ]]
     [[ "$output" == *"Base doctor found no blocking issues."* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl doctor linux-debian reports missing prerequisite apt hints" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$fake_bin" "$(dirname "$venv_python")"
+    cat > "$fake_bin/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && "${3:-}" == "--help" ]]; then
+    exit 1
+fi
+exit 1
+EOF
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+exit 1
+EOF
+    chmod +x "$fake_bin/python3" "$venv_python"
+    touch "$TEST_HOME/.base.d/base/.venv/pyvenv.cfg"
+
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="linux-gnu" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_MODE=true \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_LINUX_TOOLS=git,gh,bats,shellcheck,jq,go \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"error"*"BASE-D009"*"Python venv support"*"Python venv support is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Fix: Install python3-venv with 'sudo apt-get install python3-venv', then rerun 'basectl check'."* ]]
+    [[ "$output" == *"error"*"BASE-D010"*"Git"*"Git is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Fix: Install git with 'sudo apt-get install git', then rerun 'basectl check'."* ]]
+    [[ "$output" == *"error"*"BASE-D011"*"GitHub CLI"*"GitHub CLI 'gh' is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Fix: Install GitHub CLI 'gh' from the official GitHub CLI apt repository"* ]]
+    [[ "$output" == *"error"*"BASE-D015"*"Go"*"Go is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Fix: Install Go with 'sudo apt-get install golang-go', then rerun 'basectl check'."* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
 }
@@ -650,6 +718,14 @@ EOF
     [[ "$output" == *'"id":"BASE-D004","status":"ok","name":"base_virtualenv"'* ]]
     [[ "$output" == *'"id":"BASE-D005","status":"ok","name":"pyyaml"'* ]]
     [[ "$output" == *'"id":"BASE-D006","status":"ok","name":"click"'* ]]
+    [[ "$output" == *'"id":"BASE-D008","status":"ok","name":"bash"'* ]]
+    [[ "$output" == *'"id":"BASE-D009","status":"ok","name":"python_venv"'* ]]
+    [[ "$output" == *'"id":"BASE-D010","status":"ok","name":"git"'* ]]
+    [[ "$output" == *'"id":"BASE-D011","status":"ok","name":"gh"'* ]]
+    [[ "$output" == *'"id":"BASE-D012","status":"ok","name":"bats"'* ]]
+    [[ "$output" == *'"id":"BASE-D013","status":"ok","name":"shellcheck"'* ]]
+    [[ "$output" == *'"id":"BASE-D014","status":"ok","name":"jq"'* ]]
+    [[ "$output" == *'"id":"BASE-D015","status":"ok","name":"go"'* ]]
     assert_base_bash_libraries_json_finding "$output"
     [[ "$output" != *'"name":"homebrew"'* ]]
     [[ "$output" != *'"name":"xcode_command_line_tools"'* ]]

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -160,6 +160,10 @@ create_system_python3_stub() {
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash
 touch "${BASE_SETUP_TEST_STATE_DIR:?}/system-python-ran"
+if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && "${3:-}" == "--help" ]]; then
+    printf 'usage: python3 -m venv ENV_DIR\n'
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     mkdir -p "$3/bin"
     printf 'python-home = system-test\n' > "$3/pyvenv.cfg"
@@ -208,6 +212,18 @@ printf 'unexpected system python3 args: %s\n' "$*" >&2
 exit 1
 EOF
     chmod +x "$TEST_MOCKBIN/python3"
+}
+
+create_linux_prerequisite_stubs() {
+    local tool
+
+    for tool in git gh bats shellcheck jq go; do
+        cat > "$TEST_MOCKBIN/$tool" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+        chmod +x "$TEST_MOCKBIN/$tool"
+    done
 }
 
 create_brew_stub() {

--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -30,6 +30,14 @@ BASE_CHECK_FINDING_IDS = {
     "pyyaml": "BASE-D005",
     "click": "BASE-D006",
     "base_bash_libraries": "BASE-D007",
+    "bash": "BASE-D008",
+    "python_venv": "BASE-D009",
+    "git": "BASE-D010",
+    "gh": "BASE-D011",
+    "bats": "BASE-D012",
+    "shellcheck": "BASE-D013",
+    "jq": "BASE-D014",
+    "go": "BASE-D015",
 }
 
 

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -82,11 +82,19 @@ Doctor commands use the same diagnostic item fields. The top-level
 | --- | --- |
 | `BASE-D001` | Homebrew availability and PATH refresh |
 | `BASE-D002` | Xcode Command Line Tools availability and Homebrew freshness |
-| `BASE-D003` | Homebrew Python formula availability |
+| `BASE-D003` | Base Python runtime availability |
 | `BASE-D004` | Base virtual environment integrity |
 | `BASE-D005` | Base `PyYAML` package availability |
 | `BASE-D006` | Base `click` package availability |
 | `BASE-D007` | Base reusable Bash library source readiness |
+| `BASE-D008` | Bash runtime version support |
+| `BASE-D009` | Python `venv` module support |
+| `BASE-D010` | Git CLI availability |
+| `BASE-D011` | GitHub CLI availability on Ubuntu/Debian |
+| `BASE-D012` | BATS availability on Ubuntu/Debian |
+| `BASE-D013` | ShellCheck availability on Ubuntu/Debian |
+| `BASE-D014` | jq availability on Ubuntu/Debian |
+| `BASE-D015` | Go availability on Ubuntu/Debian source checkouts |
 | `BASE-D101` | Unsupported prerequisite profile manager |
 | `BASE-D102` | Unsupported prerequisite profile version |
 | `BASE-D103` | Homebrew unavailable for prerequisite profile checks |

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -85,8 +85,13 @@ Initial Ubuntu/Debian mappings:
 | --- | --- | --- |
 | Bash 4.2+ | Homebrew `bash` | `apt install bash` |
 | Python 3.13 | Homebrew `python@3.13` | documented manual install first |
+| Python venv support | Homebrew `python@3.13` | `apt install python3-venv` |
+| Git | Xcode Command Line Tools or Homebrew `git` | `apt install git` |
 | BATS | Homebrew `bats-core` | `apt install bats` when available |
 | GitHub CLI | Homebrew `gh` | GitHub CLI apt repository |
+| ShellCheck | Homebrew `shellcheck` | `apt install shellcheck` |
+| jq | Homebrew `jq` | `apt install jq` |
+| Go for source-checkout tests | Homebrew `go` | `apt install golang-go` |
 
 Python should be the conservative piece. Do not silently use arbitrary system
 Python for Base setup unless Linux support explicitly opts into that behavior.


### PR DESCRIPTION
## Summary

- Add Ubuntu/Debian prerequisite diagnostics for Bash, Python venv support, Git, GitHub CLI, BATS, ShellCheck, jq, and Go.
- Keep the checks read-only with `command -v`, Bash version inspection, and `python3 -m venv --help`.
- Emit actionable Ubuntu/Debian fix hints without invoking Homebrew or Xcode paths.
- Assign stable `BASE-D008` through `BASE-D015` finding IDs and document them.

## Validation

- `bats cli/bash/commands/basectl/tests/check.bats`
- `bats cli/bash/commands/basectl/tests/doctor.bats`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/pytest tests/test_doctor_findings_docs.py cli/python/base_setup/tests/test_diagnostics_payloads.py cli/python/base_setup/tests/test_diagnostics.py`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats cli/bash/commands/basectl/tests/setup_helpers.bash`
- `git diff --check`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-1335-base-test BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Fixes #1335
Part of #562
