### PR TITLE
Clarify basectl ci mode contract

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -63,9 +63,10 @@ options.
   checkout. Plain `repo init` writes local baseline files without committing or
   pushing them; `repo init --pr` commits baseline changes on a branch, pushes to
   `origin`, and opens a PR.
-- `basectl ci <setup|check|doctor> <project>` - run Base setup/check/doctor in
-  non-interactive CI. `ci setup --format json` uses `output` for the compact
-  final status and adds `output_lines` on failures for intermediate context.
+- `basectl ci <setup|check|doctor> <project>` - run Base setup/check/doctor
+  with CI-safe defaults. It does not run project tests or create CI runners/VMs.
+  `ci setup --format json` uses `output` for the compact final status and adds
+  `output_lines` on failures for intermediate context.
 - `basectl release <check|plan|notes|publish>` - inspect release readiness,
   print plans/notes, and publish guarded GitHub-side release artifacts.
 - `basectl gh <area> <command>` - manage GitHub issues, PRs, branches, repo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,14 @@ jobs:
           ref: 424ef9fe61bc8a462ba9980ea63b38dd202ec242
           path: .dependencies/base-bash-libs
 
+      - name: Remove flaky hosted-runner apt sources
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/azure-cli.sources \
+            /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/microsoft-prod.sources \
+            /etc/apt/sources.list.d/microsoft-prod.list
+
       - name: Install BATS
         run: |
           sudo apt-get update
@@ -175,6 +183,14 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Remove flaky hosted-runner apt sources
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/azure-cli.sources \
+            /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/microsoft-prod.sources \
+            /etc/apt/sources.list.d/microsoft-prod.list
+
       - name: Install dependencies
         run: |
           python -m venv .integration-venv
@@ -217,6 +233,14 @@ jobs:
         run: |
           ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"
 
+      - name: Remove flaky hosted-runner apt sources
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/azure-cli.sources \
+            /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/microsoft-prod.sources \
+            /etc/apt/sources.list.d/microsoft-prod.list
+
       - name: Install Ubuntu source-checkout prerequisites
         run: |
           sudo apt-get update
@@ -256,6 +280,14 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.13"
+
+      - name: Remove flaky hosted-runner apt sources
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/azure-cli.sources \
+            /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/microsoft-prod.sources \
+            /etc/apt/sources.list.d/microsoft-prod.list
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified `basectl ci` help and docs so CI-safe setup/readiness/diagnostics
+  are not confused with running tests, launching GitHub Actions, or creating
+  Ubuntu/Multipass VMs.
+
+### Fixed
+
+- Hardened Ubuntu GitHub Actions package installs against hosted-runner
+  third-party apt source failures before Base test jobs install their tools.
+
 ## [1.6.1] - 2026-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -313,7 +313,10 @@ Current implemented commands include:
 - `basectl version`
 
 `basectl ci` wraps setup, check, and doctor with CI-safe defaults such as
-non-interactive behavior and JSON-capable output. See
+non-interactive behavior and JSON-capable output. It does not run project tests,
+launch GitHub Actions locally, or create Ubuntu/Multipass VMs. Use
+`basectl test` for a project's declared test command and `bin/base-test` for
+Base's full source-checkout validation suite. See
 [basectl ci](docs/basectl-ci.md) for the CI contract, and
 [Command Quick Reference](docs/command-reference.md) for a scannable command
 lookup table.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -70,8 +70,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   project argument validates `project.name`.
 - `basectl check [project]` verifies the same local requirements without making
   changes and can include project manifest artifacts.
-- `basectl ci setup/check/doctor <project>` runs Base in non-interactive CI
-  mode, sets CI-safe defaults, and supports text or JSON output.
+- `basectl ci setup/check/doctor <project>` runs Base setup, readiness checks,
+  and diagnostics with CI-safe defaults and text or JSON output. It does not
+  run project tests or launch CI runners/VMs.
 - `basectl setup/check/doctor --profile <list>` manage opt-in prerequisite
   profiles. `sre` is the first additional built-in profile, and profiles compose
   as comma-separated lists such as `--profile dev,sre`.

--- a/cli/bash/commands/basectl/subcommands/ci.sh
+++ b/cli/bash/commands/basectl/subcommands/ci.sh
@@ -32,8 +32,9 @@ Profiles:
   linux-lab - Multipass tooling for local Ubuntu lab VMs on macOS hosts.
 
 Purpose:
