### PR TITLE
Allow idempotent Ubuntu setup reruns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allowed repeated Ubuntu/Debian `basectl setup` runs without `--yes` when all
+  apt prerequisites are already installed, while still requiring `--yes` before
+  Base mutates apt-managed system packages.
+
 ## [1.5.0] - 2026-07-02
 
 ### Added

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -2566,6 +2566,18 @@ setup_linux_debian_apt_prerequisite_command() {
     printf 'sudo apt-get install -y %s\n' "$(setup_linux_debian_apt_packages)"
 }
 
+setup_linux_debian_apt_prerequisites_installed() {
+    local package
+    local status
+
+    command -v dpkg-query >/dev/null 2>&1 || return 1
+
+    for package in "$@"; do
+        status="$(dpkg-query -W -f='${Status}' "$package" 2>/dev/null)" || return 1
+        [[ "$status" == "install ok installed" ]] || return 1
+    done
+}
+
 setup_run_linux_debian_apt_prerequisites() {
     local packages
     local package_args=()
@@ -2581,6 +2593,10 @@ setup_run_linux_debian_apt_prerequisites() {
     fi
 
     if ! setup_yes_enabled; then
+        if setup_linux_debian_apt_prerequisites_installed "${package_args[@]}"; then
+            log_info "Ubuntu/Debian apt prerequisites are already installed."
+            return 0
+        fi
         fatal_error "Ubuntu/Debian setup can install apt prerequisites. Run 'basectl setup --dry-run' to review the apt commands, then rerun with '--yes' to apply them."
     fi
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -111,7 +111,12 @@ load ./setup_helpers.bash
 }
 
 @test "basectl setup linux-debian requires --yes before apt mutation" {
-    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup
+    create_linux_dpkg_query_stub
+
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=gh \
+        setup
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"Ubuntu/Debian setup can install apt prerequisites."* ]]
@@ -119,6 +124,21 @@ load ./setup_helpers.bash
     [[ "$output" != *"sudo apt-get"* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl setup linux-debian skips apt without yes when prerequisites are installed" {
+    create_linux_dpkg_query_stub
+    create_system_python3_stub
+
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Ubuntu/Debian apt prerequisites are already installed."* ]]
+    [[ "$output" == *"Base CLI setup is complete."* ]]
+    [[ "$output" != *"Ubuntu/Debian setup can install apt prerequisites."* ]]
+    [ ! -f "$TEST_STATE_DIR/apt-update-ran" ]
+    [ ! -f "$TEST_STATE_DIR/apt-install-ran" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
 @test "basectl setup --yes linux-debian installs apt prerequisites and bootstraps Base" {

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -226,6 +226,27 @@ EOF
     done
 }
 
+create_linux_dpkg_query_stub() {
+    cat > "$TEST_MOCKBIN/dpkg-query" <<'EOF'
+#!/usr/bin/env bash
+state_dir="${BASE_SETUP_TEST_STATE_DIR:?}"
+missing_packages=" ${BASE_SETUP_TEST_MISSING_APT_PACKAGES:-} "
+package=""
+
+printf '%s\n' "$*" >> "$state_dir/dpkg-query-args"
+for package_arg in "$@"; do
+    package="$package_arg"
+done
+
+if [[ "$missing_packages" == *" $package "* ]]; then
+    exit 1
+fi
+
+printf 'install ok installed\n'
+EOF
+    chmod +x "$TEST_MOCKBIN/dpkg-query"
+}
+
 create_sudo_apt_get_stub() {
     cat > "$TEST_MOCKBIN/sudo" <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- let Ubuntu/Debian `basectl setup` skip apt when all apt prerequisites are already installed
- keep the existing `--yes` guard before Base runs apt mutations
- add a regression test and changelog entry for the Ubuntu setup rerun path

Fixes #1357.

## Test Plan

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "skips apt without yes" cli/bash/commands/basectl/tests/setup.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-ubuntu-setup-idempotent-cache ./bin/base-test`
