### PR TITLE
Adopt reusable arg and string Bash helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Reused `base-bash-libs` temp-file cleanup helpers in post-bootstrap Bash
   commands that create pull request bodies, CI capture files, setup probes, and
   profile comparison files.
+- Reused `base-bash-libs` argument and string helpers in focused Bash
+  subcommands, including export-context option parsing, CSV joins, and setup
+  profile splitting.
 
 ### Fixed
 

--- a/cli/bash/commands/basectl/subcommands/export_context.sh
+++ b/cli/bash/commands/basectl/subcommands/export_context.sh
@@ -4,6 +4,8 @@
 _base_export_context_subcommand_sourced=1
 readonly _base_export_context_subcommand_sourced
 
+import_base_lib arg/lib_arg.sh
+
 base_export_context_subcommand_usage() {
     cat <<'EOF'
 Usage:
@@ -34,77 +36,54 @@ base_export_context_subcommand_main() {
     local output_format="markdown" output_path="" print_bundle=0 list_files=0 workspace_requested=0
     local resolve_args=() exporter_args=()
     local resolve_fields=()
+    local arg
+    local -a option_specs=(
+        "debug|flag|-v"
+        "workspace|value|--workspace"
+        "format|value|--format"
+        "output|value|--output"
+        "print|flag|--print"
+        "list_files|flag|--list-files"
+    )
+    local -a positionals=()
+    local -A parsed_options=()
 
-    while (($#)); do
-        case "$1" in
+    for arg in "$@"; do
+        case "$arg" in
             -h|--help|help)
                 base_export_context_subcommand_usage
                 return 0
                 ;;
-            -v)
-                exporter_args+=(--debug)
-                shift
-                ;;
-            --workspace)
-                [[ -n "${2:-}" ]] || {
-                    base_export_context_usage_error "Option '--workspace' requires an argument."
-                    return $?
-                }
-                workspace_requested=1
-                resolve_args+=(--workspace "$2")
-                shift 2
-                ;;
-            --workspace=*)
-                workspace_requested=1
-                resolve_args+=("$1")
-                shift
-                ;;
-            --format)
-                [[ -n "${2:-}" ]] || {
-                    base_export_context_usage_error "Option '--format' requires an argument."
-                    return $?
-                }
-                output_format="$2"
-                shift 2
-                ;;
-            --format=*)
-                output_format="${1#--format=}"
-                shift
-                ;;
-            --output)
-                [[ -n "${2:-}" ]] || {
-                    base_export_context_usage_error "Option '--output' requires an argument."
-                    return $?
-                }
-                output_path="$2"
-                shift 2
-                ;;
-            --output=*)
-                output_path="${1#--output=}"
-                shift
-                ;;
-            --print)
-                print_bundle=1
-                shift
-                ;;
-            --list-files)
-                list_files=1
-                shift
-                ;;
-            -*)
-                base_export_context_usage_error "Unknown export-context option '$1'."
-                return $?
-                ;;
-            *)
-                if [[ -n "$project" ]]; then
-                    base_export_context_usage_error "The 'export-context' command accepts exactly one project name."
-                    return $?
-                fi
-                project="$1"
-                shift
-                ;;
         esac
     done
