### PR TITLE
Move manifest callers off compatibility exports

### DIFF
--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -9,8 +9,9 @@ from base_setup.artifacts import reconcile_artifact
 from base_setup.artifacts import resolve_artifact_definitions  # pylint: disable=unused-import
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.errors import ArtifactError
-from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError
 from base_setup.manifest import read_manifest  # pylint: disable=unused-import
+from base_setup.manifest_loader import ManifestError
+from base_setup.manifest_model import ArtifactRequest, BaseManifest
 from base_setup.prerequisites import GitHubCliAuthCheckRequest
 from base_setup.prerequisites import HomebrewPackageCheckRequest
 from base_setup.prerequisites import PrerequisiteCheck

--- a/cli/python/base_dev/linux_profile.py
+++ b/cli/python/base_dev/linux_profile.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import base_cli
 from base_setup import process
 from base_setup.errors import ArtifactError
-from base_setup.manifest import ArtifactRequest
+from base_setup.manifest_model import ArtifactRequest
 from base_setup.process import command_exists
 
 from .checks import DevCheck

--- a/cli/python/base_dev/profiles.py
+++ b/cli/python/base_dev/profiles.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import base_cli
 from base_setup.artifacts import resolve_artifact_definitions
-from base_setup.manifest import BaseManifest, ManifestError, read_manifest
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
+from base_setup.manifest_model import BaseManifest
 from base_setup.registry import ArtifactDefinition
 
 SUPPORTED_PROFILES = ("dev", "sre", "ai", "linux-lab")

--- a/cli/python/base_pr_policy/engine.py
+++ b/cli/python/base_pr_policy/engine.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import base_cli
 from base_cli.paths import discover_manifest
 from base_setup.github_manifest import GithubPrConfig
-from base_setup.manifest import ManifestError, read_manifest
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
 
 
 class PrPolicyError(RuntimeError):

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from typing import Protocol
 
 import base_cli
-from base_setup.manifest import BaseManifest, BuildTargetConfig, ManifestError, read_manifest
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
+from base_setup.manifest_model import BaseManifest, BuildTargetConfig
 from base_setup.project_routing import route_for_manifest
 
 

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -53,7 +53,8 @@ from base_projects.workspace_reports import workspace_status_to_json
 from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
-from base_setup.manifest import ManifestError, read_manifest
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
 
 
 app = base_cli.App(name="base_projects")

--- a/cli/python/base_projects/project_commands.py
+++ b/cli/python/base_projects/project_commands.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 from base_projects.project_discovery import Project
 from base_projects.workspace_scanner import ProjectDiscoveryError
-from base_setup.manifest import BaseManifest
-from base_setup.manifest import CommandConfig
-from base_setup.manifest import TestConfig
+from base_setup.manifest_model import BaseManifest
+from base_setup.manifest_model import CommandConfig
+from base_setup.manifest_model import TestConfig
 from base_setup.project_routing import route_for_manifest
 
 

--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -13,7 +13,8 @@ from base_cli.paths import base_cache_root, discover_manifest
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_projects.workspace_scanner import workspace_manifest_entries
-from base_setup.manifest import ManifestError, read_manifest
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
 
 
 @dataclass(frozen=True, order=True)

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -20,9 +20,9 @@ from base_setup.checks import doctor_status
 from base_setup.engine import manifest_checks
 from base_setup.engine import pre_venv_manifest_checks
 from base_setup.engine import read_default_manifest
-from base_setup.manifest import BaseManifest
-from base_setup.manifest import ManifestError
 from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
+from base_setup.manifest_model import BaseManifest
 from base_setup.uv import manifest_uses_uv_project_manager
 
 

--- a/cli/python/base_projects/workspace_report_common.py
+++ b/cli/python/base_projects/workspace_report_common.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from base_cli.paths import base_state_root
 from base_projects.workspace_manifest import WorkspaceManifestRepo
-from base_setup.manifest import BaseManifest
+from base_setup.manifest_model import BaseManifest
 from base_setup.uv import manifest_uses_uv_project_manager
 
 

--- a/cli/python/base_projects/workspace_statuses.py
+++ b/cli/python/base_projects/workspace_statuses.py
@@ -14,8 +14,8 @@ from base_projects.workspace_report_common import project_venv_dir
 from base_projects.workspace_report_common import project_venv_ready
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import workspace_manifest_entries
-from base_setup.manifest import ManifestError
 from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
 from base_setup.python_runtime import ProjectPythonRuntime
 from base_setup.python_runtime import project_python_runtime
 

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -5,8 +5,8 @@ import sys
 
 import base_cli
 from base_setup import process  # pylint: disable=unused-import
-from base_setup.manifest import ManifestError
 from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
 
 from .release_model import ReleaseContext, ReleaseError, ReleaseFinding
 from .release_parser import ReleaseArguments

--- a/cli/python/base_release/release_model.py
+++ b/cli/python/base_release/release_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from base_setup.manifest import BaseManifest, ReleaseConfig
+from base_setup.manifest_model import BaseManifest, ReleaseConfig
 
 
 class ReleaseError(RuntimeError):

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -9,7 +9,7 @@ import base_cli
 from base_cli.history import base_version as read_base_version
 from base_projects import engine as project_engine
 from base_projects.workspace_scanner import ProjectDiscoveryError
-from base_setup.manifest import ManifestError
+from base_setup.manifest_loader import ManifestError
 from .trust_store import ALLOWED_COMMANDS  # pylint: disable=unused-import
 from .trust_store import SCHEMA_VERSION
 from .trust_store import TRUST_RELATIVE_ROOT  # pylint: disable=unused-import


### PR DESCRIPTION
## Summary
- Move internal manifest model imports to base_setup.manifest_model.
- Move internal ManifestError imports to base_setup.manifest_loader.
- Leave read_manifest on the manifest reader surface.

## Validation
- rg -n "^from base_setup\.manifest import .*\b(BaseManifest|ManifestError|ArtifactRequest|BuildTargetConfig|CommandConfig|TestConfig|ReleaseConfig|PythonConfig|IdeConfig|HealthConfig|PortHealthConfig|DemoConfig|ActivateConfig|BuildConfig|ReleaseGithubConfig|ReleaseHomebrewConfig)\b" cli/python lib/python -g '*.py' -g '!**/tests/**'
- git diff --check
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_dev cli/python/base_projects cli/python/base_release cli/python/base_trust cli/python/base_pr_policy
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_dev/tests
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_projects/tests
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_release/tests
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_trust/tests
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_pr_policy/tests -q

Fixes #1510