### PR TITLE
Remove dead bootstrap macOS guard

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -73,13 +73,6 @@ bootstrap_uname() {
     uname -s
 }
 
-bootstrap_require_macos() {
-    local os_name
-
-    os_name="$(bootstrap_uname)"
-    [[ "$os_name" == "Darwin" ]] || bootstrap_die "bootstrap.sh currently supports macOS only."
-}
-
 bootstrap_linux_os_release_path() {
     printf '%s\n' "${BASE_BOOTSTRAP_TEST_OS_RELEASE_PATH:-/etc/os-release}"
 }

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -145,6 +145,13 @@ sha256_file() {
     [ "$output" = "" ]
 }
 
+@test "bootstrap has no stale macOS-only guard" {
+    run grep -n 'bootstrap_require_macos' "$BASE_REPO_ROOT/bootstrap.sh"
+
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+}
+
 @test "bootstrap source dry-run installs first-mile prerequisites and prints handoff commands" {
     local install_dir="$TEST_HOME/work/base"
 


### PR DESCRIPTION
## Summary

- Remove the unreachable `bootstrap_require_macos()` helper from `bootstrap.sh`.
- Add a bootstrap regression guard so the stale macOS-only helper name does not return.

Fixes #1458

## Test Plan

- `bats --filter 'bootstrap has no stale macOS-only guard' tests/bootstrap.bats`
- `bats tests/bootstrap.bats`
- `git diff --check`
- `shellcheck --severity=error bootstrap.sh`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1458-remove-dead-bootstrap ./bin/base-test`
  - Python: `791 passed, 1 skipped`
  - BATS: `1..632`, all passed
