### PR TITLE
Extract setup reconciliation orchestration

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -11,9 +11,6 @@ from base_cli.config import UserConfig, UserIdeConfig
 from base_cli.paths import discover_manifest
 
 from .artifacts import check_artifact
-from .artifacts import merge_artifacts
-from .artifacts import ProjectRuntimeConfig
-from .artifacts import reconcile_artifacts
 from .artifacts import resolve_artifact_definitions
 from .build import check_build
 from .checks import ArtifactCheck
@@ -26,8 +23,6 @@ from .command_lint import check_manifest_commands
 from .demo import check_demo
 from .delegates import check_brewfile
 from .delegates import check_mise
-from .delegates import reconcile_brewfile
-from .delegates import reconcile_mise
 from .errors import ArtifactError
 from .git_remote import check_git_remote
 from .health import check_required_env
@@ -35,21 +30,19 @@ from .health import check_required_ports
 from .ide import check_ide_extensions
 from .ide import check_ide_installs
 from .ide import check_ide_settings
-from .ide import effective_ide_config
 from .ide import ide_preference_warning_checks
-from .ide import log_ide_preference_warnings
-from .ide import reconcile_ide_extensions
-from .ide import reconcile_ide_installs
-from .ide import reconcile_ide_settings
 from .manifest import BaseManifest, ManifestError, read_manifest
 from .pyproject import check_pyproject
 from .project_routing import route_for_manifest
 from .project_routing import route_to_text
 from .python_policy import python_requirement_checks
 from .python_runtime import project_python_runtime_check
+from .setup_reconcile import effective_manifest_with_user_config
+from .setup_reconcile import project_runtime_argument  # pylint: disable=unused-import
+from .setup_reconcile import reconcile_bootstrap_artifacts
+from .setup_reconcile import reconcile_manifest
+from .setup_reconcile import setup_artifacts
 from .uv import check_uv
-from .uv import manifest_uses_uv_project_manager
-from .uv import reconcile_uv_project
 
 
 app = base_cli.App(name="base_setup")
@@ -206,80 +199,6 @@ def read_default_manifest(ctx: base_cli.Context) -> BaseManifest:
         raise ManifestError("BASE_HOME is required to load Base's default artifact manifest.")
     default_manifest_path = ctx.base_home / "lib" / "base" / "default_manifest.yaml"
     return read_manifest(default_manifest_path)
-
-
-def reconcile_manifest(
-    ctx: base_cli.Context,
-    default_manifest: BaseManifest,
-    manifest: BaseManifest,
-    dry_run: bool,
-) -> None:
-    ctx.log.info("Reading Base manifest at '%s'.", manifest.path)
-    ctx.log.info("Setting up project '%s'.", manifest.project_name)
-    user_config = ctx.user_config
-    log_ide_preference_warnings(ctx, ide_preference_warning_checks(manifest, user_config))
-    effective_manifest = effective_manifest_with_user_config(manifest, user_config)
-
-    artifacts = setup_artifacts(default_manifest, effective_manifest)
-    definitions = resolve_artifact_definitions(artifacts)
-    if not effective_manifest.artifacts:
-        if artifacts:
-            ctx.log.info(
-                "Project '%s' declares no artifacts; installing Base default artifacts only.",
-                effective_manifest.project_name,
-            )
-        else:
-            ctx.log.info("Project '%s' has no artifacts to install.", effective_manifest.project_name)
-
-    reconcile_brewfile(ctx, effective_manifest, dry_run=dry_run)
-    reconcile_mise(ctx, effective_manifest, dry_run=dry_run)
-    reconcile_ide_installs(ctx, effective_manifest, dry_run=dry_run)
-    reconcile_ide_extensions(ctx, effective_manifest, dry_run=dry_run)
-    reconcile_ide_settings(ctx, effective_manifest, dry_run=dry_run)
-    reconcile_uv_project(ctx, effective_manifest, dry_run=dry_run)
-
-    if artifacts:
-        reconcile_artifacts(
-            ctx,
-            artifacts,
-            definitions,
-            project_runtime_argument(effective_manifest),
-            dry_run=dry_run,
-        )
-
-    ctx.log.info("Project '%s' setup is complete.", effective_manifest.project_name)
-
-
-def reconcile_bootstrap_artifacts(
-    ctx: base_cli.Context,
-    default_manifest: BaseManifest,
-    manifest: BaseManifest,
-    dry_run: bool,
-) -> None:
-    ctx.log.info("Bootstrapping project '%s' Python runtime.", manifest.project_name)
-
-    artifacts = tuple(artifact for artifact in default_manifest.artifacts if artifact.bootstrap)
-    definitions = resolve_artifact_definitions(artifacts)
-    if not artifacts:
-        ctx.log.info("Base default manifest declares no bootstrap artifacts.")
-        return
-
-    reconcile_artifacts(
-        ctx,
-        artifacts,
-        definitions,
-        project_runtime_argument(manifest),
-        dry_run=dry_run,
-    )
-
-
-def project_runtime_argument(manifest: BaseManifest) -> str | ProjectRuntimeConfig:
-    if manifest.python.requires_python is None:
-        return manifest.project_name
-    return ProjectRuntimeConfig(
-        name=manifest.project_name,
-        python_requirement=manifest.python.requires_python,
-    )
 
 
 def check_manifest(
@@ -461,31 +380,3 @@ def setup_profile_enabled(profile: str) -> bool:
 
 def empty_user_config() -> UserConfig:
     return UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))
