### PR TITLE
Clear warning-level ShellCheck findings

### DIFF
--- a/bin/basectl
+++ b/bin/basectl
@@ -158,6 +158,7 @@ basectl_ensure_supported_bash() {
             [[ -x "$candidate" ]] || continue
             [[ "$candidate" == "${BASH:-}" ]] && continue
             basectl_rosetta_bash_candidate_allowed "$candidate" || continue
+            # shellcheck disable=SC2093 # Intentional one-shot re-exec under the selected Bash.
             exec "$candidate" "$0" "$@"
         done
 
@@ -170,6 +171,7 @@ basectl_ensure_supported_bash() {
     for candidate in "${candidates[@]}"; do
         [[ -x "$candidate" ]] || continue
         [[ "$candidate" == "${BASH:-}" ]] && continue
+        # shellcheck disable=SC2093 # Intentional one-shot re-exec under a supported Bash.
         exec "$candidate" "$0" "$@"
     done
 
@@ -249,6 +251,7 @@ basectl_run_bash_script() {
     export BASE_BASH_COMMAND_DIR="$command_dir"
     export BASE_BASH_COMMAND_SCRIPT="$script_path"
 
+    # shellcheck disable=SC2034 # Consumed by base_init.sh during this source call.
     BASE_BASH_BOOTSTRAP_SOURCE="$script_path"
     # shellcheck source=/dev/null
     source "$base_home/base_init.sh" "$@" || exit $?

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,8 +38,8 @@ bootstrap_expand_path() {
     local path="$1"
 
     case "$path" in
-        "~") printf '%s\n' "$HOME" ;;
-        "~/"*) printf '%s/%s\n' "$HOME" "${path#"~/"}" ;;
+        \~) printf '%s\n' "$HOME" ;;
+        \~/*) printf '%s/%s\n' "$HOME" "${path#\~/}" ;;
         *) printf '%s\n' "$path" ;;
     esac
 }

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -209,6 +209,7 @@ basectl_verify_home() {
     local file missing=()
 
     if [[ ! -d "$base_home" ]]; then
+        # shellcheck disable=SC2034 # Read by the caller after this helper returns non-zero.
         BASE_CLI_ERROR_MESSAGE="Base home '$base_home' is not a directory."
         return 1
     fi
@@ -220,6 +221,7 @@ basectl_verify_home() {
     done
 
     if (( ${#missing[@]} > 0 )); then
+        # shellcheck disable=SC2034 # Read by the caller after this helper returns non-zero.
         BASE_CLI_ERROR_MESSAGE="Files missing in Base home '$base_home': ${missing[*]}"
         return 1
     fi

--- a/cli/bash/commands/basectl/subcommands/export_context.sh
+++ b/cli/bash/commands/basectl/subcommands/export_context.sh
@@ -37,6 +37,7 @@ base_export_context_subcommand_main() {
     local resolve_args=() exporter_args=()
     local resolve_fields=()
     local arg
+    # shellcheck disable=SC2034 # Passed by name to cli_parse_options.
     local -a option_specs=(
         "debug|flag|-v"
         "workspace|value|--workspace"

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -479,6 +479,7 @@ base_gh_issue_default_assignee_from_config() {
 
 base_gh_join_csv() {
     local joined=""
+    # shellcheck disable=SC2034 # Passed by name to str_join.
     local values=("$@")
 
     str_join joined ", " values

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -56,14 +56,16 @@ base_onboard_read_prompt_answer() {
     local tty_fd="${BASE_ONBOARD_TTY_FD:-}"
     local tty_path="${BASE_ONBOARD_TTY_PATH:-/dev/tty}"
 
+    [[ -n "$answer_var" ]] || return 1
+
     if [[ -n "$tty_fd" ]]; then
         [[ "$tty_fd" =~ ^[0-9]+$ ]] || return 1
-        IFS= read -r -u "$tty_fd" "$answer_var"
+        IFS= read -r -u "$tty_fd" "${answer_var:?}"
         return $?
     fi
 
     [[ -r "$tty_path" ]] || return 1
-    IFS= read -r "$answer_var" < "$tty_path"
+    IFS= read -r "${answer_var:?}" < "$tty_path"
 }
 
 base_onboard_prompt() {

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1260,6 +1260,7 @@ base_repo_pretty_command() {
 
 base_repo_join_csv() {
     local joined=""
+    # shellcheck disable=SC2034 # Passed by name to str_join.
     local values=("$@")
 
     str_join joined ", " values

--- a/install.sh
+++ b/install.sh
@@ -33,8 +33,8 @@ install_die() {
 install_expand_path() {
     local path="$1"
     case "$path" in
-        "~") printf '%s\n' "$HOME" ;;
-        "~/"*) printf '%s/%s\n' "$HOME" "${path#"~/"}" ;;
+        \~) printf '%s\n' "$HOME" ;;
+        \~/*) printf '%s/%s\n' "$HOME" "${path#\~/}" ;;
         *) printf '%s\n' "$path" ;;
     esac
 }

--- a/lib/shell/base_platform_tools.sh
+++ b/lib/shell/base_platform_tools.sh
@@ -89,22 +89,23 @@ base_platform_tools_set_ordered_path() {
     local base_bin="${1:-}"
     local platform_tools_bin="${2:-}"
     local project_bin="${3:-}"
+    local new_path=""
     local rest_path
 
     rest_path="$(base_platform_tools_path_without_entries "$base_bin" "$platform_tools_bin" "$project_bin" "${PATH:-}")"
 
-    PATH=""
     if [[ -n "$base_bin" && -d "$base_bin" ]]; then
-        PATH="$base_bin"
+        new_path="$base_bin"
     fi
     if [[ -n "$platform_tools_bin" && -d "$platform_tools_bin" ]]; then
-        PATH="${PATH:+$PATH:}$platform_tools_bin"
+        new_path="${new_path:+$new_path:}$platform_tools_bin"
     fi
     if [[ -n "$project_bin" && -d "$project_bin" ]]; then
-        PATH="${PATH:+$PATH:}$project_bin"
+        new_path="${new_path:+$new_path:}$project_bin"
     fi
     if [[ -n "$rest_path" ]]; then
-        PATH="${PATH:+$PATH:}$rest_path"
+        new_path="${new_path:+$new_path:}$rest_path"
     fi
+    PATH="$new_path"
     export PATH
 }

--- a/lib/shell/bash_profile
+++ b/lib/shell/bash_profile
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #
 # bash_profile
 #     Base-managed login-shell snippet for Bash.

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #
 # bashrc
 #     Base-managed interactive-shell integration for Bash dotfiles.

--- a/lib/shell/zsh_defaults.sh
+++ b/lib/shell/zsh_defaults.sh
@@ -124,4 +124,5 @@ setopt no_beep
 setopt prompt_subst
 setopt share_history
 
+# shellcheck disable=SC2034 # Consumed by zsh as the interactive prompt.
 PROMPT='%* %m $(_base_zsh_defaults_git_prompt)%1~: '


### PR DESCRIPTION
## Summary
- clear warning-level ShellCheck findings across non-test Bash entrypoints, basectl command files, and shell snippets
- keep pass-by-name Bash 4.2 contracts explicit with focused ShellCheck directives
- replace the temporary `PATH` accumulator with a local variable and escape literal tilde cases without changing expansion behavior

Fixes #1493

## Validation
- RED: `bash -lc 'shellcheck -S warning base_init.sh bin/base-test bin/base-wrapper bin/basectl bootstrap.sh install.sh demo/demo.sh templates/project-install.sh cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/*.sh lib/bash/version/lib_version.sh lib/shell/*.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/completions/basectl_completion.sh'` failed with the existing SC2093, SC2034, SC2088, SC2229, SC2123, and SC2148 findings
- `bash -lc 'shellcheck -S warning base_init.sh bin/base-test bin/base-wrapper bin/basectl bootstrap.sh install.sh demo/demo.sh templates/project-install.sh cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/*.sh lib/bash/version/lib_version.sh lib/shell/*.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/completions/basectl_completion.sh'`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/install.bats tests/base_init.bats cli/bash/commands/basectl/tests/runtime-dispatch.bats cli/bash/commands/basectl/tests/runtime-shell.bats lib/bash/runtime/tests/runtime_bashrc.bats cli/bash/commands/basectl/tests/update-profile.bats cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/repo.bats cli/bash/commands/basectl/tests/export-context.bats cli/bash/commands/basectl/tests/onboard.bats`
- `bash -n base_init.sh bin/base-test bin/base-wrapper bin/basectl bootstrap.sh install.sh demo/demo.sh templates/project-install.sh cli/bash/commands/basectl/basectl.sh cli/bash/commands/basectl/subcommands/*.sh lib/bash/version/lib_version.sh lib/shell/*.sh lib/shell/bash_profile lib/shell/bashrc lib/shell/completions/basectl_completion.sh`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-pr-train-1493 ./bin/base-test`
