### PR TITLE
Add manifest command trust commands

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -29,6 +29,8 @@ options.
 - `basectl run <project> <command>` - run a declared project command.
 - `basectl export-context [project]` - export `.ai-context/` as a Markdown or
   Zip bundle for manual upload or copy/paste into AI tools.
+- `basectl trust <status|allow|revoke> <project>` - inspect, allow, or
+  remove local approval for manifest-declared project commands.
 - `basectl prompt <list|name>` - list and render repo-owned Markdown prompts
   for AI-assisted Base workflows. `product-self-review` prints the periodic
   product assessment prompt with current Base metadata; Base does not send the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `basectl trust status|allow|revoke` to inspect and manage local
+  manifest-command approval records under Base-managed state.
+
 ## [1.6.0] - 2026-07-04
 
 ### Added

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -45,6 +45,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `onboard`
 - `prompt`
 - `repo init/clone/check/configure/agent-guidance/installer-template`
+- `trust status/allow/revoke`
 - `test`
 - `build`
 - `update-profile`
@@ -81,6 +82,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl history` lists recent structured Base command runs from the local
   history index and supports JSON output for scripts.
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
+- `basectl trust status/allow/revoke <project>` manages local approval for
+  manifest-declared project commands under `~/.base.d/trust/manifest-commands/`.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.
 - `basectl gh` manages GitHub issues, pull requests, branch naming, repository

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -63,6 +63,8 @@ Commands:
     List recent Base command history records.
   config <path|show|doctor>
     Inspect Base's machine-local user config.
+  trust <status|allow|revoke> <project> [options]
+    Manage local approval for manifest-declared project commands.
   doctor [project] [options]
     Diagnose the local Base CLI environment and optional project artifacts.
   gh <area> <command> [options]
@@ -337,6 +339,11 @@ basectl_do_config() {
     base_config_subcommand_main "$@"
 }
 
+basectl_do_trust() {
+    basectl_source_subcommand_module trust || return 1
+    base_trust_subcommand_main "$@"
+}
+
 basectl_do_doctor() {
     basectl_source_subcommand_module doctor || return 1
     base_doctor_subcommand_main "$@"
@@ -504,6 +511,7 @@ basectl_main() {
         logs)             basectl_do_logs "$@" ;;
         history)          basectl_do_history "$@" ;;
         config)           basectl_do_config "$@" ;;
+        trust)            basectl_do_trust "$@" ;;
         doctor)           basectl_do_doctor "$@" ;;
         gh)               basectl_do_gh "$@" ;;
         onboard)          basectl_do_onboard "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/trust.sh
+++ b/cli/bash/commands/basectl/subcommands/trust.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+[[ -n "${_base_trust_subcommand_sourced:-}" ]] && return 0
+_base_trust_subcommand_sourced=1
+readonly _base_trust_subcommand_sourced
+
+base_trust_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl trust status <project> [options]
+  basectl trust allow <project> [options]
+  basectl trust revoke <project> [options]
+
+Options:
+  --workspace <path>            Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --format <text|json>          Output format for status. Defaults to text.
+  --manifest-sha256 <sha256>    Expected manifest SHA-256 for allow.
+  -v                            Enable DEBUG logging for this subcommand.
+  -h, --help                    Show this help text.
+
+Manage local approval for manifest-declared project commands.
+EOF
+}
+
+base_trust_usage_error() {
+    base_trust_subcommand_usage >&2
+    print_error "$*"
+    return 2
+}
+
+base_trust_subcommand_main() {
+    local trust_command="${1:-}"
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    local args=()
+
+    case "$trust_command" in
+        ""|-h|--help|help)
+            base_trust_subcommand_usage
+            return 0
+            ;;
+        status|allow|revoke)
+            args+=("$trust_command")
+            shift
+            ;;
+        *)
+            base_trust_usage_error "Unknown trust command '$trust_command'."
+            return $?
+            ;;
+    esac
+
+    while (($# > 0)); do
+        case "$1" in
+            -h|--help)
+                base_trust_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+    BASE_CLI_DISPLAY_COMMAND="basectl trust" "$wrapper" --project base base_trust "${args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -95,6 +95,26 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "projects_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl trust ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "trust_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl trust status ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "trust_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl trust status demo --); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "trust_status_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl trust allow demo --); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "trust_allow_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl trust revoke demo --); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "trust_revoke_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl workspace ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -250,6 +270,11 @@ EOF
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"history_options=--project --command --status --limit --format"* ]]
+    [[ "$output" == *"trust_commands=status allow revoke"* ]]
+    [[ "$output" == *"trust_projects=base demo"* ]]
+    [[ "$output" == *"trust_status_options=--workspace --format"* ]]
+    [[ "$output" == *"trust_allow_options=--workspace --manifest-sha256"* ]]
+    [[ "$output" == *"trust_revoke_options=--workspace"* ]]
     [[ "$output" == *"repo_commands=init clone check configure agent-guidance installer-template"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --pr --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --copy-project-fields-from --no-project --dry-run"* ]]
     [[ "$output" == *"repo_clone_options=--owner --path --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -23,6 +23,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"logs [options]"* ]]
     [[ "$output" == *"history [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
+    [[ "$output" == *"trust <status|allow|revoke> <project> [options]"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"gh <area> <command> [options]"* ]]
     [[ "$output" == *"onboard [project] [options]"* ]]
@@ -65,6 +66,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  history [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor|clone|pull|init|configure> [options]' <<<"$output"
+    grep -Fqx '  trust <status|allow|revoke> <project> [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
@@ -154,6 +156,7 @@ load ./basectl_helpers.bash
     grep -Fqx -- "- \`basectl repo <init|clone|check|configure|agent-guidance|installer-template>\` -" "$commands_file"
     grep -Fqx -- "- \`basectl update [project]\` - update Base or a named project using the" "$commands_file"
     grep -Fqx -- "- \`basectl docs\` - open the Base documentation home page on GitHub." "$commands_file"
+    grep -Fqx -- "- \`basectl trust <status|allow|revoke> <project>\` - inspect, allow, or" "$commands_file"
 }
 
 @test "command reference documents workspace init help surface" {
@@ -178,6 +181,14 @@ load ./basectl_helpers.bash
     local command_reference="$BASE_REPO_ROOT/docs/command-reference.md"
 
     grep -Fqx -- "| \`basectl docs\` | Open the Base documentation home page on GitHub. | \`--show-url\` |" "$command_reference"
+}
+
+@test "command reference documents trust commands" {
+    local command_reference="$BASE_REPO_ROOT/docs/command-reference.md"
+
+    grep -Fqx -- "| \`basectl trust status <project>\` | Show local manifest command trust status. | \`--workspace <path>\`, \`--format <text\\|json>\` |" "$command_reference"
+    grep -Fqx -- "| \`basectl trust allow <project>\` | Approve the current manifest command contract on this machine. | \`--workspace <path>\`, \`--manifest-sha256 <sha256>\` |" "$command_reference"
+    grep -Fqx -- "| \`basectl trust revoke <project>\` | Remove local manifest command approval. | \`--workspace <path>\` |" "$command_reference"
 }
 
 @test "command reference documents repo and Project configuration options" {

--- a/cli/bash/commands/basectl/tests/trust.bats
+++ b/cli/bash/commands/basectl/tests/trust.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl trust prints help" {
+    run_basectl trust --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl trust status <project> [options]"* ]]
+    [[ "$output" == *"basectl trust allow <project> [options]"* ]]
+    [[ "$output" == *"basectl trust revoke <project> [options]"* ]]
+    [[ "$output" == *"--manifest-sha256 <sha256>"* ]]
+}
+
+@test "basectl trust forwards through the Python wrapper" {
+    local base_home="$TEST_TMPDIR/base-home"
+
+    mkdir -p "$base_home/bin"
+    cat > "$base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'display=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$base_home/bin/base-wrapper"
+
+    run env \
+        BASE_HOME="$base_home" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/trust.sh"
+            base_trust_subcommand_main status demo --workspace /tmp/work --format json
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"display=basectl trust"* ]]
+    [[ "$output" == *"args=--project base base_trust status demo --workspace /tmp/work --format json"* ]]
+}

--- a/cli/python/base_trust/__init__.py
+++ b/cli/python/base_trust/__init__.py
@@ -1,0 +1,3 @@
+"""Manifest command trust command."""
+
+from __future__ import annotations

--- a/cli/python/base_trust/__main__.py
+++ b/cli/python/base_trust/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .engine import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import base_cli
+from base_cli.history import base_version as read_base_version
+from base_cli.history import format_timestamp, utc_now
+from base_cli.paths import base_state_root
+from base_projects import engine as project_engine
+from base_projects.workspace_reports import ProjectDiscoveryError
+from base_setup import git_remote
+from base_setup.manifest import ManifestError, read_manifest
+
+
+SCHEMA_VERSION = 1
+ALLOWED_COMMANDS = ["test", "run", "build", "demo", "activate"]
+TRUST_RELATIVE_ROOT = Path("trust") / "manifest-commands"
+
+
+app = base_cli.App(
+    name="base_trust",
+    help="Manage local approval for manifest-declared project commands.",
+)
+
+
+@dataclass(frozen=True)
+class ManifestCommandTrustIdentity:
+    project_name: str
+    project_root: Path
+    manifest_path: Path
+    manifest_sha256: str
+    identity_key: str
+    git_root: Path | None = None
+    origin: str | None = None
+    head: str | None = None
+
+    def project_payload(self) -> dict[str, str]:
+        payload = {
+            "name": self.project_name,
+            "root": str(self.project_root),
+            "manifest": str(self.manifest_path),
+            "manifest_sha256": self.manifest_sha256,
+        }
+        if self.git_root is not None:
+            payload["git_root"] = str(self.git_root)
+        if self.origin is not None:
+            payload["origin"] = self.origin
+        if self.head is not None:
+            payload["head"] = self.head
+        return payload
+
+
+@dataclass(frozen=True)
+class TrustStatus:
+    status: str
+    reason: str
+    identity: ManifestCommandTrustIdentity
+    record: dict[str, Any] | None = None
+    changed_record: dict[str, Any] | None = None
+
+    @property
+    def is_allowed(self) -> bool:
+        return self.status == "allowed"
+
+
+class ManifestCommandTrustStore:
+    def __init__(self, home: Path | None = None) -> None:
+        self.root = base_state_root(home) / TRUST_RELATIVE_ROOT
+
+    def record_path(self, identity: ManifestCommandTrustIdentity) -> Path:
+        return self.root / f"{identity.identity_key}.json"
+
+    def read_record(self, identity: ManifestCommandTrustIdentity) -> dict[str, Any] | None:
+        path = self.record_path(identity)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+            return None
+        return payload
+
+    def status(self, identity: ManifestCommandTrustIdentity) -> TrustStatus:
+        record = self.read_record(identity)
+        if record is not None:
+            return TrustStatus(status="allowed", reason="allowed", identity=identity, record=record)
+
+        changed_record = self.find_changed_record(identity)
+        if changed_record is not None:
+            return TrustStatus(
+                status="blocked",
+                reason="manifest_changed",
+                identity=identity,
+                changed_record=changed_record,
+            )
+
+        return TrustStatus(status="blocked", reason="not_allowed", identity=identity)
+
+    def find_changed_record(self, identity: ManifestCommandTrustIdentity) -> dict[str, Any] | None:
+        if not self.root.is_dir():
+            return None
+        for path in sorted(self.root.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+                continue
+            project = payload.get("project")
+            if not isinstance(project, dict):
+                continue
+            if project.get("root") == str(identity.project_root) and project.get("manifest") == str(
+                identity.manifest_path
+            ):
+                return payload
+        return None
+
+    def allow(
+        self,
+        identity: ManifestCommandTrustIdentity,
+        *,
+        base_version: str | None,
+        allowed_at: str | None = None,
+    ) -> Path:
+        path = self.record_path(identity)
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "allowed_at": allowed_at or format_timestamp(utc_now()),
+            "allowed_by": "local-user",
+            "base_version": base_version,
+            "project": identity.project_payload(),
+            "allowed_commands": ALLOWED_COMMANDS,
+        }
+        write_json_atomic(path, payload)
+        return path
+
+    def revoke(self, identity: ManifestCommandTrustIdentity) -> bool:
+        removed = False
+        paths = [self.record_path(identity)]
+        changed_record = self.find_changed_record(identity)
+        if changed_record is not None:
+            changed_identity_key = identity_key_from_record(changed_record)
+            if changed_identity_key is not None:
+                paths.append(self.root / f"{changed_identity_key}.json")
+
+        for path in paths:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                continue
+            removed = True
+        return removed
+
+
+def main(argv: list[str] | None = None) -> int:
+    return base_cli.run_app(app, argv)
+
+
+@app.subcommand("status", context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("project")
+@base_cli.option(
+    "--workspace",
+    help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
+)
+@base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
+def status_command(ctx: base_cli.Context, project: str, workspace: str | None, output_format: str) -> int:
+    if output_format not in {"text", "json"}:
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
+    try:
+        identity = resolve_trust_identity(ctx, project, workspace)
+    except (ProjectDiscoveryError, ManifestError, TrustError) as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    trust_status = ManifestCommandTrustStore().status(identity)
+    if output_format == "json":
+        print(json.dumps(status_payload(trust_status), indent=2, sort_keys=True))
+    else:
+        print_status_text(trust_status)
+    return base_cli.ExitCode.SUCCESS
+
+
+@app.subcommand("allow", context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("project")
+@base_cli.option(
+    "--workspace",
+    help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
+)
+@base_cli.option("--manifest-sha256", help="Expected SHA-256 digest of base_manifest.yaml.")
+def allow_command(ctx: base_cli.Context, project: str, workspace: str | None, manifest_sha256: str | None) -> int:
+    try:
+        identity = resolve_trust_identity(ctx, project, workspace)
+    except (ProjectDiscoveryError, ManifestError, TrustError) as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    if manifest_sha256 is not None and manifest_sha256 != identity.manifest_sha256:
+        ctx.log.error(
+            "Provided --manifest-sha256 '%s' does not match current manifest SHA-256 '%s'.",
+            manifest_sha256,
+            identity.manifest_sha256,
+        )
+        return base_cli.ExitCode.USAGE_ERROR
+
+    print_identity("Allowing manifest command trust", identity)
+    ManifestCommandTrustStore().allow(identity, base_version=read_base_version(ctx.base_home))
+    print(f"Allowed manifest commands for project '{identity.project_name}'.")
+    return base_cli.ExitCode.SUCCESS
+
+
+@app.subcommand("revoke", context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("project")
+@base_cli.option(
+    "--workspace",
+    help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
+)
+def revoke_command(ctx: base_cli.Context, project: str, workspace: str | None) -> int:
+    try:
+        identity = resolve_trust_identity(ctx, project, workspace)
+    except (ProjectDiscoveryError, ManifestError, TrustError) as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    removed = ManifestCommandTrustStore().revoke(identity)
+    if removed:
+        print(f"Revoked manifest command trust for project '{identity.project_name}'.")
+    else:
+        print(f"No manifest command trust record found for project '{identity.project_name}'.")
+    return base_cli.ExitCode.SUCCESS
+
+
+class TrustError(RuntimeError):
+    pass
+
+
+def resolve_trust_identity(
+    ctx: base_cli.Context,
+    project_name: str,
+    workspace: str | None,
+) -> ManifestCommandTrustIdentity:
+    project = project_engine.resolve_named_project(ctx, project_name, workspace)
+    return compute_trust_identity_for_manifest(project.manifest_path)
+
+
+def compute_trust_identity_for_manifest(manifest_path: Path) -> ManifestCommandTrustIdentity:
+    manifest = read_manifest(manifest_path.expanduser().resolve())
+    canonical_manifest = manifest.path.resolve()
+    project_root = canonical_manifest.parent.resolve()
+    manifest_sha256 = sha256_file(canonical_manifest)
+    git_root = git_repository_root(project_root)
+    origin = git_origin(project_root)
+    head = git_head(project_root)
+    identity_key = compute_identity_key(project_root, canonical_manifest, manifest_sha256)
+    return ManifestCommandTrustIdentity(
+        project_name=manifest.project_name,
+        project_root=project_root,
+        manifest_path=canonical_manifest,
+        manifest_sha256=manifest_sha256,
+        identity_key=identity_key,
+        git_root=git_root,
+        origin=origin,
+        head=head,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compute_identity_key(project_root: Path, manifest_path: Path, manifest_sha256: str) -> str:
+    payload = "\0".join([str(project_root), str(manifest_path), manifest_sha256])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def identity_key_from_record(record: dict[str, Any]) -> str | None:
+    project = record.get("project")
+    if not isinstance(project, dict):
+        return None
+    root = project.get("root")
+    manifest = project.get("manifest")
+    digest = project.get("manifest_sha256")
+    if not all(isinstance(value, str) and value for value in (root, manifest, digest)):
+        return None
+    return compute_identity_key(Path(root), Path(manifest), digest)
+
+
+def git_repository_root(project_root: Path) -> Path | None:
+    result = git_remote.run_git(project_root, ["rev-parse", "--show-toplevel"])
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return Path(value).resolve() if value else None
+
+
+def git_origin(project_root: Path) -> str | None:
+    result = git_remote.run_git(project_root, ["remote", "get-url", "origin"])
+    if result.returncode != 0:
+        return None
+    remote_url = result.stdout.strip()
+    if not remote_url:
+        return None
+    remote_info = git_remote.parse_origin_remote(remote_url, project_root)
+    return remote_info.sanitized_url if remote_info.valid and remote_info.sanitized_url else None
+
+
+def git_head(project_root: Path) -> str | None:
+    result = git_remote.run_git(project_root, ["rev-parse", "HEAD"])
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temp_path.chmod(0o600)
+        os.replace(temp_path, path)
+        path.chmod(0o600)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def status_payload(trust_status: TrustStatus) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": trust_status.status,
+        "reason": trust_status.reason,
+        "project": trust_status.identity.project_payload(),
+    }
+    if trust_status.is_allowed:
+        payload["record"] = trust_status.record
+    else:
+        payload["allow_command"] = allow_command_text(trust_status.identity)
+    if trust_status.changed_record is not None:
+        changed_project = trust_status.changed_record.get("project", {})
+        if isinstance(changed_project, dict) and isinstance(changed_project.get("manifest_sha256"), str):
+            payload["recorded_manifest_sha256"] = changed_project["manifest_sha256"]
+    return payload
+
+
+def allow_command_text(identity: ManifestCommandTrustIdentity) -> str:
+    return f"basectl trust allow {identity.project_name} --manifest-sha256 {identity.manifest_sha256}"
+
+
+def print_status_text(trust_status: TrustStatus) -> None:
+    identity = trust_status.identity
+    if trust_status.is_allowed:
+        print(f"Manifest command trust is allowed for project '{identity.project_name}'.")
+        print_identity("Trusted identity", identity)
+        return
+
+    if trust_status.reason == "manifest_changed":
+        print(f"Manifest command trust is blocked for project '{identity.project_name}': manifest changed.")
+        changed_project = (trust_status.changed_record or {}).get("project", {})
+        if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
+            print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}")
+    else:
+        print(f"Manifest command trust is blocked for project '{identity.project_name}'.")
+    print_identity("Current identity", identity)
+    print(f"Allow after review: {allow_command_text(identity)}")
+
+
+def print_identity(title: str, identity: ManifestCommandTrustIdentity) -> None:
+    print(f"{title}:")
+    print(f"  Project: {identity.project_name}")
+    print(f"  Project root: {identity.project_root}")
+    print(f"  Manifest: {identity.manifest_path}")
+    print(f"  Manifest SHA-256: {identity.manifest_sha256}")
+    if identity.origin is not None:
+        print(f"  Origin: {identity.origin}")
+    if identity.head is not None:
+        print(f"  HEAD: {identity.head}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -167,7 +167,16 @@ class ManifestCommandTrustTests(unittest.TestCase):
                 },
             ):
                 with redirect_stdout(stdout), redirect_stderr(stderr):
-                    status = engine.main(["allow", "demo", "--workspace", str(workspace), "--manifest-sha256", "0" * 64])
+                    status = engine.main(
+                        [
+                            "allow",
+                            "demo",
+                            "--workspace",
+                            str(workspace),
+                            "--manifest-sha256",
+                            "0" * 64,
+                        ]
+                    )
 
             trust_root = home / ".base.d" / "trust" / "manifest-commands"
 

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_cli.testing import invoke
+
+
+def write_manifest(project_root: Path, name: str = "demo", command: str = "pytest tests/") -> Path:
+    project_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = project_root / "base_manifest.yaml"
+    manifest_path.write_text(
+        "\n".join(
+            [
+                "project:",
+                f"  name: {name}",
+                "test:",
+                f"  command: {command}",
+                "artifacts: []",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def init_git_repo(project_root: Path, origin: str) -> str:
+    subprocess.run(["git", "init"], cwd=project_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(
+        ["git", "config", "user.email", "base@example.invalid"],
+        cwd=project_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Base Tests"],
+        cwd=project_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    subprocess.run(["git", "add", "base_manifest.yaml"], cwd=project_root, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add manifest"],
+        cwd=project_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    subprocess.run(["git", "remote", "add", "origin", origin], cwd=project_root, check=True)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=project_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class ManifestCommandTrustTests(unittest.TestCase):
+    def test_compute_trust_identity_includes_manifest_digest_and_sanitized_git_metadata(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "work" / "demo"
+            manifest_path = write_manifest(project_root)
+            head = init_git_repo(project_root, "https://user:secret@github.com/example/demo.git")
+            expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+            identity = engine.compute_trust_identity_for_manifest(manifest_path)
+
+        self.assertEqual(identity.project_name, "demo")
+        self.assertEqual(identity.project_root, project_root.resolve())
+        self.assertEqual(identity.manifest_path, manifest_path.resolve())
+        self.assertEqual(identity.manifest_sha256, expected_digest)
+        self.assertEqual(identity.git_root, project_root.resolve())
+        self.assertEqual(identity.origin, "https://github.com/example/demo.git")
+        self.assertEqual(identity.head, head)
+        self.assertNotIn("secret", identity.identity_key)
+
+    def test_trust_store_writes_allow_record_under_base_state_with_schema_version_one(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project_root = root / "work" / "demo"
+            manifest_path = write_manifest(project_root)
+            identity = engine.compute_trust_identity_for_manifest(manifest_path)
+            store = engine.ManifestCommandTrustStore(home=home)
+
+            record_path = store.allow(identity, base_version="9.9.9", allowed_at="2026-07-03T12:00:00Z")
+
+            self.assertTrue(record_path.is_file())
+            self.assertEqual(record_path.parent, home / ".base.d" / "trust" / "manifest-commands")
+            self.assertFalse((project_root / ".base.d").exists())
+            payload = json.loads(record_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["allowed_at"], "2026-07-03T12:00:00Z")
+        self.assertEqual(payload["allowed_by"], "local-user")
+        self.assertEqual(payload["base_version"], "9.9.9")
+        self.assertEqual(payload["project"]["name"], "demo")
+        self.assertEqual(payload["project"]["root"], str(project_root.resolve()))
+        self.assertEqual(payload["project"]["manifest"], str(manifest_path.resolve()))
+        self.assertEqual(payload["project"]["manifest_sha256"], identity.manifest_sha256)
+        self.assertEqual(payload["allowed_commands"], ["test", "run", "build", "demo", "activate"])
+
+    def test_status_json_reports_blocked_project_and_allow_command(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            manifest_path = write_manifest(workspace / "demo")
+            expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+            result = invoke(
+                engine.app,
+                ["status", "demo", "--workspace", str(workspace), "--format", "json"],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["reason"], "not_allowed")
+        self.assertEqual(payload["project"]["name"], "demo")
+        self.assertEqual(payload["project"]["manifest_sha256"], expected_digest)
+        self.assertEqual(
+            payload["allow_command"],
+            f"basectl trust allow demo --manifest-sha256 {expected_digest}",
+        )
+
+    def test_allow_rejects_manifest_sha256_mismatch_without_writing_record(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            write_manifest(workspace / "demo")
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(home),
+                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_HOME": str(workspace / "base"),
+                },
+            ):
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    status = engine.main(["allow", "demo", "--workspace", str(workspace), "--manifest-sha256", "0" * 64])
+
+            trust_root = home / ".base.d" / "trust" / "manifest-commands"
+
+        self.assertEqual(status, 2, stderr.getvalue())
+        self.assertIn("does not match current manifest SHA-256", stderr.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertFalse(trust_root.exists())
+
+    def test_allow_and_revoke_update_status(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            manifest_path = write_manifest(workspace / "demo")
+            expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+            env = {"BASE_HOME": str(workspace / "base")}
+
+            allow_result = invoke(
+                engine.app,
+                ["allow", "demo", "--workspace", str(workspace), "--manifest-sha256", expected_digest],
+                home=home,
+                env=env,
+            )
+            allowed_status = invoke(
+                engine.app,
+                ["status", "demo", "--workspace", str(workspace), "--format", "json"],
+                home=home,
+                env=env,
+            )
+            revoke_result = invoke(engine.app, ["revoke", "demo", "--workspace", str(workspace)], home=home, env=env)
+            revoked_status = invoke(
+                engine.app,
+                ["status", "demo", "--workspace", str(workspace), "--format", "json"],
+                home=home,
+                env=env,
+            )
+
+        self.assertEqual(allow_result.exit_code, 0, allow_result.output)
+        self.assertIn("Allowed manifest commands for project 'demo'.", allow_result.output)
+        self.assertEqual(json.loads(allowed_status.stdout)["status"], "allowed")
+        self.assertEqual(revoke_result.exit_code, 0, revoke_result.output)
+        self.assertIn("Revoked manifest command trust for project 'demo'.", revoke_result.output)
+        self.assertEqual(json.loads(revoked_status.stdout)["status"], "blocked")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -48,6 +48,9 @@ full compatibility contract.
 | `basectl build <project> [target...]` | Run declared build targets, or `build.default` when no target is provided. | `--workspace <path>`, `--dry-run`, `-- <args>` |
 | `basectl build <project> --list` | List build targets declared by a project manifest. | `--workspace <path>` |
 | `basectl demo [project]` | Run a project-owned demo script. | `--workspace <path>`, `--dry-run`, `-- <args>` |
+| `basectl trust status <project>` | Show local manifest command trust status. | `--workspace <path>`, `--format <text\|json>` |
+| `basectl trust allow <project>` | Approve the current manifest command contract on this machine. | `--workspace <path>`, `--manifest-sha256 <sha256>` |
+| `basectl trust revoke <project>` | Remove local manifest command approval. | `--workspace <path>` |
 
 Manifest-declared `test`, `run`, and `build` commands are project-owned shell
 command strings executed from the project root. Review manifests from

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -132,7 +132,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test export-context build demo run repo ci release prompt docs clean logs history config doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test export-context build demo run repo ci release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -156,6 +156,25 @@ _base_basectl_completion() {
                 _base_basectl_completion_compgen "list" "$cur"
             else
                 _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
+            fi
+            ;;
+        trust)
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "status allow revoke" "$cur"
+            elif ((COMP_CWORD == 3)) && [[ "$cur" != -* ]]; then
+                _base_basectl_completion_project_candidates "$cur"
+            else
+                case "${COMP_WORDS[2]:-}" in
+                    status)
+                        _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
+                        ;;
+                    allow)
+                        _base_basectl_completion_compgen "--workspace --manifest-sha256 -v -h --help" "$cur"
+                        ;;
+                    revoke)
+                        _base_basectl_completion_compgen "--workspace -v -h --help" "$cur"
+                        ;;
+                esac
             fi
             ;;
         workspace)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -97,6 +97,7 @@ _base_basectl_completion() {
         'logs:List and open recent Base CLI runtime logs'
         'history:List recent Base command history records'
         'config:Inspect Base machine-local user config'
+        'trust:Manage manifest command trust approvals'
         'doctor:Diagnose the local Base environment'
         'gh:Manage GitHub issues, pull requests, branches, and hygiene'
         'onboard:Guide a user through first Base setup'
@@ -129,6 +130,36 @@ _base_basectl_completion() {
                 '--workspace[Workspace directory to scan]:path:_files' \
                 '--format[Output format]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        trust)
+            case "${words[3]:-}" in
+                status)
+                    _arguments '1:trust command:(status allow revoke)' \
+                        '2:Base project:->projects' \
+                        '--workspace[Workspace directory to scan]:path:_files' \
+                        '--format[Output format]:format:(text json)' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                allow)
+                    _arguments '1:trust command:(status allow revoke)' \
+                        '2:Base project:->projects' \
+                        '--workspace[Workspace directory to scan]:path:_files' \
+                        '--manifest-sha256[Expected manifest SHA-256]:sha256:' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                revoke)
+                    _arguments '1:trust command:(status allow revoke)' \
+                        '2:Base project:->projects' \
+                        '--workspace[Workspace directory to scan]:path:_files' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                *)
+                    _arguments '1:trust command:(status allow revoke)'
+                    ;;
+            esac
+            if [[ "$state" == projects ]]; then
+                _base_basectl_completion_describe_projects
+            fi
             ;;
         workspace)
             case "${words[3]:-}" in


### PR DESCRIPTION
## Summary

- Add `base_trust` with manifest command trust identity computation, local allow-record storage, JSON status output, allow, and revoke.
- Add `basectl trust status|allow|revoke` Bash dispatch plus Bash/Zsh completions.
- Document the trust command surface in command references, AI command context, and the changelog.

Fixes #1381

## Validation

- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1381-manifest-command-trust/lib/python:/Users/rameshhp/work/base-worktrees/1381-manifest-command-trust/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_trust/tests/test_engine.py lib/python/base_cli/tests/test_public_command_lifecycle.py -q`
- `env PYTHONPATH=/Users/rameshhp/work/base-worktrees/1381-manifest-command-trust/lib/python:/Users/rameshhp/work/base-worktrees/1381-manifest-command-trust/cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_trust`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash bats cli/bash/commands/basectl/tests/help.bats`
- `env -u BASE_HOME HOME=/private/tmp/base-trust-smoke-1381-home BASE_PROJECT_VENV_DIR=/Users/rameshhp/.base.d/base/.venv BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/basectl trust allow base --manifest-sha256 f0d990bd80d63e5afeec78759a20b4686c4995872536a83ac9345f417cde7c41`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash ./bin/base-test`
