### PR TITLE
Bootstrap mise for Ubuntu project setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Bootstrapped `mise` during Ubuntu/Debian project setup when a manifest
+  declares a project-owned mise config, while keeping the mutation guarded by
+  `--dry-run` review and `--yes`.
 - Bootstrapped `uv` during Ubuntu/Debian project setup when a manifest
   explicitly opts into `python.manager: uv` or `runner: uv`, while keeping the
   mutation guarded by `--dry-run` review and `--yes`.

--- a/cli/python/base_setup/delegates.py
+++ b/cli/python/base_setup/delegates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -12,7 +13,12 @@ from . import process
 from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
-from .platform_policy import brewfile_delegates_supported, platform_label
+from .platform_policy import brewfile_delegates_supported, current_base_platform, platform_label
+from .user_paths import prepend_user_local_bin_to_path
+from .user_paths import user_local_bin
+
+
+MISE_INSTALL_COMMAND_TEXT = "curl https://mise.run | sh"
 
 
 def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
@@ -96,23 +102,28 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
             finding_id="BASE-P020",
         )
 
-    if not process.command_exists("mise"):
+    mise_bin = mise_executable()
+    if mise_bin is None:
         return ArtifactCheck(
             name="mise",
             ok=False,
-            message=f"mise is required for project config '{mise_path}'.",
-            fix="Install mise, then run 'basectl setup'.",
+            message=f"mise is not available, but the manifest declares project config '{mise_path}'.",
+            fix=(
+                f"Run 'basectl setup {manifest.project_name} --dry-run' to review the mise bootstrap, "
+                "then rerun with '--yes', or install mise manually."
+            ),
             finding_id="BASE-P021",
+            status="warn",
         )
 
     project_root = manifest.path.parent.resolve()
     details = mise_details(project_root, mise_path)
-    trust_problem = check_mise_trust(project_root, mise_path, details)
+    trust_problem = check_mise_trust(project_root, mise_path, mise_bin, details)
     if trust_problem is not None:
         return trust_problem
 
     verified_details = details | {"trusted": True, "missing_tools_checked": True}
-    missing_problem = check_mise_missing_tools(manifest, project_root, mise_path, verified_details)
+    missing_problem = check_mise_missing_tools(manifest, project_root, mise_path, mise_bin, verified_details)
     if missing_problem is not None:
         return missing_problem
 
@@ -126,10 +137,15 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
     )
 
 
-def check_mise_trust(project_root: Path, mise_path: Path, details: dict[str, object]) -> ArtifactCheck | None:
+def check_mise_trust(
+    project_root: Path,
+    mise_path: Path,
+    mise_bin: Path,
+    details: dict[str, object],
+) -> ArtifactCheck | None:
     try:
         trust_check = process.run_capture(
-            ["mise", "trust", "--show"],
+            [str(mise_bin), "trust", "--show"],
             cwd=project_root,
             timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
         )
@@ -183,11 +199,12 @@ def check_mise_missing_tools(
     manifest: BaseManifest,
     project_root: Path,
     mise_path: Path,
+    mise_bin: Path,
     details: dict[str, object],
 ) -> ArtifactCheck | None:
     try:
         missing_check = process.run_capture(
-            ["mise", "ls", "--missing", "--json"],
+            [str(mise_bin), "ls", "--missing", "--json"],
             cwd=project_root,
             timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
         )
@@ -303,16 +320,45 @@ def reconcile_mise(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool)
 
     mise_path = resolve_mise_path(manifest)
     project_root = manifest.path.parent.resolve()
-    command = ["mise", "install"]
+    mise_bin = ensure_mise_available(ctx, manifest, dry_run=dry_run)
+    command = ["mise", "install"] if dry_run else [str(mise_bin), "install"]
     if dry_run:
         process.dry_run_command(ctx, command, cwd=project_root)
         return
 
