### PR TITLE
Document Ubuntu GitHub CLI auth recovery

### DIFF
--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -132,8 +132,28 @@ https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian, then rerun
 `./bin/basectl setup --yes`.
 
 GitHub CLI authentication remains a user-owned step. After `gh` is installed,
-run `gh auth login` when you need GitHub access. Base should check and report
-GitHub CLI readiness, but it should not handle tokens or credentials.
+run the browser-backed flow when you need GitHub access:
+
+```bash
+gh auth login --web --git-protocol https
+```
+
+Base should check and report GitHub CLI readiness, but it should not handle
+tokens or credentials. Base does not store GitHub tokens in Base-managed config.
+
+Ubuntu desktop VMs can surface a GNOME keyring prompt such as "The password you
+use to log in to your computer no longer matches that of your login keyring."
+If the keyring cannot be unlocked and the VM is disposable or otherwise
+acceptable for lower-security local storage, `gh` can use its documented
+plain text fallback explicitly:
+
+```bash
+gh auth login --web --git-protocol https --insecure-storage
+```
+
+Use that fallback only when you accept the tradeoff: the credential is written
+outside the system credential store and should be treated as a local secret.
+Prefer fixing or unlocking the desktop keyring for long-lived machines.
 
 Then run:
 

--- a/tests/test_linux_support_docs.py
+++ b/tests/test_linux_support_docs.py
@@ -19,6 +19,10 @@ def test_linux_support_docs_include_apt_backed_ubuntu_bootstrap() -> None:
     assert "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian" in text
     assert "signed apt repository/keyring" in text
     assert "GitHub CLI authentication" in text
+    assert "gh auth login --web --git-protocol https" in text
+    assert "gh auth login --web --git-protocol https --insecure-storage" in text
+    assert "plain text" in text
+    assert "Base does not store GitHub tokens" in text
     assert "under `~/work`, not under mounted macOS shared folders" in text
 
 


### PR DESCRIPTION
## Summary
- Document the normal Ubuntu `gh auth login --web --git-protocol https` flow for Base contributors.
- Capture the GNOME keyring mismatch prompt seen in Ubuntu/Parallels and explain the VM-friendly `--insecure-storage` fallback.
- Keep the security boundary explicit: Base reports `gh` readiness but does not store GitHub tokens.

## Source
- Verified against the current official GitHub CLI auth manual: https://cli.github.com/manual/gh_auth_login

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_linux_support_docs.py`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1348 ./bin/base-test`

Fixes #1348