### PR TITLE
Deduplicate workspace configure context resolution

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_configure.py
+++ b/cli/python/base_projects/tests/test_workspace_configure.py
@@ -232,6 +232,41 @@ repos:
                 ],
             )
 
+    def test_workspace_configure_from_options_uses_shared_workspace_context(self) -> None:
+        ctx = mock.Mock()
+        options = mock.Mock(
+            output_format="text",
+            workspace="workspace",
+            workspace_manifest="workspace.yaml",
+            dry_run=True,
+        )
+        workspace_root = Path("/tmp/shared-workspace")
+        manifest = mock.Mock()
+
+        with mock.patch(
+            "base_projects.workspace_context.resolve_workspace_root",
+            return_value=workspace_root,
+        ) as resolve_workspace_root:
+            with mock.patch(
+                "base_projects.workspace_context.effective_workspace_manifest",
+                return_value="workspace.yaml",
+            ) as effective_workspace_manifest:
+                with mock.patch(
+                    "base_projects.workspace_configure.resolve_workspace_manifest",
+                    return_value=manifest,
+                ) as resolve_workspace_manifest:
+                    with mock.patch(
+                        "base_projects.workspace_configure.workspace_configure_command",
+                        return_value=0,
+                    ) as configure_command:
+                        status = workspace_configure.workspace_configure_from_options(ctx, options)
+
+        self.assertEqual(status, 0)
+        resolve_workspace_root.assert_called_once_with(ctx, "workspace")
+        effective_workspace_manifest.assert_called_once_with(ctx, "workspace.yaml")
+        resolve_workspace_manifest.assert_called_once_with("workspace.yaml")
+        configure_command.assert_called_once_with(ctx, workspace_root, manifest, dry_run=True)
+
     def test_configure_workspace_repo_passes_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/workspace_configure.py
+++ b/cli/python/base_projects/workspace_configure.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import base_cli
+from base_projects import workspace_context
 from base_projects.command_helpers import github_repo_spec
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
@@ -44,8 +45,10 @@ def workspace_configure_from_options(
         return base_cli.ExitCode.USAGE_ERROR
 
     try:
-        workspace_root = resolve_workspace_root(ctx, options.workspace)
-        manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, options.workspace_manifest))
+        workspace_root = workspace_context.resolve_workspace_root(ctx, options.workspace)
+        manifest = resolve_workspace_manifest(
+            workspace_context.effective_workspace_manifest(ctx, options.workspace_manifest)
+        )
     except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
@@ -204,25 +207,6 @@ def print_workspace_configure_header(
 
     print(f"Workspace configure: {workspace_root} ({target_count} manifest repos)")
     print(f"Workspace manifest: {workspace_manifest.path} ({workspace_manifest.name})")
-
-
-def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path:
-    if workspace:
-        return Path(workspace).expanduser().resolve()
-    if ctx.workspace_root is not None:
-        return ctx.workspace_root
-    if ctx.base_home is None:
-        raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
-    return ctx.base_home.parent.resolve()
-
-
-def effective_workspace_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> str | None:
-    if workspace_manifest is not None:
-        return workspace_manifest
-    configured_manifest = ctx.user_config.workspace.manifest
-    if configured_manifest is None:
-        return None
-    return str(configured_manifest)
 
 
 def workspace_manifest_repo_spec(repo: WorkspaceManifestRepo) -> str | None:


### PR DESCRIPTION
## Summary
- Route workspace configure option handling through the shared workspace_context helpers.
- Remove the duplicate local workspace root and manifest resolution helpers.
- Add a regression test that patches the shared context boundary.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest base_projects.tests.test_workspace_configure.WorkspaceConfigureTests.test_workspace_configure_from_options_uses_shared_workspace_context
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest base_projects.tests.test_workspace_configure
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_projects/tests
- git diff --check

Fixes #1499