### PR TITLE
ci: preflight base-bash-libs before source BATS

### DIFF
--- a/bin/base-test
+++ b/bin/base-test
@@ -46,23 +46,53 @@ base_test_is_source_checkout() {
     git -C "$base_test_home" rev-parse --is-inside-work-tree >/dev/null 2>&1
 }
 
+base_test_bash_libs_available() {
+    local candidate
+
+    for candidate in \
+        "${BASE_BASH_LIBS_DIR:-}" \
+        "$base_test_home/../base-bash-libs/lib/bash"; do
+        [[ -n "$candidate" ]] || continue
+        [[ -f "$candidate/std/lib_std.sh" ]] && return 0
+    done
+
+    return 1
+}
+
+base_test_preflight_source_checkout() {
+    base_test_bash_libs_available && return 0
+
+    printf 'ERROR: Base source-checkout Bats tests require base-bash-libs.\n' >&2
+    printf 'Fix: Clone basefoundry/base-bash-libs next to Base or set BASE_BASH_LIBS_DIR.\n' >&2
+    printf 'Docs: docs/testing.md#bash-command-and-runtime-tests\n' >&2
+    return 1
+}
+
 base_test_run_python_suite() {
     env "${base_test_unset_env[@]}" \
         PYTHONPATH="$base_test_home/lib/python:$base_test_home/cli/python${PYTHONPATH:+:$PYTHONPATH}" \
         "$base_test_python" -m pytest
 }
 
-base_test_run_python_suite
-base_test_python_status=$?
-if ((base_test_python_status != 0)); then
-    exit "$base_test_python_status"
-fi
-
 if ! base_test_is_source_checkout; then
+    base_test_run_python_suite
+    base_test_python_status=$?
+    if ((base_test_python_status != 0)); then
+        exit "$base_test_python_status"
+    fi
+
     printf "INFO: Base source checkout not detected at '%s'.\n" "$base_test_home" >&2
     printf 'INFO: Skipping source-checkout-only Bats tests for packaged Base.\n' >&2
     printf "INFO: Run 'env -u BASE_HOME ./bin/base-test' from a Base source checkout for the full developer suite.\n" >&2
     exit 0
+fi
+
+base_test_preflight_source_checkout || exit $?
+
+base_test_run_python_suite
+base_test_python_status=$?
+if ((base_test_python_status != 0)); then
+    exit "$base_test_python_status"
 fi
 
 env "${base_test_unset_env[@]}" \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -85,7 +85,8 @@ From a source checkout, run the full command/library suite through:
 env -u BASE_HOME ./bin/base-test
 ```
 
-The full suite expects Base to resolve external reusable Bash libraries. A
+`bin/base-test` preflights this dependency before starting the source-checkout
+BATS suite. The full suite expects Base to resolve external reusable Bash libraries. A
 normal `~/work/base` checkout uses sibling `~/work/base-bash-libs`
 automatically. A linked issue worktree under `~/work/base-worktrees/<slug>` is a
 nonstandard layout because the sibling lookup would search

--- a/tests/base_test.bats
+++ b/tests/base_test.bats
@@ -8,6 +8,7 @@ setup() {
     TEST_HOME="$TEST_TMPDIR/home"
     TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
     TEST_PACKAGE_HOME="$TEST_TMPDIR/homebrew/opt/base/libexec"
+    TEST_SOURCE_HOME="$TEST_TMPDIR/source/base"
     TEST_STATE_DIR="$TEST_TMPDIR/state"
     mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
 }
@@ -18,6 +19,15 @@ create_packaged_base_home() {
         "$TEST_PACKAGE_HOME/cli/python" \
         "$TEST_PACKAGE_HOME/lib/python"
     cp "$BASE_REPO_ROOT/bin/base-test" "$TEST_PACKAGE_HOME/bin/base-test"
+}
+
+create_source_base_home_without_bash_libs() {
+    mkdir -p \
+        "$TEST_SOURCE_HOME/bin" \
+        "$TEST_SOURCE_HOME/cli/python" \
+        "$TEST_SOURCE_HOME/lib/python"
+    cp "$BASE_REPO_ROOT/bin/base-test" "$TEST_SOURCE_HOME/bin/base-test"
+    git -C "$TEST_SOURCE_HOME" init -q
 }
 
 create_python_stub() {
@@ -98,6 +108,27 @@ EOF
     [ "$status" -eq 7 ]
     grep -Fqx 'python -m pytest' "$TEST_STATE_DIR/python.log"
     [ ! -f "$TEST_STATE_DIR/bats.log" ]
+}
+
+@test "base-test preflights source checkout base-bash-libs dependency before Bats" {
+    create_source_base_home_without_bash_libs
+    create_python_stub
+    create_bats_stub
+
+    run env \
+        -u BASE_BASH_LIBS_DIR \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_HOME="$TEST_SOURCE_HOME" \
+        BASE_TEST_PYTHON="$TEST_MOCKBIN/python" \
+        BASE_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        "$TEST_SOURCE_HOME/bin/base-test"
+
+    [ "$status" -eq 1 ]
+    [ ! -f "$TEST_STATE_DIR/python.log" ]
+    [ ! -f "$TEST_STATE_DIR/bats.log" ]
+    [[ "$output" == *"Base source-checkout Bats tests require base-bash-libs."* ]]
+    [[ "$output" == *"Clone basefoundry/base-bash-libs next to Base or set BASE_BASH_LIBS_DIR."* ]]
 }
 
 @test "base-test includes source guard coverage in the source checkout suite" {


### PR DESCRIPTION
## Summary
- Add a source-checkout preflight in `bin/base-test` for the external `base-bash-libs` dependency.
- Stop before Python/BATS when the source checkout cannot resolve `base-bash-libs`.
- Document the preflight in `docs/testing.md`.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "base-test preflights source checkout base-bash-libs dependency before Bats" tests/base_test.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/base_test.bats`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1370-full ./bin/base-test`

Fixes #1370