### PR TITLE
shell: back up and remove profile sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,7 +1250,19 @@ By default it updates all four startup files:
 - `~/.zshrc`
 
 Missing files are created. Existing files keep their non-Base content; Base only
-adds or replaces its marked section.
+adds or replaces its marked section. Before changing an existing startup file,
+`basectl update-profile` writes a timestamped sibling backup such as
+`~/.bashrc.backup.YYYYMMDDTHHMMSS`.
+
+To remove Base from shell startup files without hand-editing dotfiles, run:
+
+```bash
+basectl update-profile --remove
+```
+
+This removes only Base-managed marked sections from Bash and Zsh startup files.
+Use `basectl update-profile --remove --dry-run` to preview the planned backups
+and removals.
 
 `basectl update-profile` also creates `~/.base.d/profile.conf`, which records
 whether the user has opted into Base's optional shell defaults. The managed

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -157,7 +157,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
   for AI-assisted workflows. `basectl prompt product-self-review` prints the
   periodic Base product self-review prompt with current Base metadata. Base
   renders the prompt only; an AI tool performs the review.
-- `basectl update-profile` creates or refreshes managed sections in Bash and Zsh dotfiles.
+- `basectl update-profile` creates, refreshes, or removes managed sections in
+  Bash and Zsh dotfiles, backing up existing dotfiles before changes.
 - `basectl update [project]` updates the selected project checkout through Git
   and then runs `basectl setup <project>`. Omitting the project selects `base`;
   Homebrew-managed Base installs still hand off only the Base package to

--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -17,6 +17,7 @@ Options:
   --defaults  Enable Base's optional Bash/Zsh shell defaults.
   --no-defaults
               Disable Base's optional Bash/Zsh shell defaults.
+  --remove    Remove Base-managed sections from Bash/Zsh startup files.
   --dry-run   Show what would be updated without changing files.
   -v          Enable DEBUG logging for this subcommand.
   -h, --help  Show this help text.
@@ -115,24 +116,203 @@ base_update_profile_prepare_section_spacing() {
     printf '\n' >> "$target_file"
 }
 
