### PR TITLE
Add conservative Ubuntu setup guidance

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -30,7 +30,7 @@ Profiles:
   ai  - AI coding assistant tooling.
 
 Purpose:
-  Prepare the local Base CLI environment on macOS.
+  Prepare the local Base CLI environment on supported setup platforms.
 
 Setup does:
   1. Install Homebrew if needed.
@@ -44,6 +44,7 @@ Setup does:
 
 Notes:
   - This command is intentionally idempotent.
+  - On Ubuntu/Debian Linux, setup currently provides dry-run manual prerequisite guidance only.
   - The optional project argument resolves a Base project from the workspace
     unless --manifest is provided explicitly.
   - Use `basectl check` to verify the same requirements without making changes.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -2509,6 +2509,22 @@ setup_run_macos_install() {
     fi
 }
 
+setup_linux_debian_apt_prerequisite_command() {
+    printf '%s\n' "sudo apt-get install bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"
+}
+
+setup_run_linux_debian_install() {
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Ubuntu/Debian setup is manual in this release."
+        log_info "Install apt prerequisites with: $(setup_linux_debian_apt_prerequisite_command)"
+        log_info "Install GitHub CLI 'gh' from the official GitHub CLI apt repository."
+        log_info "After installing prerequisites, run 'basectl check' to verify readiness."
+        return 0
+    fi
+
+    fatal_error "Ubuntu/Debian setup is currently manual. Run 'basectl setup --dry-run' for prerequisite guidance, install the listed packages, then rerun 'basectl check'."
+}
+
 setup_run_platform_install() {
     local platform
 
@@ -2516,6 +2532,9 @@ setup_run_platform_install() {
     case "$platform" in
         macos)
             setup_run_macos_install
+            ;;
+        linux-debian)
+            setup_run_linux_debian_install
             ;;
         *)
             fatal_error "$(setup_unsupported_install_platform_message "$platform")"

--- a/cli/bash/commands/basectl/tests/setup-command.bats
+++ b/cli/bash/commands/basectl/tests/setup-command.bats
@@ -9,5 +9,5 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl setup [options]"* ]]
-    [[ "$output" == *"Prepare the local Base CLI environment on macOS."* ]]
+    [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
 }

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -18,7 +18,8 @@ load ./setup_helpers.bash
     [[ "$output" == *"--notify"* ]]
     [[ "$output" == *"--no-notify"* ]]
     [[ "$output" == *"--recreate-venv"* ]]
-    [[ "$output" == *"Prepare the local Base CLI environment on macOS."* ]]
+    [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
+    [[ "$output" == *"On Ubuntu/Debian Linux, setup currently provides dry-run manual prerequisite guidance only."* ]]
     [[ "$output" == *"Create ~/.base.d/config.yaml with workspace.root: ~/work if missing."* ]]
 }
 
@@ -91,6 +92,29 @@ load ./setup_helpers.bash
     [ "$status" -eq 1 ]
     [[ "$output" == *"supports macOS only"* ]]
     [[ "$output" == *"BASE_PLATFORM='linux-unknown'"* ]]
+}
+
+@test "basectl setup --dry-run gives linux-debian manual prerequisite guidance" {
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Ubuntu/Debian setup is manual in this release."* ]]
+    [[ "$output" == *"sudo apt-get install bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
+    [[ "$output" == *"Install GitHub CLI 'gh' from the official GitHub CLI apt repository"* ]]
+    [[ "$output" == *"After installing prerequisites, run 'basectl check' to verify readiness."* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl setup linux-debian fails conservatively with manual guidance" {
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Ubuntu/Debian setup is currently manual."* ]]
+    [[ "$output" == *"Run 'basectl setup --dry-run' for prerequisite guidance"* ]]
+    [[ "$output" == *"then rerun 'basectl check'."* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
 }
 
 @test "basectl setup is idempotent when brew, xcode tools, python, and the venv already exist" {


### PR DESCRIPTION
## Summary
- Route `basectl setup` for `linux-debian` through the centralized platform install boundary.
- Make `setup --dry-run` print manual Ubuntu/Debian prerequisite guidance.
- Keep non-dry-run Linux setup conservative until apt-backed mutation is implemented.
- Update setup help to describe Ubuntu/Debian guidance-only behavior.

## Validation
- `bats --print-output-on-failure --filter "basectl setup prints setup-specific help" cli/bash/commands/basectl/tests/setup-command.bats`
- `bats cli/bash/commands/basectl/tests/setup.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/setup.sh cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/setup-command.bats`
- `git diff --check`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-1336-base-test BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`

Fixes #1336
Part of #562
