### PR TITLE
Add Ubuntu bootstrap guidance path

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ When `workspace.manifest` is set, workspace commands use it unless
 `workspace.manifest_source` is set, `basectl workspace pull` can explicitly
 refresh the local manifest from that canonical source.
 
-### New Or Uncertain macOS Machine?
+### New Or Uncertain Machine?
 
 On a new macOS machine, or any machine where Homebrew, Git, or a supported Bash
 may be missing, start with the first-mile bootstrap script:
@@ -176,6 +176,16 @@ curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh 
 
 For mode selection, dry-run behavior, and contributor setup details, see
 [First-Mile Bootstrap](docs/bootstrap.md).
+
+On Ubuntu/Debian Linux, the same bootstrap script prints the manual
+source-checkout path instead of running apt itself:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source --dry-run
+```
+
+Review the printed apt, clone, `basectl setup --yes`, and `update-profile`
+commands, then run them in the Ubuntu shell.
 
 ### Team Or Security-Conscious Rollout
 
@@ -1133,6 +1143,11 @@ Pass `--source` or `--brew` with `bash -s --` to choose the route explicitly.
 Without an explicit choice, the bootstrapper preserves an existing Homebrew Base
 install, then an existing source checkout, and otherwise defaults to source mode.
 See [First-Mile Bootstrap](docs/bootstrap.md) for the full bootstrap contract.
+
+On Ubuntu/Debian Linux, `bootstrap.sh` does not run `sudo apt` automatically.
+It prints the manual source-checkout path, including the supported apt
+prerequisites, a sibling `base-bash-libs` checkout, `basectl setup --dry-run`,
+`basectl setup --yes`, and `basectl update-profile`.
 
 Base can be installed through its Homebrew tap:
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -80,6 +80,113 @@ bootstrap_require_macos() {
     [[ "$os_name" == "Darwin" ]] || bootstrap_die "bootstrap.sh currently supports macOS only."
 }
 
+bootstrap_linux_os_release_path() {
+    printf '%s\n' "${BASE_BOOTSTRAP_TEST_OS_RELEASE_PATH:-/etc/os-release}"
+}
+
+bootstrap_detect_linux_platform() {
+    local ID="" ID_LIKE=""
+    local id id_like
+    local os_release_path
+
+    os_release_path="$(bootstrap_linux_os_release_path)"
+    if [[ -r "$os_release_path" ]]; then
+        # shellcheck source=/dev/null
+        source "$os_release_path"
+    fi
+
+    id="${ID,,}"
+    id_like="${ID_LIKE,,}"
+    case " $id $id_like " in
+        *" ubuntu "*|*" debian "*)
+            printf 'linux-debian\n'
+            ;;
+        *)
+            printf 'linux-unknown\n'
+            ;;
+    esac
+}
+
+bootstrap_current_platform() {
+    local os_name
+
+    if [[ -n "${BASE_BOOTSTRAP_TEST_PLATFORM:-}" ]]; then
+        printf '%s\n' "$BASE_BOOTSTRAP_TEST_PLATFORM"
+        return 0
+    fi
+
+    os_name="$(bootstrap_uname)"
+    case "$os_name" in
+        Darwin)
+            printf 'macos\n'
+            ;;
+        Linux)
+            bootstrap_detect_linux_platform
+            ;;
+        *)
+            printf 'unsupported\n'
+            ;;
+    esac
+}
+
+bootstrap_linux_debian_apt_packages() {
+    printf '%s\n' "bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"
+}
+
+bootstrap_linux_debian_github_cli_install_url() {
+    printf '%s\n' "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"
+}
+
+bootstrap_linux_debian_github_cli_install_guidance() {
+    printf "Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh': %s.\n" "$(bootstrap_linux_debian_github_cli_install_url)"
+}
+
+bootstrap_print_linux_debian_source_path() {
+    local base_bash_libs_dir
+    local branch="$3"
+    local install_dir="$2"
+    local parent_dir
+    local repo_url="$1"
+
+    parent_dir="$(bootstrap_parent_dir "$install_dir")"
+    base_bash_libs_dir="$parent_dir/base-bash-libs"
+
+    bootstrap_log "Ubuntu/Debian Linux bootstrap path"
+    bootstrap_log "Install mode: source"
+    bootstrap_log ""
+    bootstrap_log "Review and run these commands on Ubuntu/Debian Linux:"
+    bootstrap_log "  sudo apt-get update"
+    bootstrap_log "  sudo apt-get install -y $(bootstrap_linux_debian_apt_packages)"
+    bootstrap_log "  $(bootstrap_linux_debian_github_cli_install_guidance)"
+    bootstrap_log "  mkdir -p $parent_dir"
+    if [[ -n "$branch" ]]; then
+        bootstrap_log "  git clone --branch $branch $repo_url $install_dir"
+    else
+        bootstrap_log "  git clone $repo_url $install_dir"
+    fi
+    bootstrap_log "  git clone https://github.com/basefoundry/base-bash-libs.git $base_bash_libs_dir"
+    bootstrap_log "  $install_dir/bin/basectl setup --dry-run"
+    bootstrap_log "  $install_dir/bin/basectl setup --yes"
+    bootstrap_log "  $install_dir/bin/basectl update-profile"
+    bootstrap_log "  exec \"\$SHELL\" -l"
+}
+
+bootstrap_run_linux_debian_bootstrap() {
+    local branch="$4"
+    local install_dir="$3"
+    local mode="$1"
+    local repo_url="$2"
+
+    case "$mode" in
+        ""|source)
+            bootstrap_print_linux_debian_source_path "$repo_url" "$install_dir" "$branch"
+            ;;
+        brew)
+            bootstrap_die "Homebrew bootstrap mode is macOS-only; use --source on Ubuntu/Debian Linux."
+            ;;
+    esac
+}
+
 bootstrap_find_brew() {
     local candidate
     local candidates="${BASE_BOOTSTRAP_BREW_CANDIDATES:-/opt/homebrew/bin/brew:/usr/local/bin/brew}"
@@ -540,6 +647,7 @@ bootstrap_main() {
     local formula="${BASE_BOOTSTRAP_BREW_FORMULA:-basefoundry/base/base}"
     local install_dir="${BASE_BOOTSTRAP_INSTALL_DIR:-${BASE_HOME:-$HOME/work/base}}"
     local mode="${BASE_BOOTSTRAP_MODE:-}"
+    local platform
     local repo_url="${BASE_BOOTSTRAP_REPO_URL:-https://github.com/basefoundry/base.git}"
 
     BASE_BOOTSTRAP_DRY_RUN="${BASE_BOOTSTRAP_DRY_RUN:-false}"
@@ -592,7 +700,18 @@ bootstrap_main() {
     install_dir="$(bootstrap_expand_path "$install_dir")" || return $?
 
     bootstrap_log "Base bootstrap"
-    bootstrap_require_macos || return $?
+    platform="$(bootstrap_current_platform)" || return $?
+    case "$platform" in
+        macos)
+            ;;
+        linux-debian)
+            bootstrap_run_linux_debian_bootstrap "$mode" "$repo_url" "$install_dir" "$branch"
+            return $?
+            ;;
+        *)
+            bootstrap_die "bootstrap.sh currently supports macOS and Ubuntu/Debian Linux only."
+            ;;
+    esac
     bootstrap_ensure_homebrew "$allow_homebrew_install" brew_bin || return $?
     bootstrap_ensure_git "$brew_bin" || return $?
     bootstrap_ensure_supported_bash "$brew_bin" || return $?

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -5,6 +5,11 @@ machine. It handles the minimum prerequisites needed before `basectl` can take
 over: Homebrew, Git, Bash 4.2+, and either a source checkout or Homebrew
 installation of Base.
 
+On Ubuntu/Debian Linux, `bootstrap.sh` stays conservative: it does not run
+`sudo apt` from a piped script. Instead, it detects the platform and prints the
+manual source-checkout commands, including apt prerequisites and the
+`basectl setup --yes` handoff.
+
 ## Quick Start
 
 Run the bootstrapper from GitHub:
@@ -13,9 +18,9 @@ Run the bootstrapper from GitHub:
 curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
 ```
 
