### PR TITLE
Split setup manifest check aggregation

### DIFF
--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -1,52 +1,35 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
-from base_cli.config import UserConfig, UserIdeConfig
+from base_cli.config import UserConfig
 from base_cli.paths import discover_manifest
 
-from .artifacts import check_artifact
-from .artifacts import resolve_artifact_definitions
-from .build import check_build
-from .checks import ArtifactCheck
 from .checks import check_to_json
 from .checks import checks_payload_to_json
 from .checks import checks_status
 from .checks import doctor_status
 from .checks import print_doctor_finding
-from .command_lint import check_manifest_commands
-from .demo import check_demo
-from .delegates import check_brewfile
-from .delegates import check_mise
 from .errors import ArtifactError
-from .git_remote import check_git_remote
-from .health import check_required_env
-from .health import check_required_ports
-from .ide import check_ide_extensions
-from .ide import check_ide_installs
-from .ide import check_ide_settings
-from .ide import ide_preference_warning_checks
 from .manifest import BaseManifest, ManifestError, read_manifest
-from .pyproject import check_pyproject
+from .manifest_checks import empty_user_config  # pylint: disable=unused-import
+from .manifest_checks import IDE_EXTENSION_PROFILE  # pylint: disable=unused-import
+from .manifest_checks import manifest_checks
+from .manifest_checks import pre_venv_manifest_checks
+from .manifest_checks import setup_profile_enabled  # pylint: disable=unused-import
 from .project_routing import route_for_manifest
 from .project_routing import route_to_text
-from .python_policy import python_requirement_checks
-from .python_runtime import project_python_runtime_check
-from .setup_reconcile import effective_manifest_with_user_config
+from .setup_reconcile import effective_manifest_with_user_config  # pylint: disable=unused-import
 from .setup_reconcile import project_runtime_argument  # pylint: disable=unused-import
 from .setup_reconcile import reconcile_bootstrap_artifacts
 from .setup_reconcile import reconcile_manifest
-from .setup_reconcile import setup_artifacts
-from .uv import check_uv
 
 
 app = base_cli.App(name="base_setup")
-IDE_EXTENSION_PROFILE = "dev"
 
 
 @dataclass(frozen=True)
@@ -314,69 +297,3 @@ def doctor_pre_venv_manifest(
         if status == "error":
             error_count += 1
     return min(error_count, 125)
-
-
-def pre_venv_manifest_checks(manifest: BaseManifest, remote_network: bool = False) -> tuple[ArtifactCheck, ...]:
-    checks: list[ArtifactCheck] = []
-    checks.extend(python_requirement_checks(manifest))
-    checks.extend(check_git_remote(manifest, check_network=remote_network))
-    return tuple(checks)
-
-
-def manifest_checks(
-    default_manifest: BaseManifest,
-    manifest: BaseManifest,
-    remote_network: bool = False,
-    *,
-    user_config: UserConfig | None = None,
-) -> tuple[ArtifactCheck, ...]:
-    pre_venv_checks: list[ArtifactCheck] = []
-    checks: list[ArtifactCheck] = []
-    active_user_config = user_config if user_config is not None else empty_user_config()
-    effective_manifest = effective_manifest_with_user_config(manifest, active_user_config)
-    artifacts = setup_artifacts(default_manifest, effective_manifest)
-    definitions = resolve_artifact_definitions(artifacts)
-
-    pre_venv_checks.extend(pre_venv_manifest_checks(effective_manifest, remote_network=remote_network))
-    checks.extend(ide_preference_warning_checks(manifest, active_user_config))
-
-    if effective_manifest.brewfile is not None:
-        checks.append(check_brewfile(effective_manifest))
-    if effective_manifest.mise is not None:
-        checks.append(check_mise(effective_manifest))
-
-    checks.extend(check_required_env(effective_manifest))
-    checks.extend(check_required_ports(effective_manifest))
-    checks.extend(check_build(effective_manifest))
-    checks.extend(check_demo(effective_manifest))
-    checks.extend(check_manifest_commands(effective_manifest))
-    checks.extend(check_ide_installs(effective_manifest))
-    if setup_profile_enabled(IDE_EXTENSION_PROFILE):
-        checks.extend(check_ide_extensions(effective_manifest))
-    checks.extend(check_ide_settings(effective_manifest))
-    checks.extend(check_uv(effective_manifest))
-    checks.extend(check_pyproject(effective_manifest))
-    checks.extend(project_python_runtime_check(effective_manifest))
-
-    for artifact, definition in zip(artifacts, definitions, strict=True):
-        checks.append(check_artifact(effective_manifest.project_name, artifact, definition))
-
-    if not pre_venv_checks and not checks:
-        checks.append(
-            ArtifactCheck(
-                name="manifest",
-                ok=True,
-                message=f"Project '{effective_manifest.project_name}' declares no artifacts.",
-                fix="",
-                finding_id="BASE-P001",
-            )
-        )
-    return tuple(pre_venv_checks + checks)
-
-
-def setup_profile_enabled(profile: str) -> bool:
-    return profile in os.environ.get("BASE_SETUP_PROFILES", "").split()
-
-
-def empty_user_config() -> UserConfig:
-    return UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))