-
-
-def effective_manifest_with_user_config(manifest: BaseManifest, user_config: UserConfig) -> BaseManifest:
-    return BaseManifest(
-        path=manifest.path,
-        project_name=manifest.project_name,
-        brewfile=manifest.brewfile,
-        artifacts=manifest.artifacts,
-        ide=effective_ide_config(manifest.ide, user_config),
-        mise=manifest.mise,
-        test=manifest.test,
-        schema_version=manifest.schema_version,
-        health=manifest.health,
-        commands=manifest.commands,
-        activate=manifest.activate,
-        python=manifest.python,
-        github=manifest.github,
-        demo=manifest.demo,
-        build=manifest.build,
-        release=manifest.release,
-    )
-
-
-def setup_artifacts(default_manifest: BaseManifest, manifest: BaseManifest) -> tuple:
-    artifacts = merge_artifacts(default_manifest.artifacts, manifest.artifacts)
-    if not manifest_uses_uv_project_manager(manifest):
-        return artifacts
-    return tuple(artifact for artifact in artifacts if artifact.artifact_type != "python-package")

--- a/cli/python/base_setup/setup_reconcile.py
+++ b/cli/python/base_setup/setup_reconcile.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import base_cli
+from base_cli.config import UserConfig
+
+from .artifacts import merge_artifacts
+from .artifacts import ProjectRuntimeConfig
+from .artifacts import reconcile_artifacts
+from .artifacts import resolve_artifact_definitions
+from .delegates import reconcile_brewfile
+from .delegates import reconcile_mise
+from .ide import effective_ide_config
+from .ide import ide_preference_warning_checks
+from .ide import log_ide_preference_warnings
+from .ide import reconcile_ide_extensions
+from .ide import reconcile_ide_installs
+from .ide import reconcile_ide_settings
+from .manifest import BaseManifest
+from .uv import manifest_uses_uv_project_manager
+from .uv import reconcile_uv_project
+
+
+def reconcile_manifest(
+    ctx: base_cli.Context,
+    default_manifest: BaseManifest,
+    manifest: BaseManifest,
+    dry_run: bool,
+) -> None:
+    ctx.log.info("Reading Base manifest at '%s'.", manifest.path)
+    ctx.log.info("Setting up project '%s'.", manifest.project_name)
+    user_config = ctx.user_config
+    log_ide_preference_warnings(ctx, ide_preference_warning_checks(manifest, user_config))
+    effective_manifest = effective_manifest_with_user_config(manifest, user_config)
+
+    artifacts = setup_artifacts(default_manifest, effective_manifest)
+    definitions = resolve_artifact_definitions(artifacts)
+    if not effective_manifest.artifacts:
+        if artifacts:
+            ctx.log.info(
+                "Project '%s' declares no artifacts; installing Base default artifacts only.",
+                effective_manifest.project_name,
+            )
+        else:
+            ctx.log.info("Project '%s' has no artifacts to install.", effective_manifest.project_name)
+
+    reconcile_brewfile(ctx, effective_manifest, dry_run=dry_run)
+    reconcile_mise(ctx, effective_manifest, dry_run=dry_run)
+    reconcile_ide_installs(ctx, effective_manifest, dry_run=dry_run)
+    reconcile_ide_extensions(ctx, effective_manifest, dry_run=dry_run)
+    reconcile_ide_settings(ctx, effective_manifest, dry_run=dry_run)
+    reconcile_uv_project(ctx, effective_manifest, dry_run=dry_run)
+
+    if artifacts:
+        reconcile_artifacts(
+            ctx,
+            artifacts,
+            definitions,
+            project_runtime_argument(effective_manifest),
+            dry_run=dry_run,
+        )
+
+    ctx.log.info("Project '%s' setup is complete.", effective_manifest.project_name)
+
+
+def reconcile_bootstrap_artifacts(
+    ctx: base_cli.Context,
+    default_manifest: BaseManifest,
+    manifest: BaseManifest,
+    dry_run: bool,
+) -> None:
+    ctx.log.info("Bootstrapping project '%s' Python runtime.", manifest.project_name)
+
+    artifacts = tuple(artifact for artifact in default_manifest.artifacts if artifact.bootstrap)
+    definitions = resolve_artifact_definitions(artifacts)
+    if not artifacts:
+        ctx.log.info("Base default manifest declares no bootstrap artifacts.")
+        return
+
+    reconcile_artifacts(
+        ctx,
+        artifacts,
+        definitions,
+        project_runtime_argument(manifest),
+        dry_run=dry_run,
+    )
+
+
+def project_runtime_argument(manifest: BaseManifest) -> str | ProjectRuntimeConfig:
+    if manifest.python.requires_python is None:
+        return manifest.project_name
+    return ProjectRuntimeConfig(
+        name=manifest.project_name,
+        python_requirement=manifest.python.requires_python,
+    )
+
+
+def effective_manifest_with_user_config(manifest: BaseManifest, user_config: UserConfig) -> BaseManifest:
+    return BaseManifest(
+        path=manifest.path,
+        project_name=manifest.project_name,
+        brewfile=manifest.brewfile,
+        artifacts=manifest.artifacts,
+        ide=effective_ide_config(manifest.ide, user_config),
+        mise=manifest.mise,
+        test=manifest.test,
+        schema_version=manifest.schema_version,
+        health=manifest.health,
+        commands=manifest.commands,
+        activate=manifest.activate,
+        python=manifest.python,
+        github=manifest.github,
+        demo=manifest.demo,
+        build=manifest.build,
+        release=manifest.release,
+    )
+
+
+def setup_artifacts(default_manifest: BaseManifest, manifest: BaseManifest) -> tuple:
+    artifacts = merge_artifacts(default_manifest.artifacts, manifest.artifacts)
+    if not manifest_uses_uv_project_manager(manifest):
+        return artifacts
+    return tuple(artifact for artifact in artifacts if artifact.artifact_type != "python-package")

