### PR TITLE
Preflight mise trust before setup install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Preflighted `mise` trust before `basectl setup` runs `mise install`, so
+  untrusted project configs fail with a Base recovery message instead of raw
+  lower-level `mise install` output.
 - Bootstrapped `mise` during Ubuntu/Debian project setup when a manifest
   declares a project-owned mise config, while keeping the mutation guarded by
   `--dry-run` review and `--yes`.

--- a/cli/python/base_setup/delegates.py
+++ b/cli/python/base_setup/delegates.py
@@ -326,8 +326,25 @@ def reconcile_mise(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool)
         process.dry_run_command(ctx, command, cwd=project_root)
         return
 
+    require_mise_trusted_for_setup(manifest, project_root, mise_path, mise_bin)
     ctx.log.info("Installing mise-managed tools from '%s'.", mise_path)
     process.run_command(ctx, command, cwd=project_root)
+
+
+def require_mise_trusted_for_setup(
+    manifest: BaseManifest,
+    project_root: Path,
+    mise_path: Path,
+    mise_bin: Path,
+) -> None:
+    trust_problem = check_mise_trust(project_root, mise_path, mise_bin, mise_details(project_root, mise_path))
+    if trust_problem is None:
+        return
+
+    raise ArtifactError(
+        f"{trust_problem.message} "
+        f"Run '{trust_problem.fix}', then rerun 'basectl setup {manifest.project_name} --yes'."
+    )
 
 
 def ensure_mise_available(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> Path:

--- a/cli/python/base_setup/tests/test_mise.py
+++ b/cli/python/base_setup/tests/test_mise.py
@@ -52,6 +52,15 @@ def write_fake_mise(bin_dir: Path, log_path: Path, trust_output: str, missing_ou
     mise.chmod(0o755)
 
 
+def trusted_mise_check(project_root: Path, mise_bin: Path = Path("mise")) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        [str(mise_bin), "trust", "--show"],
+        0,
+        stdout=f"{project_root.resolve()}: trusted",
+        stderr="",
+    )
+
+
 class MiseTests(unittest.TestCase):
 
     def test_mise_dry_run_invokes_mise_install_in_project_root(self) -> None:
@@ -103,6 +112,7 @@ class MiseTests(unittest.TestCase):
             with (
                 mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian", "BASE_SETUP_YES": "true"}),
                 mock.patch("base_setup.delegates.mise_executable", side_effect=[None, mise_path]),
+                mock.patch("base_setup.delegates.process.run_capture", return_value=trusted_mise_check(project_root)),
                 mock.patch("base_setup.delegates.process.run_command") as run_command,
             ):
                 delegates.reconcile_mise(ctx, manifest, dry_run=False)
@@ -141,10 +151,40 @@ class MiseTests(unittest.TestCase):
 
             with mock.patch("base_setup.delegates.mise_executable", return_value=Path("mise")), mock.patch(
                 "base_setup.process.run_command"
-            ) as run_command:
+            ) as run_command, mock.patch(
+                "base_setup.delegates.process.run_capture",
+                return_value=trusted_mise_check(project_root),
+            ):
                 delegates.reconcile_mise(ctx, manifest, dry_run=False)
 
         run_command.assert_called_once_with(ctx, ["mise", "install"], cwd=project_root.resolve())
+
+    def test_mise_setup_refuses_untrusted_project_config_before_install(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "demo"
+            project_root.mkdir()
+            manifest = make_manifest(project_root)
+            mise_bin = Path("mise")
+            trust_check = subprocess.CompletedProcess(
+                [str(mise_bin), "trust", "--show"],
+                0,
+                stdout=f"{project_root.resolve()}: untrusted",
+                stderr="",
+            )
+
+            with (
+                mock.patch("base_setup.delegates.mise_executable", return_value=mise_bin),
+                mock.patch("base_setup.delegates.process.run_capture", return_value=trust_check),
+                mock.patch("base_setup.delegates.process.run_command") as run_command,
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    f"mise config '{project_root.resolve() / '.mise.toml'}' is not trusted by mise",
+                ):
+                    delegates.reconcile_mise(ctx, manifest, dry_run=False)
+
+        run_command.assert_not_called()
 
 
     def test_mise_check_passes_when_trusted_and_no_tools_missing(self) -> None:


### PR DESCRIPTION
## Summary

- preflight mise trust before `basectl setup` runs `mise install`
- fail untrusted mise configs with a Base recovery message instead of raw `mise install` output
- preserve dry-run behavior and trusted-config setup behavior

Fixes #1391.

## Validation

- `python -m pytest cli/python/base_setup/tests/test_mise.py -k "setup_refuses_untrusted"`
- `python -m pytest cli/python/base_setup/tests/test_mise.py`
- `PATH=/usr/bin:/bin python -m pytest` (`753 passed, 1 skipped`)
- `python -m pylint cli/python/base_setup/delegates.py cli/python/base_setup/tests/test_mise.py`
- `git diff --check`