-The bootstrapper verifies macOS, installs missing first-mile prerequisites, and
-then prints the exact commands needed to finish setup. For the default source
-checkout path, the handoff usually looks like:
+On macOS, the bootstrapper verifies macOS, installs missing first-mile
+prerequisites, and then prints the exact commands needed to finish setup. For
+the default source checkout path, the handoff usually looks like:
 
 ```bash
 ~/work/base/bin/basectl setup
@@ -26,6 +31,16 @@ exec "$SHELL" -l
 `bootstrap.sh` does not edit shell startup files automatically. Shell profile
 integration remains an explicit `basectl update-profile` step so the user can
 see what was installed before Base changes future interactive shells.
+
+On Ubuntu/Debian, inspect the manual path first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source --dry-run
+```
+
+The output includes `sudo apt-get update`, the supported apt prerequisite list,
+the sibling `base-bash-libs` clone, and the source checkout `setup --dry-run`,
+`setup --yes`, and `update-profile` commands.
 
 ## Install Mode
 
@@ -60,7 +75,8 @@ bootstrap.sh --dry-run
 ```
 
 Use `--dry-run` to inspect the planned prerequisite installs and Base install
-route without changing the machine.
+route without changing the machine. On Ubuntu/Debian, the bootstrapper always
+prints manual commands rather than mutating apt state itself.
 
 ## Contributor Path
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -98,10 +98,22 @@ the apt-backed setup path has installed `python3` and `python3-venv`.
 
 ## Ubuntu Bootstrap
 
-For v1.6.0, Ubuntu/Debian setup can install the simple apt prerequisites that
-Base knows how to own. The mutation path is intentionally explicit:
-`basectl setup --dry-run` prints the apt commands, and `basectl setup --yes`
-applies them. Without `--yes`, Linux setup fails before invoking `apt`.
+Ubuntu/Debian bootstrap is intentionally conservative. The first-mile
+`bootstrap.sh` entry point detects Ubuntu/Debian Linux and prints the manual
+source-checkout path instead of running `sudo apt` from a piped script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source --dry-run
+```
+
+The printed path includes apt prerequisites, cloning Base and
+`base-bash-libs`, `basectl setup --dry-run`, `basectl setup --yes`, and
+`basectl update-profile`.
+
+Ubuntu/Debian setup can install the simple apt prerequisites that Base knows
+how to own. The mutation path is intentionally explicit: `basectl setup
+--dry-run` prints the apt commands, and `basectl setup --yes` applies them.
+Without `--yes`, Linux setup fails before invoking `apt`.
 
 Use native Linux filesystem paths for source checkouts. In Parallels, keep Base
 under `~/work`, not under mounted macOS shared folders, so file permissions,
