### PR TITLE
Add basectl prompt output support

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -33,8 +33,8 @@ options.
   remove local approval for manifest-declared project commands.
 - `basectl prompt <list|name>` - list and render repo-owned Markdown prompts
   for AI-assisted Base workflows. `product-self-review` prints the periodic
-  product assessment prompt with current Base metadata; Base does not send the
-  prompt to an AI provider.
+  product assessment prompt with current Base metadata, and `--output <path>`
+  writes the rendered Markdown; Base does not send the prompt to an AI provider.
 - `basectl docs` - open the Base documentation home page on GitHub.
 - `basectl projects list` - list Base-managed projects discovered in the
   workspace.

--- a/README.md
+++ b/README.md
@@ -845,11 +845,13 @@ Print repo-owned AI workflow prompts with:
 ```bash
 basectl prompt list
 basectl prompt product-self-review
+basectl prompt product-self-review --output /tmp/base-product-self-review.md
 ```
 
 `basectl prompt` renders maintained Markdown prompts from Base's repo-visible
-prompt library. The command prints prompts to stdout for manual use with AI
-tools; Base does not run the review or send the prompt to any provider. The
+prompt library. The command prints prompts to stdout by default and can write
+rendered Markdown to a path with `--output`; Base does not run the review or
+send the prompt to any provider. The
 first built-in prompt, `product-self-review`, is the periodic product
 assessment ritual for revisiting Base's originality, usefulness, adoption
 potential, creator-skill evidence, risks, and next directions.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -162,8 +162,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   `--show-url` to print the URL without opening a browser.
 - `basectl prompt list` lists repo-owned Markdown prompts that Base can render
   for AI-assisted workflows. `basectl prompt product-self-review` prints the
-  periodic Base product self-review prompt with current Base metadata. Base
-  renders the prompt only; an AI tool performs the review.
+  periodic Base product self-review prompt with current Base metadata, or writes
+  the rendered Markdown with `--output <path>`. Base renders the prompt only;
+  an AI tool performs the review.
 - `basectl update-profile` creates, refreshes, or removes managed sections in
   Bash and Zsh dotfiles, backing up existing dotfiles before changes.
 - `basectl update [project]` updates the selected project checkout through Git

