### PR TITLE
Split manifest mapping loader

### DIFF
--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -13,15 +13,10 @@ from base_cli.ide_schema import parse_ide_settings
 from base_setup.github_manifest import GithubConfig
 from base_setup.github_manifest import GithubManifestError
 from base_setup.github_manifest import read_github_config
+from base_setup.manifest_loader import ManifestError
+from base_setup.manifest_loader import read_manifest_mapping
+from base_setup.manifest_loader import yaml  # pylint: disable=unused-import
 from base_setup.release_title import release_title_template_error
-
-try:
-    import yaml
-except ImportError as exc:
-    yaml = None
-    _yaml_import_error = exc
-else:
-    _yaml_import_error = None
 
 
 CURRENT_MANIFEST_SCHEMA_VERSION = 1
@@ -32,10 +27,6 @@ HOMEBREW_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[A-Za-z0-9_.
 PORT_HEALTH_STATES = {"free", "listening"}
 SUPPORTED_PYTHON_MANAGERS = {"uv"}
 SUPPORTED_COMMAND_RUNNERS = {"uv"}
-
-
-class ManifestError(ValueError):
-    pass
 
 
 @dataclass(frozen=True)
@@ -157,45 +148,7 @@ class BaseManifest:
 
 
 def read_manifest(path: Path) -> BaseManifest:
-    if yaml is None:
-        raise ManifestError(
-            "PyYAML is required to read base_manifest.yaml. "
-            "Run 'basectl setup' to install Base Python bootstrap dependencies."
-        ) from _yaml_import_error
-
-    try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except OSError as exc:
-        raise ManifestError(f"{path}: unable to read manifest: {exc}") from exc
-    except yaml.YAMLError as exc:
-        raise ManifestError(f"{path}: invalid YAML: {exc}") from exc
-
-    if data is None:
-        data = {}
-    if not isinstance(data, dict):
-        raise ManifestError(f"{path}: manifest must be a YAML mapping.")
-
-    allowed_top_level = {
-        "schema_version",
-        "project",
-        "brewfile",
-        "mise",
-        "ide",
-        "artifacts",
-        "test",
-        "health",
-        "commands",
-        "activate",
-        "python",
-        "github",
-        "demo",
-        "build",
-        "release",
-    }
-    unknown_top_level = sorted(set(data) - allowed_top_level)
-    if unknown_top_level:
-        raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
-
+    data = read_manifest_mapping(path)
     schema_version = _read_schema_version(path, data.get("schema_version"))
     project_name = _read_project_name(path, data.get("project"))
     brewfile = _read_brewfile(path, data.get("brewfile"))

--- a/cli/python/base_setup/manifest_loader.py
+++ b/cli/python/base_setup/manifest_loader.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:
+    yaml = None
+    _yaml_import_error = exc
+else:
+    _yaml_import_error = None
+
+
+class ManifestError(ValueError):
+    pass
+
+
+MANIFEST_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "project",
+    "brewfile",
+    "mise",
+    "ide",
+    "artifacts",
+    "test",
+    "health",
+    "commands",
+    "activate",
+    "python",
+    "github",
+    "demo",
+    "build",
+    "release",
+}
+
+
+def read_manifest_mapping(path: Path) -> dict[Any, Any]:
+    if yaml is None:
+        raise ManifestError(
+            "PyYAML is required to read base_manifest.yaml. "
+            "Run 'basectl setup' to install Base Python bootstrap dependencies."
+        ) from _yaml_import_error
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ManifestError(f"{path}: unable to read manifest: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"{path}: invalid YAML: {exc}") from exc
+
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ManifestError(f"{path}: manifest must be a YAML mapping.")
+
+    unknown_top_level = sorted(set(data) - MANIFEST_TOP_LEVEL_KEYS)
+    if unknown_top_level:
+        raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
+
+    return data

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from base_setup.manifest import BaseManifest, ManifestError, read_manifest
 
@@ -18,6 +19,18 @@ class ManifestParsingTests(unittest.TestCase):
             manifest_path.write_text("\n".join(lines), encoding="utf-8")
 
             return read_manifest(manifest_path)
+
+    def test_read_manifest_uses_mapping_loader(self) -> None:
+        manifest_path = Path("base_manifest.yaml")
+
+        with mock.patch(
+            "base_setup.manifest.read_manifest_mapping",
+            return_value={"project": {"name": "demo"}, "artifacts": []},
+        ) as read_manifest_mapping:
+            manifest = read_manifest(manifest_path)
+
+        read_manifest_mapping.assert_called_once_with(manifest_path)
+        self.assertEqual(manifest.project_name, "demo")
 
     def test_reads_basic_manifest(self) -> None:
         manifest = self.read_manifest_lines(


### PR DESCRIPTION
Fixes #1420

## Summary
- Move YAML loading and top-level manifest key validation into `base_setup.manifest_loader`.
- Keep `BaseManifest`, `ManifestError`, `read_manifest`, and the existing `yaml` import surface available from `base_setup.manifest`.
- Add manifest-suite coverage that `read_manifest` delegates mapping loading to the sibling loader.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_setup/manifest_loader.py cli/python/base_setup/manifest.py cli/python/base_setup/tests/test_manifest.py`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests -q`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1420-cache env -u BASE_HOME ./bin/base-test`