### PR TITLE
Bootstrap uv for Ubuntu project setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Bootstrapped `uv` during Ubuntu/Debian project setup when a manifest
+  explicitly opts into `python.manager: uv` or `runner: uv`, while keeping the
+  mutation guarded by `--dry-run` review and `--yes`.
 - Allowed repeated Ubuntu/Debian `basectl setup` runs without `--yes` when all
   apt prerequisites are already installed, while still requiring `--yes` before
   Base mutates apt-managed system packages.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -1589,7 +1589,7 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path precheck_json project project_uses_uv_manager project_venv_dir python_bin remote_network resolved_name resolved_root resolve_output route_output venv_dir
+    local exit_code manifest_path platform precheck_json project project_uses_uv_manager project_venv_dir python_bin remote_network resolved_name resolved_root resolve_output route_output venv_dir
     local args=()
     local project_env_args=()
     local resolve_fields=()
@@ -1664,6 +1664,7 @@ setup_run_project_artifact_layer() {
         remote_network=true
     fi
     args+=("$project")
+    platform="$(setup_current_platform)" || return 1
 
     if [[ "$output_format" != json ]]; then
         if [[ "$action" == setup ]]; then
@@ -1729,6 +1730,7 @@ setup_run_project_artifact_layer() {
     if [[ "$project_uses_uv_manager" == true ]]; then
         env "${project_env_args[@]}" \
             BASE_HOME="$BASE_HOME" \
+            BASE_PLATFORM="$platform" \
             BASE_PROJECT="$project" \
             BASE_PROJECT_ROOT="$resolved_root" \
             BASE_PROJECT_MANIFEST="$manifest_path" \
@@ -1737,6 +1739,7 @@ setup_run_project_artifact_layer() {
             "$python_bin" -m base_setup "${args[@]}"
     else
         env "${project_env_args[@]}" \
+            BASE_PLATFORM="$platform" \
             BASE_PROJECT="$project" \
             BASE_PROJECT_ROOT="$resolved_root" \
             BASE_PROJECT_MANIFEST="$manifest_path" \

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -700,6 +700,24 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
 }
 
+@test "basectl setup --yes linux-debian forwards consent to uv-managed project setup" {
+    local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local project_root="$TEST_TMPDIR/demo"
+    local manifest_path="$project_root/base_manifest.yaml"
+
+    mkdir -p "$project_root"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_project_setup_venv_stub "$base_venv_dir"
+    printf 'project:\n  name: demo\npython:\n  manager: uv\nartifacts: []\n' > "$manifest_path"
+
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --yes --dry-run --manifest "$manifest_path"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-yes")" = "true" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-platform")" = "linux-debian" ]
+}
+
 @test "project setup resolves named project manifests from the workspace" {
     local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -784,6 +784,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     printf '%s\n' "${BASE_CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-base-ci"
     printf '%s\n' "${CI:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-ci"
     printf '%s\n' "${BASE_SETUP_NOTIFY:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-notify"
+    printf '%s\n' "${BASE_SETUP_YES:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-yes"
+    printf '%s\n' "${BASE_PLATFORM:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-platform"
     touch "$BASE_SETUP_TEST_STATE_DIR/project-setup-ran"
     if [[ "$action" == "bootstrap" ]]; then
         printf '%s\n' "${BASE_SETUP_RECREATE_PROJECT_VENV:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-bootstrap-recreate-venv"

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -246,7 +246,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_default_manifest(base_home)
             write_uv_manifest(workspace / "bankbuddy", "bankbuddy")
 
-            with mock.patch("base_setup.uv.process.command_exists", return_value=True):
+            with mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")):
                 status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
 
         self.assertEqual(status, 0)
@@ -267,7 +267,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_default_manifest(base_home)
             write_uv_manifest(workspace / "bankbuddy", "bankbuddy")
 
-            with mock.patch("base_setup.uv.process.command_exists", return_value=True):
+            with mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")):
                 status, stdout, stderr = invoke_engine(["doctor", "--workspace", str(workspace)], base_home, home)
 
         self.assertEqual(status, 0)

--- a/cli/python/base_setup/tests/test_command_lint.py
+++ b/cli/python/base_setup/tests/test_command_lint.py
@@ -239,7 +239,7 @@ class CommandLintDiagnosticsTests(unittest.TestCase):
                 },
             )
 
