### PR TITLE
Share first-mile Homebrew installer helpers

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,11 +38,70 @@ bootstrap_expand_path() {
     local path="$1"
 
     case "$path" in
-        \~) printf '%s\n' "$HOME" ;;
-        \~/*) printf '%s/%s\n' "$HOME" "${path#\~/}" ;;
+        "~") printf '%s\n' "$HOME" ;;
+        "~"/*) printf '%s/%s\n' "$HOME" "${path#"~/"}" ;;
         *) printf '%s\n' "$path" ;;
     esac
 }
+
+# BEGIN shared first-mile Homebrew helpers
+# This block is duplicated in install.sh and bootstrap.sh because both scripts
+# must run before Base runtime libraries are available. Keep copies identical.
+base_first_mile_fetch_homebrew_installer() {
+    local installer_url="$1"
+    local target="$2"
+    local installer_path
+
+    case "$installer_url" in
+        file://*)
+            installer_path="${installer_url#file://}"
+            cp "$installer_path" "$target"
+            ;;
+        /*|./*|../*)
+            cp "$installer_url" "$target"
+            ;;
+        *)
+            command -v curl >/dev/null 2>&1 || return 127
+            curl -fsSL "$installer_url" -o "$target"
+            ;;
+    esac
+}
+
+base_first_mile_run_verified_homebrew_installer() {
+    local installer_url="$1"
+    local expected_sha256="$2"
+    local die_fn="$3"
+    local installer_file
+    local checksum
+    local actual_sha256
+    local exit_code
+
+    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || "$die_fn" "Failed to create a temporary Homebrew installer file."
+    base_first_mile_fetch_homebrew_installer "$installer_url" "$installer_file" || {
+        rm -f "$installer_file"
+        "$die_fn" "Failed to read pinned Homebrew installer content from '$installer_url'."
+    }
+
+    command -v shasum >/dev/null 2>&1 || {
+        rm -f "$installer_file"
+        "$die_fn" "shasum is required to verify pinned Homebrew installer content."
+    }
+    checksum="$(shasum -a 256 "$installer_file")" || {
+        rm -f "$installer_file"
+        "$die_fn" "Failed to compute Homebrew installer checksum."
+    }
+    actual_sha256="${checksum%% *}"
+    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+        rm -f "$installer_file"
+        "$die_fn" "Homebrew installer checksum mismatch (expected $expected_sha256, got $actual_sha256)."
+    fi
+
+    /bin/bash "$installer_file"
+    exit_code=$?
+    rm -f "$installer_file"
+    [[ "$exit_code" -eq 0 ]] || "$die_fn" "Homebrew installer failed."
+}
+# END shared first-mile Homebrew helpers
 
 bootstrap_parent_dir() {
     local path="${1%/}"
@@ -270,57 +329,11 @@ bootstrap_log_homebrew_mutable_policy() {
 }
 
 bootstrap_fetch_homebrew_installer() {
-    local installer_url="$1"
-    local target="$2"
-    local installer_path
-
-    case "$installer_url" in
-        file://*)
-            installer_path="${installer_url#file://}"
-            cp "$installer_path" "$target"
-            ;;
-        /*|./*|../*)
-            cp "$installer_url" "$target"
-            ;;
-        *)
-            command -v curl >/dev/null 2>&1 || return 127
-            curl -fsSL "$installer_url" -o "$target"
-            ;;
-    esac
+    base_first_mile_fetch_homebrew_installer "$@"
 }
 
 bootstrap_run_verified_homebrew_installer() {
-    local installer_url="$1"
-    local expected_sha256="$2"
-    local installer_file
-    local checksum
-    local actual_sha256
-    local exit_code
-
-    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || bootstrap_die "Failed to create a temporary Homebrew installer file."
-    bootstrap_fetch_homebrew_installer "$installer_url" "$installer_file" || {
-        rm -f "$installer_file"
-        bootstrap_die "Failed to read pinned Homebrew installer content from '$installer_url'."
-    }
-
-    command -v shasum >/dev/null 2>&1 || {
-        rm -f "$installer_file"
-        bootstrap_die "shasum is required to verify pinned Homebrew installer content."
-    }
-    checksum="$(shasum -a 256 "$installer_file")" || {
-        rm -f "$installer_file"
-        bootstrap_die "Failed to compute Homebrew installer checksum."
-    }
-    actual_sha256="${checksum%% *}"
-    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
-        rm -f "$installer_file"
-        bootstrap_die "Homebrew installer checksum mismatch (expected $expected_sha256, got $actual_sha256)."
-    fi
-
-    /bin/bash "$installer_file"
-    exit_code=$?
-    rm -f "$installer_file"
-    [[ "$exit_code" -eq 0 ]] || bootstrap_die "Homebrew installer failed."
+    base_first_mile_run_verified_homebrew_installer "$1" "$2" bootstrap_die
 }
 
 bootstrap_install_homebrew() {

--- a/install.sh
+++ b/install.sh
@@ -33,11 +33,70 @@ install_die() {
 install_expand_path() {
     local path="$1"
     case "$path" in
-        \~) printf '%s\n' "$HOME" ;;
-        \~/*) printf '%s/%s\n' "$HOME" "${path#\~/}" ;;
+        "~") printf '%s\n' "$HOME" ;;
+        "~"/*) printf '%s/%s\n' "$HOME" "${path#"~/"}" ;;
         *) printf '%s\n' "$path" ;;
     esac
 }
+
+# BEGIN shared first-mile Homebrew helpers
+# This block is duplicated in install.sh and bootstrap.sh because both scripts
+# must run before Base runtime libraries are available. Keep copies identical.
+base_first_mile_fetch_homebrew_installer() {
+    local installer_url="$1"
+    local target="$2"
+    local installer_path
+
+    case "$installer_url" in
+        file://*)
+            installer_path="${installer_url#file://}"
+            cp "$installer_path" "$target"
+            ;;
+        /*|./*|../*)
+            cp "$installer_url" "$target"
+            ;;
+        *)
+            command -v curl >/dev/null 2>&1 || return 127
+            curl -fsSL "$installer_url" -o "$target"
+            ;;
+    esac
+}
+
+base_first_mile_run_verified_homebrew_installer() {
+    local installer_url="$1"
+    local expected_sha256="$2"
+    local die_fn="$3"
+    local installer_file
+    local checksum
+    local actual_sha256
+    local exit_code
+
+    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || "$die_fn" "Failed to create a temporary Homebrew installer file."
+    base_first_mile_fetch_homebrew_installer "$installer_url" "$installer_file" || {
+        rm -f "$installer_file"
+        "$die_fn" "Failed to read pinned Homebrew installer content from '$installer_url'."
+    }
+
+    command -v shasum >/dev/null 2>&1 || {
+        rm -f "$installer_file"
+        "$die_fn" "shasum is required to verify pinned Homebrew installer content."
+    }
+    checksum="$(shasum -a 256 "$installer_file")" || {
+        rm -f "$installer_file"
+        "$die_fn" "Failed to compute Homebrew installer checksum."
+    }
+    actual_sha256="${checksum%% *}"
+    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+        rm -f "$installer_file"
+        "$die_fn" "Homebrew installer checksum mismatch (expected $expected_sha256, got $actual_sha256)."
+    fi
+
+    /bin/bash "$installer_file"
+    exit_code=$?
+    rm -f "$installer_file"
+    [[ "$exit_code" -eq 0 ]] || "$die_fn" "Homebrew installer failed."
+}
+# END shared first-mile Homebrew helpers
 
 install_run() {
     if [[ "${BASE_INSTALL_DRY_RUN:-false}" == "true" ]]; then
@@ -148,57 +207,11 @@ install_log_homebrew_mutable_policy() {
 }
 
 install_fetch_homebrew_installer() {
-    local installer_url="$1"
-    local target="$2"
-    local installer_path
-
-    case "$installer_url" in
-        file://*)
-            installer_path="${installer_url#file://}"
-            cp "$installer_path" "$target"
-            ;;
-        /*|./*|../*)
-            cp "$installer_url" "$target"
-            ;;
-        *)
-            command -v curl >/dev/null 2>&1 || return 127
-            curl -fsSL "$installer_url" -o "$target"
-            ;;
-    esac
+    base_first_mile_fetch_homebrew_installer "$@"
 }
 
 install_run_verified_homebrew_installer() {
-    local installer_url="$1"
-    local expected_sha256="$2"
-    local installer_file
-    local checksum
-    local actual_sha256
-    local exit_code
-
-    installer_file="$(mktemp "${TMPDIR:-/tmp}/base-homebrew-installer.XXXXXX")" || install_die "Failed to create a temporary Homebrew installer file."
-    install_fetch_homebrew_installer "$installer_url" "$installer_file" || {
-        rm -f "$installer_file"
-        install_die "Failed to read pinned Homebrew installer content from '$installer_url'."
-    }
-
-    command -v shasum >/dev/null 2>&1 || {
-        rm -f "$installer_file"
-        install_die "shasum is required to verify pinned Homebrew installer content."
-    }
-    checksum="$(shasum -a 256 "$installer_file")" || {
-        rm -f "$installer_file"
-        install_die "Failed to compute Homebrew installer checksum."
-    }
-    actual_sha256="${checksum%% *}"
-    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
-        rm -f "$installer_file"
-        install_die "Homebrew installer checksum mismatch (expected $expected_sha256, got $actual_sha256)."
-    fi
-
-    /bin/bash "$installer_file"
-    exit_code=$?
-    rm -f "$installer_file"
-    [[ "$exit_code" -eq 0 ]] || install_die "Homebrew installer failed."
+    base_first_mile_run_verified_homebrew_installer "$1" "$2" install_die
 }
 
 install_homebrew() {

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -109,7 +109,12 @@ assert_base_init_loads() {
 }
 
 @test "installer expands tilde install paths" {
-    run_installer --dry-run --dir "~/custom/base" --no-profile
+    local install_dir
+    local tilde="~"
+
+    install_dir="${tilde}/custom/base"
+
+    run_installer --dry-run --dir "$install_dir" --no-profile
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Install path: $TEST_HOME/custom/base"* ]]
@@ -149,6 +154,27 @@ assert_base_init_loads() {
     run grep -c 'IFS=: read -ra' "$BASE_REPO_ROOT/install.sh"
     [ "$status" -eq 0 ]
     [ "$output" -eq 2 ]
+}
+
+@test "installer and bootstrap share first-mile Homebrew helper snippet" {
+    local bootstrap_block="$TEST_TMPDIR/bootstrap-first-mile.txt"
+    local install_block="$TEST_TMPDIR/install-first-mile.txt"
+
+    awk '
+        /# BEGIN shared first-mile Homebrew helpers/ { capture = 1 }
+        capture { print }
+        /# END shared first-mile Homebrew helpers/ { capture = 0 }
+    ' "$BASE_REPO_ROOT/bootstrap.sh" > "$bootstrap_block"
+    awk '
+        /# BEGIN shared first-mile Homebrew helpers/ { capture = 1 }
+        capture { print }
+        /# END shared first-mile Homebrew helpers/ { capture = 0 }
+    ' "$BASE_REPO_ROOT/install.sh" > "$install_block"
+
+    [ -s "$bootstrap_block" ]
+    [ -s "$install_block" ]
+    run cmp -s "$install_block" "$bootstrap_block"
+    [ "$status" -eq 0 ]
 }
 
 @test "installer bootstraps Homebrew Bash before setup when system Bash is too old" {


### PR DESCRIPTION
## Summary

- Add an identical neutral first-mile Homebrew helper block to `install.sh` and `bootstrap.sh`.
- Keep each script standalone by preserving the existing `install_*` and `bootstrap_*` wrapper functions.
- Add a BATS guard that extracts the marked helper blocks from both scripts and requires them to stay byte-for-byte identical.
- Fix the literal tilde path pattern in both expand helpers without changing expansion behavior.

Fixes #1491.

## Validation

- RED: `bats --filter "first-mile Homebrew helper snippet" tests/install.bats` failed before implementation because the marked shared block was absent.
- PASS: `bats --filter "first-mile Homebrew helper snippet" tests/install.bats`
- PASS: `bats tests/install.bats tests/bootstrap.bats`
- PASS: `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter "pinned Homebrew|verified pinned Homebrew|mismatched pinned Homebrew" cli/bash/commands/basectl/tests/setup.bats`
- PASS: `bash -n install.sh bootstrap.sh tests/install.bats tests/bootstrap.bats`
- PASS: `shellcheck -S warning install.sh bootstrap.sh tests/install.bats tests/bootstrap.bats`
- PASS: `git diff --check`
- PASS: `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-pr-train-1491 ./bin/base-test`
