### PR TITLE
[codex] Guard basectl against Rosetta Homebrew mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Stopped `basectl` from continuing under Rosetta when it resolves native
+  Apple Silicon Homebrew at `/opt/homebrew`, so setup fails early with Bash
+  recovery guidance instead of breaking during a later `brew install`.
 - Replaced stray shell `run` calls in setup's virtualenv and apt install paths
   with direct command execution so spawned `basectl setup` runs do not depend on
   a test-harness helper.

--- a/bin/basectl
+++ b/bin/basectl
@@ -71,6 +71,74 @@ basectl_print_version() {
     printf 'basectl %s\n' "$(base_read_version "$base_home")"
 }
 
+basectl_proc_translated() {
+    local translated
+
+    if [[ -n "${BASE_TEST_PROC_TRANSLATED+x}" ]]; then
+        [[ "$BASE_TEST_PROC_TRANSLATED" == 1 ]]
+        return $?
+    fi
+
+    translated="$(sysctl -in sysctl.proc_translated 2>/dev/null || true)"
+    [[ "$translated" == 1 ]]
+}
+
+basectl_homebrew_prefix() {
+    local brew_bin
+
+    if [[ -n "${BASE_TEST_HOMEBREW_PREFIX+x}" ]]; then
+        [[ -n "$BASE_TEST_HOMEBREW_PREFIX" ]] || return 1
+        printf '%s\n' "$BASE_TEST_HOMEBREW_PREFIX"
+        return 0
+    fi
+
+    if [[ -n "${HOMEBREW_PREFIX:-}" ]]; then
+        printf '%s\n' "$HOMEBREW_PREFIX"
+        return 0
+    fi
+
+    brew_bin="$(command -v brew 2>/dev/null || true)"
+    case "$brew_bin" in
+        /opt/homebrew/bin/brew)
+            printf '%s\n' "/opt/homebrew"
+            return 0
+            ;;
+        /usr/local/bin/brew)
+            printf '%s\n' "/usr/local"
+            return 0
+            ;;
+    esac
+
+    [[ -n "$brew_bin" ]] || return 1
+    "$brew_bin" --prefix 2>/dev/null
+}
+
+basectl_rosetta_arm_homebrew_active() {
+    local prefix
+
+    basectl_proc_translated || return 1
+    prefix="$(basectl_homebrew_prefix)" || return 1
+    [[ "$prefix" == "/opt/homebrew" ]]
+}
+
+basectl_rosetta_bash_candidate_allowed() {
+    local candidate="$1"
+
+    [[ "$candidate" != "/usr/local/bin/bash" ]]
+}
+
+basectl_print_rosetta_arm_homebrew_error() {
+    {
+        printf 'ERROR: Base is running under Rosetta while Homebrew resolves to /opt/homebrew.\n'
+        printf 'This can happen when /usr/local/bin/bash appears before native Bash on PATH.\n'
+        printf '\n'
+        printf 'Install native Homebrew Bash with:\n'
+        printf '  arch -arm64 /opt/homebrew/bin/brew install bash\n'
+        printf '\n'
+        printf 'Then start Base from /opt/homebrew/bin/bash or move /usr/local/bin behind /opt/homebrew/bin on PATH.\n'
+    } >&2
+}
+
 basectl_ensure_supported_bash() {
     local candidate
     local candidates=()
@@ -78,13 +146,26 @@ basectl_ensure_supported_bash() {
     local display_version
 
     current_version="${BASE_TEST_BASH_VERSION:-${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}}"
-    ((current_version >= 42)) && return 0
 
     if [[ -n "${BASE_TEST_BASH_CANDIDATES:-}" ]]; then
         IFS=: read -r -a candidates <<<"$BASE_TEST_BASH_CANDIDATES"
     else
         candidates=(/opt/homebrew/bin/bash /usr/local/bin/bash)
     fi
+
+    if basectl_rosetta_arm_homebrew_active; then
+        for candidate in "${candidates[@]}"; do
+            [[ -x "$candidate" ]] || continue
+            [[ "$candidate" == "${BASH:-}" ]] && continue
+            basectl_rosetta_bash_candidate_allowed "$candidate" || continue
+            exec "$candidate" "$0" "$@"
+        done
+
+        basectl_print_rosetta_arm_homebrew_error
+        exit 1
+    fi
+
+    ((current_version >= 42)) && return 0
 
     for candidate in "${candidates[@]}"; do
         [[ -x "$candidate" ]] || continue

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -114,6 +114,46 @@ EOF
     [[ "$output" == *"args=$BASE_REPO_ROOT/bin/basectl --version"* ]]
 }
 
+@test "basectl re-execs through native Bash when translated under ARM Homebrew" {
+    local fake_bash="$TEST_TMPDIR/fake-arm-bash"
+
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'fake_arm_bash=%s\n' "$0"
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$fake_bash"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_BASH_VERSION=50 \
+        BASE_TEST_PROC_TRANSLATED=1 \
+        BASE_TEST_HOMEBREW_PREFIX=/opt/homebrew \
+        BASE_TEST_BASH_CANDIDATES="$fake_bash" \
+        "$BASE_REPO_ROOT/bin/basectl" --version
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fake_arm_bash=$fake_bash"* ]]
+    [[ "$output" == *"args=$BASE_REPO_ROOT/bin/basectl --version"* ]]
+}
+
+@test "basectl rejects translated Bash when ARM Homebrew is active and no native Bash is available" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_BASH_VERSION=50 \
+        BASE_TEST_PROC_TRANSLATED=1 \
+        BASE_TEST_HOMEBREW_PREFIX=/opt/homebrew \
+        BASE_TEST_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        "$BASE_REPO_ROOT/bin/basectl" --version
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Base is running under Rosetta while Homebrew resolves to /opt/homebrew."* ]]
+    [[ "$output" == *"Install native Homebrew Bash with:"* ]]
+    [[ "$output" == *"arch -arm64 /opt/homebrew/bin/brew install bash"* ]]
+}
+
 @test "basectl gives setup guidance when current Bash is too old and no supported Bash is installed" {
     run env \
         HOME="$TEST_HOME" \


### PR DESCRIPTION
Fixes #1398

## Summary

- add a `bin/basectl` startup guard for the Apple Silicon/Rosetta mismatch where Base is running in a translated Bash while Homebrew resolves to `/opt/homebrew`
- re-exec into an available non-`/usr/local/bin/bash` supported Bash before dispatching commands
- fail early with native Homebrew Bash recovery guidance when Base cannot escape the translated process
- cover the behavior with focused runtime-dispatch regression tests and add a changelog note

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1398-cache bats cli/bash/commands/basectl/tests/runtime-dispatch.bats`
- `/bin/bash -n bin/basectl`
- `shellcheck -S error bin/basectl`
- `git diff --check`

## Notes

I also started `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1398-cache ./bin/base-test`. The Python portion completed with `762 passed, 1 skipped`, and the BATS run reached `update-profile.bats` before failing an existing output expectation:

```text
not ok 441 basectl update-profile creates Base-managed sections in all shell dotfiles
[[ "$output" == *"Updating '$TEST_HOME/.bash_profile'"* ]] failed
```

Rerunning `update-profile.bats` alone reproduces the same failure. A manual reproduction shows the command now emits `Adding section to ...`, which comes from the shared file helper output and is not touched by this PR.
