### PR TITLE
setup: warn on missing Linux dev tools

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -2185,21 +2185,32 @@ setup_add_linux_command_check_result() {
     local finding_name="$2"
     local display_name="$3"
     local recovery="$4"
+    local missing_status="${5:-error}"
+    local check_context="${6:-runtime checks}"
     local command_path
+
+    case "$missing_status" in
+        warn|error)
+            ;;
+        *)
+            fatal_error "Invalid Linux command check missing status '$missing_status'."
+            ;;
+    esac
 
     if command_path="$(setup_linux_command_path "$command_name")"; then
         setup_add_check_result \
             "$finding_name" \
             true \
-            "$display_name is available for Ubuntu/Debian runtime checks." \
+            "$display_name is available for Ubuntu/Debian $check_context." \
             "" \
             "Resolved $display_name binary: $command_path"
     else
-        setup_add_check_result \
+        setup_add_check_result_with_status \
             "$finding_name" \
-            false \
-            "$display_name is not available for Ubuntu/Debian runtime checks." \
+            "$missing_status" \
+            "$display_name is not available for Ubuntu/Debian $check_context." \
             "$recovery"
+        [[ "$missing_status" != error ]] && return 0
         return 1
     fi
 }
@@ -2276,27 +2287,37 @@ setup_collect_linux_debian_base_check_results() {
         "gh" \
         "gh" \
         "GitHub CLI 'gh'" \
-        "$(setup_recovery_linux_github_cli)" || missing=1
+        "$(setup_recovery_linux_github_cli)" \
+        warn \
+        "developer tooling checks" || missing=1
     setup_add_linux_command_check_result \
         "bats" \
         "bats" \
         "BATS" \
-        "$(setup_recovery_linux_apt_package bats bats)" || missing=1
+        "$(setup_recovery_linux_apt_package bats bats)" \
+        warn \
+        "developer tooling checks" || missing=1
     setup_add_linux_command_check_result \
         "shellcheck" \
         "shellcheck" \
         "ShellCheck" \
-        "$(setup_recovery_linux_apt_package shellcheck shellcheck)" || missing=1
+        "$(setup_recovery_linux_apt_package shellcheck shellcheck)" \
+        warn \
+        "developer tooling checks" || missing=1
     setup_add_linux_command_check_result \
         "jq" \
         "jq" \
         "jq" \
-        "$(setup_recovery_linux_apt_package jq jq)" || missing=1
+        "$(setup_recovery_linux_apt_package jq jq)" \
+        warn \
+        "developer tooling checks" || missing=1
     setup_add_linux_command_check_result \
         "go" \
         "go" \
         "Go" \
-        "$(setup_recovery_linux_apt_package Go golang-go)" || missing=1
+        "$(setup_recovery_linux_apt_package Go golang-go)" \
+        warn \
+        "developer tooling checks" || missing=1
 
     return "$missing"
 }

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -101,6 +101,30 @@ load ./setup_helpers.bash
     [[ "$output" != *"Xcode"* ]]
 }
 
+@test "basectl check linux-debian treats missing dev tools as warnings" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_system_python3_stub
+    create_linux_prerequisite_stubs
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_LINUX_TOOLS=gh,bats,shellcheck,jq,go \
+        check
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GitHub CLI 'gh' is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"BATS is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"ShellCheck is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"jq is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"Go is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"Base CLI environment check passed."* ]]
+    [[ "$output" != *"found missing requirements"* ]]
+}
+
 @test "basectl check linux-debian reports missing prerequisite apt hints" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
@@ -130,17 +154,17 @@ EOF
     [[ "$output" == *"Install python3-venv with 'sudo apt-get install python3-venv', then rerun 'basectl check'."* ]]
     [[ "$output" == *"Git is not available for Ubuntu/Debian runtime checks."* ]]
     [[ "$output" == *"Install git with 'sudo apt-get install git', then rerun 'basectl check'."* ]]