--- a/cli/bash/commands/basectl/subcommands/prompt.sh
+++ b/cli/bash/commands/basectl/subcommands/prompt.sh
@@ -8,14 +8,15 @@ base_prompt_subcommand_usage() {
     cat <<'EOF'
 Usage:
   basectl prompt list
-  basectl prompt <name>
+  basectl prompt <name> [--output <path>]
 
 Prompts:
   product-self-review  Periodic Base product self-review
 
 Options:
-  -v          Enable DEBUG logging for this subcommand.
-  -h, --help  Show this help text.
+  --output <path>  Write the rendered prompt Markdown to this path.
+  -v               Enable DEBUG logging for this subcommand.
+  -h, --help       Show this help text.
 
 Print repo-owned Markdown prompts for AI-assisted Base workflows. Base renders
 the prompt; an AI tool performs the review.
@@ -31,8 +32,10 @@ base_prompt_usage_error() {
 base_prompt_subcommand_main() {
     local wrapper="$BASE_HOME/bin/base-wrapper"
     local debug=0
+    local output_path=""
     local prompt_args=()
     local renderer_args=()
+    local output_args=()
 
     while (($#)); do
         case "$1" in
@@ -42,6 +45,15 @@ base_prompt_subcommand_main() {
                 ;;
             -v)
                 debug=1
+                shift
+                ;;
+            --output)
+                shift
+                if (($# == 0)); then
+                    base_prompt_usage_error "Option '--output' requires a path."
+                    return $?
+                fi
+                output_path="$1"
                 shift
                 ;;
             -*)
@@ -65,7 +77,10 @@ base_prompt_subcommand_main() {
     fi
 
     ((debug)) && renderer_args+=(--debug)
+    [[ -z "$output_path" ]] || output_args+=(--output "$output_path")
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    BASE_CLI_DISPLAY_COMMAND="basectl prompt" "$wrapper" --project base base_prompt "${renderer_args[@]}" "${prompt_args[@]}"
+    BASE_CLI_DISPLAY_COMMAND="basectl prompt" \
+        "$wrapper" --project base base_prompt \
+        "${renderer_args[@]}" "${prompt_args[@]}" "${output_args[@]}"
 }

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -265,7 +265,7 @@ EOF
     [[ "$output" == *"onboard_projects=base demo"* ]]
     [[ "$output" == *"onboard_profiles=dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab"* ]]
     [[ "$output" == *"prompt_names=list product-self-review"* ]]
-    [[ "$output" == *"prompt_options=--help"* ]]
+    [[ "$output" == *"prompt_options=--output --help"* ]]
     [[ "$output" == *"docs_options=--show-url"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]

--- a/cli/bash/commands/basectl/tests/prompt.bats
+++ b/cli/bash/commands/basectl/tests/prompt.bats
@@ -11,6 +11,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl prompt list"* ]]
     [[ "$output" == *"basectl prompt <name>"* ]]
     [[ "$output" == *"product-self-review"* ]]
+    [[ "$output" == *"--output <path>"* ]]
 }
 
 @test "basectl prompt forwards prompt names to the Python prompt renderer" {
@@ -69,6 +70,37 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"# rendered prompt"* ]]
     [ "$(cat "$state_file")" = "--debug product-self-review" ]
+}
+
+@test "basectl prompt forwards output path to the Python prompt renderer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local state_file="$TEST_TMPDIR/prompt-output-state"
+    local output_path="$TEST_TMPDIR/product-self-review.md"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" ]]; then
+    shift 2
+    printf '%s\n' "$*" > "${BASE_TEST_PROMPT_STATE:?}"
+    printf "Wrote prompt 'product-self-review' to %s\n" "${BASE_TEST_PROMPT_OUTPUT:?}"
+    exit 0
+fi
+printf 'unexpected prompt python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROMPT_STATE="$state_file" \
+        BASE_TEST_PROMPT_OUTPUT="$output_path" \
+        "$BASE_REPO_ROOT/bin/basectl" prompt product-self-review --output "$output_path"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Wrote prompt 'product-self-review' to $output_path"* ]]
+    [ "$(cat "$state_file")" = "product-self-review --output $output_path" ]
 }
 
 @test "basectl prompt list delegates to the Python prompt renderer" {

--- a/cli/python/base_prompt/engine.py
+++ b/cli/python/base_prompt/engine.py
@@ -42,15 +42,24 @@ def main(argv: list[str] | None = None) -> int:
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
+@base_cli.option("--output", "output_path", help="Output path for the rendered prompt Markdown.")
 @base_cli.argument("prompt_name", required=False)
-def run(ctx: base_cli.Context, prompt_name: str | None) -> int:
+def run(ctx: base_cli.Context, output_path: str | None, prompt_name: str | None) -> int:
     try:
         if prompt_name == "list":
+            if output_path:
+                raise PromptUsageError("Option '--output' can only be used with a prompt name.")
             return list_prompts()
         if not prompt_name:
             raise PromptUsageError("The 'prompt' command requires 'list' or a prompt name.")
         prompt = prompt_definition(prompt_name)
-        print(render_prompt(ctx.base_home, prompt), end="")
+        content = render_prompt(ctx.base_home, prompt)
+        if output_path:
+            destination = Path(output_path).expanduser()
+            write_prompt(destination, content)
+            print(f"Wrote prompt '{prompt.name}' to {destination}")
+        else:
+            print(content, end="")
         return base_cli.ExitCode.SUCCESS
     except PromptUsageError as exc:
         print_usage(file=sys.stderr)
@@ -66,10 +75,13 @@ def print_usage(file=sys.stdout) -> None:
     print(
         f"""Usage:
   {command} list
-  {command} <name>
+  {command} <name> [--output <path>]
 
 Prompts:
   product-self-review  Periodic Base product self-review
+
+Options:
+  --output <path>  Write the rendered prompt Markdown to this path.
 
 Purpose:
   Print repo-owned Markdown prompts for AI-assisted Base workflows. Base
@@ -106,6 +118,14 @@ def render_prompt(base_home: Path, prompt: PromptDefinition) -> str:
         "version": read_version(base_home),
     }
     return render_template(template, values)
+
+
+def write_prompt(destination: Path, content: str) -> None:
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise PromptError(f"Unable to write prompt to '{destination}': {exc}") from exc
 
 
 def read_version(base_home: Path) -> str:

--- a/cli/python/base_prompt/tests/test_engine.py
+++ b/cli/python/base_prompt/tests/test_engine.py
@@ -50,6 +50,20 @@ class BasePromptTests(unittest.TestCase):
         self.assertIn("How useful is Base, and for whom?", stdout)
         self.assertIn("Do not update files unless explicitly asked.", stdout)
 
+    def test_product_self_review_prompt_can_write_to_output_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "product-self-review.md"
+
+            status, stdout, stderr = invoke(["product-self-review", "--output", str(output_path)])
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertEqual(stdout, f"Wrote prompt 'product-self-review' to {output_path}\n")
+            written = output_path.read_text(encoding="utf-8")
+            self.assertIn("# Base Product Self-Review", written)
+            self.assertIn("Project: base", written)
+            self.assertIn("Do not update files unless explicitly asked.", written)
+
     def test_unknown_prompt_reports_usage_error(self) -> None:
         status, stdout, stderr = invoke(["missing-prompt"])
 
@@ -57,6 +71,17 @@ class BasePromptTests(unittest.TestCase):
         self.assertEqual(stdout, "")
         self.assertIn("Usage:", stderr)
         self.assertIn("ERROR: Unknown prompt 'missing-prompt'.", stderr)
+
+    def test_output_is_not_allowed_for_prompt_list(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "prompts.md"
+
+            status, stdout, stderr = invoke(["list", "--output", str(output_path)])
+
+            self.assertEqual(status, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("ERROR: Option '--output' can only be used with a prompt name.", stderr)
+            self.assertFalse(output_path.exists())
 
     def test_usage_errors_use_delegated_display_command(self) -> None:
         status, stdout, stderr = invoke(

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -124,4 +124,4 @@ daily project loop commands from the local checkout.
 | `basectl docs` | Open the Base documentation home page on GitHub. | `--show-url` |
 | `basectl export-context [project]` | Export a project's `.ai-context/` directory as Markdown or Zip. | `--workspace <path>`, `--format <markdown\|zip>`, `--output <path>`, `--print`, `--list-files` |
 | `basectl prompt list` | List repo-owned Markdown prompts that Base can render for AI-assisted workflows. | none |
-| `basectl prompt product-self-review` | Print the periodic Base product self-review prompt with current Base metadata. | none |
+| `basectl prompt product-self-review` | Print the periodic Base product self-review prompt with current Base metadata. | `--output <path>` |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -272,7 +272,7 @@ _base_basectl_completion() {
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "list product-self-review" "$cur"
             else
-                _base_basectl_completion_compgen "-v -h --help" "$cur"
+                _base_basectl_completion_compgen "--output -v -h --help" "$cur"
             fi
             ;;
         docs)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -280,6 +280,7 @@ _base_basectl_completion() {
             ;;
         prompt)
             _arguments '1:prompt:(list product-self-review)' \
+                '--output[Write rendered prompt Markdown to this path]:path:_files' \
                 '-v[Enable DEBUG logging]' \
                 '(-h --help)'{-h,--help}'[Show help text]'
             ;;

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -246,6 +246,20 @@ assert_bash_completion_options_match_help() {
     [[ "$block" == *"--replace-project"* ]]
 }
 
+@test "Zsh prompt completion includes output option" {
+    local block
+
+    block="$(
+        awk '
+            /^[[:space:]]*prompt\)/ { in_block = 1 }
+            in_block && /^[[:space:]]*;;/ { exit }
+            in_block { print }
+        ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
+    )"
+
+    [[ "$block" == *"--output"* ]]
+}
+
 @test "Bash project-name completions reuse shell-session project cache" {
     local base_home="$TEST_TMPDIR/base"
     local wrapper="$base_home/bin/base-wrapper"


### PR DESCRIPTION
## Summary

- add `basectl prompt <name> --output <path>` for writing rendered prompt Markdown
- keep `prompt list` as a listing command and reject `--output` there
- update Bash/Zsh completions and prompt docs for the new option

Fixes #1017

## Validation

- `env UV_CACHE_DIR=/private/tmp/base-uv-cache PYTHONPATH=cli/python:lib/python uv run --with click python -m unittest cli.python.base_prompt.tests.test_engine`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/prompt.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1017-cache /Users/rameshhp/work/base-worktrees/1017-prompt-output/bin/basectl prompt product-self-review --output /private/tmp/base-product-self-review-test.md`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1017-cache UV_CACHE_DIR=/private/tmp/base-uv-cache ./bin/base-test`
