### PR TITLE
Guard prompt rendering when Base home is unavailable

### DIFF
--- a/cli/python/base_prompt/engine.py
+++ b/cli/python/base_prompt/engine.py
@@ -53,7 +53,7 @@ def run(ctx: base_cli.Context, output_path: str | None, prompt_name: str | None)
         if not prompt_name:
             raise PromptUsageError("The 'prompt' command requires 'list' or a prompt name.")
         prompt = prompt_definition(prompt_name)
-        content = render_prompt(ctx.base_home, prompt)
+        content = render_prompt(require_base_home(ctx), prompt)
         if output_path:
             destination = Path(output_path).expanduser()
             write_prompt(destination, content)
@@ -101,6 +101,12 @@ def prompt_definition(name: str) -> PromptDefinition:
         if prompt.name == name:
             return prompt
     raise PromptUsageError(f"Unknown prompt '{name}'.")
+
+
+def require_base_home(ctx: base_cli.Context) -> Path:
+    if ctx.base_home is None:
+        raise PromptError("Base home is unavailable. Run this command through 'basectl prompt'.")
+    return ctx.base_home
 
 
 def render_prompt(base_home: Path, prompt: PromptDefinition) -> str:

--- a/cli/python/base_prompt/tests/test_engine.py
+++ b/cli/python/base_prompt/tests/test_engine.py
@@ -25,6 +25,16 @@ def invoke(args: list[str], env: dict[str, str] | None = None) -> tuple[int, str
     return status, stdout.getvalue(), stderr.getvalue()
 
 
+def invoke_without_base_home(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with tempfile.TemporaryDirectory() as home_dir:
+        with mock.patch.dict(os.environ, {"HOME": home_dir}, clear=True):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
 class BasePromptTests(unittest.TestCase):
     def test_list_includes_product_self_review_prompt(self) -> None:
         status, stdout, stderr = invoke(["list"])
@@ -63,6 +73,14 @@ class BasePromptTests(unittest.TestCase):
             self.assertIn("# Base Product Self-Review", written)
             self.assertIn("Project: base", written)
             self.assertIn("Do not update files unless explicitly asked.", written)
+
+    def test_product_self_review_prompt_requires_base_home(self) -> None:
+        status, stdout, stderr = invoke_without_base_home(["product-self-review"])
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("ERROR: Base home is unavailable.", stderr)
+        self.assertIn("basectl prompt", stderr)
 
     def test_unknown_prompt_reports_usage_error(self) -> None:
         status, stdout, stderr = invoke(["missing-prompt"])


### PR DESCRIPTION
## Summary

- Add a controlled prompt error when `BASE_HOME` is unavailable during prompt rendering.
- Add a regression test for direct package execution without `BASE_HOME`.

## Issue

Closes #1460

## Validation

- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_prompt/tests/test_engine.py::BasePromptTests::test_product_self_review_prompt_requires_base_home -q`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_prompt/tests/test_engine.py`
- `env -u BASE_HOME bin/base-wrapper --project base base_prompt list`
- `git diff --check`

## Demo Impact

None.

## Notes

- `.ai-context` not updated; this is a narrow error-handling hardening change with no product surface change.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`