### PR TITLE
Refactor setup artifact facade exports

### DIFF
--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -13,6 +13,7 @@ from .prerequisites import HomebrewPackageCheckRequest
 from .prerequisites import PrerequisiteCheck
 from .prerequisites import check_homebrew_package
 from .prerequisites import homebrew_package_outdated
+# Keep these re-exports until downstream callers move to base_setup.python_artifacts.
 from .python_artifacts import PIP_INSTALL_COMMAND_PREFIX  # pylint: disable=unused-import
 from .python_artifacts import backup_existing_project_venv  # pylint: disable=unused-import
 from .python_artifacts import create_project_virtualenv  # pylint: disable=unused-import
@@ -30,6 +31,44 @@ from .python_artifacts import reconcile_python_artifact
 from .python_artifacts import reconcile_python_artifacts
 from .python_artifacts import reconcile_python_artifacts_sequential  # pylint: disable=unused-import
 from .registry import ArtifactDefinition, get_artifact_definition
+
+PYTHON_ARTIFACT_COMPAT_EXPORTS = (
+    "PIP_INSTALL_COMMAND_PREFIX",
+    "ProjectRuntimeConfig",
+    "PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS",
+    "backup_existing_project_venv",
+    "create_project_virtualenv",
+    "ensure_existing_project_venv_matches_requirement",
+    "pip_install_command",
+    "project_python_interpreter",
+    "project_runtime_config",
+    "project_venv_dir",
+    "project_venv_recreate_enabled",
+    "python_artifact_installed",
+    "python_package_requirement",
+    "reconcile_python_artifact",
+    "reconcile_python_artifacts",
+    "reconcile_python_artifacts_sequential",
+)
+
+__all__ = (
+    "LINUX_DEBIAN_SYSTEM_TOOL_PACKAGES",
+    "PYTHON_ARTIFACT_COMPAT_EXPORTS",
+    "artifact_check_from_prerequisite",
+    "artifact_details",
+    "check_artifact",
+    "check_homebrew_artifact",
+    "check_python_artifact",
+    "check_system_package_artifact",
+    "merge_artifacts",
+    "platform_artifact_definition",
+    "reconcile_artifact",
+    "reconcile_artifacts",
+    "reconcile_homebrew_artifact",
+    "reconcile_system_package_artifact",
+    "resolve_artifact_definitions",
+    *PYTHON_ARTIFACT_COMPAT_EXPORTS,
+)
 
 LINUX_DEBIAN_SYSTEM_TOOL_PACKAGES = {
     ("tool", "bats-core"): "bats",

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -13,7 +13,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_setup import artifacts, process
+from base_setup import artifacts, process, python_artifacts
 from base_setup.artifacts import merge_artifacts
 from base_setup.errors import ArtifactError
 from base_setup.manifest import ArtifactRequest, read_manifest
@@ -21,6 +21,33 @@ from base_setup.process import format_command
 from base_setup.prerequisites import PrerequisiteCheck
 from base_setup.registry import get_artifact_definition, load_artifact_definitions
 from base_setup.tests.helpers import fake_context, run_engine
+
+
+class ArtifactFacadeTests(unittest.TestCase):
+    def test_artifacts_declares_python_artifact_compatibility_exports(self) -> None:
+        expected_names = {
+            "PIP_INSTALL_COMMAND_PREFIX",
+            "ProjectRuntimeConfig",
+            "PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS",
+            "backup_existing_project_venv",
+            "create_project_virtualenv",
+            "ensure_existing_project_venv_matches_requirement",
+            "pip_install_command",
+            "project_python_interpreter",
+            "project_runtime_config",
+            "project_venv_dir",
+            "project_venv_recreate_enabled",
+            "python_artifact_installed",
+            "python_package_requirement",
+            "reconcile_python_artifact",
+            "reconcile_python_artifacts",
+            "reconcile_python_artifacts_sequential",
+        }
+
+        self.assertLessEqual(expected_names, set(artifacts.__all__))
+        for name in expected_names:
+            with self.subTest(name=name):
+                self.assertIs(getattr(artifacts, name), getattr(python_artifacts, name))
 
 
 class BaseSetupMainTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- declare the public compatibility exports that `base_setup.artifacts` still provides for Python artifact helpers
- add a focused facade test that verifies those names point at `base_setup.python_artifacts`

## Validation
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py::ArtifactFacadeTests::test_artifacts_declares_python_artifact_compatibility_exports -q`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_artifacts.py -q`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/artifacts.py cli/python/base_setup/tests/test_artifacts.py`
- `python3 -m compileall -q cli/python/base_setup/artifacts.py cli/python/base_setup/tests/test_artifacts.py`
- `git diff --check`

Closes #1471
