### PR TITLE
Align Ubuntu gh setup policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,14 +1078,16 @@ artifact setup, Base first seeds the target project venv with `bootstrap: true`
 default artifacts and then invokes the Python project setup layer through
 `base-wrapper --project <project>`.
 Prerequisite profiles are opt-in. Use `--profile dev` to install Base
-contributor tools such as BATS, the GitHub CLI, and ShellCheck from
-`lib/base/dev_manifest.yaml`. Use `--profile sre` for the initial
-site-reliability profile in `lib/base/sre_manifest.yaml`, which installs local
-diagnostic tools such as `kubectl`, `helm`, `k9s`, `httpie`, `grpcurl`, `jq`,
-`yq`, `nmap`, and `mtr`. Use `--profile ai` for optional AI coding tools:
-Codex CLI and Claude Code. Use `--profile linux-lab` on a macOS host to install
-and check Multipass for local Ubuntu lab VMs. Profiles compose with a
-comma-separated list.
+contributor tools from `lib/base/dev_manifest.yaml`. On macOS that includes
+Homebrew-managed BATS, GitHub CLI, and ShellCheck. On Ubuntu/Debian it installs
+Base-owned apt-backed tools such as BATS and ShellCheck, while GitHub CLI
+remains user-managed through GitHub CLI's official Debian/Ubuntu repository
+guidance. Use `--profile sre` for the initial site-reliability profile in
+`lib/base/sre_manifest.yaml`, which installs local diagnostic tools such as
+`kubectl`, `helm`, `k9s`, `httpie`, `grpcurl`, `jq`, `yq`, `nmap`, and `mtr`.
+Use `--profile ai` for optional AI coding tools: Codex CLI and Claude Code.
+Use `--profile linux-lab` on a macOS host to install and check Multipass for
+local Ubuntu lab VMs. Profiles compose with a comma-separated list.
 
 ```bash
 basectl setup --profile dev

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -216,7 +216,7 @@ base_onboard_subcommand_main() {
     fi
 
     base_onboard_print_heading "Setup"
-    printf '%s\n' "This installs or verifies Homebrew, Xcode Command Line Tools, Base Python, and Base-managed artifacts."
+    printf '%s\n' "This installs or verifies Base platform prerequisites, Base Python, and Base-managed artifacts."
     if ((dry_run)); then
         base_onboard_execute "$dry_run" "${setup_args[@]}" || return $?
     elif base_onboard_confirm "$yes" "Proceed with setup?"; then

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -35,14 +35,13 @@ Purpose:
   Prepare the local Base CLI environment on supported setup platforms.
 
 Setup does:
-  1. Install Homebrew if needed.
-  2. Install Xcode Command Line Tools if needed.
-  3. Install Python 3.13 via Homebrew if needed.
-  4. Install prerequisite profiles when --profile is passed.
-  5. Create ~/.base.d/base/.venv if it does not already exist.
-  6. Install Base Python bootstrap packages into the Base virtual environment.
-  7. Invoke the Python project setup layer for base_manifest.yaml artifacts.
-  8. Create ~/.base.d/config.yaml with workspace.root: ~/work if missing.
+  1. Install or verify macOS prerequisites on macOS.
+  2. Install or verify apt prerequisites on Ubuntu/Debian Linux when --yes is passed.
+  3. Install prerequisite profiles when --profile is passed.
+  4. Create ~/.base.d/base/.venv if it does not already exist.
+  5. Install Base Python bootstrap packages into the Base virtual environment.
+  6. Invoke the Python project setup layer for base_manifest.yaml artifacts.
+  7. Create ~/.base.d/config.yaml with workspace.root: ~/work if missing.
 
 Notes:
   - This command is intentionally idempotent.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -405,7 +405,7 @@ setup_unsupported_platform_message() {
 setup_unsupported_install_platform_message() {
     local platform="$1"
 
-    printf "The setup platform path currently supports macOS only (BASE_PLATFORM='%s').\n" "$platform"
+    printf "The setup platform path currently supports macOS and Ubuntu/Debian Linux only (BASE_PLATFORM='%s').\n" "$platform"
 }
 
 setup_allow_test_hooks() {

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -190,6 +190,8 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Proceed with setup? [yes]"* ]]
+    [[ "$output" == *"This installs or verifies Base platform prerequisites, Base Python, and Base-managed artifacts."* ]]
+    [[ "$output" != *"This installs or verifies Homebrew, Xcode Command Line Tools"* ]]
     [[ "$output" == *"RUN:setup base"* ]]
     [[ "$output" == *"Shell profile updates skipped because --no-profile was set."* ]]
     [[ "$output" != *"RUN:update-profile"* ]]

--- a/cli/bash/commands/basectl/tests/setup-command.bats
+++ b/cli/bash/commands/basectl/tests/setup-command.bats
@@ -10,4 +10,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl setup [options]"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
+    [[ "$output" == *"Install or verify macOS prerequisites on macOS."* ]]
+    [[ "$output" == *"Install or verify apt prerequisites on Ubuntu/Debian Linux when --yes is passed."* ]]
+    [[ "$output" != *"Install Homebrew if needed."* ]]
 }

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -92,7 +92,7 @@ load ./setup_helpers.bash
     run_base_command BASE_SETUP_TEST_PLATFORM=linux-unknown setup
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"supports macOS only"* ]]
+    [[ "$output" == *"supports macOS and Ubuntu/Debian Linux only"* ]]
     [[ "$output" == *"BASE_PLATFORM='linux-unknown'"* ]]
 }
 

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -56,9 +56,10 @@ class ProfileError(ValueError):
 
 LINUX_DEBIAN_DEV_TOOLS = {
     "bats-core": LinuxDebianDevTool(apt_package="bats", command="bats"),
-    "gh": LinuxDebianDevTool(apt_package="gh", command="gh"),
     "shellcheck": LinuxDebianDevTool(apt_package="shellcheck", command="shellcheck"),
 }
+
+GITHUB_CLI_LINUX_INSTALL_URL = "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -412,8 +413,29 @@ def profile_setup_fix(profile: str) -> str:
     return f"basectl setup --profile {profile}"
 
 
+def github_cli_linux_install_fix(rerun_command: str) -> str:
+    return f"Follow {GITHUB_CLI_LINUX_INSTALL_URL}, then rerun '{rerun_command}'."
+
+
+def github_cli_linux_install_guidance() -> str:
+    return (
+        "GitHub CLI 'gh' is user-managed on Ubuntu/Debian. "
+        "Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh': "
+        f"{GITHUB_CLI_LINUX_INSTALL_URL}."
+    )
+
+
 def current_base_platform() -> str:
     return os.environ.get("BASE_PLATFORM", "")
+
+
+def linux_debian_github_cli_artifact(artifact: ArtifactRequest, profile: str) -> bool:
+    return (
+        profile == "dev"
+        and current_base_platform() == "linux-debian"
+        and artifact.artifact_type == "tool"
+        and artifact.name == "gh"
+    )
 
 
 def linux_debian_dev_tool(artifact: ArtifactRequest, profile: str) -> LinuxDebianDevTool | None:
@@ -429,10 +451,45 @@ def check_profile_artifact(
     definition: ArtifactDefinition,
     profile: str = "dev",
 ) -> DevCheck:
+    if linux_debian_github_cli_artifact(artifact, profile):
+        return check_linux_debian_github_cli_artifact(artifact, profile=profile)
     linux_debian_tool = linux_debian_dev_tool(artifact, profile)
     if linux_debian_tool is not None:
         return check_linux_debian_apt_artifact(artifact, linux_debian_tool, profile=profile)
     return check_homebrew_artifact(artifact, definition, profile=profile)
+
+
+def check_linux_debian_github_cli_artifact(
+    artifact: ArtifactRequest,
+    profile: str = "dev",
+) -> DevCheck:
+    if artifact.version != "latest":
+        return DevCheck(
+            name=artifact.name,
+            ok=False,
+            message=f"Artifact '{artifact.name}' uses unsupported developer prerequisite version '{artifact.version}'.",
+            fix="Use version 'latest' for GitHub CLI developer prerequisite checks.",
+            finding_id="BASE-D102",
+        )
+
+    if command_exists("gh"):
+        return DevCheck(
+            name=artifact.name,
+            ok=True,
+            message="GitHub CLI 'gh' is installed; authentication remains user-owned.",
+            fix="",
+            finding_id="BASE-D107",
+        )
+    return DevCheck(
+        name=artifact.name,
+        ok=False,
+        message=(
+            "GitHub CLI 'gh' is not installed; install it from GitHub CLI's official "
+            "Debian/Ubuntu apt repository."
+        ),
+        fix=github_cli_linux_install_fix(f"basectl check --profile {profile}"),
+        finding_id="BASE-D107",
+    )
 
 
 def check_linux_debian_apt_artifact(
@@ -556,11 +613,31 @@ def reconcile_profile_artifact(
     runtime: ProfileRuntime,
     dry_run: bool,
 ) -> None:
+    if linux_debian_github_cli_artifact(artifact, runtime.profile):
+        reconcile_linux_debian_github_cli_artifact(ctx, artifact)
+        return
     linux_debian_tool = linux_debian_dev_tool(artifact, runtime.profile)
     if linux_debian_tool is not None:
         reconcile_linux_debian_apt_artifact(ctx, artifact, linux_debian_tool, profile=runtime.profile, dry_run=dry_run)
         return
     reconcile_artifact(ctx, definition, artifact.version, runtime.project, dry_run=dry_run)
+
+
+def reconcile_linux_debian_github_cli_artifact(
+    ctx: base_cli.Context,
+    artifact: ArtifactRequest,
+) -> None:
+    if artifact.version != "latest":
+        raise ArtifactError(
+            f"GitHub CLI developer prerequisite '{artifact.name}' specifies version '{artifact.version}', "
+            "but Base only supports GitHub CLI developer prerequisite version 'latest' right now."
+        )
+
+    if command_exists("gh"):
+        ctx.log.info("GitHub CLI 'gh' is already installed; authentication remains user-owned.")
+        return
+
+    ctx.log.info(github_cli_linux_install_guidance())
 
 
 def reconcile_linux_debian_apt_artifact(
@@ -606,11 +683,16 @@ def reconcile_linux_debian_apt_artifact(
 
 def check_github_cli_auth() -> DevCheck:
     if not command_exists("gh"):
+        fix = (
+            github_cli_linux_install_fix("basectl check --profile dev")
+            if current_base_platform() == "linux-debian"
+            else "basectl setup --profile dev"
+        )
         return DevCheck(
             name="gh-auth",
             ok=False,
             message="GitHub CLI 'gh' was not found.",
-            fix="basectl setup --profile dev",
+            fix=fix,
             finding_id="BASE-D105",
         )
 

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -512,6 +512,22 @@ class DevManifestTests(unittest.TestCase):
             },
             findings,
         )
+        self.assertIn(
+            {
+                "id": "BASE-D107",
+                "status": "error",
+                "name": "gh",
+                "message": (
+                    "GitHub CLI 'gh' is not installed; install it from GitHub CLI's official "
+                    "Debian/Ubuntu apt repository."
+                ),
+                "fix": (
+                    "Follow https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian, "
+                    "then rerun 'basectl check --profile dev'."
+                ),
+            },
+            findings,
+        )
         self.assertTrue(all("Homebrew" not in finding["message"] for finding in findings))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
@@ -572,7 +588,7 @@ class DevManifestTests(unittest.TestCase):
         self.assertIn("[DRY-RUN] Would run: brew install shellcheck", stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
-    def test_setup_dry_run_linux_debian_uses_apt_registry_mapping(self) -> None:
+    def test_setup_dry_run_linux_debian_skips_user_managed_github_cli(self) -> None:
         with tempfile.TemporaryDirectory() as bin_dir:
             status, _stdout, stderr = run_engine(
                 ["setup", "--profile", "dev", "--dry-run"],
@@ -581,8 +597,10 @@ class DevManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y bats", stderr)
-        self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y gh", stderr)
         self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y shellcheck", stderr)
+        self.assertNotIn("apt-get install -y gh", stderr)
+        self.assertIn("GitHub CLI 'gh' is user-managed on Ubuntu/Debian.", stderr)
+        self.assertIn("github.com/cli/cli/blob/trunk/docs/install_linux.md#debian", stderr)
         self.assertNotIn("brew install", stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
@@ -601,7 +619,8 @@ class DevManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn("Artifact 'bats-core' is already installed via apt package 'bats'.", stderr)
-        self.assertIn("Artifact 'gh' is already installed via apt package 'gh'.", stderr)
+        self.assertIn("GitHub CLI 'gh' is already installed; authentication remains user-owned.", stderr)
+        self.assertNotIn("Artifact 'gh' is already installed via apt package 'gh'.", stderr)
         self.assertIn("Artifact 'shellcheck' is already installed via apt package 'shellcheck'.", stderr)
         self.assertNotIn("Homebrew is required", stderr)
         run_command.assert_not_called()

--- a/cli/python/base_setup/git_remote.py
+++ b/cli/python/base_setup/git_remote.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ from .manifest import BaseManifest
 
 
 GITHUB_HOST = "github.com"
+GITHUB_CLI_LINUX_INSTALL_URL = "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"
 REMOTE_REACHABILITY_TIMEOUT_SECONDS = 5
 SCP_REMOTE_RE = re.compile(r"^(?:(?P<user>[^@\s]+)@)?(?P<host>[^:\s/]+):(?P<path>.+)$")
 
@@ -177,11 +179,17 @@ def check_github_cli_auth(remote_info: RemoteInfo) -> ArtifactCheck:
         "gh_auth_checked": True,
     }
     if not process.command_exists("gh"):
+        fix = "Install GitHub CLI or run 'basectl setup --profile dev'."
+        if os.environ.get("BASE_PLATFORM") == "linux-debian":
+            fix = (
+                "Install GitHub CLI from GitHub CLI's official Debian/Ubuntu apt repository: "
+                f"{GITHUB_CLI_LINUX_INSTALL_URL}."
+            )
         return ArtifactCheck(
             name="github_cli_auth",
             ok=False,
             message="GitHub CLI 'gh' was not found; GitHub authentication for origin was not checked.",
-            fix="Install GitHub CLI or run 'basectl setup --profile dev'.",
+            fix=fix,
             finding_id="BASE-P082",
             status="warn",
             details=details | {"gh_available": False},

--- a/cli/python/base_setup/tests/test_git_remote.py
+++ b/cli/python/base_setup/tests/test_git_remote.py
@@ -89,6 +89,29 @@ class GitRemoteCheckTests(unittest.TestCase):
             timeout_seconds=git_remote_module.REMOTE_REACHABILITY_TIMEOUT_SECONDS,
         )
 
+    def test_reports_missing_github_cli_with_linux_install_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            git(project_root, "init")
+            git(project_root, "remote", "add", "origin", "git@github.com:codeforester/base.git")
+            manifest = manifest_for(project_root)
+
+            def command_exists(name: str) -> bool:
+                return name == "git"
+
+            with (
+                mock.patch("base_setup.git_remote.process.command_exists", side_effect=command_exists),
+                mock.patch.dict("os.environ", {"BASE_PLATFORM": "linux-debian"}, clear=False),
+            ):
+                checks = check_git_remote(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P080", "BASE-P081", "BASE-P082"])
+        self.assertFalse(checks[2].ok)
+        self.assertEqual(doctor_status(checks[2]), "warn")
+        self.assertIn("official Debian/Ubuntu apt repository", checks[2].fix)
+        self.assertIn("github.com/cli/cli/blob/trunk/docs/install_linux.md#debian", checks[2].fix)
+        self.assertNotIn("basectl setup --profile dev", checks[2].fix)
+
     def test_reports_github_auth_timeout_as_warning(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -105,8 +105,10 @@ exec "$SHELL" -l
 The sibling `base-bash-libs` checkout gives the source-tree BATS suite the
 reusable Bash libraries it validates against. If that checkout already exists,
 update it before running the full contributor test contract. The `dev` profile
-installs contributor prerequisites such as BATS, the GitHub CLI, and ShellCheck.
-After that, use `basectl test base` for the dogfood test contract.
+installs contributor prerequisites such as BATS and ShellCheck. On
+Ubuntu/Debian, GitHub CLI remains user-managed through GitHub CLI's official
+Debian/Ubuntu repository guidance. After that, use `basectl test base` for the
+dogfood test contract.
 
 Named profiles compose when a contributor also wants site-reliability tools:
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -147,13 +147,17 @@ The `gh` package should come from GitHub CLI's official Debian/Ubuntu
 signed apt repository/keyring when the configured distro repositories do not
 provide a current package. Follow the current official instructions at
 https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian, then rerun
-`./bin/basectl setup --yes`.
+`./bin/basectl check --profile dev`.
 
 On Ubuntu/Debian, the `dev` prerequisite profile uses apt-backed developer
-tools for the initial supported set: `bats-core` maps to `bats`, `gh` maps to
-`gh`, and `shellcheck` maps to `shellcheck`. Once the apt-backed setup path has
-installed those tools, `./bin/basectl setup --profile dev` is idempotent and
-does not require Homebrew.
+tools for the initial supported set Base can install from default apt
+repositories: `bats-core` maps to `bats`, and `shellcheck` maps to
+`shellcheck`.
+`basectl setup --profile dev` does not install `gh` from default apt repositories;
+it reports GitHub CLI's official Debian/Ubuntu repository
+guidance and leaves installation/authentication user-owned. Once the apt-backed
+setup path has installed the Base-owned tools, `./bin/basectl setup --profile
+dev` is idempotent and does not require Homebrew.
 
 Project-level `brewfile` delegates remain macOS/Homebrew-only. On
 Ubuntu/Debian, Base validates the Brewfile path but skips `brew bundle` setup and
@@ -309,8 +313,8 @@ environment and the sibling `base-bash-libs` checkout expected by source tests.
 | 4. Add Ubuntu CI coverage for read-only commands and the source-checkout suite. | Done for source-checkout validation | The `ubuntu-source-checkout` job installs hosted-runner prerequisites, runs `basectl ci check base --format json`, and runs `env -u BASE_HOME ./bin/base-test`. |
 | 5. Add conservative Ubuntu setup guidance. | Done | `basectl setup --dry-run` previews Ubuntu/Debian apt prerequisites before mutation. |
 | 6. Add apt-backed setup for simple prerequisites. | Done | `basectl setup --yes` runs `apt-get update`, installs the supported apt package list, creates the Base virtual environment, installs Base Python bootstrap packages, invokes the project setup layer, and seeds user config. |
-| 7. Make `basectl setup --profile dev` use apt-backed developer tools on Ubuntu/Debian. | Done | The dev profile maps `bats-core`, `gh`, and `shellcheck` to apt-backed tools and skips them when already installed. |
-| 8. Polish GitHub CLI install/auth guidance. | Future | Keep token handling user-owned; add clearer setup/check/docs guidance for official `gh` install sources and login/keyring recovery. |
+| 7. Make `basectl setup --profile dev` use apt-backed developer tools on Ubuntu/Debian. | Done | The dev profile maps `bats-core` and `shellcheck` to apt-backed tools and skips them when already installed. |
+| 8. Polish GitHub CLI install/auth guidance. | Done | Keep token handling user-owned; point Linux setup/check/docs to GitHub CLI's official Debian/Ubuntu install source and login/keyring recovery. |
 
 ## Non-Goals
 

--- a/tests/test_linux_support_docs.py
+++ b/tests/test_linux_support_docs.py
@@ -19,6 +19,8 @@ def test_linux_support_docs_include_apt_backed_ubuntu_bootstrap() -> None:
     assert "sudo apt-get install -y bash git gh python3" not in text
     assert "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian" in text
     assert "signed apt repository/keyring" in text
+    assert "`basectl setup --profile dev` does not install `gh` from default apt repositories" in text
+    assert "`gh` maps to" not in text
     assert "GitHub CLI authentication" in text
     assert "gh auth login --web --git-protocol https" in text
     assert "gh auth login --web --git-protocol https --insecure-storage" in text


### PR DESCRIPTION
## Summary

- Keep Ubuntu/Debian `gh` user-managed instead of installing it through the dev profile's default apt path.
- Point Linux dev-profile and project remote diagnostics to GitHub CLI's official Debian/Ubuntu install guidance.
- Update setup/onboard wording and docs so Linux, Brew, and apt responsibilities are consistent.

## Test Plan

- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_dev/tests/test_engine.py cli/python/base_setup/tests/test_git_remote.py tests/test_linux_support_docs.py tests/test_bootstrap_docs.py tests/test_base_cli_docs.py -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats --filter 'unsupported operating systems|linux-debian'`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup-command.bats cli/bash/commands/basectl/tests/onboard.bats --filter 'setup-specific help|onboard --yes accepts'`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1412-gh-policy ./bin/base-test`

Fixes #1412
