### PR TITLE
Extract project Python artifact lifecycle

### DIFF
--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
-import os
-import subprocess
-import time
-import venv
-from collections.abc import Iterable
-from dataclasses import dataclass
 from dataclasses import replace
-from pathlib import Path
 
 import base_cli
 
@@ -20,25 +13,27 @@ from .prerequisites import HomebrewPackageCheckRequest
 from .prerequisites import PrerequisiteCheck
 from .prerequisites import check_homebrew_package
 from .prerequisites import homebrew_package_outdated
-from .python_policy import evaluate_python_requirement
-from .python_policy import inspect_python_interpreter
-from .python_policy import PythonInterpreter
-from .python_policy import resolve_python_interpreter
-from .python_policy import version_label
-from .project_environment import project_venv_dir_override
+from .python_artifacts import PIP_INSTALL_COMMAND_PREFIX  # pylint: disable=unused-import
+from .python_artifacts import backup_existing_project_venv  # pylint: disable=unused-import
+from .python_artifacts import create_project_virtualenv  # pylint: disable=unused-import
+from .python_artifacts import ensure_existing_project_venv_matches_requirement  # pylint: disable=unused-import
+from .python_artifacts import pip_install_command  # pylint: disable=unused-import
+from .python_artifacts import project_python_interpreter  # pylint: disable=unused-import
+from .python_artifacts import project_runtime_config
+from .python_artifacts import project_venv_dir
+from .python_artifacts import project_venv_recreate_enabled  # pylint: disable=unused-import
+from .python_artifacts import ProjectRuntimeConfig
+from .python_artifacts import python_artifact_installed
+from .python_artifacts import python_package_requirement  # pylint: disable=unused-import
+from .python_artifacts import PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS  # pylint: disable=unused-import
+from .python_artifacts import reconcile_python_artifact
+from .python_artifacts import reconcile_python_artifacts
+from .python_artifacts import reconcile_python_artifacts_sequential  # pylint: disable=unused-import
 from .registry import ArtifactDefinition, get_artifact_definition
 
-PIP_INSTALL_COMMAND_PREFIX = ("-m", "pip", "install", "--disable-pip-version-check")
-PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS = process.DIAGNOSTIC_TIMEOUT_SECONDS
 LINUX_DEBIAN_SYSTEM_TOOL_PACKAGES = {
     ("tool", "bats-core"): "bats",
 }
-
-
-@dataclass(frozen=True)
-class ProjectRuntimeConfig:
-    name: str
-    python_requirement: str | None = None
 
 
 def resolve_artifact_definitions(artifacts: tuple[ArtifactRequest, ...]) -> tuple[ArtifactDefinition, ...]:
@@ -410,217 +405,3 @@ def reconcile_system_package_artifact(
         f"System package '{definition.package}' is required for artifact '{definition.name}'. "
         "Run 'basectl setup --yes' or install the package manually, then rerun setup."
     )
