### PR TITLE
Clarify Python artifact compatibility facade

### DIFF
--- a/cli/python/base_setup/artifacts.py
+++ b/cli/python/base_setup/artifacts.py
@@ -13,7 +13,9 @@ from .prerequisites import HomebrewPackageCheckRequest
 from .prerequisites import PrerequisiteCheck
 from .prerequisites import check_homebrew_package
 from .prerequisites import homebrew_package_outdated
-# Keep these re-exports until downstream callers move to base_setup.python_artifacts.
+# Public compatibility exports for callers that still import Python artifact
+# helpers through base_setup.artifacts. Internal callers should import the
+# focused base_setup.python_artifacts module directly.
 from .python_artifacts import PIP_INSTALL_COMMAND_PREFIX  # pylint: disable=unused-import
 from .python_artifacts import backup_existing_project_venv  # pylint: disable=unused-import
 from .python_artifacts import create_project_virtualenv  # pylint: disable=unused-import

--- a/cli/python/base_setup/ide_settings.py
+++ b/cli/python/base_setup/ide_settings.py
@@ -11,10 +11,10 @@ import base_cli
 from base_cli.ide_schema import IDE_DEFINITIONS
 from base_cli.ide_schema import IdeDefinition
 
-from . import artifacts
 from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
+from .python_artifacts import project_venv_dir
 
 if TYPE_CHECKING:
     from .ide_diagnostics import IdeDiagnosticSnapshot
@@ -33,7 +33,7 @@ def resolve_ide_settings(project: str, settings: dict[str, object]) -> dict[str,
     resolved: dict[str, object] = {}
     for key, value in settings.items():
         if key == "python.defaultInterpreterPath" and value == "auto":
-            resolved[key] = str(artifacts.project_venv_dir(project) / "bin" / "python")
+            resolved[key] = str(project_venv_dir(project) / "bin" / "python")
         else:
             resolved[key] = value
     return resolved

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -24,7 +24,7 @@ from base_setup.tests.helpers import fake_context, run_engine
 
 
 class ArtifactFacadeTests(unittest.TestCase):
-    def test_artifacts_declares_python_artifact_compatibility_exports(self) -> None:
+    def test_artifacts_declares_public_python_artifact_compatibility_exports(self) -> None:
         expected_names = {
             "PIP_INSTALL_COMMAND_PREFIX",
             "ProjectRuntimeConfig",


### PR DESCRIPTION
## Summary
- Move IDE settings venv resolution to base_setup.python_artifacts.project_venv_dir.
- Document base_setup.artifacts Python helper re-exports as public compatibility only.
- Rename the facade test to match the public compatibility contract.

## Validation
- rg -n "artifacts\.project_venv_dir|from base_setup\.artifacts import .*project_venv_dir|from \. import artifacts" cli/python lib/python -g '*.py' -g '!**/tests/**'
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_ide_settings
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli.python.base_setup.tests.test_artifacts.ArtifactFacadeTests
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests -q
- git diff --check

Fixes #1501