### PR TITLE
Fix gh project completion drift

### DIFF
--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -286,8 +286,8 @@ EOF
     [[ "$output" == *"ci_check_options=--format --manifest --profile"* ]]
     [[ "$output" == *"gh_areas=issue pr branch worktree project"* ]]
     [[ "$output" == *"gh_project_commands=doctor configure issue"* ]]
-    [[ "$output" == *"gh_project_configure_options=--project --owner --schema --initiative-option --repo --replace-project --dry-run"* ]]
-    [[ "$output" == *"gh_project_issue_set_fields_options=--repo --project --owner --status --priority --area --initiative --size --dry-run"* ]]
+    [[ "$output" == *"gh_project_configure_options=--project --owner --schema --config --copy-fields-from --initiative-option --repo --replace-project --dry-run"* ]]
+    [[ "$output" == *"gh_project_issue_set_fields_options=--repo --project --owner --config --status --priority --area --initiative --size --dry-run"* ]]
     [[ "$output" == *"gh_worktree_commands=prune"* ]]
     [[ "$output" == *"gh_worktree_prune_options=--dry-run --yes"* ]]
 }

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -335,13 +335,13 @@ _base_basectl_completion() {
                             _base_basectl_completion_compgen "--project --owner --schema -h --help" "$cur"
                             ;;
                         configure)
-                            _base_basectl_completion_compgen "--project --owner --schema --initiative-option --repo --replace-project --dry-run -h --help" "$cur"
+                            _base_basectl_completion_compgen "--project --owner --schema --config --copy-fields-from --initiative-option --repo --replace-project --dry-run -h --help" "$cur"
                             ;;
                         issue)
                             if ((COMP_CWORD == 4)); then
                                 _base_basectl_completion_compgen "set-fields" "$cur"
                             else
-                                _base_basectl_completion_compgen "--repo --project --owner --status --priority --area --initiative --size --dry-run -h --help" "$cur"
+                                _base_basectl_completion_compgen "--repo --project --owner --config --status --priority --area --initiative --size --dry-run -h --help" "$cur"
                             fi
                             ;;
                     esac


### PR DESCRIPTION
## Summary

- add the missing `basectl gh project configure` completion options for `--config` and `--copy-fields-from`
- add the missing `basectl gh project issue set-fields` completion option for `--config`
- update the completion regression test to match the documented Project command help

Fixes #1487.

## Validation

- Red: `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/completions.bats` failed on the missing `gh_project_configure_options` assertion before the production change
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/completions.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats`
- `bash -n lib/shell/completions/basectl_completion.sh cli/bash/commands/basectl/tests/completions.bats`
- `shellcheck -S warning lib/shell/completions/basectl_completion.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-pr-train-1487 ./bin/base-test`
