### PR TITLE
Implement apt-backed Ubuntu setup

### DIFF
--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -37,7 +37,7 @@ The current command surface covers:
 ## Active Development Direction
 
 The `v1.5.0` release is complete. Future work is tracked in GitHub Issues,
-with full Linux bootstrap support, GitHub CLI install/auth polish for Ubuntu,
+with Linux bootstrap polish, GitHub CLI install/auth polish for Ubuntu,
 Docker/service artifacts, broader prompt ergonomics, and broader setup policy
 work remaining outside the 1.5 release contract.
 
@@ -48,9 +48,8 @@ source builds treated as fallback validation rather than the normal user path.
 Recent released work includes:
 
 - Ubuntu/Debian runtime support through `BASE_PLATFORM=linux-debian`,
-  platform-aware setup/check/doctor dispatch, and source-checkout CI coverage
-- conservative Ubuntu setup guidance until apt-backed bootstrap support is
-  implemented
+  platform-aware setup/check/doctor dispatch, source-checkout CI coverage, and
+  apt-backed setup behind explicit `--dry-run` / `--yes` confirmation
 - `basectl docs` for opening the GitHub README documentation entrypoint
 - standardized `basectl` help, option, logging, and usage-error behavior
 - Python-backed CI setup JSON rendering and Project issue-default handling

--- a/README.md
+++ b/README.md
@@ -1209,7 +1209,7 @@ Intended supported platforms are:
 
 - macOS 14 Sonoma or newer on Apple Silicon
 - macOS 14 Sonoma or newer on Intel Macs
-- Ubuntu/Debian runtime environments with prerequisites installed manually
+- Ubuntu/Debian runtime environments with apt-backed Base setup
 
 The supported macOS version floor is macOS 14 Sonoma. Support means Base is
 tested and expected to work on macOS 14 or newer with Homebrew's supported
@@ -1218,10 +1218,10 @@ Python installed through Base setup. Older macOS releases may work from source,
 but they are outside Base's tested support contract.
 
 Ubuntu/Debian support currently covers runtime checks, project diagnostics,
-source-checkout validation, and clear setup guidance when prerequisites are
-already installed. Full Linux bootstrap support is still narrower than macOS
-setup and should stay behind the platform-policy boundary described in
-[docs/linux-support.md](docs/linux-support.md). Windows is out of scope.
+source-checkout validation, and apt-backed setup for the simple prerequisites
+Base owns. Linux setup remains narrower than macOS setup and should stay behind
+the platform-policy boundary described in [docs/linux-support.md](docs/linux-support.md).
+Windows is out of scope.
 
 The macOS CI floor runs on GitHub's `macos-14` runner. Newer macOS runners may
 be added for coverage, but the floor job should stay until Base intentionally

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -20,6 +20,7 @@ Options:
   --notify           Force a best-effort macOS notification when setup ends.
   --no-notify        Disable the default best-effort macOS completion notification.
   --recreate-venv    Back up and recreate the project virtual environment.
+  --yes              Apply setup changes that require explicit confirmation.
   -v                 Enable DEBUG logging for this subcommand.
   -h, --help         Show this help text.
 
@@ -44,7 +45,7 @@ Setup does:
 
 Notes:
   - This command is intentionally idempotent.
-  - On Ubuntu/Debian Linux, setup currently provides dry-run manual prerequisite guidance only.
+  - On Ubuntu/Debian Linux, setup can install apt prerequisites when --yes is passed.
   - The optional project argument resolves a Base project from the workspace
     unless --manifest is provided explicitly.
   - Use `basectl check` to verify the same requirements without making changes.
@@ -71,6 +72,9 @@ base_setup_subcommand_main() {
                 ;;
             --dry-run)
                 setup_enable_dry_run
+                ;;
+            --yes)
+                setup_enable_yes
                 ;;
             --profile)
                 shift

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -54,7 +54,7 @@ setup_ensure_cached_paths() {
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset dry_run DRY_RUN BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_PROJECT
+    unset dry_run DRY_RUN BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_YES BASE_PROJECT
     setup_refresh_cached_paths
 }
 
