### PR TITLE
Separate workspace discovery primitives from reporting

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -26,7 +26,6 @@ from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_configure import workspace_configure_from_options
 from base_projects.workspace_init import workspace_init_command
 from base_projects.workspace_pull import pull_workspace_manifest
-from base_projects.workspace_reports import ProjectDiscoveryError
 from base_projects.workspace_reports import dumps_json
 from base_projects.workspace_reports import print_workspace_check
 from base_projects.workspace_reports import print_workspace_doctor
@@ -38,6 +37,7 @@ from base_projects.workspace_reports import workspace_error_count
 from base_projects.workspace_reports import workspace_project_check_results
 from base_projects.workspace_reports import workspace_project_statuses
 from base_projects.workspace_reports import workspace_status_to_json
+from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest, CommandConfig, ManifestError, TestConfig, read_manifest

--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -10,9 +10,9 @@ from typing import Any
 
 import base_cli
 from base_cli.paths import base_cache_root, discover_manifest
-from base_projects.workspace_reports import ManifestEntry
-from base_projects.workspace_reports import ProjectDiscoveryError
-from base_projects.workspace_reports import workspace_manifest_entries
+from base_projects.workspace_scanner import ManifestEntry
+from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.manifest import ManifestError, read_manifest
 
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -233,6 +233,11 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertIn("def discover_projects_cached", discovery_path.read_text(encoding="utf-8"))
         self.assertNotIn("def discover_projects_cached", engine_path.read_text(encoding="utf-8"))
 
+    def test_project_discovery_does_not_import_workspace_reports(self) -> None:
+        discovery_path = Path(project_discovery.__file__)
+
+        self.assertNotIn("workspace_reports", discovery_path.read_text(encoding="utf-8"))
+
     def test_main_reports_config_errors_without_traceback(self) -> None:
         status, _stdout, stderr = run_engine(
             ["list"],

--- a/cli/python/base_projects/workspace_configure.py
+++ b/cli/python/base_projects/workspace_configure.py
@@ -12,9 +12,9 @@ from base_projects.command_helpers import github_repo_spec
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_manifest import WorkspaceManifestRepo
-from base_projects.workspace_reports import ProjectDiscoveryError
 from base_projects.workspace_reports import resolve_workspace_manifest
-from base_projects.workspace_reports import workspace_manifest_entries
+from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_projects.workspace_scanner import workspace_manifest_entries
 
 GIT_CONFIG_TIMEOUT_SECONDS = 10
 WORKSPACE_CONFIGURE_TIMEOUT_SECONDS = 120

--- a/cli/python/base_projects/workspace_init.py
+++ b/cli/python/base_projects/workspace_init.py
@@ -15,8 +15,8 @@ from base_projects.command_helpers import github_repo_spec
 from base_projects.command_helpers import run_project_command
 from base_projects.command_helpers import write_project_command_output
 from base_projects.workspace_manifest import WorkspaceManifestError
-from base_projects.workspace_reports import ProjectDiscoveryError
 from base_projects.workspace_reports import resolve_workspace_manifest
+from base_projects.workspace_scanner import ProjectDiscoveryError
 
 
 class WorkspaceInitOptions(Protocol):

--- a/cli/python/base_projects/workspace_reports.py
+++ b/cli/python/base_projects/workspace_reports.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import base_cli
 from base_cli.paths import base_state_root
+from base_projects.workspace_scanner import ManifestEntry
+from base_projects.workspace_scanner import workspace_manifest_entries
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_manifest import read_workspace_manifest
@@ -25,17 +27,6 @@ from base_setup.manifest import BaseManifest, ManifestError, read_manifest
 from base_setup.python_runtime import ProjectPythonRuntime
 from base_setup.python_runtime import project_python_runtime
 from base_setup.uv import manifest_uses_uv_project_manager
-
-
-class ProjectDiscoveryError(RuntimeError):
-    pass
-
-
-@dataclass(frozen=True)
-class ManifestEntry:
-    path: Path
-    mtime_ns: int
-    size: int
 
 
 @dataclass(frozen=True)
@@ -828,29 +819,6 @@ def print_workspace_check_results(
 
 def yes_no(value: bool) -> str:
     return "yes" if value else "no"
-
-
-def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...]:
-    if not workspace_root.is_dir():
-        raise ProjectDiscoveryError(f"Workspace '{workspace_root}' is not a directory.")
-
-    entries: list[ManifestEntry] = []
-    for candidate in sorted(workspace_root.iterdir(), key=lambda path: path.name):
-        if not candidate.is_dir():
-            continue
-        manifest_path = candidate / "base_manifest.yaml"
-        if not manifest_path.is_file():
-            continue
-        stat_result = manifest_path.stat()
-        entries.append(
-            ManifestEntry(
-                path=manifest_path,
-                mtime_ns=stat_result.st_mtime_ns,
-                size=stat_result.st_size,
-            )
-        )
-
-    return tuple(entries)
 
 
 def dumps_json(payload: dict[str, Any]) -> str:

--- a/cli/python/base_projects/workspace_scanner.py
+++ b/cli/python/base_projects/workspace_scanner.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class ProjectDiscoveryError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    path: Path
+    mtime_ns: int
+    size: int
+
+
+def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...]:
+    if not workspace_root.is_dir():
+        raise ProjectDiscoveryError(f"Workspace '{workspace_root}' is not a directory.")
+
+    entries: list[ManifestEntry] = []
+    for candidate in sorted(workspace_root.iterdir(), key=lambda path: path.name):
+        if not candidate.is_dir():
+            continue
+        manifest_path = candidate / "base_manifest.yaml"
+        if not manifest_path.is_file():
+            continue
+        stat_result = manifest_path.stat()
+        entries.append(
+            ManifestEntry(
+                path=manifest_path,
+                mtime_ns=stat_result.st_mtime_ns,
+                size=stat_result.st_size,
+            )
+        )
+
+    return tuple(entries)

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -13,7 +13,7 @@ from base_cli.history import base_version as read_base_version
 from base_cli.history import format_timestamp, utc_now
 from base_cli.paths import base_state_root
 from base_projects import engine as project_engine
-from base_projects.workspace_reports import ProjectDiscoveryError
+from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_setup import git_remote
 from base_setup.manifest import ManifestError, read_manifest
 


### PR DESCRIPTION
Fixes #1417

## Summary
- Add `workspace_scanner` for workspace manifest scanning primitives and discovery errors.
- Update project discovery, workspace commands, and manifest trust to import discovery primitives directly from the scanner.
- Keep `workspace_reports` focused on report/status formatting while reusing scanner primitives.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py::ProjectDiscoveryTests::test_project_discovery_does_not_import_workspace_reports -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_workspace_checks.py cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_workspace_configure.py cli/python/base_projects/tests/test_workspace_init.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_trust/tests/test_engine.py cli/python/base_projects/tests/test_workspace_checks.py cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_workspace_configure.py cli/python/base_projects/tests/test_workspace_init.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_projects/project_discovery.py cli/python/base_projects/workspace_scanner.py cli/python/base_projects/workspace_reports.py cli/python/base_projects/workspace_configure.py cli/python/base_projects/workspace_init.py cli/python/base_projects/engine.py cli/python/base_trust/engine.py cli/python/base_projects/tests/test_engine.py`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1417-cache env -u BASE_HOME ./bin/base-test`