### PR TITLE
Use reusable temp cleanup helpers in Bash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Reused the external `base-bash-libs` GitHub CLI helpers in `basectl gh` and
   `basectl repo`, and updated the pinned CI dependency to the helper-library
   commit that provides them.
+- Reused `base-bash-libs` temp-file cleanup helpers in post-bootstrap Bash
+  commands that create pull request bodies, CI capture files, setup probes, and
+  profile comparison files.
 
 ### Fixed
 

--- a/cli/bash/commands/basectl/subcommands/ci.sh
+++ b/cli/bash/commands/basectl/subcommands/ci.sh
@@ -195,11 +195,8 @@ base_ci_run_setup_json() {
     local exit_code
     local render_status
 
-    stdout_file="$(mktemp "${TMPDIR:-/tmp}/base-ci-setup-stdout.XXXXXX")" || return 1
-    stderr_file="$(mktemp "${TMPDIR:-/tmp}/base-ci-setup-stderr.XXXXXX")" || {
-        rm -f "$stdout_file"
-        return 1
-    }
+    std_make_temp_file stdout_file base-ci-setup-stdout || return 1
+    std_make_temp_file stderr_file base-ci-setup-stderr || return 1
 
     base_setup_subcommand_main "${args[@]}" > "$stdout_file" 2> "$stderr_file"
     exit_code=$?

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -804,7 +804,7 @@ base_gh_pr_create() {
     base_gh_require_git_repo || return 1
     issue="$(base_gh_current_issue_from_branch || true)"
     if [[ -n "$issue" && "$no_fixes" -eq 0 ]]; then
-        body_file="$(mktemp "${TMPDIR:-/tmp}/basectl-gh-pr.XXXXXX")" || return 1
+        std_make_temp_file body_file basectl-gh-pr || return 1
         base_gh_pr_policy_body "$issue" > "$body_file" || {
             status=$?
             rm -f "$body_file"

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -2003,12 +2003,11 @@ base_repo_finish_pr_baseline() {
         return 1
     }
 
-    body_file="$(mktemp "${TMPDIR:-/tmp}/base-repo-init-pr.XXXXXX")" || {
+    std_make_temp_file body_file base-repo-init-pr || {
         log_error "Failed to create a temporary pull request body file."
         return 1
     }
-    output_file="$(mktemp "${TMPDIR:-/tmp}/base-repo-init-pr-output.XXXXXX")" || {
-        rm -f "$body_file"
+    std_make_temp_file output_file base-repo-init-pr-output || {
         log_error "Failed to create a temporary pull request output file."
         return 1
     }

--- a/cli/bash/commands/basectl/subcommands/repo_agent_guidance.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_agent_guidance.sh
@@ -299,7 +299,7 @@ base_repo_finish_agent_guidance_pr() {
         return $?
     fi
 
-    body_file="$(mktemp "${TMPDIR:-/tmp}/base-repo-agent-guidance-pr.XXXXXX")" || {
+    std_make_temp_file body_file base-repo-agent-guidance-pr || {
         log_error "Failed to create a temporary pull request body file."
         return 1
     }

--- a/cli/bash/commands/basectl/subcommands/repo_installer_template.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_installer_template.sh
@@ -103,7 +103,7 @@ base_repo_finish_installer_template_pr() {
         return $?
     fi
 
-    body_file="$(mktemp "${TMPDIR:-/tmp}/base-repo-installer-template-pr.XXXXXX")" || {
+    std_make_temp_file body_file base-repo-installer-template-pr || {
         log_error "Failed to create a temporary pull request body file."
         return 1
     }

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -733,7 +733,7 @@ setup_run_verified_homebrew_installer() {
     local actual_sha256
     local exit_code
 
-    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || fatal_error "Failed to create a temporary Homebrew installer file."
+    std_make_temp_file installer_file base-homebrew-installer || fatal_error "Failed to create a temporary Homebrew installer file."
     setup_fetch_homebrew_installer "$installer_url" "$installer_file" || {
         rm -f "$installer_file"
         fatal_error "Failed to read pinned Homebrew installer content from '$installer_url'."
@@ -2201,7 +2201,7 @@ setup_collect_macos_base_check_results() {
     pyyaml_package="$(setup_pyyaml_package)"
     setup_ensure_cached_paths
 
-    tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/base-check.XXXXXX")" ||
+    std_make_temp_dir tmpdir base-check ||
         fatal_error "Unable to create temporary directory for Base check probes."
 
     setup_write_homebrew_check_probe "$tmpdir/homebrew" &
@@ -2768,9 +2768,8 @@ setup_run_linux_debian_github_cli_prerequisite() {
     arch="$(dpkg --print-architecture)" || fatal_error "Unable to read Debian architecture for GitHub CLI apt repository setup."
     [[ -n "$arch" ]] || fatal_error "Unable to read Debian architecture for GitHub CLI apt repository setup."
 
-    keyring_tmp="$(mktemp "${TMPDIR:-/tmp}/base-github-cli-keyring.XXXXXX")" || fatal_error "Failed to create a temporary GitHub CLI keyring file."
-    source_tmp="$(mktemp "${TMPDIR:-/tmp}/base-github-cli-source.XXXXXX")" || {
-        rm -f "$keyring_tmp"
+    std_make_temp_file keyring_tmp base-github-cli-keyring || fatal_error "Failed to create a temporary GitHub CLI keyring file."
+    std_make_temp_file source_tmp base-github-cli-source || {
         fatal_error "Failed to create a temporary GitHub CLI apt source file."
     }
 

--- a/cli/bash/commands/basectl/subcommands/update_profile.sh
+++ b/cli/bash/commands/basectl/subcommands/update_profile.sh
@@ -222,10 +222,9 @@ base_update_profile_update_file_needs_change() {
         return 0
     fi
 
-    current_content_file="$(mktemp "${TMPDIR:-/tmp}/base-profile-current.XXXXXX")" ||
+    std_make_temp_file current_content_file base-profile-current ||
         fatal_error "Unable to create temporary section content file for '$target_file'."
-    desired_content_file="$(mktemp "${TMPDIR:-/tmp}/base-profile-desired.XXXXXX")" || {
-        rm -f "$current_content_file"
+    std_make_temp_file desired_content_file base-profile-desired || {
         fatal_error "Unable to create temporary desired content file for '$target_file'."
     }
 

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -1376,6 +1376,46 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/body")" = "Fixes #117" ]
 }
 
+@test "basectl gh pr create uses reusable temp helper for PR body" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c "enhancement/117-20260528-basectl-gh-workflow" >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" > "${BASE_GH_TEST_STATE_DIR:?}/gh-args"
+exit 0
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            eval "$(declare -f std_make_temp_file | sed "1s/std_make_temp_file/__orig_std_make_temp_file/")"
+            std_make_temp_file() {
+                printf "%s\n" "$*" >> "${BASE_GH_TEST_STATE_DIR:?}/temp-helper"
+                __orig_std_make_temp_file "$@"
+            }
+            base_gh_subcommand_main pr create
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/temp-helper")" = "body_file basectl-gh-pr" ]
+}
+
 @test "basectl gh pr create renders project PR policy body" {
     local repo repo_root
 


### PR DESCRIPTION
## Summary
- replace post-bootstrap `mktemp` usage with `std_make_temp_file`/`std_make_temp_dir` in PR body, CI capture, setup probe, and profile comparison paths
- leave first-mile bootstrap/install temp files and same-directory atomic-write temps unchanged
- add BATS coverage proving `basectl gh pr create` uses the reusable temp helper

Fixes #1434

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter 'uses reusable temp helper' cli/bash/commands/basectl/tests/gh.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/ci.bats cli/bash/commands/basectl/tests/setup-common.bats cli/bash/commands/basectl/tests/update-profile.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo-installer-template.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/gh.sh cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/repo_agent_guidance.sh cli/bash/commands/basectl/subcommands/repo_installer_template.sh cli/bash/commands/basectl/subcommands/ci.sh cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/update_profile.sh`