### PR TITLE
Make Brewfile delegates platform-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Made explicit project setup/check routing ignore active-project virtualenv
   overrides from a different shell project, so commands such as
   `basectl setup base-demo` cannot accidentally reuse the `base` venv.
+- Made project Brewfile delegates platform-aware: macOS still runs Homebrew
+  `brew bundle`, while Ubuntu/Debian skips Brewfile setup/check as a warning so
+  uv-managed projects can proceed through `uv sync`.
 
 ## [1.5.0] - 2026-07-02
 

--- a/cli/python/base_setup/delegates.py
+++ b/cli/python/base_setup/delegates.py
@@ -12,6 +12,7 @@ from . import process
 from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
+from .platform_policy import brewfile_delegates_supported, platform_label
 
 
 def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
@@ -24,6 +25,19 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             message=str(exc),
             fix=f"Update '{manifest.path}' or run 'basectl setup {manifest.project_name}'.",
             finding_id="BASE-P010",
+        )
+
+    if not brewfile_delegates_supported():
+        return ArtifactCheck(
+            name="brewfile",
+            ok=False,
+            message=(
+                f"Brewfile delegates are macOS/Homebrew-only; skipping '{brewfile_path}' "
+                f"on BASE_PLATFORM='{platform_label()}'."
+            ),
+            fix="Use a platform-native project setup path; for uv projects, install uv and rerun basectl setup/check.",
+            finding_id="BASE-P011",
+            status="warn",
         )
 
     if not process.command_exists("brew"):
@@ -254,6 +268,14 @@ def reconcile_brewfile(ctx: base_cli.Context, manifest: BaseManifest, dry_run: b
     brewfile_path = resolve_brewfile_path(manifest)
     command = ["brew", "bundle", f"--file={brewfile_path}"]
     check_command = ["brew", "bundle", "check", f"--file={brewfile_path}"]
+
+    if not brewfile_delegates_supported():
+        ctx.log.info(
+            "Skipping Brewfile '%s' on BASE_PLATFORM='%s'; Brewfile delegates are macOS/Homebrew-only.",
+            brewfile_path,
+            platform_label(),
+        )
+        return
 
     if dry_run:
         process.dry_run_command(ctx, command)

--- a/cli/python/base_setup/platform_policy.py
+++ b/cli/python/base_setup/platform_policy.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+
+def current_base_platform() -> str:
+    return os.environ.get("BASE_PLATFORM", "")
+
+
+def platform_label() -> str:
+    return current_base_platform() or "unspecified"
+
+
+def brewfile_delegates_supported() -> bool:
+    return current_base_platform() in {"", "macos"}

--- a/cli/python/base_setup/tests/test_brewfile.py
+++ b/cli/python/base_setup/tests/test_brewfile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import tempfile
 import unittest
@@ -96,6 +97,33 @@ class BrewfileTests(unittest.TestCase):
             timeout_seconds=delegates.process.DIAGNOSTIC_TIMEOUT_SECONDS,
         )
 
+    def test_brewfile_check_warns_and_skips_homebrew_off_macos(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            brewfile = project_root / "Brewfile"
+            brewfile.write_text('brew "uv"\n', encoding="utf-8")
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}),
+                mock.patch("base_setup.process.command_exists") as command_exists,
+                mock.patch("base_setup.process.run_check") as run_check,
+            ):
+                check = delegates.check_brewfile(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.finding_id, "BASE-P011")
+        self.assertIn("Brewfile delegates are macOS/Homebrew-only", check.message)
+        self.assertIn("linux-debian", check.message)
+        command_exists.assert_not_called()
+        run_check.assert_not_called()
+
     def test_brewfile_skips_brew_bundle_when_dependencies_are_satisfied(self) -> None:
         ctx = fake_context()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -154,6 +182,38 @@ class BrewfileTests(unittest.TestCase):
             env=mock.ANY,
         )
         self.assertEqual(run_command.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
+
+    def test_brewfile_setup_skips_homebrew_off_macos(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            brewfile = project_root / "Brewfile"
+            brewfile.write_text('brew "uv"\n', encoding="utf-8")
+            manifest = BaseManifest(
+                path=project_root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile="Brewfile",
+                artifacts=(),
+            )
+            expected_brewfile = brewfile.resolve()
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}),
+                mock.patch("base_setup.process.command_exists") as command_exists,
+                mock.patch("base_setup.process.run_check") as run_check,
+                mock.patch("base_setup.process.run_command") as run_command,
+            ):
+                delegates.reconcile_brewfile(ctx, manifest, dry_run=False)
+
+        command_exists.assert_not_called()
+        run_check.assert_not_called()
+        run_command.assert_not_called()
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertIn(
+            f"Skipping Brewfile '{expected_brewfile}' on BASE_PLATFORM='linux-debian'; "
+            "Brewfile delegates are macOS/Homebrew-only.",
+            info_messages,
+        )
 
     def test_brewfile_missing_file_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/tests/test_uv.py
+++ b/cli/python/base_setup/tests/test_uv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -258,4 +259,40 @@ class UvProjectTests(unittest.TestCase):
                 engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=True)
 
         reconcile_uv.assert_called_once_with(ctx, manifest, dry_run=True)
