### PR TITLE
Use platform Python finder for CI runtime checks

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -2359,7 +2359,7 @@ setup_collect_ci_runtime_check_results() {
     pyyaml_package="$(setup_pyyaml_package)"
     setup_ensure_cached_paths
 
-    if python_bin="$(setup_find_python_bin)"; then
+    if python_bin="$(setup_find_platform_python_bin)"; then
         setup_add_check_result \
             "python" \
             true \

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -79,3 +79,20 @@ run_setup_common_script() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"platform=macos"* ]]
 }
+
+@test "setup_common CI runtime checks use the Linux platform Python finder" {
+    create_system_python3_stub
+    create_project_setup_venv_stub "$TEST_HOME/.base.d/base/.venv"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+
+    run_setup_common_script '
+        BASE_TEST_MODE=true
+        BASE_SETUP_TEST_PLATFORM=linux-debian
+        setup_collect_ci_runtime_check_results
+        setup_print_check_text_results
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Python is available for CI runtime checks."* ]]
+}


### PR DESCRIPTION
## Summary
- switch CI runtime Python discovery to the platform-aware finder
- add a regression proving Linux CI runtime checks can find PATH python3 without relying on BASE_SETUP_ALLOW_SYSTEM_PYTHON

Fixes #1404

## Verification
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash bats --filter 'setup_common CI runtime checks use the Linux platform Python finder' cli/bash/commands/basectl/tests/setup-common.bats
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash bats cli/bash/commands/basectl/tests/setup-common.bats cli/bash/commands/basectl/tests/ci.bats
- git diff --check
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/opt/homebrew/opt/base-bash-libs/libexec/lib/bash ./bin/base-test