-    [[ "$output" == *"GitHub CLI 'gh' is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"GitHub CLI 'gh' is not available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh'"* ]]
     [[ "$output" == *"https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"* ]]
     [[ "$output" == *"sudo apt install gh -y"* ]]
-    [[ "$output" == *"BATS is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"BATS is not available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Install bats with 'sudo apt-get install bats', then rerun 'basectl check'."* ]]
-    [[ "$output" == *"ShellCheck is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"ShellCheck is not available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Install shellcheck with 'sudo apt-get install shellcheck', then rerun 'basectl check'."* ]]
-    [[ "$output" == *"jq is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"jq is not available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Install jq with 'sudo apt-get install jq', then rerun 'basectl check'."* ]]
-    [[ "$output" == *"Go is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"Go is not available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Install Go with 'sudo apt-get install golang-go', then rerun 'basectl check'."* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
@@ -535,6 +559,32 @@ EOF
     assert_base_bash_libraries_json_finding "$output"
     [[ "$output" != *'"name":"homebrew"'* ]]
     [[ "$output" != *'"name":"xcode_command_line_tools"'* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl check --format json reports missing linux dev tools as warnings" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_system_python3_stub
+    create_linux_prerequisite_stubs
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_base_venv_stub "$venv_dir"
+
+    run_base_command_separate_stderr \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_LINUX_TOOLS=gh,bats,shellcheck,jq,go \
+        check --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema_version": 1'* ]]
+    [[ "$output" == *'"status": "warn"'* ]]
+    [[ "$output" == *'"id":"BASE-D010","status":"ok","name":"git"'* ]]
+    [[ "$output" == *'"id":"BASE-D011","status":"warn","name":"gh"'* ]]
+    [[ "$output" == *'"id":"BASE-D012","status":"warn","name":"bats"'* ]]
+    [[ "$output" == *'"id":"BASE-D013","status":"warn","name":"shellcheck"'* ]]
+    [[ "$output" == *'"id":"BASE-D014","status":"warn","name":"jq"'* ]]
+    [[ "$output" == *'"id":"BASE-D015","status":"warn","name":"go"'* ]]
     [ "${stderr:-}" = "" ]
 }
 

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -354,10 +354,35 @@ EOF
     [[ "$output" == *"ok"*"BASE-D003"*"Python"*"Python is available for Ubuntu/Debian runtime checks."* ]]
     [[ "$output" == *"ok"*"BASE-D004"*"Base virtualenv"*"Virtual environment is healthy at"* ]]
     [[ "$output" == *"ok"*"BASE-D010"*"Git"*"Git is available for Ubuntu/Debian runtime checks."* ]]
-    [[ "$output" == *"ok"*"BASE-D015"*"Go"*"Go is available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"ok"*"BASE-D015"*"Go"*"Go is available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Base doctor found no blocking issues."* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl doctor linux-debian treats missing dev tools as warnings" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    create_doctor_linux_success_stubs "$fake_bin" "$venv_python"
+
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="linux-gnu" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_MODE=true \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_LINUX_TOOLS=gh,bats,shellcheck,jq,go \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"warn"*"BASE-D011"*"GitHub CLI"*"GitHub CLI 'gh' is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"warn"*"BASE-D012"*"BATS"*"BATS is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"warn"*"BASE-D013"*"ShellCheck"*"ShellCheck is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"warn"*"BASE-D014"*"jq"*"jq is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"warn"*"BASE-D015"*"Go"*"Go is not available for Ubuntu/Debian developer tooling checks."* ]]
+    [[ "$output" == *"Base doctor found no blocking issues."* ]]
 }
 
 @test "basectl doctor linux-debian reports missing prerequisite apt hints" {
@@ -407,11 +432,11 @@ EOF
     [[ "$output" == *"Fix: Install python3-venv with 'sudo apt-get install python3-venv', then rerun 'basectl check'."* ]]
     [[ "$output" == *"error"*"BASE-D010"*"Git"*"Git is not available for Ubuntu/Debian runtime checks."* ]]
     [[ "$output" == *"Fix: Install git with 'sudo apt-get install git', then rerun 'basectl check'."* ]]
-    [[ "$output" == *"error"*"BASE-D011"*"GitHub CLI"*"GitHub CLI 'gh' is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"warn"*"BASE-D011"*"GitHub CLI"*"GitHub CLI 'gh' is not available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Fix: Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh'"* ]]
     [[ "$output" == *"https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"* ]]
     [[ "$output" == *"sudo apt install gh -y"* ]]
-    [[ "$output" == *"error"*"BASE-D015"*"Go"*"Go is not available for Ubuntu/Debian runtime checks."* ]]
+    [[ "$output" == *"warn"*"BASE-D015"*"Go"*"Go is not available for Ubuntu/Debian developer tooling checks."* ]]
     [[ "$output" == *"Fix: Install Go with 'sudo apt-get install golang-go', then rerun 'basectl check'."* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -127,6 +127,10 @@ sudo apt-get update
 sudo apt-get install -y bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go
 ```
 
+`basectl check` and `basectl doctor` keep the basic Ubuntu/Debian runtime path
+separate from contributor tooling. Missing `gh`, BATS, ShellCheck, `jq`, or Go
+are advisory warnings unless another runtime prerequisite is also failing.
+
 The `gh` package should come from GitHub CLI's official Debian/Ubuntu
 signed apt repository/keyring when the configured distro repositories do not
 provide a current package. Follow the current official instructions at


### PR DESCRIPTION
## Summary
- Classify missing Ubuntu/Debian developer tools (`gh`, BATS, ShellCheck, `jq`, Go) as warning findings for the basic runtime path.
- Keep true runtime prerequisites such as Git and Python support blocking.
- Document the runtime-vs-developer-tooling split in Linux support docs.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/check.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/doctor.bats`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_linux_support_docs.py -q`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1365-full-2 ./bin/base-test`

Fixes #1365