-            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+            with mock.patch("base_setup.uv.uv_executable", return_value=None):
                 checks = engine.manifest_checks(default_manifest(project_root / "default.yaml"), manifest)
 
         self.assertIn("BASE-P150", [check.finding_id for check in checks])

--- a/cli/python/base_setup/tests/test_uv.py
+++ b/cli/python/base_setup/tests/test_uv.py
@@ -9,7 +9,7 @@ from unittest import mock
 from base_setup import engine
 from base_setup.manifest import ArtifactRequest, BaseManifest, read_manifest
 from base_setup.tests.helpers import fake_context
-from base_setup.uv import check_uv, reconcile_uv_project
+from base_setup.uv import UV_INSTALL_COMMAND_TEXT, check_uv, reconcile_uv_project
 
 
 def write_manifest(root: Path, content: str) -> BaseManifest:
@@ -37,9 +37,123 @@ class UvProjectTests(unittest.TestCase):
             )
             ctx = fake_context()
 
-            reconcile_uv_project(ctx, manifest, dry_run=True)
+            with mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")):
+                reconcile_uv_project(ctx, manifest, dry_run=True)
 
         ctx.log.info.assert_any_call("[DRY-RUN] Would run in '%s': %s", root, "uv sync")
+
+    def test_reconcile_uv_project_dry_run_plans_linux_debian_uv_bootstrap_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}),
+                mock.patch("base_setup.uv.uv_executable", return_value=None),
+            ):
+                reconcile_uv_project(ctx, manifest, dry_run=True)
+
+        ctx.log.info.assert_any_call("[DRY-RUN] Would bootstrap uv: %s", UV_INSTALL_COMMAND_TEXT)
+        ctx.log.info.assert_any_call("[DRY-RUN] Would run in '%s': %s", root, "uv sync")
+
+    def test_reconcile_uv_project_bootstraps_uv_on_linux_debian_with_yes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+            uv_path = Path(tmpdir) / ".local" / "bin" / "uv"
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian", "BASE_SETUP_YES": "true"}),
+                mock.patch("base_setup.uv.uv_executable", side_effect=[None, uv_path, uv_path]),
+                mock.patch("base_setup.uv.process.run_command") as run_command,
+                mock.patch("base_setup.uv.process.run_check", return_value=False),
+            ):
+                reconcile_uv_project(ctx, manifest, dry_run=False)
+
+        self.assertEqual(
+            run_command.call_args_list[0].args[1],
+            ["sh", "-c", UV_INSTALL_COMMAND_TEXT],
+        )
+        self.assertEqual(run_command.call_args_list[1].args[1], [str(uv_path), "sync"])
+        self.assertEqual(run_command.call_args_list[1].kwargs["cwd"], root)
+
+    def test_reconcile_uv_project_requires_yes_before_linux_debian_uv_bootstrap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = write_manifest(
+                Path(tmpdir),
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}, clear=False),
+                mock.patch("base_setup.uv.uv_executable", return_value=None),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "Run 'basectl setup demo --dry-run'.*'--yes'"):
+                    reconcile_uv_project(ctx, manifest, dry_run=False)
+
+    def test_reconcile_uv_runner_project_bootstraps_uv_without_sync_on_linux_debian(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "commands:",
+                        "  audit:",
+                        "    command: pytest tests",
+                        "    runner: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            ctx = fake_context()
+            uv_path = Path(tmpdir) / ".local" / "bin" / "uv"
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian", "BASE_SETUP_YES": "true"}),
+                mock.patch("base_setup.uv.uv_executable", side_effect=[None, uv_path]),
+                mock.patch("base_setup.uv.process.run_command") as run_command,
+                mock.patch("base_setup.uv.process.run_check") as run_check,
+            ):
+                reconcile_uv_project(ctx, manifest, dry_run=False)
+
+        run_command.assert_called_once_with(ctx, ["sh", "-c", UV_INSTALL_COMMAND_TEXT])
+        run_check.assert_not_called()
 
     def test_reconcile_uv_project_requires_uv_for_real_setup(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -57,7 +171,7 @@ class UvProjectTests(unittest.TestCase):
             )
             ctx = fake_context()
 