--- a/cli/python/base_setup/tests/test_bootstrap.py
+++ b/cli/python/base_setup/tests/test_bootstrap.py
@@ -30,7 +30,7 @@ class BootstrapManifestTests(unittest.TestCase):
             artifacts=(),
         )
 
-        with mock.patch("base_setup.engine.reconcile_artifacts") as reconcile_artifacts:
+        with mock.patch("base_setup.setup_reconcile.reconcile_artifacts") as reconcile_artifacts:
             engine.reconcile_bootstrap_artifacts(ctx, default_manifest, manifest, dry_run=True)
 
         reconcile_artifacts.assert_called_once()

--- a/cli/python/base_setup/tests/test_user_ide_preferences.py
+++ b/cli/python/base_setup/tests/test_user_ide_preferences.py
@@ -169,12 +169,12 @@ class UserIdePreferenceMergeTests(unittest.TestCase):
         ctx.user_config = UserConfig(raw={}, ide=UserIdeConfig(enabled=False, preferences={}))
 
         with (
-            mock.patch("base_setup.engine.reconcile_brewfile"),
-            mock.patch("base_setup.engine.reconcile_mise"),
-            mock.patch("base_setup.engine.reconcile_ide_installs") as reconcile_ide_installs,
-            mock.patch("base_setup.engine.reconcile_ide_extensions"),
-            mock.patch("base_setup.engine.reconcile_ide_settings"),
-            mock.patch("base_setup.engine.reconcile_uv_project"),
+            mock.patch("base_setup.setup_reconcile.reconcile_brewfile"),
+            mock.patch("base_setup.setup_reconcile.reconcile_mise"),
+            mock.patch("base_setup.setup_reconcile.reconcile_ide_installs") as reconcile_ide_installs,
+            mock.patch("base_setup.setup_reconcile.reconcile_ide_extensions"),
+            mock.patch("base_setup.setup_reconcile.reconcile_ide_settings"),
+            mock.patch("base_setup.setup_reconcile.reconcile_uv_project"),
         ):
             engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=True)
 