--- a/cli/python/base_setup/manifest_checks.py
+++ b/cli/python/base_setup/manifest_checks.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+
+from base_cli.config import UserConfig, UserIdeConfig
+
+from .artifacts import check_artifact
+from .artifacts import resolve_artifact_definitions
+from .build import check_build
+from .checks import ArtifactCheck
+from .command_lint import check_manifest_commands
+from .demo import check_demo
+from .delegates import check_brewfile
+from .delegates import check_mise
+from .git_remote import check_git_remote
+from .health import check_required_env
+from .health import check_required_ports
+from .ide import check_ide_extensions
+from .ide import check_ide_installs
+from .ide import check_ide_settings
+from .ide import ide_preference_warning_checks
+from .manifest import BaseManifest
+from .pyproject import check_pyproject
+from .python_policy import python_requirement_checks
+from .python_runtime import project_python_runtime_check
+from .setup_reconcile import effective_manifest_with_user_config
+from .setup_reconcile import setup_artifacts
+from .uv import check_uv
+
+IDE_EXTENSION_PROFILE = "dev"
+
+
+def pre_venv_manifest_checks(manifest: BaseManifest, remote_network: bool = False) -> tuple[ArtifactCheck, ...]:
+    checks: list[ArtifactCheck] = []
+    checks.extend(python_requirement_checks(manifest))
+    checks.extend(check_git_remote(manifest, check_network=remote_network))
+    return tuple(checks)
+
+
+def manifest_checks(
+    default_manifest: BaseManifest,
+    manifest: BaseManifest,
+    remote_network: bool = False,
+    *,
+    user_config: UserConfig | None = None,
+) -> tuple[ArtifactCheck, ...]:
+    pre_venv_checks: list[ArtifactCheck] = []
+    checks: list[ArtifactCheck] = []
+    active_user_config = user_config if user_config is not None else empty_user_config()
+    effective_manifest = effective_manifest_with_user_config(manifest, active_user_config)
+    artifacts = setup_artifacts(default_manifest, effective_manifest)
+    definitions = resolve_artifact_definitions(artifacts)
+
+    pre_venv_checks.extend(pre_venv_manifest_checks(effective_manifest, remote_network=remote_network))
+    checks.extend(ide_preference_warning_checks(manifest, active_user_config))
+
+    if effective_manifest.brewfile is not None:
+        checks.append(check_brewfile(effective_manifest))
+    if effective_manifest.mise is not None:
+        checks.append(check_mise(effective_manifest))
+
+    checks.extend(check_required_env(effective_manifest))
+    checks.extend(check_required_ports(effective_manifest))
+    checks.extend(check_build(effective_manifest))
+    checks.extend(check_demo(effective_manifest))
+    checks.extend(check_manifest_commands(effective_manifest))
+    checks.extend(check_ide_installs(effective_manifest))
+    if setup_profile_enabled(IDE_EXTENSION_PROFILE):
+        checks.extend(check_ide_extensions(effective_manifest))
+    checks.extend(check_ide_settings(effective_manifest))
+    checks.extend(check_uv(effective_manifest))
+    checks.extend(check_pyproject(effective_manifest))
+    checks.extend(project_python_runtime_check(effective_manifest))
+
+    for artifact, definition in zip(artifacts, definitions, strict=True):
+        checks.append(check_artifact(effective_manifest.project_name, artifact, definition))
+
+    if not pre_venv_checks and not checks:
+        checks.append(
+            ArtifactCheck(
+                name="manifest",
+                ok=True,
+                message=f"Project '{effective_manifest.project_name}' declares no artifacts.",
+                fix="",
+                finding_id="BASE-P001",
+            )
+        )
+    return tuple(pre_venv_checks + checks)
+
+
+def setup_profile_enabled(profile: str) -> bool:
+    return profile in os.environ.get("BASE_SETUP_PROFILES", "").split()
+
+
+def empty_user_config() -> UserConfig:
+    return UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))

--- a/cli/python/base_setup/tests/test_manifest_checks.py
+++ b/cli/python/base_setup/tests/test_manifest_checks.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import unittest
+
+from base_setup import engine
+from base_setup import manifest_checks
+
+
+class ManifestChecksModuleTests(unittest.TestCase):
+    def test_engine_reexports_manifest_check_helpers(self) -> None:
+        self.assertIs(engine.manifest_checks, manifest_checks.manifest_checks)
+        self.assertIs(engine.pre_venv_manifest_checks, manifest_checks.pre_venv_manifest_checks)
+        self.assertIs(engine.setup_profile_enabled, manifest_checks.setup_profile_enabled)
+        self.assertIs(engine.empty_user_config, manifest_checks.empty_user_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Move setup manifest check aggregation into `base_setup.manifest_checks`.
- Keep `base_setup.engine` compatibility re-exports for existing callers/tests.
- Add a contract test for the new module and engine compatibility surface.

## Issue

Closes #1474

## Validation

- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_manifest_checks.py -q`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_build.py cli/python/base_setup/tests/test_bootstrap.py -q`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/engine.py cli/python/base_setup/manifest_checks.py cli/python/base_setup/tests/test_manifest_checks.py`
- `python3 -m compileall -q cli/python/base_setup/engine.py cli/python/base_setup/manifest_checks.py`
- `git diff --check`

## Demo Impact

None.

## Notes

- `.ai-context` not updated; this is an internal setup-module refactor with no user-facing behavior change.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`