### PR TITLE
Preserve manifest GitHub policy when applying user config

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -477,6 +477,7 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
         commands=manifest.commands,
         activate=manifest.activate,
         python=manifest.python,
+        github=manifest.github,
         demo=manifest.demo,
         build=manifest.build,
         release=manifest.release,

--- a/cli/python/base_setup/tests/test_user_ide_preferences.py
+++ b/cli/python/base_setup/tests/test_user_ide_preferences.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from base_cli.config import UserConfig, UserIdeConfig, UserIdePreference
 from base_setup import engine, ide
+from base_setup.github_manifest import GithubConfig, GithubPrConfig
 from base_setup.manifest import BaseManifest, IdeConfig
 from base_setup.tests.helpers import fake_context
 
@@ -55,6 +56,21 @@ class UserIdePreferenceMergeTests(unittest.TestCase):
                 "python.defaultInterpreterPath": "auto",
             },
         )
+
+    def test_effective_manifest_preserves_github_config(self) -> None:
+        github = GithubConfig(pr=GithubPrConfig(template=".github/pull_request_template.md"))
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            github=github,
+        )
+        user_config = UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))
+
+        effective = engine.effective_manifest_with_user_config(manifest, user_config)
+
+        self.assertIs(effective.github, github)
 
 
 


### PR DESCRIPTION
## Summary
- Preserve `manifest.github` when applying user IDE config to an effective manifest.
- Add regression coverage for GitHub PR policy preservation.

## Issue
Fixes #1416

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_user_ide_preferences.py::UserIdePreferenceMergeTests::test_effective_manifest_preserves_github_config -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_user_ide_preferences.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_setup/engine.py cli/python/base_setup/tests/test_user_ide_preferences.py`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1416-cache env -u BASE_HOME ./bin/base-test`

## Notes
- Created through the REST pulls API because GitHub GraphQL rate limit is currently exhausted for this token.