-  Run Base setup, checks, and diagnostics in a non-interactive CI environment.
+  Run Base setup, checks, and diagnostics with CI-safe defaults.
   Sets BASE_CI=true so setup and diagnostic paths can choose CI-safe behavior.
+  Does not run project tests, launch GitHub Actions, or create Ubuntu/Multipass VMs.
 EOF
 }
 

--- a/cli/bash/commands/basectl/tests/ci.bats
+++ b/cli/bash/commands/basectl/tests/ci.bats
@@ -47,6 +47,7 @@ prepare_ci_runtime() {
     [[ "$output" == *"ai        - AI coding assistant tooling."* ]]
     [[ "$output" == *"linux-lab - Multipass tooling for local Ubuntu lab VMs on macOS hosts."* ]]
     [[ "$output" == *"BASE_CI=true"* ]]
+    [[ "$output" == *"Does not run project tests, launch GitHub Actions, or create Ubuntu/Multipass VMs."* ]]
 }
 
 @test "basectl ci requires a command and project" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,8 +135,8 @@ reference. The filename should answer "what is this about?"
   path for reducing Bash ownership without adding shell fragments by topic.
 - [`basectl onboard`](basectl-onboard.md) captures the guided setup experience
   and its relationship to project installers.
-- [`basectl ci`](basectl-ci.md) defines the non-interactive CI entry point and
-  its relationship to Linux runtime support.
+- [`basectl ci`](basectl-ci.md) defines CI-safe setup/readiness/diagnostic
+  behavior and its relationship to Linux runtime support.
 - [`basectl check` parallelism](check-parallelism.md) documents the shipped
   base-probe concurrency model and its deterministic rendering constraints.
 - [Doctor Finding IDs](doctor-findings.md) is the stable reference for

--- a/docs/basectl-ci.md
+++ b/docs/basectl-ci.md
@@ -1,9 +1,13 @@
 # basectl ci
 
-`basectl ci` is the non-interactive entry point for running Base in CI systems.
-It reuses the same setup, check, doctor, and project manifest logic as local
-development, while avoiding user-facing prompts and macOS-specific UI
-behaviors.
+`basectl ci` is the CI-safe entry point for Base setup, readiness checks, and
+diagnostics. It reuses the same setup, check, doctor, and project manifest
+logic as local development, while avoiding user-facing prompts and macOS-specific
+UI behaviors.
+
+It is not a CI runner. It does not run project tests, launch GitHub Actions
+locally, or create Ubuntu or Multipass virtual machines. CI systems compose it
+with their own runners and test commands.
 
 ## Goals
 
@@ -61,6 +65,13 @@ path that can allow system Python when Homebrew bootstrap is not available.
 - support `--format json`
 - keep warning and error severity distinct
 
+## Relationship To Tests
+
+`basectl ci check <project>` verifies readiness for a CI environment. It does
+not execute the project's declared test command. Use `basectl test <project>` to
+run the manifest-declared test command, or `bin/base-test` in the Base
+repository when the job needs the full source-checkout validation suite.
+
 ## Linux Relationship
 
 The first useful version supports "runtime-only Linux":
@@ -73,9 +84,15 @@ The first useful version supports "runtime-only Linux":
 
 Full Linux bootstrap can come later through the Linux support plan.
 
+The optional `linux-lab` profile prepares or checks local Multipass tooling for
+manual Ubuntu lab work on macOS. It does not create or mutate VM instances.
+
 ## Non-Goals
 
 - Do not invent a second manifest format for CI.
+- Do not run project tests or replace `basectl test`.
+- Do not launch GitHub Actions locally.
+- Do not create or mutate Ubuntu or Multipass VM instances.
 - Do not make CI mutate user dotfiles.
 - Do not start GUI installers or display notifications.
 - Do not hide missing prerequisites behind best-effort behavior.
@@ -101,10 +118,15 @@ Full Linux bootstrap can come later through the Linux support plan.
 
 - name: Check Base project
   run: ./bin/basectl ci check base --format json
