### PR TITLE
Make Ubuntu setup consent platform-consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh 
 ```
 
 Review the printed apt, clone, `basectl setup --yes`, and `update-profile`
-commands, then run them in the Ubuntu shell.
+commands, then run them in the Ubuntu shell. The printed `--yes` handoff is for
+unattended pasted commands; interactive `basectl setup` still applies setup
+after prompting for Ubuntu/Debian system changes.
 
 ### Team Or Security-Conscious Rollout
 
@@ -1080,9 +1082,10 @@ default artifacts and then invokes the Python project setup layer through
 Prerequisite profiles are opt-in. Use `--profile dev` to install Base
 contributor tools from `lib/base/dev_manifest.yaml`. On macOS that includes
 Homebrew-managed BATS, GitHub CLI, and ShellCheck. On Ubuntu/Debian it installs
-Base-owned apt-backed tools such as BATS and ShellCheck, while GitHub CLI
-remains user-managed through GitHub CLI's official Debian/Ubuntu repository
-guidance. Use `--profile sre` for the initial site-reliability profile in
+Base-owned apt-backed tools such as BATS and ShellCheck. It installs GitHub CLI
+from GitHub CLI's official Debian/Ubuntu apt repository/keyring instead of the
+default distro package; authentication remains user-owned. Use `--profile sre`
+for the initial site-reliability profile in
 `lib/base/sre_manifest.yaml`, which installs local diagnostic tools such as
 `kubectl`, `helm`, `k9s`, `httpie`, `grpcurl`, `jq`, `yq`, `nmap`, and `mtr`.
 Use `--profile ai` for optional AI coding tools: Codex CLI and Claude Code.

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -36,7 +36,7 @@ Purpose:
 
 Setup does:
   1. Install or verify macOS prerequisites on macOS.
-  2. Install or verify apt prerequisites on Ubuntu/Debian Linux when --yes is passed.
+  2. Install or verify apt prerequisites on Ubuntu/Debian Linux with interactive consent or --yes.
   3. Install prerequisite profiles when --profile is passed.
   4. Create ~/.base.d/base/.venv if it does not already exist.
   5. Install Base Python bootstrap packages into the Base virtual environment.
@@ -45,7 +45,8 @@ Setup does:
 
 Notes:
   - This command is intentionally idempotent.
-  - On Ubuntu/Debian Linux, setup can install apt prerequisites when --yes is passed.
+  - On Ubuntu/Debian Linux, setup can install apt prerequisites with
+    interactive consent or --yes.
   - The optional project argument resolves a Base project from the workspace
     unless --manifest is provided explicitly.
   - Use `basectl check` to verify the same requirements without making changes.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -183,6 +183,66 @@ setup_yes_enabled() {
     [[ "${BASE_SETUP_YES:-false}" == true ]]
 }
 
+setup_test_assume_interactive() {
+    [[ -n "${BASE_SETUP_TEST_ASSUME_INTERACTIVE+x}" ]] || return 1
+    setup_reject_test_hook_if_disallowed BASE_SETUP_TEST_ASSUME_INTERACTIVE
+    [[ "${BASE_SETUP_TEST_ASSUME_INTERACTIVE:-false}" == true ]]
+}
+
+setup_test_confirm_response() {
+    [[ -n "${BASE_SETUP_TEST_CONFIRM_RESPONSE+x}" ]] || return 1
+    setup_reject_test_hook_if_disallowed BASE_SETUP_TEST_CONFIRM_RESPONSE
+    printf '%s\n' "$BASE_SETUP_TEST_CONFIRM_RESPONSE"
+}
+
+setup_interactive_consent_available() {
+    setup_test_assume_interactive && return 0
+    is_interactive
+}
+
+setup_read_confirmation_response() {
+    local response
+
+    if response="$(setup_test_confirm_response)"; then
+        printf '%s\n' "$response"
+        return 0
+    fi
+
+    if [[ -r /dev/tty ]]; then
+        IFS= read -r response </dev/tty || return 1
+    else
+        IFS= read -r response || return 1
+    fi
+    printf '%s\n' "$response"
+}
+
+setup_require_linux_debian_system_consent() {
+    local reason="$1"
+    local response
+
+    setup_yes_enabled && return 0
+
+    if ! setup_interactive_consent_available; then
+        fatal_error "$reason Run 'basectl setup --dry-run' to review the apt commands, then rerun with '--yes' to apply them."
+    fi
+
+    log_info "$reason"
+    if [[ -n "${BASE_SETUP_TEST_STATE_DIR:-}" ]]; then
+        setup_allow_test_hooks && touch "$BASE_SETUP_TEST_STATE_DIR/linux-consent-prompted"
+    fi
+    printf "Proceed with Ubuntu/Debian setup changes? [y/N] " >&2
+    response="$(setup_read_confirmation_response)" || fatal_error "Ubuntu/Debian setup was not approved."
+    case "${response,,}" in
+        y|yes)
+            setup_enable_yes
+            return 0
+            ;;
+        *)
+            fatal_error "Ubuntu/Debian setup was not approved."
+            ;;
+    esac
+}
+
 setup_enable_recreate_venv() {
     export BASE_SETUP_RECREATE_VENV=true
 }
@@ -468,6 +528,26 @@ setup_recovery_linux_apt_package() {
 
 setup_linux_debian_github_cli_install_url() {
     printf '%s\n' "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"
+}
+
+setup_linux_debian_github_cli_keyring_url() {
+    printf '%s\n' "https://cli.github.com/packages/githubcli-archive-keyring.gpg"
+}
+
+setup_linux_debian_github_cli_keyring_path() {
+    printf '%s\n' "/etc/apt/keyrings/githubcli-archive-keyring.gpg"
+}
+
+setup_linux_debian_github_cli_source_path() {
+    printf '%s\n' "/etc/apt/sources.list.d/github-cli.list"
+}
+
+setup_linux_debian_github_cli_source_line() {
+    local arch="${1:-\$(dpkg --print-architecture)}"
+
+    printf 'deb [arch=%s signed-by=%s] https://cli.github.com/packages stable main\n' \
+        "$arch" \
+        "$(setup_linux_debian_github_cli_keyring_path)"
 }
 
 setup_linux_debian_github_cli_install_guidance() {
@@ -2642,26 +2722,94 @@ setup_run_linux_debian_apt_prerequisites() {
     if setup_is_dry_run; then
         log_info "[DRY-RUN] Would run: $(setup_linux_debian_apt_update_command)"
         log_info "[DRY-RUN] Would run: $(setup_linux_debian_apt_prerequisite_command)"
-        log_info "$(setup_linux_debian_github_cli_install_guidance)"
         return 0
     fi
 
-    if ! setup_yes_enabled; then
-        if setup_linux_debian_apt_prerequisites_installed "${package_args[@]}"; then
-            log_info "Ubuntu/Debian apt prerequisites are already installed."
-            return 0
-        fi
-        fatal_error "Ubuntu/Debian setup can install apt prerequisites. Run 'basectl setup --dry-run' to review the apt commands, then rerun with '--yes' to apply them."
+    if setup_linux_debian_apt_prerequisites_installed "${package_args[@]}"; then
+        log_info "Ubuntu/Debian apt prerequisites are already installed."
+        return 0
     fi
+
+    setup_require_linux_debian_system_consent \
+        "Ubuntu/Debian setup can install apt packages, configure package repositories, and run platform bootstraps." || return $?
 
     log_info "Installing Ubuntu/Debian apt prerequisites."
     sudo apt-get update || return $?
     sudo apt-get install -y "${package_args[@]}" || return $?
-    log_info "$(setup_linux_debian_github_cli_install_guidance)"
+}
+
+setup_run_linux_debian_github_cli_prerequisite() {
+    local arch
+    local keyring_tmp
+    local source_tmp
+
+    if setup_linux_command_path gh >/dev/null 2>&1; then
+        log_info "GitHub CLI 'gh' is already installed; authentication remains user-owned."
+        return 0
+    fi
+
+    if setup_is_dry_run; then
+        log_info "$(setup_linux_debian_github_cli_install_guidance)"
+        log_info "[DRY-RUN] Would run: sudo install -d -m 0755 /etc/apt/keyrings"
+        log_info "[DRY-RUN] Would fetch: $(setup_linux_debian_github_cli_keyring_url)"
+        log_info "[DRY-RUN] Would run: sudo install -m 0644 <downloaded GitHub CLI keyring> $(setup_linux_debian_github_cli_keyring_path)"
+        log_info "[DRY-RUN] Would run: sudo install -d -m 0755 /etc/apt/sources.list.d"
+        log_info "[DRY-RUN] Would write apt source: $(setup_linux_debian_github_cli_source_line)"
+        log_info "[DRY-RUN] Would run: sudo apt-get update"
+        log_info "[DRY-RUN] Would run: sudo apt-get install -y gh"
+        return 0
+    fi
+
+    setup_require_linux_debian_system_consent \
+        "Ubuntu/Debian setup can install apt packages, configure package repositories, and run platform bootstraps." || return $?
+
+    command -v curl >/dev/null 2>&1 || fatal_error "curl is required to install GitHub CLI 'gh' from its official Debian/Ubuntu apt repository."
+    command -v dpkg >/dev/null 2>&1 || fatal_error "dpkg is required to configure GitHub CLI's official Debian/Ubuntu apt repository."
+    arch="$(dpkg --print-architecture)" || fatal_error "Unable to read Debian architecture for GitHub CLI apt repository setup."
+    [[ -n "$arch" ]] || fatal_error "Unable to read Debian architecture for GitHub CLI apt repository setup."
+
+    keyring_tmp="$(mktemp "${TMPDIR:-/tmp}/base-github-cli-keyring.XXXXXX")" || fatal_error "Failed to create a temporary GitHub CLI keyring file."
+    source_tmp="$(mktemp "${TMPDIR:-/tmp}/base-github-cli-source.XXXXXX")" || {
+        rm -f "$keyring_tmp"
+        fatal_error "Failed to create a temporary GitHub CLI apt source file."
+    }
+
+    if ! curl -fsSL -o "$keyring_tmp" "$(setup_linux_debian_github_cli_keyring_url)"; then
+        rm -f "$keyring_tmp" "$source_tmp"
+        fatal_error "Failed to download GitHub CLI's official Debian/Ubuntu apt keyring."
+    fi
+    setup_linux_debian_github_cli_source_line "$arch" >"$source_tmp" || {
+        rm -f "$keyring_tmp" "$source_tmp"
+        fatal_error "Failed to prepare GitHub CLI apt source configuration."
+    }
+
+    log_info "Installing GitHub CLI 'gh' from GitHub CLI's official Debian/Ubuntu apt repository."
+    sudo install -d -m 0755 /etc/apt/keyrings || {
+        rm -f "$keyring_tmp" "$source_tmp"
+        return 1
+    }
+    sudo install -m 0644 "$keyring_tmp" "$(setup_linux_debian_github_cli_keyring_path)" || {
+        rm -f "$keyring_tmp" "$source_tmp"
+        return 1
+    }
+    sudo install -d -m 0755 /etc/apt/sources.list.d || {
+        rm -f "$keyring_tmp" "$source_tmp"
+        return 1
+    }
+    sudo install -m 0644 "$source_tmp" "$(setup_linux_debian_github_cli_source_path)" || {
+        rm -f "$keyring_tmp" "$source_tmp"
+        return 1
+    }
+    rm -f "$keyring_tmp" "$source_tmp"
+    sudo apt-get update || return $?
+    sudo apt-get install -y gh || return $?
 }
 
 setup_run_linux_debian_install() {
     setup_run_linux_debian_apt_prerequisites || return $?
+    if setup_profile_enabled dev; then
+        setup_run_linux_debian_github_cli_prerequisite || return $?
+    fi
     setup_create_virtualenv
     setup_install_pyyaml
     setup_install_click

--- a/cli/bash/commands/basectl/tests/setup-command.bats
+++ b/cli/bash/commands/basectl/tests/setup-command.bats
@@ -11,6 +11,6 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl setup [options]"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
     [[ "$output" == *"Install or verify macOS prerequisites on macOS."* ]]
-    [[ "$output" == *"Install or verify apt prerequisites on Ubuntu/Debian Linux when --yes is passed."* ]]
+    [[ "$output" == *"Install or verify apt prerequisites on Ubuntu/Debian Linux with interactive consent or --yes."* ]]
     [[ "$output" != *"Install Homebrew if needed."* ]]
 }

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -117,7 +117,7 @@ run_setup_common_script() {
     [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh':"* ]]
 }
 
-@test "setup_common logs GitHub CLI guidance after Ubuntu apt prerequisite install" {
+@test "setup_common keeps GitHub CLI guidance out of bulk Ubuntu apt prerequisite install" {
     cat > "$TEST_MOCKBIN/sudo" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$TEST_STATE_DIR/sudo-args"
@@ -133,5 +133,5 @@ EOF
     [ "$status" -eq 0 ]
     [ "$(sed -n '1p' "$TEST_STATE_DIR/sudo-args")" = "apt-get update" ]
     [ "$(sed -n '2p' "$TEST_STATE_DIR/sudo-args")" = "apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go" ]
-    [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh':"* ]]
+    [[ "$output" != *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh':"* ]]
 }

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -127,6 +127,7 @@ EOF
 
     run_setup_common_script '
         setup_enable_yes
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=python3-venv
         setup_run_linux_debian_apt_prerequisites
     '
 

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -118,6 +118,8 @@ run_setup_common_script() {
 }
 
 @test "setup_common keeps GitHub CLI guidance out of bulk Ubuntu apt prerequisite install" {
+    create_linux_dpkg_query_stub
+
     cat > "$TEST_MOCKBIN/sudo" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$TEST_STATE_DIR/sudo-args"

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -21,7 +21,8 @@ load ./setup_helpers.bash
     [[ "$output" == *"--recreate-venv"* ]]
     [[ "$output" == *"--yes"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
-    [[ "$output" == *"On Ubuntu/Debian Linux, setup can install apt prerequisites when --yes is passed."* ]]
+    [[ "$output" == *"On Ubuntu/Debian Linux, setup can install apt prerequisites with"* ]]
+    [[ "$output" == *"interactive consent or --yes."* ]]
     [[ "$output" == *"Create ~/.base.d/config.yaml with workspace.root: ~/work if missing."* ]]
 }
 
@@ -102,16 +103,15 @@ load ./setup_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get update"* ]]
     [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
-    [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh'"* ]]
-    [[ "$output" == *"https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"* ]]
     [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python package 'PyYAML' in the Base virtual environment."* ]]
     [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
+    [[ "$output" != *"github-cli.list"* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
 }
 
-@test "basectl setup linux-debian requires --yes before apt mutation" {
+@test "basectl setup linux-debian non-interactive requires --yes before apt mutation" {
     create_linux_dpkg_query_stub
 
     run_base_command \
@@ -120,11 +120,51 @@ load ./setup_helpers.bash
         setup
 
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Ubuntu/Debian setup can install apt prerequisites."* ]]
+    [[ "$output" == *"Ubuntu/Debian setup can install apt packages, configure package repositories, and run platform bootstraps."* ]]
     [[ "$output" == *"Run 'basectl setup --dry-run' to review the apt commands, then rerun with '--yes' to apply them."* ]]
     [[ "$output" != *"sudo apt-get"* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl setup linux-debian interactive prompt can approve apt mutation" {
+    create_linux_dpkg_query_stub
+    create_sudo_apt_get_stub
+    create_system_python3_stub
+
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=python3-venv \
+        BASE_SETUP_TEST_ASSUME_INTERACTIVE=true \
+        BASE_SETUP_TEST_CONFIRM_RESPONSE=yes \
+        setup
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Ubuntu/Debian setup can install apt packages, configure package repositories, and run platform bootstraps."* ]]
+    [[ "$output" == *"Installing Ubuntu/Debian apt prerequisites."* ]]
+    [[ "$output" == *"Base CLI setup is complete."* ]]
+    [ -f "$TEST_STATE_DIR/linux-consent-prompted" ]
+    [ -f "$TEST_STATE_DIR/apt-update-ran" ]
+    [ -f "$TEST_STATE_DIR/apt-install-ran" ]
+    [ -f "$TEST_STATE_DIR/project-setup-ran" ]
+}
+
+@test "basectl setup linux-debian interactive prompt can decline apt mutation" {
+    create_linux_dpkg_query_stub
+    create_sudo_apt_get_stub
+
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=python3-venv \
+        BASE_SETUP_TEST_ASSUME_INTERACTIVE=true \
+        BASE_SETUP_TEST_CONFIRM_RESPONSE=no \
+        setup
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Ubuntu/Debian setup was not approved."* ]]
+    [ -f "$TEST_STATE_DIR/linux-consent-prompted" ]
+    [ ! -f "$TEST_STATE_DIR/apt-update-ran" ]
+    [ ! -f "$TEST_STATE_DIR/project-setup-ran" ]
 }
 
 @test "basectl setup linux-debian skips apt without yes when prerequisites are installed" {
@@ -144,6 +184,7 @@ load ./setup_helpers.bash
 
 @test "basectl setup linux-debian passes effective platform to dev profile layer" {
     create_linux_dpkg_query_stub
+    create_linux_prerequisite_stubs
     create_system_python3_stub
 
     run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --profile dev
@@ -155,6 +196,35 @@ load ./setup_helpers.bash
     [ "$(cat "$TEST_STATE_DIR/dev-args")" = "$(printf '%s\n' setup --profile dev)" ]
 }
 
+@test "basectl setup --profile dev linux-debian dry-run shows official GitHub CLI apt repo setup" {
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --profile dev --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would run: sudo install -d -m 0755 /etc/apt/keyrings"* ]]
+    [[ "$output" == *"[DRY-RUN] Would fetch: https://cli.github.com/packages/githubcli-archive-keyring.gpg"* ]]
+    [[ "$output" == *"[DRY-RUN] Would write apt source: deb [arch=\$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get install -y gh"* ]]
+    [[ "$output" == *"https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian"* ]]
+}
+
+@test "basectl setup --profile dev linux-debian installs GitHub CLI through official apt repository" {
+    create_linux_dpkg_query_stub
+    create_sudo_apt_get_stub
+    create_github_cli_repo_stubs
+    create_system_python3_stub
+
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --yes --profile dev
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing GitHub CLI 'gh' from GitHub CLI's official Debian/Ubuntu apt repository."* ]]
+    [[ "$output" == *"Base CLI setup is complete."* ]]
+    [ -f "$TEST_STATE_DIR/github-cli-keyring-installed" ]
+    [ -f "$TEST_STATE_DIR/github-cli-source-installed" ]
+    [ -f "$TEST_STATE_DIR/gh-apt-install-ran" ]
+    grep -Fxq "deb [arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" "$TEST_STATE_DIR/github-cli-source-list"
+    [ -f "$TEST_STATE_DIR/dev-setup-ran" ]
+}
+
 @test "basectl setup --yes linux-debian installs apt prerequisites and bootstraps Base" {
     create_sudo_apt_get_stub
     create_system_python3_stub
@@ -163,7 +233,6 @@ load ./setup_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Installing Ubuntu/Debian apt prerequisites."* ]]
-    [[ "$output" == *"Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh'"* ]]
     [[ "$output" == *"Creating Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
     [[ "$output" == *"Base CLI setup is complete."* ]]
     [ -f "$TEST_STATE_DIR/apt-update-ran" ]
@@ -720,6 +789,31 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/project-setup-platform")" = "linux-debian" ]
 }
 
+@test "basectl setup interactive linux-debian forwards consent to uv-managed project setup" {
+    local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local project_root="$TEST_TMPDIR/demo"
+    local manifest_path="$project_root/base_manifest.yaml"
+
+    mkdir -p "$project_root"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_linux_dpkg_query_stub
+    create_sudo_apt_get_stub
+    create_project_setup_venv_stub "$base_venv_dir"
+    printf 'project:\n  name: demo\npython:\n  manager: uv\nartifacts: []\n' > "$manifest_path"
+
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=python3-venv \
+        BASE_SETUP_TEST_ASSUME_INTERACTIVE=true \
+        BASE_SETUP_TEST_CONFIRM_RESPONSE=yes \
+        setup --manifest "$manifest_path"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-yes")" = "true" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-platform")" = "linux-debian" ]
+}
+
 @test "project setup resolves named project manifests from the workspace" {
     local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
     local workspace="$TEST_TMPDIR/workspace"
@@ -888,6 +982,7 @@ EOF
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_linux_dpkg_query_stub
+    create_linux_prerequisite_stubs
     create_system_python3_stub
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
@@ -906,6 +1001,7 @@ EOF
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
 
     create_linux_dpkg_query_stub
+    create_linux_prerequisite_stubs
     create_system_python3_stub
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -197,7 +197,10 @@ load ./setup_helpers.bash
 }
 
 @test "basectl setup --profile dev linux-debian dry-run shows official GitHub CLI apt repo setup" {
-    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --profile dev --dry-run
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_LINUX_TOOLS=gh \
+        setup --profile dev --dry-run
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would run: sudo install -d -m 0755 /etc/apt/keyrings"* ]]
@@ -213,7 +216,10 @@ load ./setup_helpers.bash
     create_github_cli_repo_stubs
     create_system_python3_stub
 
-    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --yes --profile dev
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_LINUX_TOOLS=gh \
+        setup --yes --profile dev
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Installing GitHub CLI 'gh' from GitHub CLI's official Debian/Ubuntu apt repository."* ]]
@@ -226,10 +232,14 @@ load ./setup_helpers.bash
 }
 
 @test "basectl setup --yes linux-debian installs apt prerequisites and bootstraps Base" {
+    create_linux_dpkg_query_stub
     create_sudo_apt_get_stub
     create_system_python3_stub
 
-    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --yes
+    run_base_command \
+        BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=python3-venv \
+        setup --yes
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Installing Ubuntu/Debian apt prerequisites."* ]]
@@ -243,11 +253,13 @@ load ./setup_helpers.bash
 }
 
 @test "basectl setup --yes linux-debian reports apt prerequisite failures" {
+    create_linux_dpkg_query_stub
     create_sudo_apt_get_stub
     create_system_python3_stub
 
     run_base_command \
         BASE_SETUP_TEST_PLATFORM=linux-debian \
+        BASE_SETUP_TEST_MISSING_APT_PACKAGES=python3-venv \
         BASE_SETUP_TEST_APT_FAIL=true \
         setup --yes
 

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -274,12 +274,65 @@ fi
 if [[ "${1:-}" == "apt-get" && "${2:-}" == "install" && "${3:-}" == "-y" ]]; then
     touch "$state_dir/apt-install-ran"
     printf '%s\n' "${*:4}" > "$state_dir/apt-install-packages"
+    if [[ "${4:-}" == "gh" ]]; then
+        touch "$state_dir/gh-apt-install-ran"
+    fi
     exit 0
+fi
+if [[ "${1:-}" == "install" && "${2:-}" == "-d" && "${3:-}" == "-m" && "${4:-}" == "0755" ]]; then
+    case "${5:-}" in
+        /etc/apt/keyrings)
+            touch "$state_dir/github-cli-keyrings-dir-created"
+            exit 0
+            ;;
+        /etc/apt/sources.list.d)
+            touch "$state_dir/github-cli-sources-dir-created"
+            exit 0
+            ;;
+    esac
+fi
+if [[ "${1:-}" == "install" && "${2:-}" == "-m" && "${3:-}" == "0644" ]]; then
+    case "${5:-}" in
+        /etc/apt/keyrings/githubcli-archive-keyring.gpg)
+            cp "${4:-}" "$state_dir/github-cli-keyring"
+            touch "$state_dir/github-cli-keyring-installed"
+            exit 0
+            ;;
+        /etc/apt/sources.list.d/github-cli.list)
+            cp "${4:-}" "$state_dir/github-cli-source-list"
+            touch "$state_dir/github-cli-source-installed"
+            exit 0
+            ;;
+    esac
 fi
 printf 'unexpected sudo args: %s\n' "$*" >&2
 exit 1
 EOF
     chmod +x "$TEST_MOCKBIN/sudo"
+}
+
+create_github_cli_repo_stubs() {
+    cat > "$TEST_MOCKBIN/curl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-fsSL" && "${2:-}" == "-o" && -n "${3:-}" && "${4:-}" == "https://cli.github.com/packages/githubcli-archive-keyring.gpg" ]]; then
+    printf 'test github cli keyring\n' > "$3"
+    exit 0
+fi
+printf 'unexpected curl args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/curl"
+
+    cat > "$TEST_MOCKBIN/dpkg" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--print-architecture" ]]; then
+    printf 'amd64\n'
+    exit 0
+fi
+printf 'unexpected dpkg args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/dpkg"
 }
 
 create_brew_stub() {

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -414,13 +414,15 @@ def profile_setup_fix(profile: str) -> str:
 
 
 def github_cli_linux_install_fix(rerun_command: str) -> str:
-    return f"Follow {GITHUB_CLI_LINUX_INSTALL_URL}, then rerun '{rerun_command}'."
+    if rerun_command.startswith("basectl setup"):
+        return rerun_command
+    return "basectl setup --profile dev"
 
 
 def github_cli_linux_install_guidance() -> str:
     return (
-        "GitHub CLI 'gh' is user-managed on Ubuntu/Debian. "
-        "Configure GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh': "
+        "GitHub CLI 'gh' is installed by basectl setup's Ubuntu/Debian platform layer. "
+        "Base configures GitHub CLI's official Debian/Ubuntu apt repository before installing 'gh': "
         f"{GITHUB_CLI_LINUX_INSTALL_URL}."
     )
 
@@ -484,10 +486,10 @@ def check_linux_debian_github_cli_artifact(
         name=artifact.name,
         ok=False,
         message=(
-            "GitHub CLI 'gh' is not installed; install it from GitHub CLI's official "
+            "GitHub CLI 'gh' is not installed; Base setup installs it from GitHub CLI's official "
             "Debian/Ubuntu apt repository."
         ),
-        fix=github_cli_linux_install_fix(f"basectl check --profile {profile}"),
+        fix=profile_setup_fix(profile),
         finding_id="BASE-D107",
     )
 

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -518,13 +518,10 @@ class DevManifestTests(unittest.TestCase):
                 "status": "error",
                 "name": "gh",
                 "message": (
-                    "GitHub CLI 'gh' is not installed; install it from GitHub CLI's official "
+                    "GitHub CLI 'gh' is not installed; Base setup installs it from GitHub CLI's official "
                     "Debian/Ubuntu apt repository."
                 ),
-                "fix": (
-                    "Follow https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian, "
-                    "then rerun 'basectl check --profile dev'."
-                ),
+                "fix": "basectl setup --profile dev",
             },
             findings,
         )
@@ -588,7 +585,7 @@ class DevManifestTests(unittest.TestCase):
         self.assertIn("[DRY-RUN] Would run: brew install shellcheck", stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
-    def test_setup_dry_run_linux_debian_skips_user_managed_github_cli(self) -> None:
+    def test_setup_dry_run_linux_debian_delegates_github_cli_to_platform_setup(self) -> None:
         with tempfile.TemporaryDirectory() as bin_dir:
             status, _stdout, stderr = run_engine(
                 ["setup", "--profile", "dev", "--dry-run"],
@@ -599,7 +596,7 @@ class DevManifestTests(unittest.TestCase):
         self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y bats", stderr)
         self.assertIn("[DRY-RUN] Would run: sudo apt-get install -y shellcheck", stderr)
         self.assertNotIn("apt-get install -y gh", stderr)
-        self.assertIn("GitHub CLI 'gh' is user-managed on Ubuntu/Debian.", stderr)
+        self.assertIn("GitHub CLI 'gh' is installed by basectl setup's Ubuntu/Debian platform layer.", stderr)
         self.assertIn("github.com/cli/cli/blob/trunk/docs/install_linux.md#debian", stderr)
         self.assertNotIn("brew install", stderr)
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -8,7 +8,7 @@ installation of Base.
 On Ubuntu/Debian Linux, `bootstrap.sh` stays conservative: it does not run
 `sudo apt` from a piped script. Instead, it detects the platform and prints the
 manual source-checkout commands, including apt prerequisites and the
-`basectl setup --yes` handoff.
+`basectl setup --yes` handoff for unattended paste-and-run flows.
 
 ## Quick Start
 
@@ -52,7 +52,10 @@ curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh 
 
 The output includes `sudo apt-get update`, the supported apt prerequisite list,
 the sibling `base-bash-libs` clone, and the source checkout `setup --dry-run`,
-`setup --yes`, and `update-profile` commands.
+`setup --yes`, and `update-profile` commands. Interactive users can run plain
+`setup` after reviewing `setup --dry-run`; Ubuntu/Debian setup prompts before
+apt, keyring, repository, or remote-installer changes, while non-interactive
+runs use `--yes`.
 
 ## Install Mode
 
@@ -105,10 +108,10 @@ exec "$SHELL" -l
 The sibling `base-bash-libs` checkout gives the source-tree BATS suite the
 reusable Bash libraries it validates against. If that checkout already exists,
 update it before running the full contributor test contract. The `dev` profile
-installs contributor prerequisites such as BATS and ShellCheck. On
-Ubuntu/Debian, GitHub CLI remains user-managed through GitHub CLI's official
-Debian/Ubuntu repository guidance. After that, use `basectl test base` for the
-dogfood test contract.
+installs contributor prerequisites such as BATS, ShellCheck, and GitHub CLI. On
+Ubuntu/Debian, GitHub CLI is installed through GitHub CLI's official
+Debian/Ubuntu apt repository/keyring, while authentication remains user-owned.
+After that, use `basectl test base` for the dogfood test contract.
 
 Named profiles compose when a contributor also wants site-reliability tools:
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -12,8 +12,26 @@ Start with Ubuntu/Debian runtime support:
 - `base-wrapper` can select the project venv under `~/.base.d/<project>/.venv`.
 - `basectl projects list`, `check`, `doctor`, and `ci` work when
   prerequisites are already installed.
-- Setup installs conservative Ubuntu/Debian apt prerequisites only after the
-  user reviews `--dry-run` output and passes `--yes`.
+- Setup installs conservative Ubuntu/Debian apt prerequisites after dry-run
+  review plus either interactive consent or `--yes` for unattended runs.
+
+## Setup Contract
+
+Setup behavior should stay platform-invariant as Base adds more operating
+systems:
+
+- `basectl check` inspects and reports readiness without changing the machine.
+- `basectl setup --dry-run` previews planned changes without changing the
+  machine.
+- `basectl setup` and `basectl setup --profile <name>` apply setup on supported
+  platforms.
+- `--yes` means non-interactive consent for unattended setup. It is not the
+  switch that turns setup from dry-run to apply.
+
+Platform-specific package manager work belongs behind this contract. macOS can
+use Homebrew, Ubuntu/Debian can use apt, and future Red Hat, CentOS, Windows, or
+other platform families should add their own installer/check adapters without
+changing what these user-facing commands mean.
 
 ## Platform Detection
 
@@ -108,12 +126,16 @@ curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh 
 
 The printed path includes apt prerequisites, cloning Base and
 `base-bash-libs`, `basectl setup --dry-run`, `basectl setup --yes`, and
-`basectl update-profile`.
+`basectl update-profile`. The printed `setup --yes` handoff is for users who
+want to paste the reviewed command sequence into an unattended shell; an
+interactive user can run `basectl setup` after reviewing `--dry-run` and confirm
+the Ubuntu/Debian system-change prompt.
 
 Ubuntu/Debian setup can install the simple apt prerequisites that Base knows
 how to own. The mutation path is intentionally explicit: `basectl setup