@@ -139,6 +139,7 @@ setup_enable_profile_argument() {
     for profile in "${profiles[@]}"; do
         profile="$(setup_normalize_profile_name "$profile")"
         if ! setup_profile_supported "$profile"; then
+            # shellcheck disable=SC2034 # Consumed by setup.sh after this helper returns.
             BASE_SETUP_PROFILE_ERROR="Unsupported profile '$profile'. Expected one of: $(setup_supported_profiles_display)."
             return 1
         fi
@@ -172,6 +173,14 @@ setup_profiles_csv() {
 
 setup_is_dry_run() {
     [[ "${DRY_RUN-}" == true ]]
+}
+
+setup_enable_yes() {
+    export BASE_SETUP_YES=true
+}
+
+setup_yes_enabled() {
+    [[ "${BASE_SETUP_YES:-false}" == true ]]
 }
 
 setup_enable_recreate_venv() {
@@ -866,6 +875,34 @@ setup_find_linux_python_bin() {
     return 1
 }
 
+setup_find_platform_python_bin() {
+    local platform
+
+    platform="$(setup_current_platform)" || return 1
+    case "$platform" in
+        linux-debian)
+            setup_find_linux_python_bin
+            ;;
+        *)
+            setup_find_python_bin
+            ;;
+    esac
+}
+
+setup_recovery_platform_python() {
+    local platform
+
+    platform="$(setup_current_platform)" || return 1
+    case "$platform" in
+        linux-debian)
+            setup_recovery_linux_python
+            ;;
+        *)
+            setup_recovery_python
+            ;;
+    esac
+}
+
 setup_test_linux_tool_forced_missing() {
     local missing_tools="${BASE_SETUP_TEST_MISSING_LINUX_TOOLS:-}"
     local tool="$1"
@@ -925,7 +962,7 @@ setup_create_virtualenv() {
         return 0
     fi
 
-    python_bin="$(setup_find_python_bin)" || fatal_error "Unable to locate a python3 executable after installation. $(setup_recovery_python)"
+    python_bin="$(setup_find_platform_python_bin)" || fatal_error "Unable to locate a python3 executable after installation. $(setup_recovery_platform_python)"
 
     safe_mkdir -p "$(dirname "$venv_dir")"
     log_info "Creating Python virtual environment at '$venv_dir'."
@@ -2509,20 +2546,60 @@ setup_run_macos_install() {
     fi
 }
 
-setup_linux_debian_apt_prerequisite_command() {
-    printf '%s\n' "sudo apt-get install bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"
+setup_linux_debian_apt_packages() {
+    printf '%s\n' "bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go"
 }
 
-setup_run_linux_debian_install() {
+setup_linux_debian_apt_update_command() {
+    printf '%s\n' "sudo apt-get update"
+}
+
+setup_linux_debian_apt_prerequisite_command() {
+    printf 'sudo apt-get install -y %s\n' "$(setup_linux_debian_apt_packages)"
+}
+
+setup_run_linux_debian_apt_prerequisites() {
+    local packages
+    local package_args=()
+
+    packages="$(setup_linux_debian_apt_packages)"
+    IFS=' ' read -r -a package_args <<<"$packages"
+
     if setup_is_dry_run; then
-        log_info "[DRY-RUN] Ubuntu/Debian setup is manual in this release."
-        log_info "Install apt prerequisites with: $(setup_linux_debian_apt_prerequisite_command)"
-        log_info "Install GitHub CLI 'gh' from the official GitHub CLI apt repository."
-        log_info "After installing prerequisites, run 'basectl check' to verify readiness."
+        log_info "[DRY-RUN] Would run: $(setup_linux_debian_apt_update_command)"
+        log_info "[DRY-RUN] Would run: $(setup_linux_debian_apt_prerequisite_command)"
         return 0
     fi
 
-    fatal_error "Ubuntu/Debian setup is currently manual. Run 'basectl setup --dry-run' for prerequisite guidance, install the listed packages, then rerun 'basectl check'."
+    if ! setup_yes_enabled; then
+        fatal_error "Ubuntu/Debian setup can install apt prerequisites. Run 'basectl setup --dry-run' to review the apt commands, then rerun with '--yes' to apply them."
+    fi
+
+    log_info "Installing Ubuntu/Debian apt prerequisites."
+    run sudo apt-get update || return $?
+    run sudo apt-get install -y "${package_args[@]}"
+}
+
+setup_run_linux_debian_install() {
+    setup_run_linux_debian_apt_prerequisites || return $?
+    setup_create_virtualenv
+    setup_install_pyyaml
+    setup_install_click
+    if setup_profiles_enabled; then
+        if setup_is_dry_run; then
+            setup_run_base_dev_layer setup --dry-run || fatal_error "Python prerequisite profile layer failed."
+        else
+            setup_run_base_dev_layer setup || fatal_error "Python prerequisite profile layer failed."
+        fi
+    fi
+    setup_run_project_artifact_setup || return $?
+    setup_seed_user_config
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Base CLI setup check is complete."
+    else
+        log_info "Base CLI setup is complete."
+    fi
 }
 
 setup_run_platform_install() {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -18,8 +18,9 @@ load ./setup_helpers.bash
     [[ "$output" == *"--notify"* ]]
     [[ "$output" == *"--no-notify"* ]]
     [[ "$output" == *"--recreate-venv"* ]]
+    [[ "$output" == *"--yes"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
-    [[ "$output" == *"On Ubuntu/Debian Linux, setup currently provides dry-run manual prerequisite guidance only."* ]]
+    [[ "$output" == *"On Ubuntu/Debian Linux, setup can install apt prerequisites when --yes is passed."* ]]
     [[ "$output" == *"Create ~/.base.d/config.yaml with workspace.root: ~/work if missing."* ]]
 }
 
@@ -94,27 +95,61 @@ load ./setup_helpers.bash
     [[ "$output" == *"BASE_PLATFORM='linux-unknown'"* ]]
 }
 
-@test "basectl setup --dry-run gives linux-debian manual prerequisite guidance" {
+@test "basectl setup --dry-run gives linux-debian apt setup plan" {
     run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --dry-run
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"[DRY-RUN] Ubuntu/Debian setup is manual in this release."* ]]
-    [[ "$output" == *"sudo apt-get install bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
-    [[ "$output" == *"Install GitHub CLI 'gh' from the official GitHub CLI apt repository"* ]]
-    [[ "$output" == *"After installing prerequisites, run 'basectl check' to verify readiness."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get update"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get install -y bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
+    [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would install Python package 'PyYAML' in the Base virtual environment."* ]]
+    [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
 }
 
-@test "basectl setup linux-debian fails conservatively with manual guidance" {
+@test "basectl setup linux-debian requires --yes before apt mutation" {
     run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Ubuntu/Debian setup is currently manual."* ]]
-    [[ "$output" == *"Run 'basectl setup --dry-run' for prerequisite guidance"* ]]
-    [[ "$output" == *"then rerun 'basectl check'."* ]]
+    [[ "$output" == *"Ubuntu/Debian setup can install apt prerequisites."* ]]
+    [[ "$output" == *"Run 'basectl setup --dry-run' to review the apt commands, then rerun with '--yes' to apply them."* ]]
+    [[ "$output" != *"sudo apt-get"* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl setup --yes linux-debian installs apt prerequisites and bootstraps Base" {
+    create_sudo_apt_get_stub
+    create_system_python3_stub
+
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --yes
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing Ubuntu/Debian apt prerequisites."* ]]
+    [[ "$output" == *"Creating Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
+    [[ "$output" == *"Base CLI setup is complete."* ]]
+    [ -f "$TEST_STATE_DIR/apt-update-ran" ]
+    [ -f "$TEST_STATE_DIR/apt-install-ran" ]
+    [ "$(cat "$TEST_STATE_DIR/apt-install-packages")" = "bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go" ]
+    [ -f "$TEST_STATE_DIR/system-python-ran" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
+}
+
+@test "basectl setup --yes linux-debian reports apt prerequisite failures" {
+    create_sudo_apt_get_stub
+    create_system_python3_stub
+
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_APT_FAIL=true \
+        setup --yes
+
+    [ "$status" -eq 42 ]
+    [[ "$output" == *"Installing Ubuntu/Debian apt prerequisites."* ]]
+    [[ "$output" == *"apt failed"* ]]
+    [ -f "$TEST_STATE_DIR/sudo-args" ]
+    [ ! -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
 @test "basectl setup is idempotent when brew, xcode tools, python, and the venv already exist" {

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -226,6 +226,30 @@ EOF
     done
 }
 
+create_sudo_apt_get_stub() {
+    cat > "$TEST_MOCKBIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
+printf '%s\n' "$*" >> "$state_dir/sudo-args"
+if [[ "${BASE_SETUP_TEST_APT_FAIL:-}" == true ]]; then
+    printf 'apt failed\n' >&2
+    exit 42
+fi
+if [[ "${1:-}" == "apt-get" && "${2:-}" == "update" ]]; then
+    touch "$state_dir/apt-update-ran"
+    exit 0
+fi
+if [[ "${1:-}" == "apt-get" && "${2:-}" == "install" && "${3:-}" == "-y" ]]; then
+    touch "$state_dir/apt-install-ran"
+    printf '%s\n' "${*:4}" > "$state_dir/apt-install-packages"
+    exit 0
+fi
+printf 'unexpected sudo args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/sudo"
+}
+
 create_brew_stub() {
     cat > "$TEST_MOCKBIN/brew" <<'EOF'
 #!/usr/bin/env bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,8 +64,8 @@ reference. The filename should answer "what is this about?"
   repeatable Homebrew and source checkout validation checklist.
 - [Execution Model](execution-model.md) documents the current `basectl` runtime,
   dispatch order, public launchers, and runtime shell behavior.
-- [Linux Support](linux-support.md) defines the first Ubuntu/Debian runtime
-  support plan and bootstrap boundaries.
+- [Linux Support](linux-support.md) defines the Ubuntu/Debian runtime support,
+  apt-backed setup path, and bootstrap boundaries.
 - [Runtime Environment](runtime-environment.md) is the canonical reference for
   Base-managed environment variables, `~/.baserc`, and mutability rules.
 - [Base Bash Libraries](base-bash-libs.md) documents the standalone

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -12,9 +12,8 @@ Start with Ubuntu/Debian runtime support:
 - `base-wrapper` can select the project venv under `~/.base.d/<project>/.venv`.
 - `basectl projects list`, `check`, `doctor`, and `ci` work when
   prerequisites are already installed.
-- Setup gives clear guidance instead of invoking macOS-only installers.
-
-Full bootstrap support can come after runtime support is stable.
+- Setup installs conservative Ubuntu/Debian apt prerequisites only after the
+  user reviews `--dry-run` output and passes `--yes`.
 
 ## Platform Detection
 
@@ -67,10 +66,10 @@ every platform. Prefer names such as `setup_collect_macos_base_check_results`,
 `setup_collect_linux_debian_base_check_results`, `setup_run_macos_install`, and
 `setup_run_linux_debian_install`.
 
-Package-manager selection belongs behind this boundary. macOS setup can use
-Homebrew-specific helpers, and Ubuntu/Debian setup can later use apt-specific
-helpers, but ordinary command, diagnostic, and artifact code should call the
-platform boundary instead of checking `BASE_PLATFORM` directly.
+Package-manager selection belongs behind this boundary. macOS setup uses
+Homebrew-specific helpers, and Ubuntu/Debian setup uses apt-specific helpers,
+but ordinary command, diagnostic, and artifact code should call the platform
+boundary instead of checking `BASE_PLATFORM` directly.
 
 Python project artifact management has a separate future seam. If system
 packages become project artifacts on Linux, the Python artifact registry should
@@ -84,23 +83,25 @@ Initial Ubuntu/Debian mappings:
 | Base prerequisite | macOS source | Ubuntu/Debian source |
 | --- | --- | --- |
 | Bash 4.2+ | Homebrew `bash` | `apt install bash` |
-| Python 3.13 | Homebrew `python@3.13` | documented manual install first |
+| Python 3 | Homebrew `python@3.13` | `apt install python3` |
 | Python venv support | Homebrew `python@3.13` | `apt install python3-venv` |
 | Git | Xcode Command Line Tools or Homebrew `git` | `apt install git` |
 | BATS | Homebrew `bats-core` | `apt install bats` when available |
-| GitHub CLI | Homebrew `gh` | GitHub CLI apt repository |
+| GitHub CLI | Homebrew `gh` | `apt install gh` when available |
 | ShellCheck | Homebrew `shellcheck` | `apt install shellcheck` |
 | jq | Homebrew `jq` | `apt install jq` |
 | Go for source-checkout tests | Homebrew `go` | `apt install golang-go` |
 
-Python should be the conservative piece. Do not silently use arbitrary system
-Python for Base setup unless Linux support explicitly opts into that behavior.
+Python remains conservative by platform. macOS setup uses Base-managed
+Homebrew Python. Ubuntu/Debian setup uses the platform `python3` package after
+the apt-backed setup path has installed `python3` and `python3-venv`.
 
-## Manual Ubuntu Bootstrap
+## Ubuntu Bootstrap
 
-For v1.5.0, Ubuntu/Debian support is runtime-first. `basectl setup` does not
-mutate Linux hosts yet; `basectl setup --dry-run` prints the manual
-prerequisite guidance that should be applied outside Base.
+For v1.6.0, Ubuntu/Debian setup can install the simple apt prerequisites that
+Base knows how to own. The mutation path is intentionally explicit:
+`basectl setup --dry-run` prints the apt commands, and `basectl setup --yes`
+applies them. Without `--yes`, Linux setup fails before invoking `apt`.
 
 Use native Linux filesystem paths for source checkouts. In Parallels, keep Base
 under `~/work`, not under mounted macOS shared folders, so file permissions,
@@ -113,19 +114,24 @@ git clone https://github.com/basefoundry/base.git
 git clone https://github.com/basefoundry/base-bash-libs.git
 cd base
 
-sudo apt-get update
-sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go
+./bin/basectl setup --dry-run
+./bin/basectl setup --yes
 ```
 
-Install GitHub CLI (`gh`) from the official GitHub CLI Debian/Ubuntu apt
-repository instructions. The `gh` package in older distro repositories can lag
-behind GitHub API changes, so prefer the maintained upstream repository for
-developer machines.
+The Ubuntu/Debian setup path runs:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go
+```
+
+GitHub CLI authentication remains a user-owned step. After `gh` is installed,
+run `gh auth login` when you need GitHub access. Base should check and report
+GitHub CLI readiness, but it should not handle tokens or credentials.
 
 Then run:
 
 ```bash
-./bin/basectl setup --dry-run
 ./bin/basectl ci check base --format text
 ./bin/basectl check base --format text
 ./bin/basectl doctor base --format text
@@ -139,8 +145,10 @@ directory containing its reusable Bash libraries before running the suite.
 GitHub Actions hosted Ubuntu runners use the same runtime contract but prepare
 prerequisites in the workflow instead of asking `basectl setup` to mutate the
 machine. Apple Silicon Macs running Ubuntu in Parallels should follow the same
-manual commands; `golang-go`, `bats`, `shellcheck`, and `jq` are available for
-the hosted runner and Ubuntu ARM64 package archives used by Parallels.
+`basectl setup --dry-run` / `basectl setup --yes` flow; `golang-go`, `bats`,
+`shellcheck`, `jq`, and `gh` are available from the hosted runner and Ubuntu
+ARM64 package archives used by Parallels when the configured apt repositories
+provide them.
 
 ## Shell Startup
 
@@ -189,13 +197,13 @@ environment and the sibling `base-bash-libs` checkout expected by source tests.
 | 2. Add platform detection and explicit unsupported-platform messages. | Done | `BASE_PLATFORM` classifies Ubuntu/Debian as `linux-debian`, keeps `BASE_OS=linux`, and fails unsupported platforms explicitly. |
 | 3. Make `basectl check` and `doctor` report Linux prerequisite status without requiring Homebrew or Xcode. | Done | `check` and `doctor` report Ubuntu/Debian prerequisite findings with apt-oriented recovery hints. |
 | 4. Add Ubuntu CI coverage for read-only commands and the source-checkout suite. | Done for source-checkout validation | The `ubuntu-source-checkout` job installs hosted-runner prerequisites, runs `basectl ci check base --format json`, and runs `env -u BASE_HOME ./bin/base-test`. |
-| 5. Add conservative Ubuntu setup guidance. | Done | `basectl setup --dry-run` gives manual Ubuntu/Debian prerequisite guidance; non-dry-run Linux setup remains conservative. |
-| 6. Add apt-backed setup for simple prerequisites. | Future | Keep setup mutation conservative until the first supported Linux distribution contract is finalized. |
-| 7. Revisit Python installation once the desired Linux Python distribution strategy is clear. | Future | Do not silently fall back to arbitrary system Python. |
+| 5. Add conservative Ubuntu setup guidance. | Done | `basectl setup --dry-run` previews Ubuntu/Debian apt prerequisites before mutation. |
+| 6. Add apt-backed setup for simple prerequisites. | Done | `basectl setup --yes` runs `apt-get update`, installs the supported apt package list, creates the Base virtual environment, installs Base Python bootstrap packages, invokes the project setup layer, and seeds user config. |
+| 7. Polish GitHub CLI install/auth guidance. | Future | Keep token handling user-owned; add clearer setup/check/docs guidance for official `gh` install sources and login/keyring recovery. |
 
 ## Non-Goals
 
 - Do not support every Linux distribution in the first pass.
 - Do not add a second manifest format for Linux.
-- Do not use arbitrary `python3` silently to create Base-managed venvs.
+- Do not use arbitrary `python3` silently on macOS to create Base-managed venvs.
 - Do not attempt GUI IDE installation on Linux until a real project needs it.

--- a/tests/test_linux_support_docs.py
+++ b/tests/test_linux_support_docs.py
@@ -9,13 +9,14 @@ def linux_support_text() -> str:
     return LINUX_SUPPORT_DOC.read_text(encoding="utf-8")
 
 
-def test_linux_support_docs_include_manual_ubuntu_bootstrap() -> None:
+def test_linux_support_docs_include_apt_backed_ubuntu_bootstrap() -> None:
     text = linux_support_text()
 
-    assert "## Manual Ubuntu Bootstrap" in text
+    assert "## Ubuntu Bootstrap" in text
     assert "basectl setup --dry-run" in text
-    assert "sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go" in text
-    assert "GitHub CLI Debian/Ubuntu apt" in text
+    assert "basectl setup --yes" in text
+    assert "sudo apt-get install -y bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go" in text
+    assert "GitHub CLI authentication" in text
     assert "under `~/work`, not under mounted macOS shared folders" in text
 
 


### PR DESCRIPTION
## Summary
- Add a linux-debian setup path that previews apt commands in --dry-run and requires --yes before running apt-get.
- Reuse the centralized platform setup boundary for Ubuntu/Debian, including Linux-specific python3 venv creation after apt prerequisites are installed.
- Update Ubuntu support docs, README compatibility text, and doc tests for the v1.6.0 apt-backed setup contract while keeping gh authentication user-owned.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_linux_support_docs.py`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/check.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/doctor.bats`
- `shellcheck -x cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/setup.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1352 ./bin/base-test`

Fixes #1352