### PR TITLE
Refactor Homebrew prerequisite request construction

### DIFF
--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -174,41 +174,13 @@ def check_homebrew_artifact(
     artifact: ArtifactRequest,
     definition: ArtifactDefinition,
 ) -> ArtifactCheck:
-    request = HomebrewPackageCheckRequest(
+    request = HomebrewPackageCheckRequest.for_artifact(
+        project=project,
         name=artifact.name,
         manager=definition.manager,
         version=artifact.version,
         package=definition.package,
         timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
-        unsupported_manager_message=f"Artifact manager '{definition.manager}' is not implemented.",
-        unsupported_manager_fix=f"basectl setup {project}",
-        unsupported_manager_finding_id="BASE-P030",
-        unsupported_version_message=(
-            f"Homebrew artifact '{artifact.name}' specifies version '{artifact.version}', "
-            "but Base only supports Homebrew artifact version 'latest' right now."
-        ),
-        unsupported_version_fix=f"Update '{artifact.name}' in the project manifest to use version 'latest'.",
-        unsupported_version_finding_id="BASE-P031",
-        missing_homebrew_message=f"Homebrew is required to check artifact '{artifact.name}'.",
-        missing_homebrew_fix="basectl setup",
-        missing_homebrew_finding_id="BASE-P032",
-        timeout_message=(
-            f"Homebrew check for artifact '{artifact.name}' timed out after "
-            f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
-        ),
-        timeout_fix=f"Retry 'basectl doctor {project}' or inspect Homebrew with 'brew doctor'.",
-        timeout_finding_id="BASE-P033",
-        outdated_message=f"Artifact '{artifact.name}' is outdated via Homebrew package '{definition.package}'.",
-        outdated_fix=f"basectl setup {project}",
-        package_finding_id="BASE-P033",
-        installed_message=(
-            f"Artifact '{artifact.name}' is installed via Homebrew package "
-            f"'{definition.package}' and is current."
-        ),
-        missing_package_message=(
-            f"Artifact '{artifact.name}' is not installed via Homebrew package '{definition.package}'."
-        ),
-        missing_package_fix=f"basectl setup {project}",
         details=artifact_details(definition),
     )
     return artifact_check_from_prerequisite(

--- a/cli/python/base_setup/prerequisites.py
+++ b/cli/python/base_setup/prerequisites.py
@@ -49,6 +49,48 @@ class HomebrewPackageCheckRequest:
     missing_package_fix: str
     details: Mapping[str, Any] = field(default_factory=dict)
 
+    @classmethod
+    def for_artifact(  # pylint: disable=too-many-arguments
+        cls,
+        *,
+        project: str,
+        name: str,
+        manager: str,
+        version: str,
+        package: str,
+        timeout_seconds: int,
+        details: Mapping[str, Any] | None = None,
+    ) -> HomebrewPackageCheckRequest:
+        return cls(
+            name=name,
+            manager=manager,
+            version=version,
+            package=package,
+            timeout_seconds=timeout_seconds,
+            unsupported_manager_message=f"Artifact manager '{manager}' is not implemented.",
+            unsupported_manager_fix=f"basectl setup {project}",
+            unsupported_manager_finding_id="BASE-P030",
+            unsupported_version_message=(
+                f"Homebrew artifact '{name}' specifies version '{version}', "
+                "but Base only supports Homebrew artifact version 'latest' right now."
+            ),
+            unsupported_version_fix=f"Update '{name}' in the project manifest to use version 'latest'.",
+            unsupported_version_finding_id="BASE-P031",
+            missing_homebrew_message=f"Homebrew is required to check artifact '{name}'.",
+            missing_homebrew_fix="basectl setup",
+            missing_homebrew_finding_id="BASE-P032",
+            timeout_message=f"Homebrew check for artifact '{name}' timed out after {timeout_seconds} seconds.",
+            timeout_fix=f"Retry 'basectl doctor {project}' or inspect Homebrew with 'brew doctor'.",
+            timeout_finding_id="BASE-P033",
+            outdated_message=f"Artifact '{name}' is outdated via Homebrew package '{package}'.",
+            outdated_fix=f"basectl setup {project}",
+            package_finding_id="BASE-P033",
+            installed_message=f"Artifact '{name}' is installed via Homebrew package '{package}' and is current.",
+            missing_package_message=f"Artifact '{name}' is not installed via Homebrew package '{package}'.",
+            missing_package_fix=f"basectl setup {project}",
+            details={} if details is None else details,
+        )
+
 
 @dataclass(frozen=True)
 class GitHubCliAuthCheckRequest:

--- a/cli/python/base_setup/tests/test_prerequisites.py
+++ b/cli/python/base_setup/tests/test_prerequisites.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import unittest
+
+from base_setup.prerequisites import HomebrewPackageCheckRequest
+
+
+class HomebrewPackageCheckRequestTests(unittest.TestCase):
+    def test_for_artifact_builds_stable_homebrew_messages(self) -> None:
+        request = HomebrewPackageCheckRequest.for_artifact(
+            project="demo",
+            name="terraform",
+            manager="apt",
+            version="1.8.5",
+            package="terraform",
+            timeout_seconds=11,
+            details={"target": "system"},
+        )
+
+        self.assertEqual(request.name, "terraform")
+        self.assertEqual(request.manager, "apt")
+        self.assertEqual(request.version, "1.8.5")
+        self.assertEqual(request.package, "terraform")
+        self.assertEqual(request.timeout_seconds, 11)
+        self.assertEqual(request.unsupported_manager_message, "Artifact manager 'apt' is not implemented.")
+        self.assertEqual(request.unsupported_manager_fix, "basectl setup demo")
+        self.assertEqual(request.unsupported_manager_finding_id, "BASE-P030")
+        self.assertEqual(
+            request.unsupported_version_message,
+            "Homebrew artifact 'terraform' specifies version '1.8.5', "
+            "but Base only supports Homebrew artifact version 'latest' right now.",
+        )
+        self.assertEqual(
+            request.unsupported_version_fix,
+            "Update 'terraform' in the project manifest to use version 'latest'.",
+        )
+        self.assertEqual(request.unsupported_version_finding_id, "BASE-P031")
+        self.assertEqual(request.missing_homebrew_message, "Homebrew is required to check artifact 'terraform'.")
+        self.assertEqual(request.missing_homebrew_fix, "basectl setup")
+        self.assertEqual(request.missing_homebrew_finding_id, "BASE-P032")
+        self.assertEqual(request.timeout_message, "Homebrew check for artifact 'terraform' timed out after 11 seconds.")
+        self.assertEqual(request.timeout_fix, "Retry 'basectl doctor demo' or inspect Homebrew with 'brew doctor'.")
+        self.assertEqual(request.timeout_finding_id, "BASE-P033")
+        self.assertEqual(request.outdated_message, "Artifact 'terraform' is outdated via Homebrew package 'terraform'.")
+        self.assertEqual(request.outdated_fix, "basectl setup demo")
+        self.assertEqual(request.package_finding_id, "BASE-P033")
+        self.assertEqual(
+            request.installed_message,
+            "Artifact 'terraform' is installed via Homebrew package 'terraform' and is current.",
+        )
+        self.assertEqual(
+            request.missing_package_message,
+            "Artifact 'terraform' is not installed via Homebrew package 'terraform'.",
+        )
+        self.assertEqual(request.missing_package_fix, "basectl setup demo")
+        self.assertEqual(request.details, {"target": "system"})


### PR DESCRIPTION
## Summary
- add `HomebrewPackageCheckRequest.for_artifact()` to centralize Base artifact diagnostic text
- switch `check_homebrew_artifact()` to the builder while preserving existing Homebrew check behavior
- add focused prerequisite coverage for the generated request fields

## Validation
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_prerequisites.py cli/python/base_setup/tests/test_artifacts.py cli/python/base_setup/tests/test_diagnostics.py -q`
- `PYTHONPATH=lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pylint cli/python/base_setup/prerequisites.py cli/python/base_setup/artifacts.py cli/python/base_setup/tests/test_prerequisites.py`
- `python3 -m compileall -q cli/python/base_setup/prerequisites.py cli/python/base_setup/artifacts.py cli/python/base_setup/tests/test_prerequisites.py`
- `git diff --check`

Closes #1472