-    if not process.command_exists("mise"):
-        raise ArtifactError(f"mise is required to install project tool versions from '{mise_path}'.")
-
     ctx.log.info("Installing mise-managed tools from '%s'.", mise_path)
     process.run_command(ctx, command, cwd=project_root)
+
+
+def ensure_mise_available(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> Path:
+    mise_bin = mise_executable()
+    if mise_bin is not None:
+        return mise_bin
+
+    if current_base_platform() != "linux-debian":
+        raise ArtifactError("mise is required to set up this project. Install mise and rerun basectl setup.")
+
+    if dry_run:
+        ctx.log.info("[DRY-RUN] Would bootstrap mise: %s", MISE_INSTALL_COMMAND_TEXT)
+        return Path("mise")
+
+    if os.environ.get("BASE_SETUP_YES") != "true":
+        raise ArtifactError(
+            f"mise is required to set up project '{manifest.project_name}'. "
+            f"Run 'basectl setup {manifest.project_name} --dry-run' to review the mise bootstrap, "
+            "then rerun with '--yes' to apply it."
+        )
+
+    ctx.log.info("Bootstrapping mise for project '%s'.", manifest.project_name)
+    process.run_command(ctx, ["sh", "-c", MISE_INSTALL_COMMAND_TEXT])
+    prepend_user_local_bin_to_path()
+    mise_bin = mise_executable()
+    if mise_bin is None:
+        raise ArtifactError(
+            "mise bootstrap completed, but mise was not found. "
+            "Add '$HOME/.local/bin' to PATH or install mise, then rerun basectl setup."
+        )
+    return mise_bin
 
 
 def resolve_brewfile_path(manifest: BaseManifest) -> Path:
@@ -352,6 +398,17 @@ def missing_tool_names(payload: Any) -> list[str]:
         return ["unknown"] if payload else []
     names = [str(name) for name, value in payload.items() if value]
     return sorted(names)
+
+
+def mise_executable() -> Path | None:
+    resolved = shutil.which("mise")
+    if resolved:
+        return Path(resolved)
+
+    candidate = user_local_bin() / "mise"
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return candidate
+    return None
 
 
 def resolve_mise_path(manifest: BaseManifest) -> Path:

--- a/cli/python/base_setup/tests/test_mise.py
+++ b/cli/python/base_setup/tests/test_mise.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest import mock
 
 from base_setup import delegates, engine
+from base_setup.delegates import MISE_INSTALL_COMMAND_TEXT
 from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest
 from base_setup.tests.helpers import fake_context
@@ -67,12 +68,62 @@ class MiseTests(unittest.TestCase):
                 artifacts=(),
             )
 
-            delegates.reconcile_mise(ctx, manifest, dry_run=True)
+            with mock.patch("base_setup.delegates.mise_executable", return_value=Path("mise")):
+                delegates.reconcile_mise(ctx, manifest, dry_run=True)
 
         info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
         self.assertIn(f"[DRY-RUN] Would run in '{project_root.resolve()}': mise install", info_messages)
 
 
+
+    def test_mise_dry_run_plans_linux_debian_bootstrap_when_missing(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = make_manifest(project_root)
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}),
+                mock.patch("base_setup.delegates.mise_executable", return_value=None),
+            ):
+                delegates.reconcile_mise(ctx, manifest, dry_run=True)
+
+        ctx.log.info.assert_any_call("[DRY-RUN] Would bootstrap mise: %s", MISE_INSTALL_COMMAND_TEXT)
+        ctx.log.info.assert_any_call("[DRY-RUN] Would run in '%s': %s", project_root.resolve(), "mise install")
+
+    def test_mise_bootstraps_on_linux_debian_with_yes(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = make_manifest(project_root)
+            mise_path = Path(tmpdir) / ".local" / "bin" / "mise"
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian", "BASE_SETUP_YES": "true"}),
+                mock.patch("base_setup.delegates.mise_executable", side_effect=[None, mise_path]),
+                mock.patch("base_setup.delegates.process.run_command") as run_command,
+            ):
+                delegates.reconcile_mise(ctx, manifest, dry_run=False)
+
+        self.assertEqual(run_command.call_args_list[0].args[1], ["sh", "-c", MISE_INSTALL_COMMAND_TEXT])
+        self.assertEqual(run_command.call_args_list[1].args[1], [str(mise_path), "install"])
+        self.assertEqual(run_command.call_args_list[1].kwargs["cwd"], project_root.resolve())
+
+    def test_mise_requires_yes_before_linux_debian_bootstrap(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = make_manifest(project_root)
+
+            with (
+                mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}, clear=False),
+                mock.patch("base_setup.delegates.mise_executable", return_value=None),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "Run 'basectl setup demo --dry-run'.*'--yes'"):
+                    delegates.reconcile_mise(ctx, manifest, dry_run=False)
 
     def test_mise_invokes_install_in_project_root(self) -> None:
         ctx = fake_context()