-
-
-def reconcile_python_artifact(
-    ctx: base_cli.Context,
-    definition: ArtifactDefinition,
-    version: str,
-    project: str | ProjectRuntimeConfig,
-    dry_run: bool,
-) -> None:
-    reconcile_python_artifacts(ctx, ((definition, version),), project, dry_run=dry_run)
-
-
-def reconcile_python_artifacts(
-    ctx: base_cli.Context,
-    artifact_definitions: tuple[tuple[ArtifactDefinition, str], ...],
-    project: str | ProjectRuntimeConfig,
-    dry_run: bool,
-) -> None:
-    runtime_config = project_runtime_config(project)
-    python_requirement = runtime_config.python_requirement
-    venv_dir = project_venv_dir(runtime_config.name)
-    python_bin = venv_dir / "bin" / "python"
-    recreate_venv = project_venv_recreate_enabled()
-    missing = []
-
-    if recreate_venv:
-        backup_existing_project_venv(ctx, venv_dir, dry_run=dry_run)
-    elif python_requirement is not None and python_bin.exists():
-        ensure_existing_project_venv_matches_requirement(python_bin, runtime_config.name, python_requirement)
-
-    for definition, version in artifact_definitions:
-        if not recreate_venv and python_artifact_installed(python_bin, definition.package, version):
-            ctx.log.info(
-                "Python artifact '%s' is already installed in the project virtual environment.",
-                definition.name,
-            )
-            continue
-        missing.append((definition, version, python_package_requirement(definition, version)))
-
-    if not missing:
-        return
-
-    requirements = [requirement for _definition, _version, requirement in missing]
-
-    if dry_run:
-        if recreate_venv or not python_bin.exists():
-            if python_requirement is None:
-                ctx.log.info("[DRY-RUN] Would create project virtual environment at '%s'.", venv_dir)
-            else:
-                interpreter = project_python_interpreter(python_requirement)
-                ctx.log.info(
-                    "[DRY-RUN] Would create project virtual environment at '%s' with Python %s from '%s'.",
-                    venv_dir,
-                    version_label(interpreter.version),
-                    interpreter.path,
-                )
-        process.dry_run_command(ctx, pip_install_command(python_bin, requirements))
-        return
-
-    if recreate_venv or not python_bin.exists():
-        create_project_virtualenv(ctx, venv_dir, python_requirement)
-
-    names = ", ".join(definition.name for definition, _version, _requirement in missing)
-    ctx.log.info("Installing Python artifacts into project virtual environment: %s.", names)
-    command = pip_install_command(python_bin, requirements)
-    try:
-        process.run_command(ctx, command)
-    except ArtifactError as exc:
-        if len(missing) == 1:
-            raise
-        ctx.log.warning("Batch Python artifact install failed; retrying one artifact at a time.")
-        ctx.log.debug("Batch Python artifact install failed: %s", exc)
-        reconcile_python_artifacts_sequential(ctx, python_bin, missing)
-
-
-def project_venv_recreate_enabled() -> bool:
-    return os.environ.get("BASE_SETUP_RECREATE_PROJECT_VENV") == "true"
-
-
-def project_runtime_config(project: str | ProjectRuntimeConfig) -> ProjectRuntimeConfig:
-    if isinstance(project, ProjectRuntimeConfig):
-        return project
-    return ProjectRuntimeConfig(name=project)
-
-
-def create_project_virtualenv(ctx: base_cli.Context, venv_dir: Path, python_requirement: str | None) -> None:
-    if python_requirement is None:
-        ctx.log.info("Creating project virtual environment at '%s'.", venv_dir)
-        venv.create(venv_dir, with_pip=True)
-        return
-
-    interpreter = project_python_interpreter(python_requirement)
-    ctx.log.info(
-        "Creating project virtual environment at '%s' with Python %s.",
-        venv_dir,
-        version_label(interpreter.version),
-    )
-    process.run_command(ctx, [str(interpreter.path), "-m", "venv", str(venv_dir)])
-
-
-def project_python_interpreter(python_requirement: str) -> PythonInterpreter:
-    policy = evaluate_python_requirement(python_requirement)
-    if not policy.ok or policy.selected_version is None:
-        raise ArtifactError(
-            f"python.requires_python '{python_requirement}' {policy.error}. "
-            "Choose a Python version supported by Base."
-        )
-    interpreter = resolve_python_interpreter(policy.selected_version)
-    if interpreter is None:
-        selected = version_label(policy.selected_version)
-        raise ArtifactError(
-            f"Python {selected} is not available for python.requires_python '{python_requirement}'. "
-            f"Install Python {selected} or update base_manifest.yaml."
-        )
-    return interpreter
-
-
-def ensure_existing_project_venv_matches_requirement(
-    python_bin: Path,
-    project: str,
-    python_requirement: str,
-) -> None:
-    policy = evaluate_python_requirement(python_requirement)
-    if not policy.ok or policy.selected_version is None:
-        raise ArtifactError(
-            f"python.requires_python '{python_requirement}' {policy.error}. "
-            "Choose a Python version supported by Base."
-        )
-
-    interpreter = inspect_python_interpreter(python_bin)
-    if interpreter is None or interpreter.version == policy.selected_version:
-        return
-
-    expected = version_label(policy.selected_version)
-    actual = version_label(interpreter.version)
-    raise ArtifactError(
-        f"Project virtual environment '{python_bin.parent.parent}' uses Python {actual}, "
-        f"but python.requires_python '{python_requirement}' selects Python {expected}. "
-        f"Run 'basectl setup {project} --recreate-venv' to recreate the project virtual environment."
-    )
-
-
-def backup_existing_project_venv(ctx: base_cli.Context, venv_dir: Path, dry_run: bool) -> None:
-    if not venv_dir.exists():
-        return
-    timestamp = time.strftime("%Y%m%dT%H%M%S")
-    backup_path = venv_dir.with_name(f"{venv_dir.name}.backup.{timestamp}")
-    if backup_path.exists():
-        raise ArtifactError(f"Project virtual environment backup path already exists at '{backup_path}'.")
-    if dry_run:
-        ctx.log.info(
-            "[DRY-RUN] Would move existing project virtual environment '%s' to '%s'.",
-            venv_dir,
-            backup_path,
-        )
-        return
-    ctx.log.info("Moving existing project virtual environment '%s' to '%s'.", venv_dir, backup_path)
-    venv_dir.rename(backup_path)
-
-
-def reconcile_python_artifacts_sequential(
-    ctx: base_cli.Context,
-    python_bin: Path,
-    missing: list[tuple[ArtifactDefinition, str, str]],
-) -> None:
-    for definition, version, requirement in missing:
-        if python_artifact_installed(python_bin, definition.package, version):
-            ctx.log.info(
-                "Python artifact '%s' is already installed in the project virtual environment.",
-                definition.name,
-            )
-            continue
-        ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
-        process.run_command(ctx, pip_install_command(python_bin, (requirement,)))
-
-
-def python_package_requirement(definition: ArtifactDefinition, version: str) -> str:
-    return f"{definition.package}=={version}" if version != "latest" else definition.package
-
-
-def pip_install_command(python_bin: Path, requirements: Iterable[str]) -> list[str]:
-    return [str(python_bin), *PIP_INSTALL_COMMAND_PREFIX, *requirements]
-
-
-def project_venv_dir(project: str) -> Path:
-    override = project_venv_dir_override(project)
-    if override is not None:
-        return override
-    return Path.home() / ".base.d" / project / ".venv"
-
-
-def python_artifact_installed(python_bin: Path, package: str, version: str) -> bool:
-    if not python_bin.exists():
-        return False
-    command = [str(python_bin), "-m", "pip", "show", package]
-    try:
-        completed = subprocess.run(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            check=False,
-            timeout=PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    if completed.returncode:
-        return False
-    if version == "latest":
-        return True
-    for line in completed.stdout.splitlines():
-        if line.startswith("Version: "):
-            return line.removeprefix("Version: ").strip() == version
-    return False

--- a/cli/python/base_setup/python_artifacts.py
+++ b/cli/python/base_setup/python_artifacts.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import venv
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import base_cli
+
+from . import process
+from .errors import ArtifactError
+from .python_policy import evaluate_python_requirement
+from .python_policy import inspect_python_interpreter
+from .python_policy import PythonInterpreter
+from .python_policy import resolve_python_interpreter
+from .python_policy import version_label
+from .project_environment import project_venv_dir_override
+from .registry import ArtifactDefinition
+
+PIP_INSTALL_COMMAND_PREFIX = ("-m", "pip", "install", "--disable-pip-version-check")
+PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS = process.DIAGNOSTIC_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True)
+class ProjectRuntimeConfig:
+    name: str
+    python_requirement: str | None = None
+
+
+def reconcile_python_artifact(
+    ctx: base_cli.Context,
+    definition: ArtifactDefinition,
+    version: str,
+    project: str | ProjectRuntimeConfig,
+    dry_run: bool,
+) -> None:
+    reconcile_python_artifacts(ctx, ((definition, version),), project, dry_run=dry_run)
+
+
+def reconcile_python_artifacts(
+    ctx: base_cli.Context,
+    artifact_definitions: tuple[tuple[ArtifactDefinition, str], ...],
+    project: str | ProjectRuntimeConfig,
+    dry_run: bool,
+) -> None:
+    runtime_config = project_runtime_config(project)
+    python_requirement = runtime_config.python_requirement
+    venv_dir = project_venv_dir(runtime_config.name)
+    python_bin = venv_dir / "bin" / "python"
+    recreate_venv = project_venv_recreate_enabled()
+    missing = []
+
+    if recreate_venv:
+        backup_existing_project_venv(ctx, venv_dir, dry_run=dry_run)
+    elif python_requirement is not None and python_bin.exists():
+        ensure_existing_project_venv_matches_requirement(python_bin, runtime_config.name, python_requirement)
+
+    for definition, version in artifact_definitions:
+        if not recreate_venv and python_artifact_installed(python_bin, definition.package, version):
+            ctx.log.info(
+                "Python artifact '%s' is already installed in the project virtual environment.",
+                definition.name,
+            )
+            continue
+        missing.append((definition, version, python_package_requirement(definition, version)))
+
+    if not missing:
+        return
+
+    requirements = [requirement for _definition, _version, requirement in missing]
+
+    if dry_run:
+        if recreate_venv or not python_bin.exists():
+            if python_requirement is None:
+                ctx.log.info("[DRY-RUN] Would create project virtual environment at '%s'.", venv_dir)
+            else:
+                interpreter = project_python_interpreter(python_requirement)
+                ctx.log.info(
+                    "[DRY-RUN] Would create project virtual environment at '%s' with Python %s from '%s'.",
+                    venv_dir,
+                    version_label(interpreter.version),
+                    interpreter.path,
+                )
+        process.dry_run_command(ctx, pip_install_command(python_bin, requirements))
+        return
+
+    if recreate_venv or not python_bin.exists():
+        create_project_virtualenv(ctx, venv_dir, python_requirement)
+
+    names = ", ".join(definition.name for definition, _version, _requirement in missing)
+    ctx.log.info("Installing Python artifacts into project virtual environment: %s.", names)
+    command = pip_install_command(python_bin, requirements)
+    try:
+        process.run_command(ctx, command)
+    except ArtifactError as exc:
+        if len(missing) == 1:
+            raise
+        ctx.log.warning("Batch Python artifact install failed; retrying one artifact at a time.")
+        ctx.log.debug("Batch Python artifact install failed: %s", exc)
+        reconcile_python_artifacts_sequential(ctx, python_bin, missing)
+
+
+def project_venv_recreate_enabled() -> bool:
+    return os.environ.get("BASE_SETUP_RECREATE_PROJECT_VENV") == "true"
+
+
+def project_runtime_config(project: str | ProjectRuntimeConfig) -> ProjectRuntimeConfig:
+    if isinstance(project, ProjectRuntimeConfig):
+        return project
+    return ProjectRuntimeConfig(name=project)
+
+
+def create_project_virtualenv(ctx: base_cli.Context, venv_dir: Path, python_requirement: str | None) -> None:
+    if python_requirement is None:
+        ctx.log.info("Creating project virtual environment at '%s'.", venv_dir)
+        venv.create(venv_dir, with_pip=True)
+        return
+
+    interpreter = project_python_interpreter(python_requirement)
+    ctx.log.info(
+        "Creating project virtual environment at '%s' with Python %s.",
+        venv_dir,
+        version_label(interpreter.version),
+    )
+    process.run_command(ctx, [str(interpreter.path), "-m", "venv", str(venv_dir)])
+
+
+def project_python_interpreter(python_requirement: str) -> PythonInterpreter:
+    policy = evaluate_python_requirement(python_requirement)
+    if not policy.ok or policy.selected_version is None:
+        raise ArtifactError(
+            f"python.requires_python '{python_requirement}' {policy.error}. "
+            "Choose a Python version supported by Base."
+        )
+    interpreter = resolve_python_interpreter(policy.selected_version)
+    if interpreter is None:
+        selected = version_label(policy.selected_version)
+        raise ArtifactError(
+            f"Python {selected} is not available for python.requires_python '{python_requirement}'. "
+            f"Install Python {selected} or update base_manifest.yaml."
+        )
+    return interpreter
+
+
+def ensure_existing_project_venv_matches_requirement(
+    python_bin: Path,
+    project: str,
+    python_requirement: str,
+) -> None:
+    policy = evaluate_python_requirement(python_requirement)
+    if not policy.ok or policy.selected_version is None:
+        raise ArtifactError(
+            f"python.requires_python '{python_requirement}' {policy.error}. "
+            "Choose a Python version supported by Base."
+        )
+
+    interpreter = inspect_python_interpreter(python_bin)
+    if interpreter is None or interpreter.version == policy.selected_version:
+        return
+
+    expected = version_label(policy.selected_version)
+    actual = version_label(interpreter.version)
+    raise ArtifactError(
+        f"Project virtual environment '{python_bin.parent.parent}' uses Python {actual}, "
+        f"but python.requires_python '{python_requirement}' selects Python {expected}. "
+        f"Run 'basectl setup {project} --recreate-venv' to recreate the project virtual environment."
+    )
+
+
+def backup_existing_project_venv(ctx: base_cli.Context, venv_dir: Path, dry_run: bool) -> None:
+    if not venv_dir.exists():
+        return
+    timestamp = time.strftime("%Y%m%dT%H%M%S")
+    backup_path = venv_dir.with_name(f"{venv_dir.name}.backup.{timestamp}")
+    if backup_path.exists():
+        raise ArtifactError(f"Project virtual environment backup path already exists at '{backup_path}'.")
+    if dry_run:
+        ctx.log.info(
+            "[DRY-RUN] Would move existing project virtual environment '%s' to '%s'.",
+            venv_dir,
+            backup_path,
+        )
+        return
+    ctx.log.info("Moving existing project virtual environment '%s' to '%s'.", venv_dir, backup_path)
+    venv_dir.rename(backup_path)
+
+
+def reconcile_python_artifacts_sequential(
+    ctx: base_cli.Context,
+    python_bin: Path,
+    missing: list[tuple[ArtifactDefinition, str, str]],
+) -> None:
+    for definition, version, requirement in missing:
+        if python_artifact_installed(python_bin, definition.package, version):
+            ctx.log.info(
+                "Python artifact '%s' is already installed in the project virtual environment.",
+                definition.name,
+            )
+            continue
+        ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
+        process.run_command(ctx, pip_install_command(python_bin, (requirement,)))
+
+
+def python_package_requirement(definition: ArtifactDefinition, version: str) -> str:
+    return f"{definition.package}=={version}" if version != "latest" else definition.package
+
+
+def pip_install_command(python_bin: Path, requirements: Iterable[str]) -> list[str]:
+    return [str(python_bin), *PIP_INSTALL_COMMAND_PREFIX, *requirements]
+
+
+def project_venv_dir(project: str) -> Path:
+    override = project_venv_dir_override(project)
+    if override is not None:
+        return override
+    return Path.home() / ".base.d" / project / ".venv"
+
+
+def python_artifact_installed(python_bin: Path, package: str, version: str) -> bool:
+    if not python_bin.exists():
+        return False
+    command = [str(python_bin), "-m", "pip", "show", package]
+    try:
+        completed = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if completed.returncode:
+        return False
+    if version == "latest":
+        return True
+    for line in completed.stdout.splitlines():
+        if line.startswith("Version: "):
+            return line.removeprefix("Version: ").strip() == version
+    return False