@@ -124,7 +136,7 @@ The Ubuntu/Debian setup path runs:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go
+sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go
 ```
 
 `basectl check` and `basectl doctor` keep the basic Ubuntu/Debian runtime path

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -345,6 +345,60 @@ sha256_file() {
     [[ "$output" != *"Formula: basefoundry/base/base"* ]]
 }
 
+@test "bootstrap linux-debian dry-run prints manual source checkout path" {
+    local install_dir="$TEST_HOME/work/base"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_PLATFORM=linux-debian \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --dry-run --source --install-dir "$install_dir" --repo-url https://example.test/base.git
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base bootstrap"* ]]
+    [[ "$output" == *"Ubuntu/Debian Linux bootstrap path"* ]]
+    [[ "$output" == *"sudo apt-get update"* ]]
+    [[ "$output" == *"sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
+    [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh'"* ]]
+    [[ "$output" == *"git clone https://example.test/base.git $install_dir"* ]]
+    [[ "$output" == *"git clone https://github.com/basefoundry/base-bash-libs.git $TEST_HOME/work/base-bash-libs"* ]]
+    [[ "$output" == *"$install_dir/bin/basectl setup --dry-run"* ]]
+    [[ "$output" == *"$install_dir/bin/basectl setup --yes"* ]]
+    [[ "$output" == *"$install_dir/bin/basectl update-profile"* ]]
+    [[ "$output" == *"exec \"\$SHELL\" -l"* ]]
+    [[ "$output" != *"Homebrew"* ]]
+    [[ "$output" != *"Xcode"* ]]
+}
+
+@test "bootstrap linux-debian rejects Homebrew mode" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_PLATFORM=linux-debian \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --dry-run --brew
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Homebrew bootstrap mode is macOS-only; use --source on Ubuntu/Debian Linux."* ]]
+}
+
+@test "bootstrap detects Ubuntu from os-release" {
+    local install_dir="$TEST_HOME/work/base"
+    local os_release="$TEST_TMPDIR/os-release"
+
+    printf 'ID=ubuntu\nID_LIKE=debian\n' > "$os_release"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_OS=Linux \
+        BASE_BOOTSTRAP_TEST_OS_RELEASE_PATH="$os_release" \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --dry-run --source --install-dir "$install_dir" --repo-url https://example.test/base.git
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Ubuntu/Debian Linux bootstrap path"* ]]
+    [[ "$output" == *"git clone https://example.test/base.git $install_dir"* ]]
+}
+
 @test "bootstrap can refuse to install missing Homebrew" {
     run_bootstrap --no-homebrew-install
 
@@ -353,13 +407,18 @@ sha256_file() {
     [[ "$output" == *"Homebrew is required"* ]]
 }
 
-@test "bootstrap rejects non-macOS systems" {
+@test "bootstrap rejects unsupported Linux systems" {
+    local os_release="$TEST_TMPDIR/os-release"
+
+    printf 'ID=fedora\nID_LIKE="rhel fedora"\n' > "$os_release"
+
     run env \
         HOME="$TEST_HOME" \
         PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
         BASE_BOOTSTRAP_TEST_OS=Linux \
+        BASE_BOOTSTRAP_TEST_OS_RELEASE_PATH="$os_release" \
         "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --dry-run
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"bootstrap.sh currently supports macOS only"* ]]
+    [[ "$output" == *"bootstrap.sh currently supports macOS and Ubuntu/Debian Linux only"* ]]
 }

--- a/tests/test_linux_support_docs.py
+++ b/tests/test_linux_support_docs.py
@@ -15,7 +15,8 @@ def test_linux_support_docs_include_apt_backed_ubuntu_bootstrap() -> None:
     assert "## Ubuntu Bootstrap" in text
     assert "basectl setup --dry-run" in text
     assert "basectl setup --yes" in text
-    assert "sudo apt-get install -y bash git gh python3 python3-venv python3-pip bats shellcheck jq golang-go" in text
+    assert "sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go" in text
+    assert "sudo apt-get install -y bash git gh python3" not in text
     assert "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian" in text
     assert "signed apt repository/keyring" in text
     assert "GitHub CLI authentication" in text


### PR DESCRIPTION
## Summary

- Add an Ubuntu/Debian branch to `bootstrap.sh` that prints a manual source-checkout bootstrap path instead of failing with a macOS-only error.
- Keep Homebrew bootstrap mode macOS-only and reject `--brew` on Ubuntu/Debian with targeted guidance.
- Document the Ubuntu/Debian bootstrap handoff in README, first-mile bootstrap docs, and Linux support docs.

Fixes #1403

## Verification

- `bats --filter 'bootstrap linux-debian' tests/bootstrap.bats`
- `bats --filter 'bootstrap detects Ubuntu from os-release|bootstrap rejects unsupported Linux systems' tests/bootstrap.bats`
- `bats tests/bootstrap.bats`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_linux_support_docs.py tests/test_base_cli_docs.py -q`
- `shellcheck --severity=error bootstrap.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1403-cache ./bin/base-test`
  - Python: `773 passed, 1 skipped`
  - Bats: `1..621`, all passed
