### PR TITLE
Enforce manifest command trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Added `basectl trust status|allow|revoke` to inspect and manage local
   manifest-command approval records under Base-managed state.
+- Enforced manifest-command trust before `basectl test`, `run`, `build`,
+  `demo`, and `activate` execute project-owned manifest code, while preserving
+  dry-run and list inspection paths before approval.
 
 ## [1.6.0] - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -376,8 +376,8 @@ only want to inspect the resolved command contract. `basectl check <project>`
 and `basectl doctor <project>` include advisory command-lint warnings for
 obvious missing executables or project scripts; those warnings do not make an
 untrusted manifest safe to run. See
-[Manifest Command Trust](docs/manifest-command-trust.md) for the planned local
-allow flow before first execution of unfamiliar manifest commands.
+[Manifest Command Trust](docs/manifest-command-trust.md) for the local allow
+flow before first execution of unfamiliar manifest commands.
 
 The optional top-level `brewfile` field points to a Homebrew `Brewfile` relative
 to the project root. When present, `basectl setup` runs

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -118,6 +118,8 @@ base_activate_subcommand_main() {
         fatal_error "Unable to resolve project '$project'."
     }
 
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:3}" || return $?
+
     venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root" "$manifest_path" "${resolve_fields[@]:3}")"
     venv_fix="Run 'basectl setup $resolved_name' first."
     if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_project_route_uses_uv_manager "${resolve_fields[@]:3}"; then

--- a/cli/bash/commands/basectl/subcommands/build.sh
+++ b/cli/bash/commands/basectl/subcommands/build.sh
@@ -180,11 +180,6 @@ base_build_subcommand_main() {
             fatal_error "Unable to parse build target '$target_name' for project '$project'."
         }
 
-        if ((environment_prepared == 0)); then
-            base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${target_fields[@]:7}" >/dev/null
-            environment_prepared=1
-        fi
-
         command_runner="${command_runner:-}"
         command_to_run="$(base_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
         display_command="$(base_display_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