+
+- name: Run Base source-checkout tests
+  run: env -u BASE_HOME ./bin/base-test
 ```
 
-This example is a minimal starter for source-checkout CI. Workflows that install
-Python packages or third-party Actions should also follow the
+This example is a minimal starter for source-checkout CI. The `ci check` step
+validates Base readiness; the separate `bin/base-test` step runs the repository's
+full validation suite. Workflows that install Python packages or third-party
+Actions should also follow the
 [CI Supply Chain Policy](ci-supply-chain-policy.md), including pinned
 `requirements-dev.txt` installs for Base-managed CI dependencies.
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -63,9 +63,9 @@ inspect the resolved command contract first.
 |---|---|---|
 | `basectl check [project]` | Verify Base and optional project readiness without making changes. Project checks record the latest result under `~/.base.d/<project>/checks/last.json`. | `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
 | `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
-| `basectl ci setup <project>` | Run setup in non-interactive CI mode. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv` |
-| `basectl ci check <project>` | Run readiness checks in non-interactive CI mode. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>` |
-| `basectl ci doctor <project>` | Run diagnostics in non-interactive CI mode. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>` |
+| `basectl ci setup <project>` | Run setup with CI-safe defaults. Does not run tests or create runners/VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv` |
+| `basectl ci check <project>` | Run readiness checks with CI-safe defaults. Does not run the project test command. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>` |
+| `basectl ci doctor <project>` | Run diagnostics with CI-safe defaults. Does not launch GitHub Actions or Ubuntu VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>` |
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
 | `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |
 | `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name>` |

--- a/docs/presentations/base-newcomer-orientation.md
+++ b/docs/presentations/base-newcomer-orientation.md
@@ -227,7 +227,7 @@ Read more: [Base-managed demo project](../base-managed-demo-project.md)
 
 ## CI Posture
 
-`basectl ci` is the non-interactive CI entry point.
+`basectl ci` is the CI-safe setup, readiness, and diagnostics entry point.
 
 ```bash
 basectl ci setup <project> --format json
@@ -236,7 +236,8 @@ basectl ci doctor <project> --format json
 ```
 
 It sets CI-safe defaults, avoids prompts, and reuses the same manifest and
-diagnostic paths as local development.
+diagnostic paths as local development. It does not run project tests, launch
+GitHub Actions locally, or create Ubuntu/Multipass VMs.
 
 Read more: [`basectl ci`](../basectl-ci.md)
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -202,7 +202,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 
 | Command | What it does |
 |---|---|
-| `basectl ci setup\|check\|doctor [--format json]` | Non-interactive CI entry point |
+| `basectl ci setup\|check\|doctor [--format json]` | CI-safe setup/readiness/diagnostics |
 
 **Prerequisite profiles** (compose with commas: `--profile dev,linux-lab`):
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -283,6 +283,27 @@ def test_macos_smoke_tests_cover_bootstrap_dry_run_routes() -> None:
     assert "basectl update-profile" in run_command
 
 
+def test_ubuntu_apt_jobs_remove_flaky_runner_third_party_sources() -> None:
+    workflow = load_workflow(WORKFLOW_DIR / "tests.yml")
+    jobs = workflow["jobs"]
+
+    for job_name in ("bats", "integration", "ubuntu-source-checkout", "security"):
+        steps = jobs[job_name]["steps"]
+        first_apt_update_index = next(
+            index
+            for index, step in enumerate(steps)
+            if isinstance(step, dict) and "sudo apt-get update" in step.get("run", "")
+        )
+        setup_commands = "\n".join(
+            step.get("run", "")
+            for step in steps[:first_apt_update_index]
+            if isinstance(step, dict)
+        )
+
+        assert "/etc/apt/sources.list.d/azure-cli.sources" in setup_commands
+        assert "/etc/apt/sources.list.d/microsoft-prod.list" in setup_commands
+
+
 def test_project_intake_requires_base_project_token() -> None:
     workflow = load_workflow(WORKFLOW_DIR / "project-intake.yml")
     sync_job = workflow["jobs"]["sync"]


### PR DESCRIPTION
## Summary

- Clarifies `basectl ci` help text as CI-safe setup/readiness/diagnostics rather than a CI runner.
- Updates README, command reference, `.ai-context`, newcomer orientation, and `docs/basectl-ci.md` to distinguish `basectl ci` from `basectl test`, `bin/base-test`, GitHub Actions, and Ubuntu/Multipass VM creation.
- Adds Bats coverage for the new help text boundary.
- Hardens Ubuntu GitHub Actions apt setup by removing hosted-runner third-party Microsoft apt feeds before package installs.

Fixes #1515

## Verification

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1515-cache bats cli/bash/commands/basectl/tests/ci.bats`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1515-cache bats cli/bash/commands/basectl/tests/ci.bats cli/bash/commands/basectl/tests/help.bats`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py tests/test_linux_support_docs.py tests/test_bootstrap_docs.py`
- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py -k flaky_runner_third_party_sources`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1515-cache ./bin/base-test`