---dry-run` prints the apt commands, and `basectl setup --yes` applies them.
-Without `--yes`, Linux setup fails before invoking `apt`.
+--dry-run` prints the apt commands, interactive `basectl setup` prompts before
+system changes, and non-interactive setup requires `--yes` before invoking
+`apt`, writing keyrings/source lists, or running remote installer bootstraps.
 
 Use native Linux filesystem paths for source checkouts. In Parallels, keep Base
 under `~/work`, not under mounted macOS shared folders, so file permissions,
@@ -144,20 +166,18 @@ separate from contributor tooling. Missing `gh`, BATS, ShellCheck, `jq`, or Go
 are advisory warnings unless another runtime prerequisite is also failing.
 
 The `gh` package should come from GitHub CLI's official Debian/Ubuntu
-signed apt repository/keyring when the configured distro repositories do not
-provide a current package. Follow the current official instructions at
-https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian, then rerun
-`./bin/basectl check --profile dev`.
+signed apt repository/keyring, not the default distro package. Base setup uses
+the current official repository shape documented at
+https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian.
 
 On Ubuntu/Debian, the `dev` prerequisite profile uses apt-backed developer
-tools for the initial supported set Base can install from default apt
-repositories: `bats-core` maps to `bats`, and `shellcheck` maps to
-`shellcheck`.
-`basectl setup --profile dev` does not install `gh` from default apt repositories;
-it reports GitHub CLI's official Debian/Ubuntu repository
-guidance and leaves installation/authentication user-owned. Once the apt-backed
-setup path has installed the Base-owned tools, `./bin/basectl setup --profile
-dev` is idempotent and does not require Homebrew.
+tools. `bats-core` maps to default apt package `bats`, and `shellcheck` maps to
+default apt package `shellcheck`. `basectl setup --profile dev` does not install
+`gh` from default apt repositories; it configures GitHub CLI's official
+Debian/Ubuntu signed apt repository/keyring and then installs `gh` from that
+source. Authentication remains user-owned. Once the apt-backed setup path has
+installed the Base-owned tools, `./bin/basectl setup --profile dev` is
+idempotent and does not require Homebrew.
 
 Project-level `brewfile` delegates remain macOS/Homebrew-only. On
 Ubuntu/Debian, Base validates the Brewfile path but skips `brew bundle` setup and