-            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+            with mock.patch("base_setup.uv.uv_executable", return_value=None):
                 with self.assertRaisesRegex(RuntimeError, "uv is required"):
                     reconcile_uv_project(ctx, manifest, dry_run=False)
 
@@ -79,7 +193,7 @@ class UvProjectTests(unittest.TestCase):
             ctx = fake_context()
 
             with (
-                mock.patch("base_setup.uv.process.command_exists", return_value=True),
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
                 mock.patch("base_setup.uv.process.run_check", return_value=True) as run_check,
                 mock.patch("base_setup.uv.process.run_command") as run_command,
             ):
@@ -107,7 +221,7 @@ class UvProjectTests(unittest.TestCase):
             ctx = fake_context()
 
             with (
-                mock.patch("base_setup.uv.process.command_exists", return_value=True),
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
                 mock.patch("base_setup.uv.process.run_check", return_value=False),
                 mock.patch("base_setup.uv.process.run_command") as run_command,
             ):
@@ -131,13 +245,15 @@ class UvProjectTests(unittest.TestCase):
                 ),
             )
 
-            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+            with mock.patch("base_setup.uv.uv_executable", return_value=None):
                 checks = check_uv(manifest)
 
         missing_uv = [check for check in checks if check.finding_id == "BASE-P150"]
         self.assertEqual(len(missing_uv), 1)
         self.assertEqual(missing_uv[0].status, "warn")
         self.assertIn("uv is not available", missing_uv[0].message)
+        self.assertIn("basectl setup demo --dry-run", missing_uv[0].fix)
+        self.assertIn("--yes", missing_uv[0].fix)
 
     def test_check_uv_warns_for_runner_without_python_manager(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -157,12 +273,13 @@ class UvProjectTests(unittest.TestCase):
                 ),
             )
 
-            with mock.patch("base_setup.uv.process.command_exists", return_value=False):
+            with mock.patch("base_setup.uv.uv_executable", return_value=None):
                 checks = check_uv(manifest)
 
         missing_uv = [check for check in checks if check.finding_id == "BASE-P150"]
         self.assertEqual(len(missing_uv), 1)
         self.assertIn("uv runner", missing_uv[0].message)