--- a/cli/python/base_setup/tests/test_artifact_probe_timeouts.py
+++ b/cli/python/base_setup/tests/test_artifact_probe_timeouts.py
@@ -17,7 +17,7 @@ def test_python_artifact_installed_passes_timeout_to_pip_show(tmp_path: Path) ->
         stderr="",
     )
 
-    with mock.patch("base_setup.artifacts.subprocess.run", return_value=completed) as run:
+    with mock.patch("base_setup.python_artifacts.subprocess.run", return_value=completed) as run:
         assert artifacts.python_artifact_installed(python_bin, "requests", "2.32.4")
 
     assert run.call_args.kwargs["timeout"] == artifacts.PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS
@@ -29,7 +29,7 @@ def test_python_artifact_installed_returns_false_on_timeout(tmp_path: Path) -> N
     command = [str(python_bin), "-m", "pip", "show", "requests"]
 
     with mock.patch(
-        "base_setup.artifacts.subprocess.run",
+        "base_setup.python_artifacts.subprocess.run",
         side_effect=subprocess.TimeoutExpired(command, timeout=10),
     ):
         assert not artifacts.python_artifact_installed(python_bin, "requests", "latest")

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -642,7 +642,7 @@ class ArtifactReconcileTests(unittest.TestCase):
             with mock.patch.dict(
                 os.environ,
                 {"BASE_PROJECT": "demo", "BASE_PROJECT_VENV_DIR": str(venv_dir)},
-            ), mock.patch("base_setup.artifacts.python_artifact_installed", return_value=False):
+            ), mock.patch("base_setup.python_artifacts.python_artifact_installed", return_value=False):
                 artifacts.reconcile_python_artifact(ctx, definition, "latest", "demo", dry_run=True)
 
         info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
