### PR TITLE
Keep gh out of bulk Ubuntu apt prerequisites

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -2609,7 +2609,7 @@ setup_run_macos_install() {
 }
 
 setup_linux_debian_apt_packages() {
-    printf '%s\n' "bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go"
+    printf '%s\n' "bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"
 }
 
 setup_linux_debian_apt_update_command() {
@@ -2656,7 +2656,8 @@ setup_run_linux_debian_apt_prerequisites() {
 
     log_info "Installing Ubuntu/Debian apt prerequisites."
     sudo apt-get update || return $?
-    sudo apt-get install -y "${package_args[@]}"
+    sudo apt-get install -y "${package_args[@]}" || return $?
+    log_info "$(setup_linux_debian_github_cli_install_guidance)"
 }
 
 setup_run_linux_debian_install() {

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -96,3 +96,42 @@ run_setup_common_script() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Python is available for CI runtime checks."* ]]
 }
+
+@test "setup_common keeps GitHub CLI out of bulk Ubuntu apt prerequisites" {
+    run_setup_common_script '
+        packages="$(setup_linux_debian_apt_packages)"
+        printf "packages=%s\n" "$packages"
+        printf "command=%s\n" "$(setup_linux_debian_apt_prerequisite_command)"
+        setup_linux_debian_github_cli_install_guidance
+        case " $packages " in
+            *" gh "*)
+                printf "gh must use official GitHub CLI apt repository guidance, not the bulk apt list\n" >&2
+                exit 20
+                ;;
+        esac
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"packages=bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
+    [[ "$output" == *"command=sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
+    [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh':"* ]]
+}
+
+@test "setup_common logs GitHub CLI guidance after Ubuntu apt prerequisite install" {
+    cat > "$TEST_MOCKBIN/sudo" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$TEST_STATE_DIR/sudo-args"
+exit 0
+EOF
+    chmod +x "$TEST_MOCKBIN/sudo"
+
+    run_setup_common_script '
+        setup_enable_yes
+        setup_run_linux_debian_apt_prerequisites
+    '
+
+    [ "$status" -eq 0 ]
+    [ "$(sed -n '1p' "$TEST_STATE_DIR/sudo-args")" = "apt-get update" ]
+    [ "$(sed -n '2p' "$TEST_STATE_DIR/sudo-args")" = "apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go" ]
+    [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh':"* ]]
+}

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -101,7 +101,7 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get update"* ]]
-    [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get install -y bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
     [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh'"* ]]
     [[ "$output" == *"https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"* ]]
     [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
@@ -116,7 +116,7 @@ load ./setup_helpers.bash
 
     run_base_command \
         BASE_SETUP_TEST_PLATFORM=linux-debian \
-        BASE_SETUP_TEST_MISSING_APT_PACKAGES=gh \
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=python3-venv \
         setup
 
     [ "$status" -eq 1 ]
@@ -163,11 +163,12 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Installing Ubuntu/Debian apt prerequisites."* ]]
+    [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh'"* ]]
     [[ "$output" == *"Creating Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [[ "$output" == *"Base CLI setup is complete."* ]]
     [ -f "$TEST_STATE_DIR/apt-update-ran" ]
     [ -f "$TEST_STATE_DIR/apt-install-ran" ]
-    [ "$(cat "$TEST_STATE_DIR/apt-install-packages")" = "bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go" ]
+    [ "$(cat "$TEST_STATE_DIR/apt-install-packages")" = "bash git python3 python3-venv python3-pip bats shellcheck jq golang-go" ]
     [ -f "$TEST_STATE_DIR/system-python-ran" ]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
 }

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -49,8 +49,8 @@ EOF
     run_base_command update-profile
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Updating '$TEST_HOME/.bash_profile'"* ]]
-    [[ "$output" == *"Updating '$TEST_HOME/.bashrc'"* ]]
+    [[ "$output" == *"Updating '$TEST_HOME/.bash_profile'"* || "$output" == *"Adding section to '$TEST_HOME/.bash_profile'"* ]]
+    [[ "$output" == *"Updating '$TEST_HOME/.bashrc'"* || "$output" == *"Adding section to '$TEST_HOME/.bashrc'"* ]]
 
     for dotfile in .bash_profile .bashrc .zprofile .zshrc; do
         [ -f "$TEST_HOME/$dotfile" ]


### PR DESCRIPTION
## Summary

- Remove `gh` from the default Ubuntu/Debian bulk apt prerequisite list so `basectl setup --yes` does not fail on fresh systems without GitHub CLI's apt repository.
- Keep GitHub CLI installation as explicit official-repository guidance in dry-run and live setup output.
- Update setup tests for the advisory `gh` path and make the update-profile assertion compatible with the latest `base-bash-libs` section-add logging.

Fixes #1402

## Verification

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup-common.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter 'basectl update-profile creates Base-managed sections in all shell dotfiles' cli/bash/commands/basectl/tests/update-profile.bats`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1402-cache ./bin/base-test`
  - Python: `773 passed, 1 skipped`
  - Bats: `1..618`, all passed