@@ -193,6 +188,12 @@ base_build_subcommand_main() {
             printf '[DRY-RUN] Would build target %q for project %q in %q: %s\n' \
                 "$target_name" "$resolved_name" "$working_dir" "$display_command"
             continue
+        fi
+
+        if ((environment_prepared == 0)); then
+            base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${target_fields[@]:7}" || return $?
+            base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${target_fields[@]:7}" >/dev/null
+            environment_prepared=1
         fi
 
         log_info "Building target '$target_name' for project '$resolved_name': $display_command"

--- a/cli/bash/commands/basectl/subcommands/demo.sh
+++ b/cli/bash/commands/basectl/subcommands/demo.sh
@@ -107,8 +107,6 @@ base_demo_subcommand_main() {
         fatal_error "Unable to resolve demo script for project '${project:-current project}'."
     }
 
-    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
-
     command_runner="${command_runner:-}"
     printf -v quoted_demo_script '%q' "$demo_script"
     command_to_run="$(base_command_with_runner "$command_runner" "$quoted_demo_script" "${extra_args[@]}")" || return $?
@@ -119,6 +117,9 @@ base_demo_subcommand_main() {
             "$resolved_name" "$project_root" "$display_command"
         return 0
     fi
+
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:4}" || return $?
+    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
 
     log_info "Running demo for project '$resolved_name': $display_command"
     if [[ -z "$command_runner" ]]; then

--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -27,6 +27,10 @@ base_project_route_uses_uv_manager() {
     [[ "$(base_project_route_value "__base_uses_uv_manager=" "$@" || true)" == "true" ]]
 }
 
+base_project_route_manifest_command_trust_required() {
+    [[ "$(base_project_route_value "__base_manifest_command_trust_required=" "$@" || true)" == "true" ]]
+}
+
 base_project_command_runner_from_field() {
     local candidate="${1:-}"
 
@@ -54,6 +58,18 @@ base_project_venv_dir() {
     fi
 
     printf '%s\n' "$HOME/.base.d/$project/.venv"
+}
+
+base_project_require_manifest_command_trust() {
+    local project="$1"
+    local manifest_path="$2"
+    local wrapper="$BASE_HOME/bin/base-wrapper"
+    shift 2
+
+    base_project_route_manifest_command_trust_required "$@" || return 0
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    "$wrapper" --project base base_trust require "$project" --manifest "$manifest_path"
 }
 
 base_project_activate_environment() {

--- a/cli/bash/commands/basectl/subcommands/run.sh
+++ b/cli/bash/commands/basectl/subcommands/run.sh
@@ -164,8 +164,6 @@ base_run_subcommand_main() {
         fatal_error "Unable to resolve command '$command_name' for project '$project'."
     }
 
-    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
-
     command_runner="${command_runner:-}"
     command_to_run="$(base_command_with_runner "$command_runner" "$run_command" "${extra_args[@]}")" || return $?
     display_command="$(base_display_command_with_runner "$command_runner" "$run_command" "${extra_args[@]}")" || return $?
@@ -175,6 +173,9 @@ base_run_subcommand_main() {
             "$command_name" "$resolved_name" "$project_root" "$display_command"
         return 0
     fi
+
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:4}" || return $?
+    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
 
     log_info "Running command '$command_name' for project '$resolved_name': $display_command"
     base_validate_command_runner "$command_runner"

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -107,8 +107,6 @@ base_test_subcommand_main() {
         fatal_error "Unable to resolve test command for project '$project'."
     }
 
-    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
-
     command_runner="${command_runner:-}"
     command_to_run="$(base_command_with_runner "$command_runner" "$test_command" "${extra_args[@]}")" || return $?
     display_command="$(base_display_command_with_runner "$command_runner" "$test_command" "${extra_args[@]}")" || return $?
@@ -117,6 +115,9 @@ base_test_subcommand_main() {
         printf '[DRY-RUN] Would run tests for project %q in %q: %s\n' "$resolved_name" "$project_root" "$display_command"
         return 0
     fi
+
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:4}" || return $?
+    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
 
     log_info "Running tests for project '$resolved_name': $display_command"
     base_validate_command_runner "$command_runner"

--- a/cli/bash/commands/basectl/tests/manifest-command-trust.bats
+++ b/cli/bash/commands/basectl/tests/manifest-command-trust.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+write_manifest_trust_python() {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_trust" && "${3:-}" == "require" && "${4:-}" == "demo" ]]; then
+    if [[ "${BASE_TEST_TRUST_ALLOWED:-0}" == "1" ]]; then
+        exit 0
+    fi
+    cat >&2 <<TRUST
+ERROR: Manifest-declared commands are not allowed for project 'demo' on this machine.
+Project root: ${BASE_TEST_PROJECT_ROOT:?}
+Manifest: ${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml
+Manifest SHA-256: 0123456789abcdef
+Origin: https://github.com/example/demo.git
+
+Review first:
+  basectl run demo --list
+  basectl build demo --list
+  basectl test demo --dry-run
+
+Allow after review:
+  basectl trust allow demo --manifest-sha256 0123456789abcdef
+TRUST
+    exit 1
+fi
+
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" ]]; then
+    route_fields="__base_project_venv_dir=${HOME:?}/.base.d/demo/.venv	__base_uses_uv_manager=false	__base_manifest_command_trust_required=true"
+    case "${3:-}" in
+        test-command)
+            printf 'demo\t%s\t%s\t%s\t%s\n' \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
+                "$route_fields"
+            exit 0
+            ;;
+        run-command)
+            printf 'demo\t%s\t%s\t%s\t%s\n' \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
+                "$route_fields"
+            exit 0
+            ;;
+        run-commands)
+            printf 'demo\t%s\t%s\tdev\t%s\n' \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7'
+            exit 0
+            ;;
+        build-targets)
+            printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
+                'Build API' \
+                "$route_fields"
+            exit 0
+            ;;
+        build-target-list)
+            printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
+                'Build API' \
+                "$route_fields"
+            exit 0
+            ;;
+        demo-script)
+            printf 'demo\t%s\t%s\t%s\t%s\n' \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+                "${BASE_TEST_PROJECT_ROOT:?}/demo.sh" \
+                "$route_fields"
+            exit 0
+            ;;
+        resolve)
+            printf 'demo\t%s\t%s\t%s\n' \
+                "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
+                "$route_fields"
+            exit 0
+            ;;
+    esac
+fi
+
+printf 'unexpected trust test python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+}
+
+setup_manifest_trust_project() {
+    local project_root="$1"
+    mkdir -p "$project_root" "$TEST_HOME/.base.d/demo/.venv/bin"
+    printf '#!/usr/bin/env bash\n' > "$TEST_HOME/.base.d/demo/.venv/bin/python"
+    chmod +x "$TEST_HOME/.base.d/demo/.venv/bin/python"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$project_root/base_manifest.yaml"
+    cat > "$project_root/demo.sh" <<'EOF'
+#!/usr/bin/env bash
+touch "$BASE_TEST_TRUST_STATE"
+exit 7
+EOF
+    chmod +x "$project_root/demo.sh"
+    write_manifest_trust_python
+}
+
+assert_untrusted_block() {
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Manifest-declared commands are not allowed for project 'demo'"* ]]
+    [[ "$output" == *"Review first:"* ]]
+    [[ "$output" == *"basectl run demo --list"* ]]
+    [[ "$output" == *"basectl trust allow demo --manifest-sha256 0123456789abcdef"* ]]
+}
+
+@test "manifest command trust blocks basectl test before project command execution" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/trust-state"
+    setup_manifest_trust_project "$workspace/demo"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" test demo
+
+    assert_untrusted_block
+    [ ! -e "$state_file" ]
+}
+
+@test "manifest command trust blocks basectl run before project command execution" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/trust-state"
+    setup_manifest_trust_project "$workspace/demo"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo dev
+
+    assert_untrusted_block
+    [ ! -e "$state_file" ]
+}
+
+@test "manifest command trust blocks basectl build before project command execution" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/trust-state"
+    setup_manifest_trust_project "$workspace/demo"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo
+
+    assert_untrusted_block
+    [ ! -e "$state_file" ]
+}
+
+@test "manifest command trust blocks basectl demo before project script execution" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/trust-state"
+    setup_manifest_trust_project "$workspace/demo"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" demo demo
+
+    assert_untrusted_block
+    [ ! -e "$state_file" ]
+}
+
+@test "manifest command trust blocks basectl activate before project activation sources can run" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/trust-state"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+    setup_manifest_trust_project "$workspace/demo"
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+touch "$BASE_TEST_TRUST_STATE"
+EOF
+    chmod +x "$fake_bash"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_ACTIVATE_SHELL="$fake_bash" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    assert_untrusted_block
+    [ ! -e "$state_file" ]
+}
+
+@test "manifest command trust preserves dry-run and list inspection paths before approval" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/trust-state"
+    setup_manifest_trust_project "$workspace/demo"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" test demo --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run tests for project demo"* ]]
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo --list
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Commands for project 'demo'"* ]]
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo --list
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Build targets for project 'demo'"* ]]
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" demo demo --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run demo for project demo"* ]]
+    [ ! -e "$state_file" ]
+}
+
+@test "manifest command trust allows execution when require succeeds" {
+    local workspace="$TEST_TMPDIR/workspace"
+    local state_file="$TEST_TMPDIR/trust-state"
+    setup_manifest_trust_project "$workspace/demo"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_TRUST_ALLOWED=1 \
+        BASE_TEST_TRUST_STATE="$state_file" \
+        "$BASE_REPO_ROOT/bin/basectl" run demo dev
+
+    [ "$status" -eq 7 ]
+    [ -e "$state_file" ]
+}

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -66,7 +66,14 @@ def build_targets_project_command(
         return base_cli.ExitCode.FAILURE
 
     for target_name, target_config, working_dir in targets:
-        print_build_target(project, manifest, target_name, target_config, working_dir)
+        print_build_target(
+            project,
+            manifest,
+            target_name,
+            target_config,
+            working_dir,
+            manifest_command_trust_required=True,
+        )
     return base_cli.ExitCode.SUCCESS
 
 
@@ -89,16 +96,25 @@ def list_build_targets_command(
         return base_cli.ExitCode.FAILURE
 
     for target_name, target_config, working_dir in targets:
-        print_build_target(project, manifest, target_name, target_config, working_dir)
+        print_build_target(
+            project,
+            manifest,
+            target_name,
+            target_config,
+            working_dir,
+            manifest_command_trust_required=False,
+        )
     return base_cli.ExitCode.SUCCESS
 
 
-def print_build_target(
+def print_build_target(  # pylint: disable=too-many-arguments
     project: ProjectLike,
     manifest: BaseManifest,
     target_name: str,
     target_config: BuildTargetConfig,
     working_dir: Path,
+    *,
+    manifest_command_trust_required: bool,
 ) -> None:
     fields = [
         project.name,
@@ -111,16 +127,23 @@ def print_build_target(
     ]
     if target_config.runner is not None:
         fields.append(target_config.runner)
-    fields.extend(route_metadata_fields(manifest))
+    fields.extend(
+        route_metadata_fields(
+            manifest,
+            manifest_command_trust_required=manifest_command_trust_required,
+        )
+    )
     print("\t".join(fields))
 
 
-def route_metadata_fields(manifest: BaseManifest) -> list[str]:
+def route_metadata_fields(manifest: BaseManifest, *, manifest_command_trust_required: bool = False) -> list[str]:
     route = route_for_manifest(manifest)
     uses_uv = "true" if route.uses_uv_manager else "false"
+    trust_required = "true" if manifest_command_trust_required else "false"
     return [
         f"__base_project_venv_dir={route.project_venv_dir}",
         f"__base_uses_uv_manager={uses_uv}",
+        f"__base_manifest_command_trust_required={trust_required}",
     ]
 
 

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -843,17 +843,29 @@ def project_command(manifest: BaseManifest, command_name: str) -> CommandConfig:
         ) from exc
 
 
-def _route_metadata_fields(manifest: BaseManifest) -> list[str]:
+def _route_metadata_fields(manifest: BaseManifest, *, manifest_command_trust_required: bool = False) -> list[str]:
     route = route_for_manifest(manifest)
     uses_uv = "true" if route.uses_uv_manager else "false"
+    trust_required = "true" if manifest_command_trust_required else "false"
     return [
         f"__base_project_venv_dir={route.project_venv_dir}",
         f"__base_uses_uv_manager={uses_uv}",
+        f"__base_manifest_command_trust_required={trust_required}",
     ]
 
 
 def _project_output(project_name: str, project_root: Path, manifest_path: Path, manifest: BaseManifest) -> str:
-    return "\t".join([project_name, str(project_root), str(manifest_path), *_route_metadata_fields(manifest)])
+    return "\t".join(
+        [
+            project_name,
+            str(project_root),
+            str(manifest_path),
+            *_route_metadata_fields(
+                manifest,
+                manifest_command_trust_required=bool(manifest.activate.source),
+            ),
+        ]
+    )
 
 
 def _command_output(
@@ -866,7 +878,7 @@ def _command_output(
     fields = [project_name, str(project_root), str(manifest_path), command.command]
     if command.runner is not None:
         fields.append(command.runner)
-    fields.extend(_route_metadata_fields(manifest))
+    fields.extend(_route_metadata_fields(manifest, manifest_command_trust_required=True))
     return "\t".join(fields)
 
 
@@ -893,7 +905,7 @@ def _demo_output(
     fields = [project_name, str(project_root), str(manifest_path), str(demo_script)]
     if manifest.demo.runner is not None:
         fields.append(manifest.demo.runner)
-    fields.extend(_route_metadata_fields(manifest))
+    fields.extend(_route_metadata_fields(manifest, manifest_command_trust_required=True))
     return "\t".join(fields)
 
 

--- a/cli/python/base_projects/tests/test_build_targets.py
+++ b/cli/python/base_projects/tests/test_build_targets.py
@@ -136,16 +136,26 @@ def run_engine(args: list[str], base_home: Path) -> tuple[int, str, str]:
     return status, stdout.getvalue(), stderr.getvalue()
 
 
-def base_route_fields(base_home: Path, project: str) -> str:
+def base_route_fields(base_home: Path, project: str, *, trust_required: bool = True) -> str:
     del base_home
     if not _engine_homes:
         raise AssertionError("run_engine must be called before base_route_fields")
     venv_dir = _engine_homes[-1] / ".base.d" / project / ".venv"
-    return f"\t__base_project_venv_dir={venv_dir}\t__base_uses_uv_manager=false"
+    trust_value = "true" if trust_required else "false"
+    return (
+        f"\t__base_project_venv_dir={venv_dir}"
+        "\t__base_uses_uv_manager=false"
+        f"\t__base_manifest_command_trust_required={trust_value}"
+    )
 
 
-def uv_route_fields(project_root: Path) -> str:
-    return f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}\t__base_uses_uv_manager=true"
+def uv_route_fields(project_root: Path, *, trust_required: bool = True) -> str:
+    trust_value = "true" if trust_required else "false"
+    return (
+        f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
+        "\t__base_uses_uv_manager=true"
+        f"\t__base_manifest_command_trust_required={trust_value}"
+    )
 
 
 class BuildTargetTests(unittest.TestCase):
@@ -221,6 +231,20 @@ class BuildTargetTests(unittest.TestCase):
             f"\tworker\t{(project_root / 'services' / 'worker').resolve()}\tgo build ./cmd/worker"
             f"\tBuild the worker service.{base_route_fields(base_home, 'demo')}\n",
         )
+
+    def test_projects_build_targets_mark_manifest_command_trust_required(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_build_manifest(project_root, "demo")
+
+            status, stdout, stderr = run_engine(["build-targets", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("__base_manifest_command_trust_required=true", stdout)
 
     def test_projects_build_targets_prints_explicit_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -57,16 +57,26 @@ def write_versioned_python_bin(python_bin: Path, version: str) -> None:
 _engine_homes: list[Path] = []
 
 
-def base_route_fields(base_home: Path, project: str) -> str:
+def base_route_fields(base_home: Path, project: str, *, trust_required: bool = True) -> str:
     del base_home
     if not _engine_homes:
         raise AssertionError("run_engine must be called before base_route_fields")
     venv_dir = _engine_homes[-1] / ".base.d" / project / ".venv"
-    return f"\t__base_project_venv_dir={venv_dir}\t__base_uses_uv_manager=false"
+    trust_value = "true" if trust_required else "false"
+    return (
+        f"\t__base_project_venv_dir={venv_dir}"
+        "\t__base_uses_uv_manager=false"
+        f"\t__base_manifest_command_trust_required={trust_value}"
+    )
 
 
-def uv_route_fields(project_root: Path) -> str:
-    return f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}\t__base_uses_uv_manager=true"
+def uv_route_fields(project_root: Path, *, trust_required: bool = True) -> str:
+    trust_value = "true" if trust_required else "false"
+    return (
+        f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
+        "\t__base_uses_uv_manager=true"
+        f"\t__base_manifest_command_trust_required={trust_value}"
+    )
 
 
 def write_last_check(home: Path, project: str, checked_at: str, status: str = "ok") -> None:
@@ -559,7 +569,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'demo')}\n",
+            f"{base_route_fields(base_home, 'demo', trust_required=False)}\n",
         )
 
     def test_projects_resolve_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
@@ -577,7 +587,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"{uv_route_fields(project_root)}\n",
+            f"{uv_route_fields(project_root, trust_required=False)}\n",
         )
 
     def test_projects_resolve_uses_active_project_manifest_without_workspace_scan(self) -> None:
@@ -606,7 +616,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
-            f"demo\t{project_root.resolve()}\t{manifest_path.resolve()}{base_route_fields(base_home, 'demo')}\n",
+            f"demo\t{project_root.resolve()}\t{manifest_path.resolve()}"
+            f"{base_route_fields(base_home, 'demo', trust_required=False)}\n",
         )
 
     def test_projects_resolve_explicit_workspace_wins_over_active_project(self) -> None:
@@ -634,7 +645,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{explicit_root.resolve()}\t{(explicit_root / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'demo')}\n",
+            f"{base_route_fields(base_home, 'demo', trust_required=False)}\n",
         )
 
     def test_projects_resolve_rejects_active_project_manifest_mismatch(self) -> None:
@@ -677,7 +688,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'demo')}\n",
+            f"{base_route_fields(base_home, 'demo', trust_required=False)}\n",
         )
 
     def test_projects_resolve_base_uses_base_home_without_workspace_scan(self) -> None:
@@ -695,7 +706,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'base')}\n",
+            f"{base_route_fields(base_home, 'base', trust_required=False)}\n",
         )
 
     def test_projects_resolve_base_uses_base_home_with_configured_workspace(self) -> None:
@@ -718,7 +729,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'base')}\n",
+            f"{base_route_fields(base_home, 'base', trust_required=False)}\n",
         )
 
     def test_projects_test_command_prints_project_details_and_command(self) -> None:
@@ -738,6 +749,20 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}\tpytest tests/"
             f"{base_route_fields(base_home, 'demo')}\n",
         )
+
+    def test_projects_test_command_marks_manifest_command_trust_required(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_test_manifest(project_root, "demo", "pytest tests/")
+
+            status, stdout, stderr = run_engine(["test-command", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("__base_manifest_command_trust_required=true", stdout)
 
     def test_projects_test_command_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -768,7 +793,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tpytest tests/\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
-            "\t__base_uses_uv_manager=true\n",
+            "\t__base_uses_uv_manager=true"
+            "\t__base_manifest_command_trust_required=true\n",
         )
 
     def test_projects_test_command_for_base_uses_base_home_without_workspace_scan(self) -> None:
@@ -867,6 +893,35 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(stdout, "")
+
+    def test_projects_resolve_marks_activation_trust_required_only_when_sources_declared(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            activation_script = project_root / ".base" / "activate.sh"
+            write_activation_manifest(project_root, "demo", [".base/activate.sh"])
+            activation_script.parent.mkdir()
+            activation_script.write_text("export DEMO=1\n", encoding="utf-8")
+
+            status, stdout, stderr = run_engine(["resolve", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("__base_manifest_command_trust_required=true", stdout)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(["resolve", "demo"], base_home)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("__base_manifest_command_trust_required=false", stdout)
 
     def test_projects_activation_sources_rejects_unsafe_paths(self) -> None:
         cases = {
@@ -989,7 +1044,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tuvicorn app:app --reload\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
-            "\t__base_uses_uv_manager=true\n",
+            "\t__base_uses_uv_manager=true"
+            "\t__base_manifest_command_trust_required=true\n",
         )
 
     def test_projects_run_command_test_delegates_to_test_contract(self) -> None:
@@ -1113,7 +1169,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\t{script.resolve()}\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
-            "\t__base_uses_uv_manager=true\n",
+            "\t__base_uses_uv_manager=true"
+            "\t__base_manifest_command_trust_required=true\n",
         )
 
     def test_projects_demo_script_prints_runner_when_declared(self) -> None:

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -187,6 +187,28 @@ def status_command(ctx: base_cli.Context, project: str, workspace: str | None, o
     return base_cli.ExitCode.SUCCESS
 
 
+@app.subcommand("require", context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.argument("project")
+@base_cli.option(
+    "--workspace",
+    help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
+)
+@base_cli.option("--manifest", "manifest_path", help="Resolved base_manifest.yaml path to verify.")
+def require_command(ctx: base_cli.Context, project: str, workspace: str | None, manifest_path: str | None) -> int:
+    try:
+        identity = resolve_trust_identity_for_require(ctx, project, workspace, manifest_path)
+    except (ProjectDiscoveryError, ManifestError, TrustError) as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    trust_status = ManifestCommandTrustStore().status(identity)
+    if trust_status.is_allowed:
+        return base_cli.ExitCode.SUCCESS
+
+    print_blocked_command_text(trust_status, stream=sys.stderr)
+    return base_cli.ExitCode.FAILURE
+
+
 @app.subcommand("allow", context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.argument("project")
 @base_cli.option(
@@ -247,6 +269,24 @@ def resolve_trust_identity(
 ) -> ManifestCommandTrustIdentity:
     project = project_engine.resolve_named_project(ctx, project_name, workspace)
     return compute_trust_identity_for_manifest(project.manifest_path)
+
+
+def resolve_trust_identity_for_require(
+    ctx: base_cli.Context,
+    project_name: str,
+    workspace: str | None,
+    manifest_path: str | None,
+) -> ManifestCommandTrustIdentity:
+    if manifest_path is None:
+        return resolve_trust_identity(ctx, project_name, workspace)
+
+    identity = compute_trust_identity_for_manifest(Path(manifest_path))
+    if identity.project_name != project_name:
+        raise TrustError(
+            f"Resolved manifest '{identity.manifest_path}' declares project '{identity.project_name}', "
+            f"not '{project_name}'."
+        )
+    return identity
 
 
 def compute_trust_identity_for_manifest(manifest_path: Path) -> ManifestCommandTrustIdentity:
@@ -375,6 +415,39 @@ def print_status_text(trust_status: TrustStatus) -> None:
         print(f"Manifest command trust is blocked for project '{identity.project_name}'.")
     print_identity("Current identity", identity)
     print(f"Allow after review: {allow_command_text(identity)}")
+
+
+def print_blocked_command_text(trust_status: TrustStatus, *, stream: Any) -> None:
+    identity = trust_status.identity
+    if trust_status.reason == "manifest_changed":
+        print(
+            f"ERROR: Manifest command trust is blocked for project '{identity.project_name}': "
+            "manifest command contract changed.",
+            file=stream,
+        )
+    else:
+        print(
+            f"ERROR: Manifest-declared commands are not allowed for project "
+            f"'{identity.project_name}' on this machine.",
+            file=stream,
+        )
+    print(f"Project root: {identity.project_root}", file=stream)
+    print(f"Manifest: {identity.manifest_path}", file=stream)
+    if trust_status.reason == "manifest_changed":
+        changed_project = (trust_status.changed_record or {}).get("project", {})
+        if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
+            print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}", file=stream)
+    print(f"Manifest SHA-256: {identity.manifest_sha256}", file=stream)
+    if identity.origin is not None:
+        print(f"Origin: {identity.origin}", file=stream)
+    print(file=stream)
+    print("Review first:", file=stream)
+    print(f"  basectl run {identity.project_name} --list", file=stream)
+    print(f"  basectl build {identity.project_name} --list", file=stream)
+    print(f"  basectl test {identity.project_name} --dry-run", file=stream)
+    print(file=stream)
+    print("Allow after review:", file=stream)
+    print(f"  {allow_command_text(identity)}", file=stream)
 
 
 def print_identity(title: str, identity: ManifestCommandTrustIdentity) -> None:

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -147,6 +147,60 @@ class ManifestCommandTrustTests(unittest.TestCase):
             f"basectl trust allow demo --manifest-sha256 {expected_digest}",
         )
 
+    def test_require_blocks_unapproved_manifest_with_review_guidance(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            manifest_path = write_manifest(workspace / "demo")
+            expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(home),
+                    "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_HOME": str(workspace / "base"),
+                },
+            ):
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    status = engine.main(["require", "demo", "--manifest", str(manifest_path)])
+
+        self.assertEqual(status, 1, stderr.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Manifest-declared commands are not allowed for project 'demo'", stderr.getvalue())
+        self.assertIn(f"Manifest SHA-256: {expected_digest}", stderr.getvalue())
+        self.assertIn("Review first:", stderr.getvalue())
+        self.assertIn("  basectl run demo --list", stderr.getvalue())
+        self.assertIn("Allow after review:", stderr.getvalue())
+        self.assertIn(f"  basectl trust allow demo --manifest-sha256 {expected_digest}", stderr.getvalue())
+
+    def test_require_allows_matching_trust_record_for_manifest_path(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            manifest_path = write_manifest(workspace / "demo")
+            identity = engine.compute_trust_identity_for_manifest(manifest_path)
+            engine.ManifestCommandTrustStore(home=home).allow(identity, base_version="9.9.9")
+
+            result = invoke(
+                engine.app,
+                ["require", "demo", "--manifest", str(manifest_path)],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+
     def test_allow_rejects_manifest_sha256_mismatch_without_writing_record(self) -> None:
         from base_trust import engine
 

--- a/docs/manifest-command-trust.md
+++ b/docs/manifest-command-trust.md
@@ -6,7 +6,6 @@ but they also create a local trust boundary: cloning or pulling a repository
 should not by itself imply consent to execute that repository's commands.
 
 This document defines the allow model for manifest-declared command execution.
-It is a design contract for the implementation that should follow.
 
 ## Goals
 
@@ -26,8 +25,8 @@ It is a design contract for the implementation that should follow.
 
 ## Commands Covered
 
-The first implementation should require an allow record before commands that
-execute manifest-declared project code:
+Base requires an allow record before commands that execute manifest-declared
+project code:
 
 - `basectl test [project]`
 - `basectl run <project> <command>`
@@ -55,8 +54,8 @@ command allow flow unless a later issue explicitly expands the scope.
 
 ## Trust Identity
 
-An allow record should bind approval to both repository identity and the manifest
-command contract. The identity should include:
+An allow record binds approval to both repository identity and the manifest
+command contract. The identity includes:
 
 - canonical project root path
 - canonical manifest path
@@ -66,10 +65,10 @@ command contract. The identity should include:
 - sanitized `origin` remote URL when available
 - current Git HEAD when available, for display and audit metadata
 
-The enforcement key should include the canonical project root, manifest path,
-and manifest digest. The remote URL and Git HEAD are stored for display and
-audit, but the manifest digest is the signal that forces re-approval after
-command declarations change.
+The enforcement key includes the canonical project root, manifest path, and
+manifest digest. The remote URL and Git HEAD are stored for display and audit,
+but the manifest digest is the signal that forces re-approval after command
+declarations change.
 
 This intentionally resembles `direnv allow`: approval is local to the machine
 and is invalidated by a content change in the trusted file. It does not try to
@@ -77,14 +76,14 @@ prove that every script reachable from the manifest is unchanged.
 
 ## Local State
 
-Store allow records under Base-managed local state:
+Base stores allow records under Base-managed local state:
 
 ```text
 ~/.base.d/trust/manifest-commands/
   <identity-key>.json
 ```
 
-Each record should use schema version `1`:
+Each record uses schema version `1`:
 
 ```json
 {
@@ -111,7 +110,7 @@ repositories.
 
 ## User-Facing Flow
 
-Add a focused trust command:
+Use the focused trust command to inspect, allow, or revoke approval:
 
 ```bash
 basectl trust status <project> [--workspace <path>] [--format text|json]
@@ -119,12 +118,12 @@ basectl trust allow <project> [--workspace <path>] [--manifest-sha256 <sha256>]
 basectl trust revoke <project> [--workspace <path>]
 ```
 
-`basectl trust allow` should print the exact identity being approved and require
-the supplied `--manifest-sha256` to match when that option is present. That flag
-is useful for scripted, non-interactive approval after a prior review step.
+`basectl trust allow` prints the exact identity being approved and requires the
+supplied `--manifest-sha256` to match when that option is present. That flag is
+useful for scripted, non-interactive approval after a prior review step.
 
-When execution is blocked, commands should fail before project environment
-activation and before changing into project directories:
+When execution is blocked, commands fail before project environment activation
+and before changing into project directories:
 
 ```text
 ERROR: Manifest-declared commands are not allowed for project 'demo' on this machine.
@@ -143,8 +142,8 @@ Allow after review:
 ```
 
 If a record exists for the same project root but a different manifest digest,
-the error should say the manifest command contract changed and show both the
-recorded and current digest.
+the error says the manifest command contract changed and shows both the recorded
+and current digest.
 
 ## Non-Interactive And CI Behavior
 
@@ -183,8 +182,8 @@ step, and then call `trust allow` with that digest.
 }
 ```
 
-Execution commands do not need to grow JSON output in the first slice; they can
-print the text block above and exit non-zero.
+Execution commands print the text block above and exit non-zero; JSON remains on
+`basectl trust status --format json`.
 
 ## Implementation Slices
 

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -236,6 +236,10 @@ run_basectl_separate_stderr() {
 }
 
 @test "basectl test delegates from the project root with project environment" {
+    run_basectl trust allow demo
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Allowed manifest commands for project 'demo'."* ]]
+
     run_basectl test demo -- -k "focused case"
     [ "$status" -eq 0 ]
 


### PR DESCRIPTION
## Summary
- require local manifest-command trust before basectl test/run/build/demo/activate execute project-owned manifest code
- keep dry-run/list inspection paths available before approval
- document the implemented allow flow and CI allow-step pattern

Fixes #1382

## Verification
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_trust/tests/test_engine.py cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_build_targets.py -q
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash bats cli/bash/commands/basectl/tests/manifest-command-trust.bats cli/bash/commands/basectl/tests/test.bats cli/bash/commands/basectl/tests/run.bats cli/bash/commands/basectl/tests/build.bats cli/bash/commands/basectl/tests/demo.bats cli/bash/commands/basectl/tests/activate.bats cli/bash/commands/basectl/tests/project-command-helpers.bats cli/bash/commands/basectl/tests/trust.bats
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash bats --filter 'basectl test delegates from the project root with project environment' tests/integration/base_workflows.bats
- env PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc
- git diff --check
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash ./bin/base-test