### PR TITLE
Share setup and dev prerequisite checks

### DIFF
--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -2,17 +2,22 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
 from base_setup import process
+from base_setup.artifacts import reconcile_artifact, resolve_artifact_definitions
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
-from base_setup.artifacts import homebrew_package_outdated, reconcile_artifact, resolve_artifact_definitions
 from base_setup.errors import ArtifactError
 from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError, read_manifest
+from base_setup.prerequisites import GitHubCliAuthCheckRequest
+from base_setup.prerequisites import HomebrewPackageCheckRequest
+from base_setup.prerequisites import PrerequisiteCheck
+from base_setup.prerequisites import check_github_cli_auth as check_github_cli_auth_prerequisite
+from base_setup.prerequisites import check_homebrew_package
+from base_setup.prerequisites import homebrew_package_outdated
 from base_setup.process import DIAGNOSTIC_TIMEOUT_SECONDS, command_exists, run_check
 from base_setup.registry import ArtifactDefinition
 
@@ -530,81 +535,63 @@ def check_homebrew_artifact(  # pylint: disable=too-many-return-statements
     definition: ArtifactDefinition,
     profile: str = "dev",
 ) -> DevCheck:
-    if definition.manager != "homebrew":
-        return DevCheck(
-            name=artifact.name,
-            ok=False,
-            message=(
-                f"Artifact '{artifact.name}' uses unsupported developer prerequisite manager '{definition.manager}'."
-            ),
-            fix=f"Update {profile_manifest_path(Path('lib/base'), profile).name} to use a Homebrew-managed tool.",
-            finding_id="BASE-D101",
-        )
-    if artifact.version != "latest":
-        return DevCheck(
-            name=artifact.name,
-            ok=False,
-            message=f"Artifact '{artifact.name}' uses unsupported developer prerequisite version '{artifact.version}'.",
-            fix="Use version 'latest' for Homebrew-managed developer prerequisites.",
-            finding_id="BASE-D102",
-        )
-
-    if not command_exists("brew"):
-        return DevCheck(
-            name=artifact.name,
-            ok=False,
-            message=f"Homebrew is required to check developer prerequisite '{artifact.name}'.",
-            fix="basectl setup",
-            finding_id="BASE-D103",
-        )
-
-    try:
-        installed = run_check(
-            ["brew", "list", definition.package],
-            timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
-        )
-        outdated = installed and homebrew_package_outdated(
-            definition.package,
-            timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        return DevCheck(
-            name=artifact.name,
-            ok=False,
-            message=(
-                f"Homebrew check for artifact '{artifact.name}' timed out after "
-                f"{DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
-            ),
-            fix=f"Retry 'basectl doctor --profile {profile}' or inspect Homebrew with 'brew doctor'.",
-            status="warn",
-            finding_id="BASE-D104",
-        )
-
-    if installed:
-        if outdated:
-            return DevCheck(
-                name=artifact.name,
-                ok=False,
-                message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
-                fix=profile_setup_fix(profile),
-                finding_id="BASE-D104",
-            )
-        return DevCheck(
-            name=artifact.name,
-            ok=True,
-            message=(
-                f"Artifact '{artifact.name}' is installed via Homebrew package "
-                f"'{definition.package}' and is current."
-            ),
-            fix="",
-            finding_id="BASE-D104",
-        )
-    return DevCheck(
+    request = HomebrewPackageCheckRequest(
         name=artifact.name,
-        ok=False,
-        message=f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'.",
-        fix=profile_setup_fix(profile),
-        finding_id="BASE-D104",
+        manager=definition.manager,
+        version=artifact.version,
+        package=definition.package,
+        timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
+        unsupported_manager_message=(
+            f"Artifact '{artifact.name}' uses unsupported developer prerequisite manager '{definition.manager}'."
+        ),
+        unsupported_manager_fix=(
+            f"Update {profile_manifest_path(Path('lib/base'), profile).name} to use a Homebrew-managed tool."
+        ),
+        unsupported_manager_finding_id="BASE-D101",
+        unsupported_version_message=(
+            f"Artifact '{artifact.name}' uses unsupported developer prerequisite version '{artifact.version}'."
+        ),
+        unsupported_version_fix="Use version 'latest' for Homebrew-managed developer prerequisites.",
+        unsupported_version_finding_id="BASE-D102",
+        missing_homebrew_message=f"Homebrew is required to check developer prerequisite '{artifact.name}'.",
+        missing_homebrew_fix="basectl setup",
+        missing_homebrew_finding_id="BASE-D103",
+        timeout_message=(
+            f"Homebrew check for artifact '{artifact.name}' timed out after "
+            f"{DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+        ),
+        timeout_fix=f"Retry 'basectl doctor --profile {profile}' or inspect Homebrew with 'brew doctor'.",
+        timeout_finding_id="BASE-D104",
+        outdated_message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
+        outdated_fix=profile_setup_fix(profile),
+        package_finding_id="BASE-D104",
+        installed_message=(
+            f"Artifact '{artifact.name}' is installed via Homebrew package "
+            f"'{definition.package}' and is current."
+        ),
+        missing_package_message=(
+            f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'."
+        ),
+        missing_package_fix=profile_setup_fix(profile),
+    )
+    return dev_check_from_prerequisite(
+        check_homebrew_package(
+            request,
+            command_exists=command_exists,
+            run_check=run_check,
+            package_outdated=homebrew_package_outdated,
+        )
+    )
+
+
+def dev_check_from_prerequisite(check: PrerequisiteCheck) -> DevCheck:
+    return DevCheck(
+        name=check.name,
+        ok=check.ok,
+        message=check.message,
+        fix=check.fix,
+        status=check.status,
+        finding_id=check.finding_id,
     )
 
 
@@ -684,46 +671,19 @@ def reconcile_linux_debian_apt_artifact(
 
 
 def check_github_cli_auth() -> DevCheck:
-    if not command_exists("gh"):
-        fix = (
-            github_cli_linux_install_fix("basectl check --profile dev")
-            if current_base_platform() == "linux-debian"
-            else "basectl setup --profile dev"
+    missing_gh_fix = (
+        github_cli_linux_install_fix("basectl check --profile dev")
+        if current_base_platform() == "linux-debian"
+        else "basectl setup --profile dev"
+    )
+    request = GitHubCliAuthCheckRequest(
+        timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
+        missing_gh_fix=missing_gh_fix,
+    )
+    return dev_check_from_prerequisite(
+        check_github_cli_auth_prerequisite(
+            request,
+            command_exists=command_exists,
+            run_check=run_check,
         )
-        return DevCheck(
-            name="gh-auth",
-            ok=False,
-            message="GitHub CLI 'gh' was not found.",
-            fix=fix,
-            finding_id="BASE-D105",
-        )
-
-    try:
-        ok = run_check(
-            ["gh", "auth", "status", "-h", "github.com"],
-            timeout_seconds=DIAGNOSTIC_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        return DevCheck(
-            name="gh-auth",
-            ok=False,
-            message=f"GitHub CLI authentication check timed out after {DIAGNOSTIC_TIMEOUT_SECONDS} seconds.",
-            fix="Retry 'gh auth status -h github.com' or run 'gh auth login -h github.com'.",
-            status="warn",
-            finding_id="BASE-D106",
-        )
-    if ok:
-        return DevCheck(
-            name="gh-auth",
-            ok=True,
-            message="GitHub CLI authentication is ready.",
-            fix="",
-            finding_id="BASE-D106",
-        )
-    return DevCheck(
-        name="gh-auth",
-        ok=False,
-        message="GitHub CLI authentication is not ready.",
-        fix="gh auth login -h github.com",
-        finding_id="BASE-D106",
     )

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines,too-many-public-methods
 
 import io
 import importlib
@@ -19,6 +19,7 @@ from unittest import mock
 from base_dev import ai_tools
 from base_dev import engine
 from base_dev.engine import main
+from base_setup.prerequisites import PrerequisiteCheck
 
 
 def run_engine(args: list[str], extra_env: dict[str, str] | None = None) -> tuple[int, str, str]:
@@ -665,6 +666,29 @@ class DevManifestTests(unittest.TestCase):
             timeout_seconds=engine.DIAGNOSTIC_TIMEOUT_SECONDS,
         )
 
+    def test_check_homebrew_artifact_uses_shared_prerequisite_core(self) -> None:
+        artifact = engine.ArtifactRequest("tool", "gh", "latest")
+        definition = engine.ArtifactDefinition("gh", "tool", "homebrew", "gh", "system")
+        expected = PrerequisiteCheck(
+            name="gh",
+            ok=True,
+            message="shared Homebrew check",
+            fix="",
+            finding_id="BASE-D104",
+        )
+
+        with mock.patch("base_dev.engine.check_homebrew_package", return_value=expected) as check_homebrew_package:
+            check = engine.check_homebrew_artifact(artifact, definition)
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.message, "shared Homebrew check")
+        self.assertEqual(check.finding_id, "BASE-D104")
+        request = check_homebrew_package.call_args.args[0]
+        self.assertEqual(request.name, "gh")
+        self.assertEqual(request.package, "gh")
+        self.assertEqual(request.version, "latest")
+        self.assertEqual(request.manager, "homebrew")
+
     def test_check_homebrew_artifact_reports_outdated_formula(self) -> None:
         artifact = engine.ArtifactRequest("tool", "gh", "latest")
         definition = engine.ArtifactDefinition("gh", "tool", "homebrew", "gh", "system")
@@ -813,6 +837,25 @@ class DevManifestTests(unittest.TestCase):
         self.assertEqual(check.fix, "basectl setup --profile dev")
         command_exists.assert_called_once_with("gh")
         run_check.assert_not_called()
+
+    def test_check_github_cli_auth_uses_shared_prerequisite_core(self) -> None:
+        expected = PrerequisiteCheck(
+            name="gh-auth",
+            ok=True,
+            message="shared GitHub auth check",
+            fix="",
+            finding_id="BASE-D106",
+        )
+
+        with mock.patch("base_dev.engine.check_github_cli_auth_prerequisite", return_value=expected) as check_auth:
+            check = engine.check_github_cli_auth()
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.message, "shared GitHub auth check")
+        self.assertEqual(check.finding_id, "BASE-D106")
+        request = check_auth.call_args.args[0]
+        self.assertEqual(request.timeout_seconds, engine.DIAGNOSTIC_TIMEOUT_SECONDS)
+        self.assertEqual(request.command, ("gh", "auth", "status", "-h", "github.com"))
 
     def test_check_github_cli_auth_reports_unauthenticated_gh(self) -> None:
         with (

--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -16,6 +16,10 @@ from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import ArtifactRequest
 from .platform_policy import current_base_platform
+from .prerequisites import HomebrewPackageCheckRequest
+from .prerequisites import PrerequisiteCheck
+from .prerequisites import check_homebrew_package
+from .prerequisites import homebrew_package_outdated
 from .python_policy import evaluate_python_requirement
 from .python_policy import inspect_python_interpreter
 from .python_policy import PythonInterpreter
@@ -35,29 +39,6 @@ LINUX_DEBIAN_SYSTEM_TOOL_PACKAGES = {
 class ProjectRuntimeConfig:
     name: str
     python_requirement: str | None = None
-
-
-def homebrew_no_auto_update_env() -> dict[str, str]:
-    env = os.environ.copy()
-    env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
-    return env
-
-
-def homebrew_package_outdated(package: str, timeout_seconds: int | None = None) -> bool:
-    completed = process.run_capture(
-        ["brew", "outdated", package],
-        env=homebrew_no_auto_update_env(),
-        timeout_seconds=timeout_seconds,
-    )
-    return homebrew_outdated_output_contains_package(completed.stdout, package)
-
-
-def homebrew_outdated_output_contains_package(output: str, package: str) -> bool:
-    for line in output.splitlines():
-        fields = line.split()
-        if fields and fields[0] == package:
-            return True
-    return False
 
 
 def resolve_artifact_definitions(artifacts: tuple[ArtifactRequest, ...]) -> tuple[ArtifactDefinition, ...]:
@@ -159,78 +140,62 @@ def check_homebrew_artifact(
     artifact: ArtifactRequest,
     definition: ArtifactDefinition,
 ) -> ArtifactCheck:
-    if artifact.version != "latest":
-        return ArtifactCheck(
-            name=artifact.name,
-            ok=False,
-            message=(
-                f"Homebrew artifact '{artifact.name}' specifies version '{artifact.version}', "
-                "but Base only supports Homebrew artifact version 'latest' right now."
-            ),
-            fix=f"Update '{artifact.name}' in the project manifest to use version 'latest'.",
-            finding_id="BASE-P031",
-            details=artifact_details(definition),
-        )
-    if not process.command_exists("brew"):
-        return ArtifactCheck(
-            name=artifact.name,
-            ok=False,
-            message=f"Homebrew is required to check artifact '{artifact.name}'.",
-            fix="basectl setup",
-            finding_id="BASE-P032",
-            details=artifact_details(definition),
-        )
-    try:
-        installed = process.run_check(
-            ["brew", "list", definition.package],
-            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
-        )
-        outdated = installed and homebrew_package_outdated(
-            definition.package,
-            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        return ArtifactCheck(
-            name=artifact.name,
-            ok=False,
-            message=(
-                f"Homebrew check for artifact '{artifact.name}' timed out after "
-                f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
-            ),
-            fix=f"Retry 'basectl doctor {project}' or inspect Homebrew with 'brew doctor'.",
-            finding_id="BASE-P033",
-            status="warn",
-            details=artifact_details(definition),
-        )
-
-    if installed:
-        if outdated:
-            return ArtifactCheck(
-                name=artifact.name,
-                ok=False,
-                message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
-                fix=f"basectl setup {project}",
-                finding_id="BASE-P033",
-                details=artifact_details(definition),
-            )
-        return ArtifactCheck(
-            name=artifact.name,
-            ok=True,
-            message=(
-                f"Artifact '{artifact.name}' is installed via Homebrew package "
-                f"'{definition.package}' and is current."
-            ),
-            fix="",
-            finding_id="BASE-P033",
-            details=artifact_details(definition),
-        )
-    return ArtifactCheck(
+    request = HomebrewPackageCheckRequest(
         name=artifact.name,
-        ok=False,
-        message=f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'.",
-        fix=f"basectl setup {project}",
-        finding_id="BASE-P033",
+        manager=definition.manager,
+        version=artifact.version,
+        package=definition.package,
+        timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        unsupported_manager_message=f"Artifact manager '{definition.manager}' is not implemented.",
+        unsupported_manager_fix=f"basectl setup {project}",
+        unsupported_manager_finding_id="BASE-P030",
+        unsupported_version_message=(
+            f"Homebrew artifact '{artifact.name}' specifies version '{artifact.version}', "
+            "but Base only supports Homebrew artifact version 'latest' right now."
+        ),
+        unsupported_version_fix=f"Update '{artifact.name}' in the project manifest to use version 'latest'.",
+        unsupported_version_finding_id="BASE-P031",
+        missing_homebrew_message=f"Homebrew is required to check artifact '{artifact.name}'.",
+        missing_homebrew_fix="basectl setup",
+        missing_homebrew_finding_id="BASE-P032",
+        timeout_message=(
+            f"Homebrew check for artifact '{artifact.name}' timed out after "
+            f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+        ),
+        timeout_fix=f"Retry 'basectl doctor {project}' or inspect Homebrew with 'brew doctor'.",
+        timeout_finding_id="BASE-P033",
+        outdated_message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
+        outdated_fix=f"basectl setup {project}",
+        package_finding_id="BASE-P033",
+        installed_message=(
+            f"Artifact '{artifact.name}' is installed via Homebrew package "
+            f"'{definition.package}' and is current."
+        ),
+        missing_package_message=(
+            f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'."
+        ),
+        missing_package_fix=f"basectl setup {project}",
         details=artifact_details(definition),
+    )
+    return artifact_check_from_prerequisite(
+        check_homebrew_package(
+            request,
+            command_exists=process.command_exists,
+            run_check=process.run_check,
+            package_outdated=homebrew_package_outdated,
+        )
+    )
+
+
+def artifact_check_from_prerequisite(check: PrerequisiteCheck) -> ArtifactCheck:
+    return ArtifactCheck(
+        name=check.name,
+        ok=check.ok,
+        message=check.message,
+        fix=check.fix,
+        finding_id=check.finding_id,
+        status=check.status,
+        details=check.details,
     )
 
 

--- a/cli/python/base_setup/prerequisites.py
+++ b/cli/python/base_setup/prerequisites.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Callable
+from collections.abc import Mapping
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+from . import process
+
+
+@dataclass(frozen=True)
+class PrerequisiteCheck:
+    name: str
+    ok: bool
+    message: str
+    fix: str
+    finding_id: str
+    status: str = ""
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HomebrewPackageCheckRequest:
+    name: str
+    manager: str
+    version: str
+    package: str
+    timeout_seconds: int
+    unsupported_manager_message: str
+    unsupported_manager_fix: str
+    unsupported_manager_finding_id: str
+    unsupported_version_message: str
+    unsupported_version_fix: str
+    unsupported_version_finding_id: str
+    missing_homebrew_message: str
+    missing_homebrew_fix: str
+    missing_homebrew_finding_id: str
+    timeout_message: str
+    timeout_fix: str
+    timeout_finding_id: str
+    outdated_message: str
+    outdated_fix: str
+    package_finding_id: str
+    installed_message: str
+    missing_package_message: str
+    missing_package_fix: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GitHubCliAuthCheckRequest:
+    timeout_seconds: int
+    missing_gh_fix: str
+    command: tuple[str, ...] = ("gh", "auth", "status", "-h", "github.com")
+    missing_gh_finding_id: str = "BASE-D105"
+    auth_finding_id: str = "BASE-D106"
+
+
+CommandExists = Callable[[str], bool]
+RunCheck = Callable[..., bool]
+PackageOutdated = Callable[[str, int | None], bool]
+
+
+def homebrew_no_auto_update_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+    return env
+
+
+def homebrew_package_outdated(package: str, timeout_seconds: int | None = None) -> bool:
+    completed = process.run_capture(
+        ["brew", "outdated", package],
+        env=homebrew_no_auto_update_env(),
+        timeout_seconds=timeout_seconds,
+    )
+    return homebrew_outdated_output_contains_package(completed.stdout, package)
+
+
+def homebrew_outdated_output_contains_package(output: str, package: str) -> bool:
+    for line in output.splitlines():
+        fields = line.split()
+        if fields and fields[0] == package:
+            return True
+    return False
+
+
+def check_homebrew_package(  # pylint: disable=too-many-return-statements
+    request: HomebrewPackageCheckRequest,
+    *,
+    command_exists: CommandExists | None = None,
+    run_check: RunCheck | None = None,
+    package_outdated: PackageOutdated | None = None,
+) -> PrerequisiteCheck:
+    command_exists = command_exists or process.command_exists
+    run_check = run_check or process.run_check
+    package_outdated = package_outdated or homebrew_package_outdated
+
+    if request.manager != "homebrew":
+        return PrerequisiteCheck(
+            name=request.name,
+            ok=False,
+            message=request.unsupported_manager_message,
+            fix=request.unsupported_manager_fix,
+            finding_id=request.unsupported_manager_finding_id,
+            details=request.details,
+        )
+
+    if request.version != "latest":
+        return PrerequisiteCheck(
+            name=request.name,
+            ok=False,
+            message=request.unsupported_version_message,
+            fix=request.unsupported_version_fix,
+            finding_id=request.unsupported_version_finding_id,
+            details=request.details,
+        )
+
+    if not command_exists("brew"):
+        return PrerequisiteCheck(
+            name=request.name,
+            ok=False,
+            message=request.missing_homebrew_message,
+            fix=request.missing_homebrew_fix,
+            finding_id=request.missing_homebrew_finding_id,
+            details=request.details,
+        )
+
+    try:
+        installed = run_check(
+            ["brew", "list", request.package],
+            timeout_seconds=request.timeout_seconds,
+        )
+        outdated = installed and package_outdated(
+            request.package,
+            timeout_seconds=request.timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        return PrerequisiteCheck(
+            name=request.name,
+            ok=False,
+            message=request.timeout_message,
+            fix=request.timeout_fix,
+            status="warn",
+            finding_id=request.timeout_finding_id,
+            details=request.details,
+        )
+
+    if installed:
+        if outdated:
+            return PrerequisiteCheck(
+                name=request.name,
+                ok=False,
+                message=request.outdated_message,
+                fix=request.outdated_fix,
+                finding_id=request.package_finding_id,
+                details=request.details,
+            )
+        return PrerequisiteCheck(
+            name=request.name,
+            ok=True,
+            message=request.installed_message,
+            fix="",
+            finding_id=request.package_finding_id,
+            details=request.details,
+        )
+
+    return PrerequisiteCheck(
+        name=request.name,
+        ok=False,
+        message=request.missing_package_message,
+        fix=request.missing_package_fix,
+        finding_id=request.package_finding_id,
+        details=request.details,
+    )
+
+
+def check_github_cli_auth(
+    request: GitHubCliAuthCheckRequest,
+    *,
+    command_exists: CommandExists | None = None,
+    run_check: RunCheck | None = None,
+) -> PrerequisiteCheck:
+    command_exists = command_exists or process.command_exists
+    run_check = run_check or process.run_check
+
+    if not command_exists("gh"):
+        return PrerequisiteCheck(
+            name="gh-auth",
+            ok=False,
+            message="GitHub CLI 'gh' was not found.",
+            fix=request.missing_gh_fix,
+            finding_id=request.missing_gh_finding_id,
+        )
+
+    try:
+        ok = run_check(
+            list(request.command),
+            timeout_seconds=request.timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        return PrerequisiteCheck(
+            name="gh-auth",
+            ok=False,
+            message=f"GitHub CLI authentication check timed out after {request.timeout_seconds} seconds.",
+            fix="Retry 'gh auth status -h github.com' or run 'gh auth login -h github.com'.",
+            status="warn",
+            finding_id=request.auth_finding_id,
+        )
+
+    if ok:
+        return PrerequisiteCheck(
+            name="gh-auth",
+            ok=True,
+            message="GitHub CLI authentication is ready.",
+            fix="",
+            finding_id=request.auth_finding_id,
+        )
+
+    return PrerequisiteCheck(
+        name="gh-auth",
+        ok=False,
+        message="GitHub CLI authentication is not ready.",
+        fix="gh auth login -h github.com",
+        finding_id=request.auth_finding_id,
+    )

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -18,6 +18,7 @@ from base_setup.artifacts import merge_artifacts
 from base_setup.errors import ArtifactError
 from base_setup.manifest import ArtifactRequest, read_manifest
 from base_setup.process import format_command
+from base_setup.prerequisites import PrerequisiteCheck
 from base_setup.registry import get_artifact_definition, load_artifact_definitions
 from base_setup.tests.helpers import fake_context, run_engine
 
@@ -577,6 +578,32 @@ class ArtifactReconcileTests(unittest.TestCase):
             ["brew", "outdated", "terraform"],
         )
         self.assertEqual(run_capture.call_args.kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"], "1")
+
+    def test_check_homebrew_artifact_uses_shared_prerequisite_core(self) -> None:
+        definition = get_artifact_definition("tool", "terraform")
+        self.assertIsNotNone(definition)
+        artifact = ArtifactRequest("tool", "terraform", "latest")
+        expected = PrerequisiteCheck(
+            name="terraform",
+            ok=True,
+            message="shared Homebrew check",
+            fix="",
+            finding_id="BASE-P033",
+            details={"source": "shared"},
+        )
+
+        with mock.patch("base_setup.artifacts.check_homebrew_package", return_value=expected) as check_homebrew_package:
+            check = artifacts.check_homebrew_artifact("demo", artifact, definition)
+
+        self.assertTrue(check.ok)
+        self.assertEqual(check.message, "shared Homebrew check")
+        self.assertEqual(check.finding_id, "BASE-P033")
+        self.assertEqual(check.details, {"source": "shared"})
+        request = check_homebrew_package.call_args.args[0]
+        self.assertEqual(request.name, "terraform")
+        self.assertEqual(request.package, "terraform")
+        self.assertEqual(request.version, "latest")
+        self.assertEqual(request.manager, "homebrew")
 
     def test_check_homebrew_artifact_warns_when_probe_times_out(self) -> None:
         definition = get_artifact_definition("tool", "terraform")


### PR DESCRIPTION
Fixes #1418

## Summary
- Add a shared prerequisite check core for Homebrew package checks and GitHub CLI auth checks.
- Adapt shared prerequisite results into both setup `ArtifactCheck` and dev `DevCheck` results.
- Keep existing setup/dev finding IDs, messages, and fix guidance while removing duplicated probe logic.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py cli/python/base_dev/tests/test_engine.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_dev/tests/test_engine.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests cli/python/base_dev/tests -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_setup/prerequisites.py cli/python/base_setup/artifacts.py cli/python/base_dev/engine.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_dev/tests/test_engine.py`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1418-cache env -u BASE_HOME ./bin/base-test`