+
+    if ! arg_parse parsed_options positionals option_specs -- "$@"; then
+        base_export_context_subcommand_usage >&2
+        return 2
+    fi
+
+    if ((${#positionals[@]} > 1)); then
+        base_export_context_usage_error "The 'export-context' command accepts exactly one project name."
+        return $?
+    fi
+    if ((${#positionals[@]} == 1)); then
+        project="${positionals[0]}"
+    fi
+    if [[ "${parsed_options[debug]:-}" == "1" ]]; then
+        exporter_args+=(--debug)
+    fi
+    if [[ -n "${parsed_options[workspace]+set}" ]]; then
+        workspace_requested=1
+        resolve_args+=(--workspace "${parsed_options[workspace]}")
+    fi
+    if [[ -n "${parsed_options[format]+set}" ]]; then
+        output_format="${parsed_options[format]}"
+    fi
+    if [[ -n "${parsed_options[output]+set}" ]]; then
+        output_path="${parsed_options[output]}"
+    fi
+    print_bundle="${parsed_options[print]:-0}"
+    list_files="${parsed_options[list_files]:-0}"
 
     case "$output_format" in
         markdown|zip) ;;

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -5,6 +5,7 @@ _base_gh_subcommand_sourced=1
 readonly _base_gh_subcommand_sourced
 
 import_base_lib gh/lib_gh.sh
+import_base_lib str/lib_str.sh
 
 base_gh_usage() {
     cat <<'EOF'
@@ -477,14 +478,10 @@ base_gh_issue_default_assignee_from_config() {
 }
 
 base_gh_join_csv() {
-    local joined="" value
+    local joined=""
+    local values=("$@")
 
-    for value in "$@"; do
-        if [[ -n "$joined" ]]; then
-            joined+=", "
-        fi
-        joined+="$value"
-    done
+    str_join joined ", " values
     printf '%s\n' "$joined"
 }
 

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -5,6 +5,7 @@ _base_repo_subcommand_sourced=1
 readonly _base_repo_subcommand_sourced
 
 import_base_lib gh/lib_gh.sh
+import_base_lib str/lib_str.sh
 
 BASE_REPO_BASELINE_FILES=(
     README.md
@@ -1258,17 +1259,11 @@ base_repo_pretty_command() {
 }
 
 base_repo_join_csv() {
-    local first=1
-    local item
+    local joined=""
+    local values=("$@")
 
-    for item in "$@"; do
-        if ((first)); then
-            first=0
-        else
-            printf ', '
-        fi
-        printf '%s' "$item"
-    done
+    str_join joined ", " values
+    printf '%s' "$joined"
 }
 
 base_repo_configure_label() {

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -17,6 +17,8 @@
 _base_setup_common_sourced=1
 readonly _base_setup_common_sourced
 
+import_base_lib str/lib_str.sh
+
 _BASE_SETUP_VENV_DIR_CACHE=""
 _BASE_SETUP_PYTHONPATH_CACHE=""
 _BASE_SETUP_CHECK_NAMES=()
@@ -135,7 +137,7 @@ setup_enable_profile_argument() {
         return 1
     fi
 
-    IFS=',' read -r -a profiles <<<"$compact"
+    str_split profiles "$compact" ","
     for profile in "${profiles[@]}"; do
         profile="$(setup_normalize_profile_name "$profile")"
         if ! setup_profile_supported "$profile"; then

--- a/cli/bash/commands/basectl/tests/export-context.bats
+++ b/cli/bash/commands/basectl/tests/export-context.bats
@@ -13,6 +13,28 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--list-files"* ]]
 }
 
+@test "basectl export-context parses options through reusable arg helper" {
+    local state_file="$TEST_TMPDIR/arg-parse-state"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="${BASE_BASH_LIBS_DIR:-}" \
+        BASE_TEST_ARG_PARSE_STATE="$state_file" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/export_context.sh"
+            arg_parse() {
+                printf "%s\n" "$*" > "${BASE_TEST_ARG_PARSE_STATE:?}"
+                return 2
+            }
+            base_export_context_subcommand_main demo --format zip
+        '
+
+    [ "$status" -eq 2 ]
+    [[ "$(cat "$state_file")" == "parsed_options positionals option_specs -- demo --format zip" ]]
+}
+
 @test "basectl export-context resolves current project when omitted" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -51,6 +51,26 @@ run_gh_subcommand() {
     [ "$status" -eq 0 ]
 }
 
+@test "basectl gh joins CSV output through reusable string helper" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_GH_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            str_join() {
+                printf "%s\n" "$*" > "${BASE_GH_TEST_STATE_DIR:?}/str-join"
+                printf -v "$1" "%s" "joined-by-helper"
+            }
+            base_gh_join_csv Status Priority Area
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "joined-by-helper" ]
+    [ "$(cat "$TEST_STATE_DIR/str-join")" = "joined ,  values" ]
+}
+
 @test "basectl gh prints help" {
     run_basectl gh --help
 


### PR DESCRIPTION
## Summary
- parse `basectl export-context` options through `arg_parse`
- replace local CSV joins with `str_join` in `basectl gh` and `basectl repo`
- split setup profile lists through `str_split` while preserving existing profile validation behavior
- add BATS coverage for the arg/string helper handoff and update the changelog

Fixes #1435

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter 'parses options through reusable arg helper' cli/bash/commands/basectl/tests/export-context.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter 'joins CSV output through reusable string helper' cli/bash/commands/basectl/tests/gh.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/export-context.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup-common.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup.bats cli/bash/commands/basectl/tests/check.bats cli/bash/commands/basectl/tests/doctor.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/export_context.sh cli/bash/commands/basectl/subcommands/gh.sh cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/setup_common.sh`