+base_update_profile_start_marker() {
+    local snippet_name="$1"
+
+    printf '# >>> base: %s managed >>>\n' "$snippet_name"
+}
+
+base_update_profile_end_marker() {
+    local snippet_name="$1"
+
+    printf '# <<< base: %s managed <<<\n' "$snippet_name"
+}
+
+base_update_profile_backup_path() {
+    local target_file="$1"
+    local timestamp="$2"
+    local backup_path="${target_file}.backup.${timestamp}"
+    local suffix=1
+
+    while [[ -e "$backup_path" ]]; do
+        backup_path="${target_file}.backup.${timestamp}.${suffix}"
+        suffix=$((suffix + 1))
+    done
+
+    printf '%s\n' "$backup_path"
+}
+
+base_update_profile_backup_existing_file() {
+    local target_file="$1"
+    local timestamp="$2"
+    local dry_run="$3"
+    local backup_path
+
+    [[ -f "$target_file" ]] || return 0
+
+    backup_path="$(base_update_profile_backup_path "$target_file" "$timestamp")" ||
+        fatal_error "Unable to resolve backup path for '$target_file'."
+
+    if ((dry_run)); then
+        log_info "[DRY-RUN] Would back up '$target_file' to '$backup_path'."
+        return 0
+    fi
+
+    log_info "Backing up '$target_file' to '$backup_path'."
+    cp -p "$target_file" "$backup_path" || fatal_error "Unable to back up '$target_file' to '$backup_path'."
+}
+
+base_update_profile_write_section_content() {
+    local snippet_name="$1"
+    local output_file="$2"
+    local lines=()
+
+    mapfile -t lines < <(base_update_profile_section_lines "$snippet_name") || return 1
+    printf '%s\n' "${lines[@]}" > "$output_file"
+}
+
+base_update_profile_existing_section_content() {
+    local target_file="$1"
+    local start_marker="$2"
+    local end_marker="$3"
+    local output_file="$4"
+
+    awk -v START_M="$start_marker" -v END_M="$end_marker" '
+    BEGIN {
+        in_section = 0
+        processed = 0
+    }
+    $0 == START_M && processed == 0 {
+        in_section = 1
+        next
+    }
+    $0 == END_M && in_section == 1 {
+        processed = 1
+        exit
+    }
+    in_section == 1 {
+        print $0
+    }
+    END {
+        if (processed == 0) {
+            exit 1
+        }
+    }
+    ' "$target_file" > "$output_file"
+}
+
+base_update_profile_update_file_needs_change() {
+    local target_file="$1"
+    local snippet_name="$2"
+    local start_marker="$3"
+    local end_marker="$4"
+    local current_content_file
+    local desired_content_file
+    local start_count
+    local end_count
+
+    [[ -f "$target_file" ]] || return 0
+
+    start_count="$(grep -cxF -- "$start_marker" "$target_file" || true)"
+    end_count="$(grep -cxF -- "$end_marker" "$target_file" || true)"
+    if ((start_count == 0 && end_count == 0)); then
+        return 0
+    fi
+    if ((start_count != end_count)); then
+        return 0
+    fi
+
+    current_content_file="$(mktemp "${TMPDIR:-/tmp}/base-profile-current.XXXXXX")" ||
+        fatal_error "Unable to create temporary section content file for '$target_file'."
+    desired_content_file="$(mktemp "${TMPDIR:-/tmp}/base-profile-desired.XXXXXX")" || {
+        rm -f "$current_content_file"
+        fatal_error "Unable to create temporary desired content file for '$target_file'."
+    }
+
+    if ! base_update_profile_existing_section_content "$target_file" "$start_marker" "$end_marker" "$current_content_file"; then
+        rm -f "$current_content_file" "$desired_content_file"
+        return 0
+    fi
+    base_update_profile_write_section_content "$snippet_name" "$desired_content_file" || {
+        rm -f "$current_content_file" "$desired_content_file"
+        return 1
+    }
+
+    if cmp -s "$current_content_file" "$desired_content_file"; then
+        rm -f "$current_content_file" "$desired_content_file"
+        return 1
+    fi
+
+    rm -f "$current_content_file" "$desired_content_file"
+    return 0
+}
+
+base_update_profile_remove_file_needs_change() {
+    local target_file="$1"
+    local start_marker="$2"
+    local end_marker="$3"
+    local start_count
+    local end_count
+
+    [[ -f "$target_file" ]] || return 1
+
+    start_count="$(grep -cxF -- "$start_marker" "$target_file" || true)"
+    end_count="$(grep -cxF -- "$end_marker" "$target_file" || true)"
+    ((start_count > 0 || end_count > 0))
+}
+
 base_update_profile_update_file() {
     local target_file="$1"
     local snippet_name="$2"
     local dry_run="$3"
-    local start_marker="# >>> base: ${snippet_name} managed >>>"
-    local end_marker="# <<< base: ${snippet_name} managed <<<"
+    local backup_timestamp="$4"
+    local start_marker
+    local end_marker
     local lines=()
 
+    start_marker="$(base_update_profile_start_marker "$snippet_name")" || return 1
+    end_marker="$(base_update_profile_end_marker "$snippet_name")" || return 1
     mapfile -t lines < <(base_update_profile_section_lines "$snippet_name") || return 1
 
+    if ! base_update_profile_update_file_needs_change "$target_file" "$snippet_name" "$start_marker" "$end_marker"; then
+        return 0
+    fi
+
     if ((dry_run)); then
+        base_update_profile_backup_existing_file "$target_file" "$backup_timestamp" "$dry_run" || return 1
         log_info "[DRY-RUN] Would update '$target_file' with section '$snippet_name'."
         return 0
     fi
 
+    base_update_profile_backup_existing_file "$target_file" "$backup_timestamp" "$dry_run" || return 1
     safe_touch "$target_file"
     base_update_profile_prepare_section_spacing "$target_file" "$start_marker" || return 1
     update_file_section "$target_file" "$start_marker" "$end_marker" "${lines[@]}"
+}
+
+base_update_profile_remove_file() {
+    local target_file="$1"
+    local snippet_name="$2"
+    local dry_run="$3"
+    local backup_timestamp="$4"
+    local start_marker
+    local end_marker
+
+    start_marker="$(base_update_profile_start_marker "$snippet_name")" || return 1
+    end_marker="$(base_update_profile_end_marker "$snippet_name")" || return 1
+
+    if ! base_update_profile_remove_file_needs_change "$target_file" "$start_marker" "$end_marker"; then
+        return 0
+    fi
+
+    if ((dry_run)); then
+        base_update_profile_backup_existing_file "$target_file" "$backup_timestamp" "$dry_run" || return 1
+        log_info "[DRY-RUN] Would remove section '$snippet_name' from '$target_file'."
+        return 0
+    fi
+
+    base_update_profile_backup_existing_file "$target_file" "$backup_timestamp" "$dry_run" || return 1
+    update_file_section -r "$target_file" "$start_marker" "$end_marker"
 }
 
 base_update_profile_state_dir() {
@@ -198,8 +378,10 @@ base_update_profile_write_profile_conf() {
 base_update_profile_subcommand_main() {
     local enable_defaults=0
     local disable_defaults=0
+    local remove_sections=0
     local dry_run=0
     local base_home
+    local backup_timestamp
 
     while (($#)); do
         case "$1" in
@@ -208,6 +390,9 @@ base_update_profile_subcommand_main() {
                 ;;
             --no-defaults)
                 disable_defaults=1
+                ;;
+            --remove)
+                remove_sections=1
                 ;;
             --dry-run)
                 dry_run=1
@@ -231,6 +416,10 @@ base_update_profile_subcommand_main() {
         base_update_profile_usage_error "Options '--defaults' and '--no-defaults' cannot be used together."
         return $?
     fi
+    if ((remove_sections && (enable_defaults || disable_defaults))); then
+        base_update_profile_usage_error "Option '--remove' cannot be combined with '--defaults' or '--no-defaults'."
+        return $?
+    fi
 
     log_debug "Running 'basectl update-profile'."
 
@@ -247,10 +436,20 @@ base_update_profile_subcommand_main() {
     export BASE_HOME
 
     base_update_profile_source_file_library || return 1
+    backup_timestamp="$(setup_backup_timestamp)" || fatal_error "Unable to generate update-profile backup timestamp."
+
+    if ((remove_sections)); then
+        base_update_profile_remove_file "$HOME/.bash_profile" bash_profile "$dry_run" "$backup_timestamp" || return 1
+        base_update_profile_remove_file "$HOME/.bashrc" bashrc "$dry_run" "$backup_timestamp" || return 1
+        base_update_profile_remove_file "$HOME/.zprofile" zprofile "$dry_run" "$backup_timestamp" || return 1
+        base_update_profile_remove_file "$HOME/.zshrc" zshrc "$dry_run" "$backup_timestamp" || return 1
+        return 0
+    fi
+
     base_update_profile_write_profile_conf "$enable_defaults" "$disable_defaults" "$dry_run" || return 1
 
-    base_update_profile_update_file "$HOME/.bash_profile" bash_profile "$dry_run" || return 1
-    base_update_profile_update_file "$HOME/.bashrc" bashrc "$dry_run" || return 1
-    base_update_profile_update_file "$HOME/.zprofile" zprofile "$dry_run" || return 1
-    base_update_profile_update_file "$HOME/.zshrc" zshrc "$dry_run" || return 1
+    base_update_profile_update_file "$HOME/.bash_profile" bash_profile "$dry_run" "$backup_timestamp" || return 1
+    base_update_profile_update_file "$HOME/.bashrc" bashrc "$dry_run" "$backup_timestamp" || return 1
+    base_update_profile_update_file "$HOME/.zprofile" zprofile "$dry_run" "$backup_timestamp" || return 1
+    base_update_profile_update_file "$HOME/.zshrc" zshrc "$dry_run" "$backup_timestamp" || return 1
 }

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -77,6 +77,53 @@ EOF
     [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_ENABLE_ZSH_DEFAULTS=false"* ]]
 }
 
+@test "basectl update-profile backs up existing dotfiles before changing them" {
+    local backup_path
+
+    printf '%s\n' 'user bashrc line' > "$TEST_HOME/.bashrc"
+
+    run_base_command update-profile
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Backing up '$TEST_HOME/.bashrc' to '$TEST_HOME/.bashrc.backup."* ]]
+    backup_path="$(find "$TEST_HOME" -maxdepth 1 -type f -name '.bashrc.backup.*' -print)"
+    [[ -n "$backup_path" ]]
+    [ "$(cat "$backup_path")" = "user bashrc line" ]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"user bashrc line"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"# >>> base: bashrc managed >>>"* ]]
+    [ -z "$(find "$TEST_HOME" -maxdepth 1 -type f -name '.bash_profile.backup.*' -print)" ]
+}
+
+@test "basectl update-profile --remove removes only Base-managed sections" {
+    printf '%s\n' 'user line before' > "$TEST_HOME/.bashrc"
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+    printf '%s\n' 'user line after' >> "$TEST_HOME/.bashrc"
+
+    run_base_command update-profile --remove
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Backing up '$TEST_HOME/.bashrc' to '$TEST_HOME/.bashrc.backup."* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"user line before"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"user line after"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" != *"# >>> base: bashrc managed >>>"* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" != *"# <<< base: bashrc managed <<<"* ]]
+    [[ "$(cat "$TEST_HOME/.base.d/profile.conf")" == *"BASE_PROFILE_VERSION=1"* ]]
+}
+
+@test "basectl update-profile --remove --dry-run reports backups and removals without writing" {
+    run_base_command update-profile
+    [ "$status" -eq 0 ]
+
+    run_base_command update-profile --remove --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would back up '$TEST_HOME/.bashrc' to '$TEST_HOME/.bashrc.backup."* ]]
+    [[ "$output" == *"[DRY-RUN] Would remove section 'bashrc' from '$TEST_HOME/.bashrc'."* ]]
+    [[ "$(cat "$TEST_HOME/.bashrc")" == *"# >>> base: bashrc managed >>>"* ]]
+    [ -z "$(find "$TEST_HOME" -maxdepth 1 -type f -name '.bashrc.backup.*' -print)" ]
+}
+
 @test "basectl update-profile writes stable Homebrew opt-style paths" {
     local cellar_parent="$TEST_TMPDIR/homebrew/Cellar/base/0.4.0"
     local opt_dir="$TEST_TMPDIR/homebrew/opt"
@@ -562,6 +609,18 @@ EOF
     [ ! -e "$TEST_HOME/.zshrc" ]
 }
 
+@test "basectl update-profile --dry-run reports backups before existing dotfile updates" {
+    printf '%s\n' 'user bash profile line' > "$TEST_HOME/.bash_profile"
+
+    run_base_command update-profile --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would back up '$TEST_HOME/.bash_profile' to '$TEST_HOME/.bash_profile.backup."* ]]
+    [[ "$output" == *"[DRY-RUN] Would update '$TEST_HOME/.bash_profile' with section 'bash_profile'."* ]]
+    [ "$(cat "$TEST_HOME/.bash_profile")" = "user bash profile line" ]
+    [ -z "$(find "$TEST_HOME" -maxdepth 1 -type f -name '.bash_profile.backup.*' -print)" ]
+}
+
 @test "basectl update-profile --defaults enables defaults through profile config" {
     run_base_command update-profile --defaults
 
@@ -670,5 +729,14 @@ EOF
     [[ "$output" == *"Options '--defaults' and '--no-defaults' cannot be used together."* ]]
     [[ "$output" == *"Run 'basectl update-profile --help' for usage."* ]]
     [[ "$output" != *"Usage:"* ]]
+    [ ! -e "$TEST_HOME/.base.d/profile.conf" ]
+}
+
+@test "basectl update-profile rejects remove with defaults options" {
+    run_base_command update-profile --remove --defaults
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Option '--remove' cannot be combined with '--defaults' or '--no-defaults'."* ]]
+    [[ "$output" == *"Run 'basectl update-profile --help' for usage."* ]]
     [ ! -e "$TEST_HOME/.base.d/profile.conf" ]
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -31,7 +31,7 @@ full compatibility contract.
 | Command | What it does | Important flags |
 |---|---|---|
 | `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv`, `--notify`, `--no-notify` |
-| `basectl update-profile` | Create or update Base-managed Bash and Zsh startup snippets. | `--defaults`, `--no-defaults`, `--dry-run` |
+| `basectl update-profile` | Create, refresh, or remove Base-managed Bash and Zsh startup snippets, backing up existing dotfiles before changes. | `--defaults`, `--no-defaults`, `--remove`, `--dry-run` |
 | `basectl update [project]` | Update a Base-managed project checkout through Git, or update Base through Homebrew when Base is Homebrew-managed, then run setup for the selected project. | `--dry-run` |
 | `basectl onboard [project]` | Guide first-run setup by orchestrating check, setup, shell profile, doctor, and project discovery. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
 | `basectl version` | Show the installed Base version. | none |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -335,7 +335,7 @@ _base_basectl_completion() {
                 "--profile --dry-run --yes --no-profile -v -h --help"
             ;;
         update-profile)
-            _base_basectl_completion_compgen "--defaults --no-defaults --dry-run -v -h --help" "$cur"
+            _base_basectl_completion_compgen "--defaults --no-defaults --remove --dry-run -v -h --help" "$cur"
             ;;
         update)
             _base_basectl_completion_project_or_options "--dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -516,6 +516,7 @@ _base_basectl_completion() {
             ;;
         update-profile)
             _arguments '--defaults[Enable shell defaults]' '--no-defaults[Disable shell defaults]' \
+                '--remove[Remove Base-managed shell startup sections]' \
                 '--dry-run[Log without changing files]' '-v[Enable DEBUG logging]' \
                 '(-h --help)'{-h,--help}'[Show help text]'
             ;;


### PR DESCRIPTION
## Summary
- Back up existing Bash/Zsh startup files before `basectl update-profile` changes their Base-managed sections.
- Add `basectl update-profile --remove` to remove only Base-managed marked sections, with dry-run backup/removal reporting.
- Add shell completion entries and docs for the reversible profile path.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "backs up existing dotfiles|--remove removes|--remove --dry-run|dry-run reports backups|rejects remove" cli/bash/commands/basectl/tests/update-profile.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/update-profile.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats`
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_base_cli_docs.py tests/test_contract_hardening.py tests/test_doctor_findings_docs.py tests/test_linux_support_docs.py tests/test_observability_docs.py -q`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1366-full ./bin/base-test`

Fixes #1366