### PR TITLE
Consume reusable GitHub CLI Bash helpers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 6ce8af02031fad2c0071880b00eb6f526ae2d779
+          ref: 8bcc1d2c1104ffa6c8bb4a95b3f328811401bf27
           path: .dependencies/base-bash-libs
 
       - name: Install BATS
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 6ce8af02031fad2c0071880b00eb6f526ae2d779
+          ref: 8bcc1d2c1104ffa6c8bb4a95b3f328811401bf27
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 6ce8af02031fad2c0071880b00eb6f526ae2d779
+          ref: 8bcc1d2c1104ffa6c8bb4a95b3f328811401bf27
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
@@ -210,7 +210,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 6ce8af02031fad2c0071880b00eb6f526ae2d779
+          ref: 8bcc1d2c1104ffa6c8bb4a95b3f328811401bf27
           path: .dependencies/base-bash-libs
 
       - name: Expose reusable Bash library checkout as sibling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Surfaced pinned Homebrew installer variables in the default first-mile
   bootstrap path so security-conscious users can choose a verified installer
   before running the mutable official Homebrew installer.
+- Reused the external `base-bash-libs` GitHub CLI helpers in `basectl gh` and
+  `basectl repo`, and updated the pinned CI dependency to the helper-library
+  commit that provides them.
 
 ### Fixed
 

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -4,6 +4,8 @@
 _base_gh_subcommand_sourced=1
 readonly _base_gh_subcommand_sourced
 
+import_base_lib gh/lib_gh.sh
+
 base_gh_usage() {
     cat <<'EOF'
 Usage:
@@ -200,6 +202,11 @@ base_gh_usage_error() {
 base_gh_require_command() {
     local command="$1"
 
+    if [[ "$command" == "gh" ]]; then
+        gh_require_cli
+        return $?
+    fi
+
     command -v "$command" >/dev/null 2>&1 || {
         base_gh_error "Required command '$command' was not found on PATH."
         return 1
@@ -207,37 +214,18 @@ base_gh_require_command() {
 }
 
 base_gh_auth_status_diagnostics() {
-    local auth_output line
-
-    base_gh_require_command gh || return 1
-
-    auth_output="$(gh auth status -h github.com 2>&1)" || {
-        while IFS= read -r line || [[ -n "$line" ]]; do
-            [[ -n "$line" ]] && base_gh_error "gh auth status: $line"
-        done <<<"$auth_output"
-        base_gh_error "Run 'gh auth login -h github.com' and retry."
-        return 1
-    }
+    gh_auth_status_diagnostics
 }
 
 base_gh_report_command_failure() {
     local status="$1"
     shift
 
-    base_gh_error "GitHub command failed: gh $*"
-    base_gh_auth_status_diagnostics || true
-    return "$status"
+    gh_report_command_failure "$status" "$@"
 }
 
 base_gh_run() {
-    local status
-
-    base_gh_require_command gh || return 1
-    gh "$@"
-    status=$?
-    ((status == 0)) && return 0
-    base_gh_report_command_failure "$status" "$@"
-    return "$status"
+    gh_run "$@"
 }
 
 base_gh_args_request_help() {

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -4,6 +4,8 @@
 _base_repo_subcommand_sourced=1
 readonly _base_repo_subcommand_sourced
 
+import_base_lib gh/lib_gh.sh
+
 BASE_REPO_BASELINE_FILES=(
     README.md
     VERSION
@@ -1201,15 +1203,8 @@ base_repo_infer_github_repo() {
 }
 
 base_repo_require_gh() {
-    command -v gh >/dev/null 2>&1 || {
-        log_error "GitHub CLI 'gh' is required for repository configuration."
-        return 1
-    }
-    gh auth status -h github.com >/dev/null 2>&1 || {
-        log_error "GitHub CLI authentication is not ready."
-        log_error "Run 'gh auth login -h github.com' and retry."
-        return 1
-    }
+    gh_require_cli "GitHub CLI 'gh' is required for repository configuration." || return 1
+    gh_auth_status_diagnostics "Run 'gh auth login -h github.com' and retry."
 }
 
 base_repo_homebrew_gh_outdated() {

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -31,6 +31,26 @@ run_gh_subcommand() {
         ' bash "$@"
 }
 
+@test "basectl gh imports reusable GitHub CLI helpers" {
+    local bash_libs_dir
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            [[ "$(type -t gh_require_cli)" == "function" ]]
+            [[ "$(type -t gh_auth_status_diagnostics)" == "function" ]]
+            [[ "$(type -t gh_run)" == "function" ]]
+        '
+
+    [ "$status" -eq 0 ]
+}
+
 @test "basectl gh prints help" {
     run_basectl gh --help
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -101,6 +101,26 @@ run_repo_command_with_mocks() {
         "$BASE_REPO_ROOT/bin/basectl" repo "$@"
 }
 
+@test "basectl repo imports reusable GitHub CLI helpers" {
+    local bash_libs_dir
+
+    bash_libs_dir="$(base_bash_libs_fixture_dir)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="$bash_libs_dir" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/repo.sh"
+            [[ "$(type -t gh_require_cli)" == "function" ]]
+            [[ "$(type -t gh_auth_status_diagnostics)" == "function" ]]
+            [[ "$(type -t gh_run)" == "function" ]]
+        '
+
+    [ "$status" -eq 0 ]
+}
+
 @test "basectl repo prints help" {
     run_basectl repo --help
 


### PR DESCRIPTION
## Summary
- import `gh/lib_gh.sh` from `basectl gh` and `basectl repo`
- delegate GitHub CLI presence/auth/run wrappers to the shared helper library
- update Base CI's pinned `base-bash-libs` dependency to the helper-library commit
- add BATS import-contract coverage for both subcommands and a changelog entry

Fixes #1433

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter 'imports reusable GitHub CLI helpers' cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/repo.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/gh.sh cli/bash/commands/basectl/subcommands/repo.sh`
- `rg -n "6ce8af02031fad2c0071880b00eb6f526ae2d779" .github . || true`
- `rg -n "8bcc1d2c1104ffa6c8bb4a95b3f328811401bf27" .github/workflows/tests.yml`

Note: local Python pytest was unavailable in this worktree; CI will run the Python supply-chain policy suite.