### PR TITLE
Share captured command execution helpers

### DIFF
--- a/cli/python/base_projects/command_helpers.py
+++ b/cli/python/base_projects/command_helpers.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+from base_setup import process
 from base_cli.redaction import redact_text_value
 
 
@@ -63,12 +64,9 @@ def run_project_command(
     timeout_seconds: int = PROJECT_COMMAND_TIMEOUT_SECONDS,
 ) -> ProjectCommandResult:
     try:
-        result = subprocess.run(
+        result = process.run_capture(
             command,
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
+            timeout_seconds=timeout_seconds,
         )
     except subprocess.TimeoutExpired as exc:
         timeout = exc.timeout if exc.timeout is not None else timeout_seconds
@@ -83,7 +81,7 @@ def run_project_command(
     return ProjectCommandResult(
         returncode=result.returncode,
         stdout=result.stdout,
-        stderr=result.stderr,
+        stderr=result.stderr or "",
     )
 
 

--- a/cli/python/base_projects/tests/test_command_helpers.py
+++ b/cli/python/base_projects/tests/test_command_helpers.py
@@ -66,22 +66,38 @@ class ProjectCommandHelperTests(unittest.TestCase):
             stderr="",
         )
 
-        with mock.patch("base_projects.command_helpers.subprocess.run", return_value=completed) as run:
+        with mock.patch("base_projects.command_helpers.process.run_capture", return_value=completed) as run_capture:
             result = run_project_command(
                 ["basectl", "repo", "clone"],
                 error_context="basectl repo clone for repository 'base'",
             )
 
-        run.assert_called_once_with(
+        run_capture.assert_called_once_with(
             ["basectl", "repo", "clone"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=PROJECT_COMMAND_TIMEOUT_SECONDS,
+            timeout_seconds=PROJECT_COMMAND_TIMEOUT_SECONDS,
         )
         self.assertEqual(result.stdout, "cloned\n")
         self.assertEqual(result.stderr, "")
         self.assertEqual(result.returncode, 0)
+
+    def test_run_project_command_uses_shared_capture_helper(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["basectl", "repo", "clone"],
+            0,
+            stdout="cloned\n",
+            stderr="",
+        )
+
+        with mock.patch("base_projects.command_helpers.process.run_capture", return_value=completed) as run_capture:
+            run_project_command(
+                ["basectl", "repo", "clone"],
+                error_context="basectl repo clone for repository 'base'",
+            )
+
+        run_capture.assert_called_once_with(
+            ["basectl", "repo", "clone"],
+            timeout_seconds=PROJECT_COMMAND_TIMEOUT_SECONDS,
+        )
 
     def test_run_project_command_reports_os_error_with_redacted_command(self) -> None:
         command = [

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TextIO
 
 import base_cli
+from base_setup import process
 from base_setup.manifest import BaseManifest
 from base_setup.manifest import ManifestError
 from base_setup.manifest import ReleaseConfig
@@ -546,14 +547,11 @@ def require_interactive_publish_confirmation(ctx: ReleaseContext, title: str) ->
 def run_release_step(command: list[str], *, cwd: Path | None = None) -> None:
     joined = shlex.join(command)
     try:
-        result = subprocess.run(
+        result = process.run_capture(
             command,
             cwd=cwd,
-            check=False,
-            stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            text=True,
-            timeout=RELEASE_STEP_TIMEOUT_SECONDS,
+            timeout_seconds=RELEASE_STEP_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired as exc:
         raise ReleaseError(f"Release command timed out after {exc.timeout} seconds: {joined}") from exc

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -552,6 +552,19 @@ class ReleaseHelperTests(unittest.TestCase):
 
         self.assertEqual(run.call_args.kwargs["timeout"], engine.RELEASE_STEP_TIMEOUT_SECONDS)
 
+    def test_run_release_step_uses_shared_capture_helper(self) -> None:
+        completed = subprocess.CompletedProcess(["git", "tag"], 0, stdout="")
+
+        with mock.patch("base_release.engine.process.run_capture", return_value=completed) as run_capture:
+            engine.run_release_step(["git", "tag"], cwd=Path("/repo"))
+
+        run_capture.assert_called_once_with(
+            ["git", "tag"],
+            cwd=Path("/repo"),
+            timeout_seconds=engine.RELEASE_STEP_TIMEOUT_SECONDS,
+            stderr=subprocess.STDOUT,
+        )
+
     def test_run_release_step_reports_timeout_as_release_error(self) -> None:
         command = ["git", "push", "origin", "v1.2.3"]
 

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -82,13 +82,14 @@ def run_capture(
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
     timeout_seconds: int | None = None,
+    stderr: int | None = subprocess.PIPE,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         cwd=cwd,
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=stderr,
         text=True,
         check=False,
         timeout=timeout_seconds,


### PR DESCRIPTION
Fixes #1419

## Summary
- Extend the shared setup process capture helper to support combined stderr output.
- Route project command execution through the shared capture helper while preserving redacted error messages.
- Route release publish steps through the shared capture helper while preserving release error text.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_command_helpers.py::ProjectCommandHelperTests::test_run_project_command_uses_shared_capture_helper cli/python/base_release/tests/test_engine.py::ReleaseHelperTests::test_run_release_step_uses_shared_capture_helper -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_command_helpers.py cli/python/base_release/tests/test_engine.py::ReleaseHelperTests -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests cli/python/base_release/tests -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_setup/process.py cli/python/base_projects/command_helpers.py cli/python/base_release/engine.py cli/python/base_projects/tests/test_command_helpers.py cli/python/base_release/tests/test_engine.py`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1419-cache env -u BASE_HOME ./bin/base-test`