### PR TITLE
Split manifest schema model

### DIFF
--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass
-from dataclasses import field
 from pathlib import Path
 from typing import Any
 
@@ -16,135 +13,31 @@ from base_setup.github_manifest import read_github_config
 from base_setup.manifest_loader import ManifestError
 from base_setup.manifest_loader import read_manifest_mapping
 from base_setup.manifest_loader import yaml  # pylint: disable=unused-import
+from base_setup.manifest_model import ActivateConfig
+from base_setup.manifest_model import ArtifactRequest
+from base_setup.manifest_model import BaseManifest
+from base_setup.manifest_model import BuildConfig
+from base_setup.manifest_model import BuildTargetConfig
+from base_setup.manifest_model import CommandConfig
+from base_setup.manifest_model import DemoConfig
+from base_setup.manifest_model import HealthConfig
+from base_setup.manifest_model import IdeConfig
+from base_setup.manifest_model import PortHealthConfig
+from base_setup.manifest_model import PythonConfig
+from base_setup.manifest_model import ReleaseConfig
+from base_setup.manifest_model import ReleaseGithubConfig
+from base_setup.manifest_model import ReleaseHomebrewConfig
+from base_setup.manifest_model import TestConfig
+from base_setup.manifest_schema import COMMAND_NAME_RE
+from base_setup.manifest_schema import CURRENT_MANIFEST_SCHEMA_VERSION
+from base_setup.manifest_schema import ENVIRONMENT_VARIABLE_NAME_RE
+from base_setup.manifest_schema import GITHUB_REPOSITORY_RE
+from base_setup.manifest_schema import HOMEBREW_PACKAGE_RE
+from base_setup.manifest_schema import PORT_HEALTH_STATES
+from base_setup.manifest_schema import SUPPORTED_COMMAND_RUNNERS
+from base_setup.manifest_schema import SUPPORTED_PYTHON_MANAGERS
+from base_setup.manifest_schema import has_control_line_break
 from base_setup.release_title import release_title_template_error
-
-
-CURRENT_MANIFEST_SCHEMA_VERSION = 1
-ENVIRONMENT_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
-GITHUB_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-HOMEBREW_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[A-Za-z0-9_.+-]+$")
-PORT_HEALTH_STATES = {"free", "listening"}
-SUPPORTED_PYTHON_MANAGERS = {"uv"}
-SUPPORTED_COMMAND_RUNNERS = {"uv"}
-
-
-@dataclass(frozen=True)
-class ArtifactRequest:
-    artifact_type: str
-    name: str
-    version: str
-    bootstrap: bool = False
-
-
-@dataclass(frozen=True)
-class IdeConfig:
-    install: bool
-    extensions: tuple[str, ...]
-    settings: dict[str, Any]
-
-
-@dataclass(frozen=True)
-class TestConfig:
-    command: str | None = None
-    mise: str | None = None
-    runner: str | None = None
-
-
-@dataclass(frozen=True)
-class CommandConfig:
-    command: str
-    runner: str | None = None
-
-
-@dataclass(frozen=True)
-class DemoConfig:
-    script: str
-    description: str | None = None
-    runner: str | None = None
-
-
-@dataclass(frozen=True)
-class ReleaseGithubConfig:
-    repository: str
-    release_title: str
-
-
-@dataclass(frozen=True)
-class ReleaseHomebrewConfig:
-    required: bool
-    tap_repository: str | None = None
-    formula_path: str | None = None
-    package: str | None = None
-
-
-@dataclass(frozen=True)
-class ReleaseConfig:
-    version_file: str
-    changelog: str
-    tag_prefix: str
-    github: ReleaseGithubConfig
-    homebrew: ReleaseHomebrewConfig | None = None
-    runner: str | None = None
-
-
-@dataclass(frozen=True)
-class BuildTargetConfig:
-    command: str
-    working_dir: str = "."
-    description: str | None = None
-    runner: str | None = None
-
-
-@dataclass(frozen=True)
-class BuildConfig:
-    default: tuple[str, ...] = ()
-    targets: dict[str, BuildTargetConfig] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class PortHealthConfig:
-    port: int
-    state: str
-    name: str | None = None
-    host: str = "127.0.0.1"
-
-
-@dataclass(frozen=True)
-class HealthConfig:
-    required_env: tuple[str, ...] = ()
-    required_ports: tuple[PortHealthConfig, ...] = ()
-
-
-@dataclass(frozen=True)
-class ActivateConfig:
-    source: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True)
-class PythonConfig:
-    manager: str | None = None
-    requires_python: str | None = None
-
-
-@dataclass(frozen=True)
-class BaseManifest:
-    path: Path
-    project_name: str
-    brewfile: str | None
-    artifacts: tuple[ArtifactRequest, ...]
-    ide: dict[str, IdeConfig] = field(default_factory=dict)
-    mise: str | None = None
-    test: TestConfig | None = None
-    schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
-    health: HealthConfig = field(default_factory=HealthConfig)
-    commands: dict[str, CommandConfig] = field(default_factory=dict)
-    activate: ActivateConfig = field(default_factory=ActivateConfig)
-    python: PythonConfig = field(default_factory=PythonConfig)
-    github: GithubConfig = field(default_factory=GithubConfig)
-    demo: DemoConfig | None = None
-    build: BuildConfig | None = None
-    release: ReleaseConfig | None = None
 
 
 def read_manifest(path: Path) -> BaseManifest:
@@ -473,7 +366,7 @@ def _read_release_string(path: Path, field_name: str, value: Any) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ManifestError(f"{path}: {field_name} must be a non-empty string.")
     value = value.strip()
-    if _has_control_line_break(value):
+    if has_control_line_break(value):
         raise ManifestError(f"{path}: {field_name} must not contain control line breaks.")
     return value
 
@@ -546,14 +439,14 @@ def _read_build_target(path: Path, target_name: str, target_data: Any) -> BuildT
     if not isinstance(command, str) or not command.strip():
         raise ManifestError(f"{path}: build.targets.{target_name}.command must be a non-empty string.")
     command = command.strip()
-    if _has_control_line_break(command):
+    if has_control_line_break(command):
         raise ManifestError(f"{path}: build.targets.{target_name}.command must not contain control line breaks.")
 
     working_dir = target_data.get("working_dir", ".")
     if not isinstance(working_dir, str) or not working_dir.strip():
         raise ManifestError(f"{path}: build.targets.{target_name}.working_dir must be a non-empty string.")
     working_dir = working_dir.strip()
-    if _has_control_line_break(working_dir):
+    if has_control_line_break(working_dir):
         raise ManifestError(
             f"{path}: build.targets.{target_name}.working_dir must not contain control line breaks."
         )
@@ -565,7 +458,7 @@ def _read_build_target(path: Path, target_name: str, target_data: Any) -> BuildT
                 f"{path}: build.targets.{target_name}.description must be a non-empty string when provided."
             )
         description = description.strip()
-        if _has_control_line_break(description):
+        if has_control_line_break(description):
             raise ManifestError(
                 f"{path}: build.targets.{target_name}.description must not contain control line breaks."
             )
@@ -630,7 +523,7 @@ def _read_command_config(path: Path, field_name: str, command_data: Any) -> Comm
     command = command_data.get("command")
     if not isinstance(command, str) or not command.strip():
         raise ManifestError(f"{path}: {field_name}.command must be a non-empty string.")
-    if _has_control_line_break(command):
+    if has_control_line_break(command):
         raise ManifestError(f"{path}: {field_name}.command must not contain control line breaks.")
 
     return CommandConfig(
@@ -828,7 +721,7 @@ def _read_required_port_name(
             f"{path}: health.required_ports[{index}].name must be a non-empty string."
         )
     name = name_data.strip()
-    if _has_control_line_break(name):
+    if has_control_line_break(name):
         raise ManifestError(
             f"{path}: health.required_ports[{index}].name must not contain control line breaks."
         )
@@ -844,16 +737,11 @@ def _read_required_port_host(path: Path, index: int, host_data: Any) -> str:
             f"{path}: health.required_ports[{index}].host must be a non-empty string."
         )
     host = host_data.strip()
-    if _has_control_line_break(host):
+    if has_control_line_break(host):
         raise ManifestError(
             f"{path}: health.required_ports[{index}].host must not contain control line breaks."
         )
     return host
-
-
-def _has_control_line_break(value: str) -> bool:
-    return any(separator in value for separator in ("\0", "\n", "\r"))
-
 
 def _read_ide_config(path: Path, ide_name: str, config_data: Any) -> IdeConfig:
     if config_data is None:

--- a/cli/python/base_setup/manifest_model.py
+++ b/cli/python/base_setup/manifest_model.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+from base_setup.github_manifest import GithubConfig
+from base_setup.manifest_schema import CURRENT_MANIFEST_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class ArtifactRequest:
+    artifact_type: str
+    name: str
+    version: str
+    bootstrap: bool = False
+
+
+@dataclass(frozen=True)
+class IdeConfig:
+    install: bool
+    extensions: tuple[str, ...]
+    settings: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TestConfig:
+    command: str | None = None
+    mise: str | None = None
+    runner: str | None = None
+
+
+@dataclass(frozen=True)
+class CommandConfig:
+    command: str
+    runner: str | None = None
+
+
+@dataclass(frozen=True)
+class DemoConfig:
+    script: str
+    description: str | None = None
+    runner: str | None = None
+
+
+@dataclass(frozen=True)
+class ReleaseGithubConfig:
+    repository: str
+    release_title: str
+
+
+@dataclass(frozen=True)
+class ReleaseHomebrewConfig:
+    required: bool
+    tap_repository: str | None = None
+    formula_path: str | None = None
+    package: str | None = None
+
+
+@dataclass(frozen=True)
+class ReleaseConfig:
+    version_file: str
+    changelog: str
+    tag_prefix: str
+    github: ReleaseGithubConfig
+    homebrew: ReleaseHomebrewConfig | None = None
+    runner: str | None = None
+
+
+@dataclass(frozen=True)
+class BuildTargetConfig:
+    command: str
+    working_dir: str = "."
+    description: str | None = None
+    runner: str | None = None
+
+
+@dataclass(frozen=True)
+class BuildConfig:
+    default: tuple[str, ...] = ()
+    targets: dict[str, BuildTargetConfig] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PortHealthConfig:
+    port: int
+    state: str
+    name: str | None = None
+    host: str = "127.0.0.1"
+
+
+@dataclass(frozen=True)
+class HealthConfig:
+    required_env: tuple[str, ...] = ()
+    required_ports: tuple[PortHealthConfig, ...] = ()
+
+
+@dataclass(frozen=True)
+class ActivateConfig:
+    source: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PythonConfig:
+    manager: str | None = None
+    requires_python: str | None = None
+
+
+@dataclass(frozen=True)
+class BaseManifest:
+    path: Path
+    project_name: str
+    brewfile: str | None
+    artifacts: tuple[ArtifactRequest, ...]
+    ide: dict[str, IdeConfig] = field(default_factory=dict)
+    mise: str | None = None
+    test: TestConfig | None = None
+    schema_version: int = CURRENT_MANIFEST_SCHEMA_VERSION
+    health: HealthConfig = field(default_factory=HealthConfig)
+    commands: dict[str, CommandConfig] = field(default_factory=dict)
+    activate: ActivateConfig = field(default_factory=ActivateConfig)
+    python: PythonConfig = field(default_factory=PythonConfig)
+    github: GithubConfig = field(default_factory=GithubConfig)
+    demo: DemoConfig | None = None
+    build: BuildConfig | None = None
+    release: ReleaseConfig | None = None

--- a/cli/python/base_setup/manifest_schema.py
+++ b/cli/python/base_setup/manifest_schema.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import re
+
+
+CURRENT_MANIFEST_SCHEMA_VERSION = 1
+ENVIRONMENT_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+GITHUB_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+HOMEBREW_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[A-Za-z0-9_.+-]+$")
+PORT_HEALTH_STATES = {"free", "listening"}
+SUPPORTED_PYTHON_MANAGERS = {"uv"}
+SUPPORTED_COMMAND_RUNNERS = {"uv"}
+
+
+def has_control_line_break(value: str) -> bool:
+    return any(separator in value for separator in ("\0", "\n", "\r"))


### PR DESCRIPTION
## Summary
- move manifest dataclasses into base_setup.manifest_model
- move manifest schema constants and the control-line-break helper into base_setup.manifest_schema
- keep base_setup.manifest as the compatibility facade for existing imports and read_manifest

Fixes #1442

## Validation
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_artifacts.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/manifest.py cli/python/base_setup/manifest_model.py cli/python/base_setup/manifest_schema.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_setup/manifest.py cli/python/base_setup/manifest_model.py cli/python/base_setup/manifest_schema.py
- git diff --check