### PR TITLE
projects: list before Base setup when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,9 @@ value is configured. If it is not configured, Base falls back to the parent
 directory of `BASE_HOME`, which matches the source-checkout sibling-repo layout.
 Use `--workspace <path>` to inspect a different workspace root for one command.
 Project list output is tab-separated as `<project-name><TAB><path>`.
+In a source checkout, `basectl projects list` can run before `basectl setup`
+when the ambient `python3` has Base's bootstrap Python dependencies available;
+otherwise it reports a targeted setup diagnostic.
 `basectl projects list` and the read-only workspace status, check, and doctor
 commands support `--format json` for machine-readable output. Workspace clone,
 pull, init, and configure use text output only. Workspace status, check, and

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -164,7 +164,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   `brew upgrade basefoundry/base/base`.
 - `basectl projects list` scans `workspace.root` from `~/.base.d/config.yaml`
   when configured, otherwise `$BASE_HOME`'s parent, and prints discovered
-  project names and paths.
+  project names and paths. Source checkouts can run this read-only command
+  before `basectl setup` when ambient `python3` has Base's bootstrap Python
+  dependencies available; otherwise the command prints a targeted setup
+  diagnostic.
 - `basectl workspace status` reports a read-only workspace summary across
   discovered projects, or across expected repositories when
   `workspace.manifest` is configured or `--manifest <path>` is supplied. When

--- a/cli/bash/commands/basectl/subcommands/projects.sh
+++ b/cli/bash/commands/basectl/subcommands/projects.sh
@@ -24,9 +24,73 @@ base_projects_usage_error() {
     return 2
 }
 
+base_projects_base_venv_python() {
+    local venv_dir="${BASE_PROJECT_VENV_DIR:-$HOME/.base.d/base/.venv}"
+
+    printf '%s\n' "$venv_dir/bin/python"
+}
+
+base_projects_source_checkout_available() {
+    [[ -f "$BASE_HOME/cli/python/base_projects/__main__.py" ]] &&
+        [[ -f "$BASE_HOME/lib/python/base_cli/__init__.py" ]]
+}
+
+base_projects_source_pythonpath() {
+    local base_pythonpath="$BASE_HOME/lib/python:$BASE_HOME/cli/python"
+
+    if [[ -n "${PYTHONPATH:-}" ]]; then
+        printf '%s:%s\n' "$base_pythonpath" "$PYTHONPATH"
+    else
+        printf '%s\n' "$base_pythonpath"
+    fi
+}
+
+base_projects_source_python() {
+    local python_bin
+    local base_pythonpath
+
+    python_bin="$(command -v python3 2>/dev/null || true)"
+    [[ -n "$python_bin" ]] || return 1
+
+    base_pythonpath="$(base_projects_source_pythonpath)"
+    env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$base_pythonpath" \
+        "$python_bin" -c 'import click; import yaml; import base_projects' >/dev/null 2>&1 || return 1
+
+    printf '%s\n' "$python_bin"
+}
+
+base_projects_list_pre_setup_error() {
+    print_error "basectl projects list needs either the Base project virtualenv or a Python 3 with Click and PyYAML available."
+    print_error "Run 'basectl setup' to create the Base project virtualenv."
+    return 1
+}
+
+base_projects_run_list() {
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local venv_python
+    local python_bin
+    local base_pythonpath
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    venv_python="$(base_projects_base_venv_python)"
+    if [[ -x "$venv_python" ]]; then
+        "$wrapper" --project base base_projects list "$@"
+        return $?
+    fi
+
+    if base_projects_source_checkout_available && python_bin="$(base_projects_source_python)"; then
+        base_pythonpath="$(base_projects_source_pythonpath)"
+        env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$base_pythonpath" \
+            "$python_bin" -m base_projects list "$@"
+        return $?
+    fi
+
+    base_projects_list_pre_setup_error
+}
+
 base_projects_subcommand_main() {
     local project_command="${1:-}"
-    local wrapper="$BASE_HOME/bin/base-wrapper"
     local args=()
 
     case "$project_command" in
@@ -60,6 +124,5 @@ base_projects_subcommand_main() {
         esac
     done
 
-    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    "$wrapper" --project base base_projects list "${args[@]}"
+    base_projects_run_list "${args[@]}"
 }

--- a/cli/bash/commands/basectl/tests/projects.bats
+++ b/cli/bash/commands/basectl/tests/projects.bats
@@ -67,6 +67,75 @@ EOF
     [ "$(cat "$TEST_TMPDIR/projects-list-state")" = "-m base_projects list --workspace $workspace --format json" ]
 }
 
+@test "basectl projects list falls back to source python before setup" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/projects-list-state"
+
+    mkdir -p "$workspace/base" "$workspace/demo"
+    cat > "$TEST_MOCKBIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-c" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" && "${4:-}" == "--workspace" ]]; then
+    {
+        printf 'BASE_PROJECT=%s\n' "${BASE_PROJECT:-}"
+        printf 'PYTHONPATH=%s\n' "${PYTHONPATH:-}"
+        printf 'ARGS=%s\n' "$*"
+    } > "${BASE_TEST_PROJECTS_LIST_STATE:?}"
+    printf '%s\t%s\n' base "$5/base"
+    printf '%s\t%s\n' demo "$5/demo"
+    exit 0
+fi
+printf 'unexpected source python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/python3"
+    printf 'project:\n  name: base\nartifacts: []\n' > "$workspace/base/base_manifest.yaml"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECTS_LIST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" projects list --workspace "$workspace"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'base\t'"$workspace/base"* ]]
+    [[ "$output" == *$'demo\t'"$workspace/demo"* ]]
+    grep -Fqx "BASE_PROJECT=base" "$state_file"
+    grep -Fqx "PYTHONPATH=$BASE_REPO_ROOT/lib/python:$BASE_REPO_ROOT/cli/python" "$state_file"
+    grep -Fqx "ARGS=-m base_projects list --workspace $workspace" "$state_file"
+}
+
+@test "basectl projects list reports a targeted pre-setup diagnostic without source python dependencies" {
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$workspace/base"
+    cat > "$TEST_MOCKBIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-c" ]]; then
+    exit 1
+fi
+printf 'unexpected source python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/python3"
+    printf 'project:\n  name: base\nartifacts: []\n' > "$workspace/base/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" projects list --workspace "$workspace"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"basectl projects list needs either the Base project virtualenv or a Python 3 with Click and PyYAML available."* ]]
+    [[ "$output" == *"Run 'basectl setup' to create the Base project virtualenv."* ]]
+    [[ "$output" != *"Project virtual environment Python was not found"* ]]
+}
+
 @test "basectl projects list prints help without requiring the Base Python venv" {
     run_basectl projects list --help
 


### PR DESCRIPTION
## Summary
- Keep the normal `base-wrapper` path when the Base project virtualenv exists.
- Let source checkouts run `basectl projects list` through ambient `python3` before setup when Click, PyYAML, and Base source imports are available.
- Replace the generic missing-venv wrapper failure with a targeted setup diagnostic when the fallback cannot run.
- Document the pre-setup behavior for project discovery.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "source python before setup|targeted pre-setup diagnostic" cli/bash/commands/basectl/tests/projects.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/projects.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py -q`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1364-full ./bin/base-test`

Fixes #1364