### PR TITLE
Gate IDE extension checks behind dev profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Stopped default project checks from failing Ubuntu/Linux acceptance solely
+  because manifest-declared IDE extension CLIs such as `code` are not on `PATH`;
+  IDE extension diagnostics now run with the developer profile.
 - Made the `tool:bats-core` project artifact platform-aware on Ubuntu/Debian,
   mapping it to the system `bats` package instead of planning a Homebrew
   `brew install bats-core` command.

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -52,6 +53,7 @@ from .uv import reconcile_uv_project
 
 
 app = base_cli.App(name="base_setup")
+IDE_EXTENSION_PROFILE = "dev"
 
 
 @dataclass(frozen=True)
@@ -430,7 +432,8 @@ def manifest_checks(
     checks.extend(check_demo(effective_manifest))
     checks.extend(check_manifest_commands(effective_manifest))
     checks.extend(check_ide_installs(effective_manifest))
-    checks.extend(check_ide_extensions(effective_manifest))
+    if setup_profile_enabled(IDE_EXTENSION_PROFILE):
+        checks.extend(check_ide_extensions(effective_manifest))
     checks.extend(check_ide_settings(effective_manifest))
     checks.extend(check_uv(effective_manifest))
     checks.extend(check_pyproject(effective_manifest))
@@ -450,6 +453,10 @@ def manifest_checks(
             )
         )
     return tuple(pre_venv_checks + checks)
+
+
+def setup_profile_enabled(profile: str) -> bool:
+    return profile in os.environ.get("BASE_SETUP_PROFILES", "").split()
 
 
 def empty_user_config() -> UserConfig:

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -718,7 +718,7 @@ class IdeDiagnosticsTests(unittest.TestCase):
             ), mock.patch(
                 "base_setup.ide.list_ide_extensions",
                 return_value={"ms-python.python"},
-            ), mock.patch.dict(os.environ, {"HOME": tmpdir, "XDG_CONFIG_HOME": ""}):
+            ), mock.patch.dict(os.environ, {"HOME": tmpdir, "XDG_CONFIG_HOME": "", "BASE_SETUP_PROFILES": "dev"}):
                 settings_file = ide.ide_settings_file(ide.IDE_DEFINITIONS["vscode"])
                 settings_file.parent.mkdir(parents=True)
                 settings_file.write_text(json.dumps({"editor.formatOnSave": True}), encoding="utf-8")
@@ -763,7 +763,10 @@ class IdeDiagnosticsTests(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as home_dir:
-            with mock.patch.dict(os.environ, {"HOME": home_dir, "XDG_CONFIG_HOME": ""}), mock.patch(
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": home_dir, "XDG_CONFIG_HOME": "", "BASE_SETUP_PROFILES": "dev"},
+            ), mock.patch(
                 "base_setup.process.command_exists",
                 return_value=False,
             ):

--- a/cli/python/base_setup/tests/test_ide_extensions.py
+++ b/cli/python/base_setup/tests/test_ide_extensions.py
@@ -257,7 +257,9 @@ class IdeExtensionTests(unittest.TestCase):
             },
         )
 
-        with mock.patch("base_setup.process.command_exists", return_value=True), mock.patch(
+        with mock.patch.dict("os.environ", {"BASE_SETUP_PROFILES": "dev"}), mock.patch(
+            "base_setup.process.command_exists", return_value=True
+        ), mock.patch(
             "base_setup.ide.list_ide_extensions",
             return_value={"ms-python.python"},
         ):
@@ -266,3 +268,34 @@ class IdeExtensionTests(unittest.TestCase):
         self.assertEqual(len(checks), 1)
         self.assertEqual(checks[0].name, "ms-python.python")
         self.assertTrue(checks[0].ok)
+
+
+    def test_manifest_checks_skip_ide_extensions_without_dev_profile(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=False,
+                    extensions=("ms-python.python",),
+                    settings={},
+                )
+            },
+        )
+
+        with mock.patch.dict("os.environ", {"BASE_SETUP_PROFILES": ""}), mock.patch(
+            "base_setup.process.command_exists", return_value=False
+        ) as command_exists, mock.patch("base_setup.ide.list_ide_extensions") as list_extensions:
+            checks = engine.manifest_checks(default_manifest, manifest)
+
+        command_exists.assert_not_called()
+        list_extensions.assert_not_called()
+        self.assertNotIn("ms-python.python", [check.name for check in checks])

--- a/docs/ide-bootstrapping.md
+++ b/docs/ide-bootstrapping.md
@@ -134,9 +134,15 @@ Use:
 ```bash
 basectl check <project>
 basectl doctor <project>
+basectl check <project> --profile dev
+basectl doctor <project> --profile dev
 ```
 
-IDE checks include:
+Default project checks keep IDE extension CLI probes out of the core runtime
+acceptance path. IDE extension diagnostics run when the developer prerequisite
+profile is active, for example with `--profile dev`.
+
+IDE checks can include:
 
 - requested IDE app installed through Homebrew cask
 - IDE CLI available on `PATH`

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -165,6 +165,12 @@ platform-aware mapping is `tool:bats-core`: the manifest keeps the portable
 artifact name, macOS continues to use Homebrew package `bats-core`, and
 Ubuntu/Debian treats the artifact as satisfied by system package `bats`.
 
+IDE extension checks are developer-workstation polish, not part of the default
+Ubuntu/Debian runtime acceptance path. Default `basectl check` and
+`basectl ci check` runs do not fail solely because editor CLIs such as `code`
+are absent; run with `--profile dev` when you want Base to validate declared IDE
+extensions.
+
 GitHub CLI authentication remains a user-owned step. After `gh` is installed,
 run the browser-backed flow when you need GitHub access:
 


### PR DESCRIPTION
## Summary
- skip manifest IDE extension diagnostics unless the dev setup profile is active
- preserve IDE extension diagnostics for `--profile dev` checks and doctor runs
- document the Ubuntu/Linux acceptance boundary for editor extension probes

Fixes #1394.

## Validation
- `python -m pytest cli/python/base_setup/tests/test_ide_extensions.py tests/test_linux_support_docs.py` (`16 passed`)
- `python -m pytest cli/python/base_setup/tests/test_ide_extensions.py cli/python/base_setup/tests/test_diagnostics.py` (`35 passed, 1 skipped`)
- `PATH=/usr/bin:/bin python -m pytest` (`758 passed, 1 skipped`)
- `python -m pylint cli/python/base_setup/engine.py cli/python/base_setup/tests/test_ide_extensions.py cli/python/base_setup/tests/test_diagnostics.py`
- `git diff --check`