@@ -88,7 +139,7 @@ class MiseTests(unittest.TestCase):
                 artifacts=(),
             )
 
-            with mock.patch("base_setup.process.command_exists", return_value=True), mock.patch(
+            with mock.patch("base_setup.delegates.mise_executable", return_value=Path("mise")), mock.patch(
                 "base_setup.process.run_command"
             ) as run_command:
                 delegates.reconcile_mise(ctx, manifest, dry_run=False)
@@ -123,6 +174,22 @@ class MiseTests(unittest.TestCase):
             ],
         )
 
+    def test_mise_check_warns_when_tool_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = make_manifest(project_root)
+
+            with mock.patch("base_setup.delegates.mise_executable", return_value=None):
+                check = delegates.check_mise(manifest)
+
+        self.assertFalse(check.ok)
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.finding_id, "BASE-P021")
+        self.assertIn("mise is not available", check.message)
+        self.assertIn("basectl setup demo --dry-run", check.fix)
+        self.assertIn("--yes", check.fix)
+
 
     def test_mise_check_reports_untrusted_project_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -152,7 +219,7 @@ class MiseTests(unittest.TestCase):
             manifest = make_manifest(project_root)
 
             with (
-                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch("base_setup.delegates.mise_executable", return_value=Path("mise")),
                 mock.patch(
                     "base_setup.process.run_capture",
                     side_effect=subprocess.TimeoutExpired(
@@ -228,7 +295,7 @@ class MiseTests(unittest.TestCase):
             )
 
             with (
-                mock.patch("base_setup.process.command_exists", return_value=True),
+                mock.patch("base_setup.delegates.mise_executable", return_value=Path("mise")),
                 mock.patch(
                     "base_setup.process.run_capture",
                     side_effect=[

--- a/cli/python/base_setup/user_paths.py
+++ b/cli/python/base_setup/user_paths.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def user_local_bin() -> Path:
+    return Path.home() / ".local" / "bin"
+
+
+def prepend_user_local_bin_to_path() -> None:
+    bin_dir = str(user_local_bin())
+    current_path = os.environ.get("PATH", "")
+    path_entries = current_path.split(os.pathsep) if current_path else []
+    if bin_dir not in path_entries:
+        os.environ["PATH"] = os.pathsep.join([bin_dir, *path_entries]) if path_entries else bin_dir

--- a/cli/python/base_setup/uv.py
+++ b/cli/python/base_setup/uv.py
@@ -11,6 +11,8 @@ from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
 from .platform_policy import current_base_platform
+from .user_paths import prepend_user_local_bin_to_path
+from .user_paths import user_local_bin
 
 
 UV_INSTALL_COMMAND_TEXT = "curl -LsSf https://astral.sh/uv/install.sh | sh"
@@ -142,18 +144,6 @@ def uv_executable() -> Path | None:
     if candidate.is_file() and os.access(candidate, os.X_OK):
         return candidate
     return None
-
-
-def user_local_bin() -> Path:
-    return Path.home() / ".local" / "bin"
-
-
-def prepend_user_local_bin_to_path() -> None:
-    bin_dir = str(user_local_bin())
-    current_path = os.environ.get("PATH", "")
-    path_entries = current_path.split(os.pathsep) if current_path else []
-    if bin_dir not in path_entries:
-        os.environ["PATH"] = os.pathsep.join([bin_dir, *path_entries]) if path_entries else bin_dir
 
 
 def pyproject_check(pyproject_path: Path) -> ArtifactCheck:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -113,7 +113,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P011` | Brewfile platform or Homebrew availability |
 | `BASE-P012` | Brewfile dependency status |
 | `BASE-P020` | mise config path validity |
-| `BASE-P021` | mise CLI availability |
+| `BASE-P021` | mise CLI availability and setup bootstrap guidance |
 | `BASE-P022` | mise trust and missing-tool status |
 | `BASE-P030` | Unsupported artifact manager |
 | `BASE-P031` | Unsupported Homebrew artifact version |

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -153,6 +153,13 @@ is missing, and `basectl setup <project> --yes` installs `uv` before delegating
 Python setup to `uv sync`. Base does not install `uv` for projects that have not
 opted into the uv contract.
 
+Projects that declare a `mise` config use the same Ubuntu/Debian review gate:
+`basectl setup <project> --dry-run` shows the planned `mise` bootstrap when
+`mise` is missing, and `basectl setup <project> --yes` installs `mise` before
+delegating project tool setup to `mise install`. Base does not automatically
+trust project-owned mise configs; if mise reports an untrusted config, review it
+and run `mise trust <path-to-mise-config>` before retrying setup.
+
 GitHub CLI authentication remains a user-owned step. After `gh` is installed,
 run the browser-backed flow when you need GitHub access:
 

--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -37,7 +37,8 @@ relative to setup.
 
 The `brewfile` delegate is platform-aware. Base runs `brew bundle` on macOS, but
 on Ubuntu/Debian it treats Brewfiles as unsupported macOS package declarations
-and continues through platform-native project setup such as `python.manager: uv`.
+and continues through platform-native project setup such as `python.manager: uv`
+or `mise: .mise.toml`.
 
 When a project needs a product-specific guided installer or imperative
 bootstrap, that logic should live in the project repository, for example:

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -98,6 +98,9 @@ How Base should coexist:
 - allow a Base-managed project to declare that it uses `mise.toml`
 - let `basectl setup` or `basectl check` invoke `mise install`, `mise doctor`, or
   `mise run ...` when that is the project's chosen substrate
+- on Ubuntu/Debian, bootstrap the `mise` CLI during `basectl setup <project>`
+  only after the manifest declares a mise config and the caller has reviewed
+  `--dry-run` output and passed `--yes`
 - support Go, Java, and other language runtimes through project-owned
   `.mise.toml` files instead of adding Base-owned package types for each
   language ecosystem


### PR DESCRIPTION
## Summary

- bootstrap `mise` on Ubuntu/Debian when a project manifest declares a mise config and the caller has reviewed `--dry-run` output and passed `--yes`
- reuse a shared `~/.local/bin` PATH helper for uv and mise installer flows
- update Linux support, tool-boundary, setup-hook, doctor-finding, and changelog docs

Closes #1387.

## Validation

- `python -m unittest cli.python.base_setup.tests.test_mise cli.python.base_setup.tests.test_uv`
- `python -m pytest cli/python/base_setup/tests/test_command_lint.py cli/python/base_projects/tests/test_workspace_checks.py cli/python/base_setup/tests/test_brewfile.py`
- `PATH=/usr/bin:/bin python -m pytest` (`752 passed, 1 skipped`)
- `python -m pylint cli/python/base_setup/delegates.py cli/python/base_setup/uv.py cli/python/base_setup/user_paths.py cli/python/base_setup/tests/test_mise.py cli/python/base_setup/tests/test_uv.py`
- `git diff --check`