+        reconcile_artifacts.assert_not_called()
+
+    def test_uv_project_with_brewfile_reaches_uv_setup_on_linux_debian(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Brewfile").write_text('brew "uv"\n', encoding="utf-8")
+            default_manifest = BaseManifest(
+                path=Path("default_manifest.yaml"),
+                project_name="base-defaults",
+                brewfile=None,
+                artifacts=(),
+            )
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "brewfile: Brewfile",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}),
+                mock.patch("base_setup.delegates.process.command_exists", return_value=False),
+                mock.patch("base_setup.engine.reconcile_uv_project") as reconcile_uv,
+                mock.patch("base_setup.engine.reconcile_artifacts") as reconcile_artifacts,
+            ):
+                engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=False)
+
+        reconcile_uv.assert_called_once_with(ctx, manifest, dry_run=False)
         reconcile_artifacts.assert_not_called()

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -110,7 +110,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P001` | Empty project manifest artifact set |
 | `BASE-P002` | Project manifest validity |
 | `BASE-P010` | Brewfile path validity |
-| `BASE-P011` | Homebrew unavailable for Brewfile checks |
+| `BASE-P011` | Brewfile platform or Homebrew availability |
 | `BASE-P012` | Brewfile dependency status |
 | `BASE-P020` | mise config path validity |
 | `BASE-P021` | mise CLI availability |

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -139,6 +139,13 @@ tools for the initial supported set: `bats-core` maps to `bats`, `gh` maps to
 installed those tools, `./bin/basectl setup --profile dev` is idempotent and
 does not require Homebrew.
 
+Project-level `brewfile` delegates remain macOS/Homebrew-only. On
+Ubuntu/Debian, Base validates the Brewfile path but skips `brew bundle` setup and
+reports a warning from check/doctor instead of asking users to install Homebrew.
+Linux project prerequisites should use a platform-native project path. For
+projects that declare `python.manager: uv`, install or make `uv` available and
+let Base delegate Python setup to `uv sync`.
+
 GitHub CLI authentication remains a user-owned step. After `gh` is installed,
 run the browser-backed flow when you need GitHub access:
 

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -188,8 +188,10 @@ model for a project that declares `python.manager: uv`.
 
 When `python.manager: uv` is present, Base skips Base-managed
 `python-package` reconciliation, including Base's default project Python
-artifacts. Non-Python artifacts such as Homebrew-managed tools still reconcile
-normally.
+artifacts. Non-Python delegates keep their own platform policy: for example,
+project Brewfiles still run through Homebrew on macOS, but Base skips `brew
+bundle` on Ubuntu/Debian and lets uv-owned Python setup proceed through
+`uv sync`.
 
 ## Activation
 

--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -20,7 +20,7 @@ hooks:
 
 Instead, use the typed contracts Base already understands:
 
-- `brewfile` for ordinary Homebrew packages and casks
+- `brewfile` for ordinary macOS/Homebrew packages and casks
 - `mise` for language runtimes, tool versions, environment variables, and tasks
 - `ide` for supported IDE app, extension, and settings bootstrap
 - `artifacts` for Base-managed artifacts
@@ -34,6 +34,10 @@ shell state that must affect the activated interactive subshell.
 See the `activate.source` field in [Architecture - Project Manifest](architecture.md#project-manifest)
 for the full shell activation contract, including when it runs and its scope
 relative to setup.
+
+The `brewfile` delegate is platform-aware. Base runs `brew bundle` on macOS, but
+on Ubuntu/Debian it treats Brewfiles as unsupported macOS package declarations
+and continues through platform-native project setup such as `python.manager: uv`.
 
 When a project needs a product-specific guided installer or imperative
 bootstrap, that logic should live in the project repository, for example:

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -434,16 +434,20 @@ What Base should not do:
 
 - invent a parallel macOS package manifest when `Brewfile` already fits the job
 - replace Homebrew's own package management behavior
+- require Linux users to install Homebrew just because a project has a Brewfile
 
 How Base should coexist:
 
-- `basectl setup` should be able to run `brew bundle` where appropriate
+- `basectl setup` should be able to run `brew bundle` on macOS
 - Base manifests can point to one or more `Brewfile`s instead of inventing a
   new package DSL too early
 - `basectl check` can validate that declared Homebrew dependencies are satisfied
+  where Homebrew is a supported platform delegate
+- on Ubuntu/Debian, Base should skip Brewfile setup/check as a warning and let
+  platform-native delegates such as uv continue
 
-Current stance: first-class integration candidate, but still as an orchestrator
-on top of Homebrew.
+Current stance: first-class macOS integration candidate, but still as an
+orchestrator on top of Homebrew.
 
 ### Docker, Docker Compose, And Colima
 


### PR DESCRIPTION
## Summary

- make project Brewfile delegates platform-aware so macOS continues to run `brew bundle`
- skip Brewfile reconciliation on Ubuntu/Debian with a warning instead of requiring Homebrew
- preserve uv project setup on Ubuntu/Debian so projects with both `brewfile` and `python.manager: uv` can reach `uv sync`
- document the current Linux policy for Brewfile delegates and uv setup

## Verification

- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1369-platform-project-delegates/lib/python:/Users/rameshhp/work/base-worktrees/1369-platform-project-delegates/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_brewfile cli.python.base_setup.tests.test_uv`
- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1369-platform-project-delegates/lib/python:/Users/rameshhp/work/base-worktrees/1369-platform-project-delegates/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_linux_support_docs.py tests/test_doctor_findings_docs.py tests/test_base_cli_docs.py`
- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1369-platform-project-delegates/lib/python:/Users/rameshhp/work/base-worktrees/1369-platform-project-delegates/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/platform_policy.py cli/python/base_setup/delegates.py cli/python/base_setup/tests/test_brewfile.py cli/python/base_setup/tests/test_uv.py`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1369-gate ./bin/base-test`

Fixes #1369