### PR TITLE
Split workspace pull command from projects engine

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -25,7 +25,7 @@ from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_configure import workspace_configure_from_options
 from base_projects.workspace_init import workspace_init_command
-from base_projects.workspace_pull import pull_workspace_manifest
+from base_projects.workspace_pull_command import workspace_pull_command
 from base_projects.workspace_reports import ProjectDiscoveryError
 from base_projects.workspace_reports import dumps_json
 from base_projects.workspace_reports import print_workspace_check
@@ -503,42 +503,6 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCommandOpti
     return base_cli.ExitCode.SUCCESS
 
 
-def workspace_pull_command(ctx: base_cli.Context, options: WorkspaceCommandOptions) -> int:
-    if options.output_format != "text":
-        raise ProjectUsageError(f"Unsupported output format '{options.output_format}'. Expected: text.")
-
-    source = effective_workspace_manifest_source(ctx, options.workspace_manifest_source)
-    if source is None:
-        raise ProjectUsageError("workspace pull requires --source <url-or-path> or workspace.manifest_source.")
-
-    target = effective_workspace_manifest_path(ctx, options.workspace_manifest)
-    if target is None:
-        raise ProjectUsageError("workspace pull requires --manifest <path> or workspace.manifest.")
-
-    try:
-        result = pull_workspace_manifest(source, target, dry_run=options.dry_run)
-    except WorkspaceManifestError as exc:
-        ctx.log.error(str(exc))
-        return base_cli.ExitCode.FAILURE
-
-    print("Workspace manifest pull")
-    print(f"Source: {result.source}")
-    print(f"Target: {result.target}")
-    print(f"Manifest: {result.manifest.name} ({len(result.manifest.repos)} repositories)")
-    print(f"Status: {result.status}")
-
-    if options.dry_run:
-        print("[DRY-RUN] No files changed.")
-        return base_cli.ExitCode.SUCCESS
-
-    if not result.changed:
-        print("Workspace manifest already up to date.")
-        return base_cli.ExitCode.SUCCESS
-
-    print(f"Updated workspace manifest: {result.target}")
-    return base_cli.ExitCode.SUCCESS
-
-
 def effective_workspace_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> str | None:
     if workspace_manifest is not None:
         return workspace_manifest
@@ -546,15 +510,6 @@ def effective_workspace_manifest(ctx: base_cli.Context, workspace_manifest: str 
     if configured_manifest is None:
         return None
     return str(configured_manifest)
-
-
-def effective_workspace_manifest_path(ctx: base_cli.Context, workspace_manifest: str | None) -> Path | None:
-    if workspace_manifest is not None:
-        return Path(workspace_manifest).expanduser().resolve(strict=False)
-    configured_manifest = ctx.user_config.workspace.manifest
-    if configured_manifest is None:
-        return None
-    return configured_manifest
 
 
 def log_workspace_status_discovery(
@@ -597,12 +552,6 @@ def workspace_manifest_source_label(ctx: base_cli.Context, workspace_manifest: s
     if ctx.user_config.workspace.manifest is not None:
         return "workspace.manifest"
     return "none"
-
-
-def effective_workspace_manifest_source(ctx: base_cli.Context, workspace_manifest_source: str | None) -> str | None:
-    if workspace_manifest_source is not None:
-        return workspace_manifest_source
-    return ctx.user_config.workspace.manifest_source
 
 
 def require_workspace_clone_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> WorkspaceManifest:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -233,6 +233,14 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertIn("def discover_projects_cached", discovery_path.read_text(encoding="utf-8"))
         self.assertNotIn("def discover_projects_cached", engine_path.read_text(encoding="utf-8"))
 
+    def test_workspace_pull_command_is_split_from_engine(self) -> None:
+        engine_path = Path(engine.__file__)
+        pull_command_path = engine_path.with_name("workspace_pull_command.py")
+
+        self.assertTrue(pull_command_path.exists())
+        self.assertIn("def workspace_pull_command", pull_command_path.read_text(encoding="utf-8"))
+        self.assertNotIn("def workspace_pull_command", engine_path.read_text(encoding="utf-8"))
+
     def test_main_reports_config_errors_without_traceback(self) -> None:
         status, _stdout, stderr = run_engine(
             ["list"],

--- a/cli/python/base_projects/workspace_pull_command.py
+++ b/cli/python/base_projects/workspace_pull_command.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import base_cli
+from base_projects.command_helpers import ProjectUsageError
+from base_projects.workspace_manifest import WorkspaceManifestError
+from base_projects.workspace_pull import pull_workspace_manifest
+
+
+class WorkspacePullOptions(Protocol):
+    output_format: str
+    workspace_manifest: str | None
+    workspace_manifest_source: str | None
+    dry_run: bool
+
+
+def workspace_pull_command(ctx: base_cli.Context, options: WorkspacePullOptions) -> int:
+    if options.output_format != "text":
+        raise ProjectUsageError(f"Unsupported output format '{options.output_format}'. Expected: text.")
+
+    source = effective_workspace_manifest_source(ctx, options.workspace_manifest_source)
+    if source is None:
+        raise ProjectUsageError("workspace pull requires --source <url-or-path> or workspace.manifest_source.")
+
+    target = effective_workspace_manifest_path(ctx, options.workspace_manifest)
+    if target is None:
+        raise ProjectUsageError("workspace pull requires --manifest <path> or workspace.manifest.")
+
+    try:
+        result = pull_workspace_manifest(source, target, dry_run=options.dry_run)
+    except WorkspaceManifestError as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    print("Workspace manifest pull")
+    print(f"Source: {result.source}")
+    print(f"Target: {result.target}")
+    print(f"Manifest: {result.manifest.name} ({len(result.manifest.repos)} repositories)")
+    print(f"Status: {result.status}")
+
+    if options.dry_run:
+        print("[DRY-RUN] No files changed.")
+        return base_cli.ExitCode.SUCCESS
+
+    if not result.changed:
+        print("Workspace manifest already up to date.")
+        return base_cli.ExitCode.SUCCESS
+
+    print(f"Updated workspace manifest: {result.target}")
+    return base_cli.ExitCode.SUCCESS
+
+
+def effective_workspace_manifest_path(ctx: base_cli.Context, workspace_manifest: str | None) -> Path | None:
+    if workspace_manifest is not None:
+        return Path(workspace_manifest).expanduser().resolve(strict=False)
+    configured_manifest = ctx.user_config.workspace.manifest
+    if configured_manifest is None:
+        return None
+    return configured_manifest
+
+
+def effective_workspace_manifest_source(ctx: base_cli.Context, workspace_manifest_source: str | None) -> str | None:
+    if workspace_manifest_source is not None:
+        return workspace_manifest_source
+    return ctx.user_config.workspace.manifest_source


### PR DESCRIPTION
## Summary
- Move workspace manifest pull command handling out of base_projects.engine into base_projects.workspace_pull_command.
- Keep engine dispatch behavior unchanged while giving the pull command its own command-family module.
- Add a structural test that keeps workspace pull out of the monolithic engine.

Fixes #1421

## Validation
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py::ProjectDiscoveryTests::test_workspace_pull_command_is_split_from_engine cli/python/base_projects/tests/test_workspace_pull.py -q
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_projects/engine.py cli/python/base_projects/workspace_pull_command.py cli/python/base_projects/tests/test_engine.py
- git diff --check
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests -q
- env -u BASE_HOME HOME=/private/tmp/base-1421-smoke-home PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m base_projects pull --help
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1421-cache env -u BASE_HOME ./bin/base-test