### PR TITLE
Support apt-backed Ubuntu dev profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Allowed repeated Ubuntu/Debian `basectl setup` runs without `--yes` when all
   apt prerequisites are already installed, while still requiring `--yes` before
   Base mutates apt-managed system packages.
+- Made `basectl setup --profile dev`, `check --profile dev`, and
+  `doctor --profile dev` use apt-backed BATS, GitHub CLI, and ShellCheck
+  handling on Ubuntu/Debian instead of requiring Homebrew.
 
 ## [1.5.0] - 2026-07-02
 

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -1763,6 +1763,7 @@ setup_run_project_artifact_doctor_json() {
 
 setup_run_base_dev_layer() {
     local args=("$@")
+    local platform
     local profile_args=()
     local venv_dir
 
@@ -1782,8 +1783,9 @@ setup_run_base_dev_layer() {
     fi
 
     profile_args=(--profile "$(setup_profiles_csv)")
+    platform="$(setup_current_platform)" || return 1
 
-    "$BASE_HOME/bin/base-wrapper" --project base base_dev "${args[@]}" "${profile_args[@]}"
+    env BASE_PLATFORM="$platform" "$BASE_HOME/bin/base-wrapper" --project base base_dev "${args[@]}" "${profile_args[@]}"
 }
 
 setup_clear_check_results() {

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -141,6 +141,19 @@ load ./setup_helpers.bash
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
+@test "basectl setup linux-debian passes effective platform to dev profile layer" {
+    create_linux_dpkg_query_stub
+    create_system_python3_stub
+
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --profile dev
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Ubuntu/Debian apt prerequisites are already installed."* ]]
+    [ -f "$TEST_STATE_DIR/dev-setup-ran" ]
+    [ "$(cat "$TEST_STATE_DIR/base-dev-platform")" = "linux-debian" ]
+    [ "$(cat "$TEST_STATE_DIR/dev-args")" = "$(printf '%s\n' setup --profile dev)" ]
+}
+
 @test "basectl setup --yes linux-debian installs apt prerequisites and bootstraps Base" {
     create_sudo_apt_get_stub
     create_system_python3_stub

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -184,6 +184,17 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
+    shift 2
+    printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/dev-args"
+    printf '%s\n' "${BASE_PLATFORM:-}" > "${BASE_SETUP_TEST_STATE_DIR:?}/base-dev-platform"
+    case "${1:-}" in
+        setup)
+            touch "${BASE_SETUP_TEST_STATE_DIR:?}/dev-setup-ran"
+            exit 0
+            ;;
+    esac
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
     [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
     exit $?

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+from base_setup import process
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.artifacts import homebrew_package_outdated, reconcile_artifact, resolve_artifact_definitions
 from base_setup.errors import ArtifactError
@@ -34,8 +36,27 @@ class ProfileManifest:
     definitions: tuple[ArtifactDefinition, ...]
 
 
+@dataclass(frozen=True)
+class LinuxDebianDevTool:
+    apt_package: str
+    command: str
+
+
+@dataclass(frozen=True)
+class ProfileRuntime:
+    profile: str
+    project: str
+
+
 class ProfileError(ValueError):
     pass
+
+
+LINUX_DEBIAN_DEV_TOOLS = {
+    "bats-core": LinuxDebianDevTool(apt_package="bats", command="bats"),
+    "gh": LinuxDebianDevTool(apt_package="gh", command="gh"),
+    "shellcheck": LinuxDebianDevTool(apt_package="shellcheck", command="shellcheck"),
+}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -195,8 +216,15 @@ def setup_profile_artifacts(
         ctx.log.info("Setting up Base '%s' prerequisites.", profile)
 
     try:
+        runtime = ProfileRuntime(profile=profile, project=manifest.project_name)
         for artifact, definition in zip(manifest.artifacts, definitions, strict=True):
-            reconcile_artifact(ctx, definition, artifact.version, manifest.project_name, dry_run=dry_run)
+            reconcile_profile_artifact(
+                ctx,
+                artifact,
+                definition,
+                runtime,
+                dry_run=dry_run,
+            )
     except ArtifactError as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
@@ -366,7 +394,7 @@ def dev_checks(
 ) -> tuple[DevCheck, ...]:
     checks: list[DevCheck] = []
     for artifact, definition in zip(artifacts, definitions):
-        check = check_homebrew_artifact(artifact, definition, profile=profile)
+        check = check_profile_artifact(artifact, definition, profile=profile)
         checks.append(check)
         if artifact.name == "gh" and check.ok:
             checks.append(check_github_cli_auth())
@@ -375,6 +403,60 @@ def dev_checks(
 
 def profile_setup_fix(profile: str) -> str:
     return f"basectl setup --profile {profile}"
+
+
+def current_base_platform() -> str:
+    return os.environ.get("BASE_PLATFORM", "")
+
+
+def linux_debian_dev_tool(artifact: ArtifactRequest, profile: str) -> LinuxDebianDevTool | None:
+    if profile != "dev" or current_base_platform() != "linux-debian":
+        return None
+    if artifact.artifact_type != "tool":
+        return None
+    return LINUX_DEBIAN_DEV_TOOLS.get(artifact.name)
+
+
+def check_profile_artifact(
+    artifact: ArtifactRequest,
+    definition: ArtifactDefinition,
+    profile: str = "dev",
+) -> DevCheck:
+    linux_debian_tool = linux_debian_dev_tool(artifact, profile)
+    if linux_debian_tool is not None:
+        return check_linux_debian_apt_artifact(artifact, linux_debian_tool, profile=profile)
+    return check_homebrew_artifact(artifact, definition, profile=profile)
+
+
+def check_linux_debian_apt_artifact(
+    artifact: ArtifactRequest,
+    tool: LinuxDebianDevTool,
+    profile: str = "dev",
+) -> DevCheck:
+    if artifact.version != "latest":
+        return DevCheck(
+            name=artifact.name,
+            ok=False,
+            message=f"Artifact '{artifact.name}' uses unsupported developer prerequisite version '{artifact.version}'.",
+            fix="Use version 'latest' for apt-backed developer prerequisites.",
+            finding_id="BASE-D102",
+        )
+
+    if command_exists(tool.command):
+        return DevCheck(
+            name=artifact.name,
+            ok=True,
+            message=f"Artifact '{artifact.name}' is installed via apt package '{tool.apt_package}'.",
+            fix="",
+            finding_id="BASE-D104",
+        )
+    return DevCheck(
+        name=artifact.name,
+        ok=False,
+        message=f"Artifact '{artifact.name}' is not installed via apt package '{tool.apt_package}'.",
+        fix=profile_setup_fix(profile),
+        finding_id="BASE-D104",
+    )
 
 
 def check_homebrew_artifact(  # pylint: disable=too-many-return-statements
@@ -458,6 +540,61 @@ def check_homebrew_artifact(  # pylint: disable=too-many-return-statements
         fix=profile_setup_fix(profile),
         finding_id="BASE-D104",
     )
+
+
+def reconcile_profile_artifact(
+    ctx: base_cli.Context,
+    artifact: ArtifactRequest,
+    definition: ArtifactDefinition,
+    runtime: ProfileRuntime,
+    dry_run: bool,
+) -> None:
+    linux_debian_tool = linux_debian_dev_tool(artifact, runtime.profile)
+    if linux_debian_tool is not None:
+        reconcile_linux_debian_apt_artifact(ctx, artifact, linux_debian_tool, profile=runtime.profile, dry_run=dry_run)
+        return
+    reconcile_artifact(ctx, definition, artifact.version, runtime.project, dry_run=dry_run)
+
+
+def reconcile_linux_debian_apt_artifact(
+    ctx: base_cli.Context,
+    artifact: ArtifactRequest,
+    tool: LinuxDebianDevTool,
+    profile: str,
+    dry_run: bool,
+) -> None:
+    if artifact.version != "latest":
+        raise ArtifactError(
+            f"Apt-backed developer prerequisite '{artifact.name}' specifies version '{artifact.version}', "
+            "but Base only supports apt-backed developer prerequisite version 'latest' right now."
+        )
+
+    install_command = ["sudo", "apt-get", "install", "-y", tool.apt_package]
+    if command_exists(tool.command):
+        ctx.log.info(
+            "Artifact '%s' is already installed via apt package '%s'.",
+            artifact.name,
+            tool.apt_package,
+        )
+        return
+
+    if dry_run:
+        process.dry_run_command(ctx, install_command)
+        return
+
+    if not command_exists("apt-get"):
+        raise ArtifactError(
+            f"apt-get is required to install developer prerequisite '{artifact.name}' "
+            f"for profile '{profile}'."
+        )
+
+    ctx.log.info(
+        "Installing artifact '%s' via apt package '%s' (%s).",
+        artifact.name,
+        tool.apt_package,
+        artifact.version,
+    )
+    process.run_command(ctx, install_command)
 
 
 def check_github_cli_auth() -> DevCheck:

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -25,7 +25,7 @@ def run_engine(args: list[str], extra_env: dict[str, str] | None = None) -> tupl
     stdout = io.StringIO()
     stderr = io.StringIO()
     with tempfile.TemporaryDirectory() as home_dir:
-        env = {"HOME": home_dir, "BASE_HOME": str(Path(__file__).resolve().parents[4])}
+        env = {"HOME": home_dir, "BASE_HOME": str(Path(__file__).resolve().parents[4]), "BASE_PLATFORM": ""}
         if extra_env:
             env.update(extra_env)
         with mock.patch.dict(os.environ, env):
@@ -40,6 +40,11 @@ def write_executable(path: Path, content: str) -> None:
 
 
 class DevManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.platform_patcher = mock.patch.dict(os.environ, {"BASE_PLATFORM": ""})
+        self.platform_patcher.start()
+        self.addCleanup(self.platform_patcher.stop)
+
     def test_importing_main_module_does_not_execute_main(self) -> None:
         sys.modules.pop("base_dev.__main__", None)
 
@@ -480,6 +485,55 @@ class DevManifestTests(unittest.TestCase):
         )
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_check_profile_dev_linux_debian_reports_missing_apt_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as bin_dir:
+            status, stdout, stderr = run_engine(
+                ["check", "--profile", "dev", "--format", "json"],
+                extra_env={"BASE_PLATFORM": "linux-debian", "PATH": bin_dir},
+            )
+
+        payload = json.loads(stdout)
+        findings = payload["checks"]
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["profiles"], ["dev"])
+        self.assertIn(
+            {
+                "id": "BASE-D104",
+                "status": "error",
+                "name": "bats-core",
+                "message": "Artifact 'bats-core' is not installed via apt package 'bats'.",
+                "fix": "basectl setup --profile dev",
+            },
+            findings,
+        )
+        self.assertTrue(all("Homebrew" not in finding["message"] for finding in findings))
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_check_profile_dev_linux_debian_reports_installed_apt_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as bin_dir:
+            bin_path = Path(bin_dir)
+            write_executable(bin_path / "bats", "#!/bin/sh\nexit 0\n")
+            write_executable(bin_path / "gh", "#!/bin/sh\nexit 0\n")
+            write_executable(bin_path / "shellcheck", "#!/bin/sh\nexit 0\n")
+
+            status, stdout, stderr = run_engine(
+                ["check", "--profile", "dev", "--format", "json"],
+                extra_env={"BASE_PLATFORM": "linux-debian", "PATH": bin_dir},
+            )
+
+        payload = json.loads(stdout)
+        findings = payload["checks"]
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["profiles"], ["dev"])
+        self.assertIn("gh-auth", [finding["name"] for finding in findings])
+        self.assertTrue(all(finding["status"] == "ok" for finding in findings))
+        self.assertTrue(all("Homebrew" not in finding["message"] for finding in findings))
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_check_json_reports_outdated_homebrew_artifact(self) -> None:
         def fake_run_capture(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
             output = "gh\n" if command == ["brew", "outdated", "gh"] else ""
@@ -512,6 +566,41 @@ class DevManifestTests(unittest.TestCase):
         self.assertIn("[DRY-RUN] Would run: brew install bats-core", stderr)
         self.assertIn("[DRY-RUN] Would run: brew install gh", stderr)
         self.assertIn("[DRY-RUN] Would run: brew install shellcheck", stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_setup_dry_run_linux_debian_uses_apt_registry_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as bin_dir:
+            status, _stdout, stderr = run_engine(
+                ["setup", "--profile", "dev", "--dry-run"],
+                extra_env={"BASE_PLATFORM": "linux-debian", "PATH": bin_dir},
+            )
+
+        self.assertEqual(status, 0)
+        self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y bats", stderr)
+        self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y gh", stderr)
+        self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y shellcheck", stderr)
+        self.assertNotIn("brew install", stderr)
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_setup_linux_debian_skips_installed_apt_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as bin_dir:
+            bin_path = Path(bin_dir)
+            write_executable(bin_path / "bats", "#!/bin/sh\nexit 0\n")
+            write_executable(bin_path / "gh", "#!/bin/sh\nexit 0\n")
+            write_executable(bin_path / "shellcheck", "#!/bin/sh\nexit 0\n")
+
+            with mock.patch("base_setup.process.run_command") as run_command:
+                status, _stdout, stderr = run_engine(
+                    ["setup", "--profile", "dev"],
+                    extra_env={"BASE_PLATFORM": "linux-debian", "PATH": bin_dir},
+                )
+
+        self.assertEqual(status, 0)
+        self.assertIn("Artifact 'bats-core' is already installed via apt package 'bats'.", stderr)
+        self.assertIn("Artifact 'gh' is already installed via apt package 'gh'.", stderr)
+        self.assertIn("Artifact 'shellcheck' is already installed via apt package 'shellcheck'.", stderr)
+        self.assertNotIn("Homebrew is required", stderr)
+        run_command.assert_not_called()
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_setup_dry_run_upgrades_outdated_homebrew_artifact(self) -> None:

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -116,6 +116,8 @@ cd base
 
 ./bin/basectl setup --dry-run
 ./bin/basectl setup --yes
+./bin/basectl setup --profile dev --dry-run
+./bin/basectl setup --profile dev
 ```
 
 The Ubuntu/Debian setup path runs:
@@ -130,6 +132,12 @@ signed apt repository/keyring when the configured distro repositories do not
 provide a current package. Follow the current official instructions at
 https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian, then rerun
 `./bin/basectl setup --yes`.
+
+On Ubuntu/Debian, the `dev` prerequisite profile uses apt-backed developer
+tools for the initial supported set: `bats-core` maps to `bats`, `gh` maps to
+`gh`, and `shellcheck` maps to `shellcheck`. Once the apt-backed setup path has
+installed those tools, `./bin/basectl setup --profile dev` is idempotent and
+does not require Homebrew.
 
 GitHub CLI authentication remains a user-owned step. After `gh` is installed,
 run the browser-backed flow when you need GitHub access:
@@ -225,7 +233,8 @@ environment and the sibling `base-bash-libs` checkout expected by source tests.
 | 4. Add Ubuntu CI coverage for read-only commands and the source-checkout suite. | Done for source-checkout validation | The `ubuntu-source-checkout` job installs hosted-runner prerequisites, runs `basectl ci check base --format json`, and runs `env -u BASE_HOME ./bin/base-test`. |
 | 5. Add conservative Ubuntu setup guidance. | Done | `basectl setup --dry-run` previews Ubuntu/Debian apt prerequisites before mutation. |
 | 6. Add apt-backed setup for simple prerequisites. | Done | `basectl setup --yes` runs `apt-get update`, installs the supported apt package list, creates the Base virtual environment, installs Base Python bootstrap packages, invokes the project setup layer, and seeds user config. |
-| 7. Polish GitHub CLI install/auth guidance. | Future | Keep token handling user-owned; add clearer setup/check/docs guidance for official `gh` install sources and login/keyring recovery. |
+| 7. Make `basectl setup --profile dev` use apt-backed developer tools on Ubuntu/Debian. | Done | The dev profile maps `bats-core`, `gh`, and `shellcheck` to apt-backed tools and skips them when already installed. |
+| 8. Polish GitHub CLI install/auth guidance. | Future | Keep token handling user-owned; add clearer setup/check/docs guidance for official `gh` install sources and login/keyring recovery. |
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

- add Ubuntu/Debian apt-backed handling for the `dev` profile tools: `bats-core`, `gh`, and `shellcheck`
- pass the shell setup layer's effective platform into the Python `base_dev` layer so test-mode and real Linux runs agree
- document the Ubuntu `--profile dev` flow and update the unreleased changelog

Fixes #1359

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_dev/tests/test_engine.py tests/test_linux_support_docs.py`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_dev/engine.py cli/python/base_dev/tests/test_engine.py`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure cli/bash/commands/basectl/tests/setup.bats`
- `BASE_TEST_MODE=true BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1359-smoke BASE_SETUP_TEST_PLATFORM=linux-debian BASE_PLATFORM=linux-debian ./bin/basectl setup --profile dev --dry-run`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1359-test ./bin/base-test`