@@ -663,9 +663,12 @@ class ArtifactReconcileTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             venv_dir = Path(tmpdir) / "demo" / ".venv"
             with mock.patch.dict(os.environ, {"BASE_PROJECT": "wrong-project"}), mock.patch(
-                "base_setup.artifacts.project_venv_dir",
+                "base_setup.python_artifacts.project_venv_dir",
                 return_value=venv_dir,
-            ) as project_venv_dir, mock.patch("base_setup.artifacts.python_artifact_installed", return_value=False):
+            ) as project_venv_dir, mock.patch(
+                "base_setup.python_artifacts.python_artifact_installed",
+                return_value=False,
+            ):
                 artifacts.reconcile_python_artifact(ctx, definition, "latest", "demo", dry_run=True)
 
         project_venv_dir.assert_called_once_with("demo")
@@ -688,8 +691,8 @@ class ArtifactReconcileTests(unittest.TestCase):
 
             with (
                 mock.patch.dict(os.environ, {"BASE_SETUP_RECREATE_PROJECT_VENV": "true"}),
-                mock.patch("base_setup.artifacts.project_venv_dir", return_value=venv_dir),
-                mock.patch("base_setup.artifacts.venv.create") as create_venv,
+                mock.patch("base_setup.python_artifacts.project_venv_dir", return_value=venv_dir),
+                mock.patch("base_setup.python_artifacts.venv.create") as create_venv,
                 mock.patch("base_setup.process.run_command") as run_command,
             ):
                 artifacts.reconcile_python_artifact(ctx, definition, "latest", "demo", dry_run=False)
