### PR TITLE
Split project command helpers

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import shlex
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,6 +19,18 @@ from base_projects.project_discovery import find_project_in_projects
 from base_projects.project_discovery import current_project
 from base_projects.project_discovery import read_project
 from base_projects.project_discovery import resolve_active_project
+from base_projects.project_commands import CommandConfig  # pylint: disable=unused-import
+from base_projects.project_commands import ProjectCommandError
+from base_projects.project_commands import TestConfig  # pylint: disable=unused-import
+from base_projects.project_commands import activation_source_paths
+from base_projects.project_commands import command_output as _command_output
+from base_projects.project_commands import demo_output as _demo_output
+from base_projects.project_commands import named_command_output as _named_command_output
+from base_projects.project_commands import project_command
+from base_projects.project_commands import project_commands
+from base_projects.project_commands import project_output as _project_output
+from base_projects.project_commands import resolve_activation_source_path  # pylint: disable=unused-import
+from base_projects.project_commands import test_command
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_manifest import WorkspaceManifestError
@@ -40,8 +51,7 @@ from base_projects.workspace_reports import workspace_status_to_json
 from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
-from base_setup.manifest import BaseManifest, CommandConfig, ManifestError, TestConfig, read_manifest
-from base_setup.project_routing import route_for_manifest
+from base_setup.manifest import ManifestError, read_manifest
 
 
 app = base_cli.App(name="base_projects")
@@ -756,137 +766,6 @@ def current_project_command(ctx: base_cli.Context) -> int:
 
     print(f"{project.name}\t{project.root}\t{project.manifest_path}")
     return base_cli.ExitCode.SUCCESS
-
-
-def test_command(test_config: TestConfig) -> CommandConfig:
-    if test_config.command is not None:
-        return CommandConfig(command=test_config.command, runner=test_config.runner)
-    if test_config.mise is not None:
-        return CommandConfig(command=shlex.join(["mise", "run", test_config.mise]), runner=test_config.runner)
-    raise ValueError("TestConfig must have command or mise set.")
-
-
-class ProjectCommandError(RuntimeError):
-    pass
-
-
-def project_commands(manifest: BaseManifest) -> dict[str, CommandConfig]:
-    commands: dict[str, CommandConfig] = {}
-    if manifest.test is not None:
-        commands["test"] = test_command(manifest.test)
-    commands.update(manifest.commands)
-    return commands
-
-
-def project_command(manifest: BaseManifest, command_name: str) -> CommandConfig:
-    commands = project_commands(manifest)
-    try:
-        return commands[command_name]
-    except KeyError as exc:
-        if command_name == "test":
-            raise ProjectCommandError(
-                f"Project '{manifest.project_name}' does not declare test.command or test.mise in '{manifest.path}'."
-            ) from exc
-        raise ProjectCommandError(
-            f"Project '{manifest.project_name}' does not declare command '{command_name}' in '{manifest.path}'."
-        ) from exc
-
-
-def _route_metadata_fields(manifest: BaseManifest, *, manifest_command_trust_required: bool = False) -> list[str]:
-    route = route_for_manifest(manifest)
-    uses_uv = "true" if route.uses_uv_manager else "false"
-    trust_required = "true" if manifest_command_trust_required else "false"
-    return [
-        f"__base_project_venv_dir={route.project_venv_dir}",
-        f"__base_uses_uv_manager={uses_uv}",
-        f"__base_manifest_command_trust_required={trust_required}",
-    ]
-
-
-def _project_output(project_name: str, project_root: Path, manifest_path: Path, manifest: BaseManifest) -> str:
-    return "\t".join(
-        [
-            project_name,
-            str(project_root),
-            str(manifest_path),
-            *_route_metadata_fields(
-                manifest,
-                manifest_command_trust_required=bool(manifest.activate.source),
-            ),
-        ]
-    )
-
-
-def _command_output(
-    project_name: str,
-    project_root: Path,
-    manifest_path: Path,
-    command: CommandConfig,
-    manifest: BaseManifest,
-) -> str:
-    fields = [project_name, str(project_root), str(manifest_path), command.command]
-    if command.runner is not None:
-        fields.append(command.runner)
-    fields.extend(_route_metadata_fields(manifest, manifest_command_trust_required=True))
-    return "\t".join(fields)
-
-
-def _named_command_output(
-    project_name: str,
-    project_root: Path,
-    manifest_path: Path,
-    command_name: str,
-    command: CommandConfig,
-) -> str:
-    fields = [project_name, str(project_root), str(manifest_path), command_name, command.command]
-    if command.runner is not None:
-        fields.append(command.runner)
-    return "\t".join(fields)
-
-
-def _demo_output(
-    project_name: str,
-    project_root: Path,
-    manifest_path: Path,
-    demo_script: Path,
-    manifest: BaseManifest,
-) -> str:
-    fields = [project_name, str(project_root), str(manifest_path), str(demo_script)]
-    if manifest.demo.runner is not None:
-        fields.append(manifest.demo.runner)
-    fields.extend(_route_metadata_fields(manifest, manifest_command_trust_required=True))
-    return "\t".join(fields)
-
-
-def activation_source_paths(project: Project, source_paths: tuple[str, ...]) -> tuple[Path, ...]:
-    return tuple(
-        resolve_activation_source_path(project, source_path, index)
-        for index, source_path in enumerate(source_paths, start=1)
-    )
-
-
-def resolve_activation_source_path(project: Project, source_path: str, index: int) -> Path:
-    field = f"activate.source[{index}]"
-    project_root = project.root.resolve()
-    declared_path = Path(source_path)
-    if declared_path.is_absolute():
-        raise ProjectDiscoveryError(
-            f"{project.manifest_path}: {field} must be a relative path inside the project root."
-        )
-
-    candidate = (project_root / declared_path).resolve()
-    try:
-        candidate.relative_to(project_root)
-    except ValueError as exc:
-        raise ProjectDiscoveryError(
-            f"{project.manifest_path}: {field} resolves outside the project root: {source_path}."
-        ) from exc
-
-    if not candidate.exists():
-        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' does not exist.")
-    if not candidate.is_file():
-        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' is not a file.")
-    return candidate
 
 
 def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:

--- a/cli/python/base_projects/project_commands.py
+++ b/cli/python/base_projects/project_commands.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+from base_projects.project_discovery import Project
+from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_setup.manifest import BaseManifest
+from base_setup.manifest import CommandConfig
+from base_setup.manifest import TestConfig
+from base_setup.project_routing import route_for_manifest
+
+
+def test_command(test_config: TestConfig) -> CommandConfig:
+    if test_config.command is not None:
+        return CommandConfig(command=test_config.command, runner=test_config.runner)
+    if test_config.mise is not None:
+        return CommandConfig(command=shlex.join(["mise", "run", test_config.mise]), runner=test_config.runner)
+    raise ValueError("TestConfig must have command or mise set.")
+
+
+class ProjectCommandError(RuntimeError):
+    pass
+
+
+def project_commands(manifest: BaseManifest) -> dict[str, CommandConfig]:
+    commands: dict[str, CommandConfig] = {}
+    if manifest.test is not None:
+        commands["test"] = test_command(manifest.test)
+    commands.update(manifest.commands)
+    return commands
+
+
+def project_command(manifest: BaseManifest, command_name: str) -> CommandConfig:
+    commands = project_commands(manifest)
+    try:
+        return commands[command_name]
+    except KeyError as exc:
+        if command_name == "test":
+            raise ProjectCommandError(
+                f"Project '{manifest.project_name}' does not declare test.command or test.mise in '{manifest.path}'."
+            ) from exc
+        raise ProjectCommandError(
+            f"Project '{manifest.project_name}' does not declare command '{command_name}' in '{manifest.path}'."
+        ) from exc
+
+
+def route_metadata_fields(manifest: BaseManifest, *, manifest_command_trust_required: bool = False) -> list[str]:
+    route = route_for_manifest(manifest)
+    uses_uv = "true" if route.uses_uv_manager else "false"
+    trust_required = "true" if manifest_command_trust_required else "false"
+    return [
+        f"__base_project_venv_dir={route.project_venv_dir}",
+        f"__base_uses_uv_manager={uses_uv}",
+        f"__base_manifest_command_trust_required={trust_required}",
+    ]
+
+
+def project_output(project_name: str, project_root: Path, manifest_path: Path, manifest: BaseManifest) -> str:
+    return "\t".join(
+        [
+            project_name,
+            str(project_root),
+            str(manifest_path),
+            *route_metadata_fields(
+                manifest,
+                manifest_command_trust_required=bool(manifest.activate.source),
+            ),
+        ]
+    )
+
+
+def command_output(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    command: CommandConfig,
+    manifest: BaseManifest,
+) -> str:
+    fields = [project_name, str(project_root), str(manifest_path), command.command]
+    if command.runner is not None:
+        fields.append(command.runner)
+    fields.extend(route_metadata_fields(manifest, manifest_command_trust_required=True))
+    return "\t".join(fields)
+
+
+def named_command_output(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    command_name: str,
+    command: CommandConfig,
+) -> str:
+    fields = [project_name, str(project_root), str(manifest_path), command_name, command.command]
+    if command.runner is not None:
+        fields.append(command.runner)
+    return "\t".join(fields)
+
+
+def demo_output(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    demo_script: Path,
+    manifest: BaseManifest,
+) -> str:
+    fields = [project_name, str(project_root), str(manifest_path), str(demo_script)]
+    if manifest.demo.runner is not None:
+        fields.append(manifest.demo.runner)
+    fields.extend(route_metadata_fields(manifest, manifest_command_trust_required=True))
+    return "\t".join(fields)
+
+
+def activation_source_paths(project: Project, source_paths: tuple[str, ...]) -> tuple[Path, ...]:
+    return tuple(
+        resolve_activation_source_path(project, source_path, index)
+        for index, source_path in enumerate(source_paths, start=1)
+    )
+
+
+def resolve_activation_source_path(project: Project, source_path: str, index: int) -> Path:
+    field = f"activate.source[{index}]"
+    project_root = project.root.resolve()
+    declared_path = Path(source_path)
+    if declared_path.is_absolute():
+        raise ProjectDiscoveryError(
+            f"{project.manifest_path}: {field} must be a relative path inside the project root."
+        )
+
+    candidate = (project_root / declared_path).resolve()
+    try:
+        candidate.relative_to(project_root)
+    except ValueError as exc:
+        raise ProjectDiscoveryError(
+            f"{project.manifest_path}: {field} resolves outside the project root: {source_path}."
+        ) from exc
+
+    if not candidate.exists():
+        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' does not exist.")
+    if not candidate.is_file():
+        raise ProjectDiscoveryError(f"{project.manifest_path}: {field} script '{source_path}' is not a file.")
+    return candidate


### PR DESCRIPTION
## Summary
- extract manifest-declared project command helpers from base_projects.engine into base_projects.project_commands
- keep engine-level compatibility imports for TestConfig, CommandConfig, test_command, and activation-source helpers
- leave the CLI dispatch and project resolution flow unchanged

Fixes #1443

## Validation
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py cli/python/base_projects/tests/test_command_helpers.py cli/python/base_projects/tests/test_build_targets.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_projects/engine.py cli/python/base_projects/project_commands.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_projects/engine.py cli/python/base_projects/project_commands.py
- git diff --check