+        self.assertIn("basectl setup demo --dry-run", missing_uv[0].fix)
 
     def test_check_uv_reports_project_files_and_stale_base_venv(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -185,8 +302,8 @@ class UvProjectTests(unittest.TestCase):
             (root / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
 
             with mock.patch.dict("os.environ", {"HOME": str(home)}), mock.patch(
-                "base_setup.uv.process.command_exists",
-                return_value=True,
+                "base_setup.uv.uv_executable",
+                return_value=Path("uv"),
             ):
                 checks = check_uv(manifest)
 
@@ -220,7 +337,7 @@ class UvProjectTests(unittest.TestCase):
             python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
             python_bin.chmod(0o755)
 
-            with mock.patch("base_setup.uv.process.command_exists", return_value=True):
+            with mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")):
                 checks = check_uv(manifest)
 
         findings = {check.finding_id: check for check in checks}

--- a/cli/python/base_setup/uv.py
+++ b/cli/python/base_setup/uv.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 
 import base_cli
@@ -9,6 +10,10 @@ from . import process
 from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
+from .platform_policy import current_base_platform
+
+
+UV_INSTALL_COMMAND_TEXT = "curl -LsSf https://astral.sh/uv/install.sh | sh"
 
 
 def manifest_uses_uv_project_manager(manifest: BaseManifest) -> bool:
@@ -30,17 +35,21 @@ def manifest_declares_uv_runner(manifest: BaseManifest) -> bool:
 
 
 def reconcile_uv_project(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
-    if not manifest_uses_uv_project_manager(manifest):
+    uses_uv_manager = manifest_uses_uv_project_manager(manifest)
+    uses_uv_runner = manifest_declares_uv_runner(manifest)
+    if not uses_uv_manager and not uses_uv_runner:
+        return
+
+    uv_bin = ensure_uv_available(ctx, manifest, dry_run=dry_run)
+    if not uses_uv_manager:
         return
 
     project_root = manifest.path.parent
-    command = ["uv", "sync"]
+    command = ["uv", "sync"] if dry_run else [str(uv_bin), "sync"]
     if dry_run:
         process.dry_run_command(ctx, command, cwd=project_root)
         return
-    if not process.command_exists("uv"):
-        raise ArtifactError("uv is required to set up this project. Install uv and rerun basectl setup.")
-    if process.run_check(["uv", "sync", "--check"], cwd=project_root):
+    if process.run_check([str(uv_bin), "sync", "--check"], cwd=project_root):
         ctx.log.info("uv project environment is already synchronized for '%s'.", project_root)
         return
     process.run_command(ctx, command, cwd=project_root)
@@ -53,8 +62,8 @@ def check_uv(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
         return ()
 
     checks: list[ArtifactCheck] = []
-    uv_available = process.command_exists("uv")
-    checks.append(uv_tool_check(uv_available, uses_uv_manager, uses_uv_runner))
+    uv_available = uv_executable() is not None
+    checks.append(uv_tool_check(manifest.project_name, uv_available, uses_uv_manager, uses_uv_runner))
 
     if uses_uv_manager:
         checks.append(pyproject_check(manifest.path.parent / "pyproject.toml"))
@@ -67,7 +76,7 @@ def check_uv(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
     return tuple(checks)
 
 
-def uv_tool_check(uv_available: bool, uses_uv_manager: bool, uses_uv_runner: bool) -> ArtifactCheck:
+def uv_tool_check(project_name: str, uv_available: bool, uses_uv_manager: bool, uses_uv_runner: bool) -> ArtifactCheck:
     if uv_available:
         return ArtifactCheck(
             name="uv",
@@ -84,10 +93,67 @@ def uv_tool_check(uv_available: bool, uses_uv_manager: bool, uses_uv_runner: boo
         name="uv",
         ok=False,
         message=f"uv is not available, but the manifest declares {reason} support.",
-        fix="Install uv, then rerun basectl setup/check.",
+        fix=(
+            f"Run 'basectl setup {project_name} --dry-run' to review the uv bootstrap, "
+            "then rerun with '--yes', or install uv manually."
+        ),
         finding_id="BASE-P150",
         status="warn",
     )
+
+
+def ensure_uv_available(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> Path:
+    uv_bin = uv_executable()
+    if uv_bin is not None:
+        return uv_bin
+
+    if current_base_platform() != "linux-debian":
+        raise ArtifactError("uv is required to set up this project. Install uv and rerun basectl setup.")
+
+    if dry_run:
+        ctx.log.info("[DRY-RUN] Would bootstrap uv: %s", UV_INSTALL_COMMAND_TEXT)
+        return Path("uv")
+
+    if os.environ.get("BASE_SETUP_YES") != "true":
+        raise ArtifactError(
+            f"uv is required to set up project '{manifest.project_name}'. "
+            f"Run 'basectl setup {manifest.project_name} --dry-run' to review the uv bootstrap, "
+            "then rerun with '--yes' to apply it."
+        )
+
+    ctx.log.info("Bootstrapping uv for project '%s'.", manifest.project_name)
+    process.run_command(ctx, ["sh", "-c", UV_INSTALL_COMMAND_TEXT])
+    prepend_user_local_bin_to_path()
+    uv_bin = uv_executable()
+    if uv_bin is None:
+        raise ArtifactError(
+            "uv bootstrap completed, but uv was not found. "
+            "Add '$HOME/.local/bin' to PATH or install uv, then rerun basectl setup."
+        )
+    return uv_bin
+
+
+def uv_executable() -> Path | None:
+    resolved = shutil.which("uv")
+    if resolved:
+        return Path(resolved)
+
+    candidate = user_local_bin() / "uv"
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return candidate
+    return None
+
+
+def user_local_bin() -> Path:
+    return Path.home() / ".local" / "bin"
+
+
+def prepend_user_local_bin_to_path() -> None:
+    bin_dir = str(user_local_bin())
+    current_path = os.environ.get("PATH", "")
+    path_entries = current_path.split(os.pathsep) if current_path else []
+    if bin_dir not in path_entries:
+        os.environ["PATH"] = os.pathsep.join([bin_dir, *path_entries]) if path_entries else bin_dir
 
 
 def pyproject_check(pyproject_path: Path) -> ArtifactCheck:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -174,7 +174,9 @@ without failing the Base manifest check by themselves.
 when uv tooling or expected uv project files are missing, because check/doctor
 should explain readiness without performing dependency resolution. Command
 invocation still fails hard when a command declares `runner: uv` and the `uv`
-executable is unavailable.
+executable is unavailable. On Ubuntu/Debian, `BASE-P150` recovery should point
+users to `basectl setup <project> --dry-run` followed by `--yes` when the
+manifest has explicitly opted into uv.
 For the full uv manifest contract, migration paths, and runner configuration,
 see [Python Manifest](python-manifest.md).
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -147,8 +147,11 @@ Project-level `brewfile` delegates remain macOS/Homebrew-only. On
 Ubuntu/Debian, Base validates the Brewfile path but skips `brew bundle` setup and
 reports a warning from check/doctor instead of asking users to install Homebrew.
 Linux project prerequisites should use a platform-native project path. For
-projects that declare `python.manager: uv`, install or make `uv` available and
-let Base delegate Python setup to `uv sync`.
+projects that declare `python.manager: uv` or command-level `runner: uv`,
+`basectl setup <project> --dry-run` shows the planned `uv` bootstrap when `uv`
+is missing, and `basectl setup <project> --yes` installs `uv` before delegating
+Python setup to `uv sync`. Base does not install `uv` for projects that have not
+opted into the uv contract.
 
 GitHub CLI authentication remains a user-owned step. After `gh` is installed,
 run the browser-backed flow when you need GitHub access:

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -110,6 +110,11 @@ Base does not infer uv ownership from `pyproject.toml` or `uv.lock` alone. The
 manifest opt-in is what lets Base choose the repo-local `.venv` and report uv
 diagnostics.
 
+On Ubuntu/Debian, the same manifest opt-in also lets Base bootstrap the `uv`
+tool when it is missing: review the planned installer with
+`basectl setup <project> --dry-run`, then rerun with `--yes` to allow the
+mutation before Base delegates to `uv sync`.
+
 ## Command Runners
 
 Command execution is independent from the project-level Python manager. Any

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -148,6 +148,9 @@ How Base should coexist:
 - report missing uv, missing `.venv`, or needed `uv sync` steps through
   Base-native check and doctor output when the project has opted into that
   contract
+- on Ubuntu/Debian, bootstrap the `uv` tool during `basectl setup <project>`
+  only after the manifest has explicitly opted into uv and the caller has
+  reviewed `--dry-run` output and passed `--yes`
 - invoke uv transparently, so dry-run output, logs, and diagnostics show the
   underlying `uv sync` or `uv run -- ...` command instead of hiding it behind
   Base


### PR DESCRIPTION
## Summary

- bootstrap `uv` during Ubuntu/Debian project setup when the manifest explicitly declares `python.manager: uv` or command-level `runner: uv`
- keep mutation guarded by `--dry-run` review and `--yes`
- pass the effective setup platform into the Python project layer so manifest delegates see `linux-debian`
- update uv diagnostics and docs to point users back to the Base setup flow

## Verification

- `env PATH=/usr/bin:/bin PYTHONPATH=/Users/rameshhp/work/base-worktrees/1386-ubuntu-uv-bootstrap/lib/python:/Users/rameshhp/work/base-worktrees/1386-ubuntu-uv-bootstrap/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest`
- `env PATH=/usr/bin:/bin PYTHONPATH=/Users/rameshhp/work/base-worktrees/1386-ubuntu-uv-bootstrap/lib/python:/Users/rameshhp/work/base-worktrees/1386-ubuntu-uv-bootstrap/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/uv.py cli/python/base_setup/tests/test_uv.py cli/python/base_setup/tests/test_command_lint.py cli/python/base_projects/tests/test_workspace_checks.py`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1386-focused-cache bats -f "basectl setup --yes linux-debian forwards consent to uv-managed project setup" cli/bash/commands/basectl/tests/setup.bats`
- `git diff --check`

Note: local full `setup.bats` currently has an environment-specific failure in the pinned Homebrew/Xcode installer test that reproduces on current `main`; this PR relies on GitHub Actions for the full shell suite.

Fixes #1386