@@ -726,9 +729,9 @@ class ArtifactReconcileTests(unittest.TestCase):
             python_bin.parent.mkdir(parents=True)
             python_bin.touch()
             with mock.patch(
-                "base_setup.artifacts.project_venv_dir",
+                "base_setup.python_artifacts.project_venv_dir",
                 return_value=venv_dir,
-            ), mock.patch("base_setup.artifacts.python_artifact_installed", return_value=False), mock.patch(
+            ), mock.patch("base_setup.python_artifacts.python_artifact_installed", return_value=False), mock.patch(
                 "base_setup.process.run_command"
             ) as run_command:
                 artifacts.reconcile_artifacts(
@@ -768,9 +771,9 @@ class ArtifactReconcileTests(unittest.TestCase):
             python_bin.parent.mkdir(parents=True)
             python_bin.touch()
             with mock.patch(
-                "base_setup.artifacts.project_venv_dir",
+                "base_setup.python_artifacts.project_venv_dir",
                 return_value=venv_dir,
-            ), mock.patch("base_setup.artifacts.python_artifact_installed", return_value=False), mock.patch(
+            ), mock.patch("base_setup.python_artifacts.python_artifact_installed", return_value=False), mock.patch(
                 "base_setup.process.run_command",
                 side_effect=[ArtifactError("batch failed"), None, None],
             ) as run_command:

--- a/cli/python/base_setup/tests/test_project_environment.py
+++ b/cli/python/base_setup/tests/test_project_environment.py
@@ -26,8 +26,8 @@ class ProjectEnvironmentTests(unittest.TestCase):
                     os.environ,
                     {"BASE_PROJECT": "base", "BASE_PROJECT_VENV_DIR": str(inherited_venv)},
                 ),