--- a/tests/test_linux_support_docs.py
+++ b/tests/test_linux_support_docs.py
@@ -15,11 +15,15 @@ def test_linux_support_docs_include_apt_backed_ubuntu_bootstrap() -> None:
     assert "## Ubuntu Bootstrap" in text
     assert "basectl setup --dry-run" in text
     assert "basectl setup --yes" in text
+    assert "`--yes` means non-interactive consent for unattended setup" in text
+    assert "Red Hat, CentOS, Windows" in text
     assert "sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go" in text
     assert "sudo apt-get install -y bash git gh python3" not in text
     assert "https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian" in text
     assert "signed apt repository/keyring" in text
-    assert "`basectl setup --profile dev` does not install `gh` from default apt repositories" in text
+    assert "`basectl setup --profile dev` does not install" in text
+    assert "`gh` from default apt repositories" in text
+    assert "then installs `gh` from that" in text
     assert "`gh` maps to" not in text
     assert "GitHub CLI authentication" in text
     assert "gh auth login --web --git-protocol https" in text


### PR DESCRIPTION
## Summary

- make Ubuntu/Debian setup use the same user-facing contract as macOS: `setup` applies, `--dry-run` previews, and `--yes` is unattended consent
- add an interactive Ubuntu/Debian consent prompt for apt, keyring, repository, and bootstrap changes, while preserving non-interactive `--yes` enforcement
- install `gh` for `setup --profile dev` through GitHub CLI's official Debian/Ubuntu apt repository/keyring flow instead of treating it as user-managed guidance
- document the cross-platform setup contract for future Red Hat, CentOS, Windows, and other platform families

Official GitHub CLI Linux install reference checked for the apt repository/keyring flow: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian

Fixes #1414

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup-common.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/setup-command.bats`
- `env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_uv.py cli/python/base_setup/tests/test_mise.py cli/python/base_dev/tests/test_engine.py tests/test_linux_support_docs.py -q`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1414-validation ./bin/base-test`