--- a/cli/python/base_setup/tests/test_uv.py
+++ b/cli/python/base_setup/tests/test_uv.py
@@ -370,8 +370,8 @@ class UvProjectTests(unittest.TestCase):
             )
             ctx = fake_context()
 
-            with mock.patch("base_setup.engine.reconcile_uv_project") as reconcile_uv, mock.patch(
-                "base_setup.engine.reconcile_artifacts"
+            with mock.patch("base_setup.setup_reconcile.reconcile_uv_project") as reconcile_uv, mock.patch(
+                "base_setup.setup_reconcile.reconcile_artifacts"
             ) as reconcile_artifacts:
                 engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=True)
 
@@ -406,8 +406,8 @@ class UvProjectTests(unittest.TestCase):
             with (
                 mock.patch.dict(os.environ, {"BASE_PLATFORM": "linux-debian"}),
                 mock.patch("base_setup.delegates.process.command_exists", return_value=False),
-                mock.patch("base_setup.engine.reconcile_uv_project") as reconcile_uv,
-                mock.patch("base_setup.engine.reconcile_artifacts") as reconcile_artifacts,
+                mock.patch("base_setup.setup_reconcile.reconcile_uv_project") as reconcile_uv,
+                mock.patch("base_setup.setup_reconcile.reconcile_artifacts") as reconcile_artifacts,
             ):
                 engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=False)
 


### PR DESCRIPTION
Closes #1448

## Summary
- move setup/bootstrap reconciliation and effective manifest shaping into base_setup.setup_reconcile
- leave engine.py as the CLI/action and check/doctor facade
- retarget reconciliation-internal test patches to the new owner module

## Tests
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_bootstrap.py cli/python/base_setup/tests/test_uv.py cli/python/base_setup/tests/test_user_ide_preferences.py cli/python/base_setup/tests/test_diagnostics.py cli/python/base_setup/tests/test_command_lint.py cli/python/base_setup/tests/test_build.py cli/python/base_setup/tests/test_demo.py cli/python/base_setup/tests/test_mise.py cli/python/base_setup/tests/test_ide_extensions.py cli/python/base_setup/tests/test_ide_installs.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/engine.py cli/python/base_setup/setup_reconcile.py
- env PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_setup/engine.py cli/python/base_setup/setup_reconcile.py
- PYTHONPATH=lib/python:cli/python git ls-files -z '*.py' | xargs -0 /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc
- git diff --check