-                mock.patch("base_setup.artifacts.Path.home", return_value=home_dir),
-                mock.patch("base_setup.artifacts.python_artifact_installed", return_value=False),
+                mock.patch("base_setup.python_artifacts.Path.home", return_value=home_dir),
+                mock.patch("base_setup.python_artifacts.python_artifact_installed", return_value=False),
             ):
                 artifacts.reconcile_python_artifact(ctx, definition, "latest", "demo", dry_run=True)
 

--- a/cli/python/base_setup/tests/test_python_version_artifacts.py
+++ b/cli/python/base_setup/tests/test_python_version_artifacts.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from unittest import mock
 
 from base_setup import artifacts
-from base_setup.artifacts import ProjectRuntimeConfig
 from base_setup.errors import ArtifactError
+from base_setup.python_artifacts import ProjectRuntimeConfig
 from base_setup.python_policy import PythonInterpreter
 from base_setup.registry import get_artifact_definition
 from base_setup.tests.helpers import fake_context
@@ -23,11 +23,11 @@ class PythonVersionArtifactTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             venv_dir = Path(tmpdir) / "demo" / ".venv"
             python_bin = Path(tmpdir) / "python3.12"
-            with mock.patch("base_setup.artifacts.project_venv_dir", return_value=venv_dir), mock.patch(
-                "base_setup.artifacts.python_artifact_installed",
+            with mock.patch("base_setup.python_artifacts.project_venv_dir", return_value=venv_dir), mock.patch(
+                "base_setup.python_artifacts.python_artifact_installed",
                 return_value=False,
             ), mock.patch(
-                "base_setup.artifacts.resolve_python_interpreter",
+                "base_setup.python_artifacts.resolve_python_interpreter",
                 return_value=PythonInterpreter(path=python_bin, version=(3, 12)),
             ), mock.patch(
                 "base_setup.process.run_command"
@@ -70,8 +70,8 @@ class PythonVersionArtifactTests(unittest.TestCase):
             python_bin.write_text("#!/bin/sh\nprintf '3.13\\n'\n", encoding="utf-8")
             python_bin.chmod(0o755)
 
-            with mock.patch("base_setup.artifacts.project_venv_dir", return_value=venv_dir), mock.patch(
-                "base_setup.artifacts.python_artifact_installed",
+            with mock.patch("base_setup.python_artifacts.project_venv_dir", return_value=venv_dir), mock.patch(
+                "base_setup.python_artifacts.python_artifact_installed",
                 return_value=False,
             ), mock.patch("base_setup.process.run_command") as run_command:
                 with self.assertRaisesRegex(ArtifactError, "uses Python 3.13"):
@@ -84,4 +84,3 @@ class PythonVersionArtifactTests(unittest.TestCase):
                     )
 
         run_command.assert_not_called()
-


### PR DESCRIPTION
Closes #1445

## Summary
- move project virtualenv and pip artifact lifecycle logic into base_setup.python_artifacts
- keep base_setup.artifacts as the artifact dispatch facade with compatibility re-exports
- retarget lifecycle tests to patch the new implementation module

## Tests
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_python_version_artifacts.py cli/python/base_setup/tests/test_project_environment.py cli/python/base_setup/tests/test_artifact_probe_timeouts.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/artifacts.py cli/python/base_setup/python_artifacts.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_setup/artifacts.py cli/python/base_setup/python_artifacts.py
- git diff --check