### PR TITLE
Extract base projects command dispatch

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
@@ -27,6 +25,9 @@ from base_projects.project_commands import project_commands
 from base_projects.project_commands import project_output as _project_output
 from base_projects.project_commands import resolve_activation_source_path  # pylint: disable=unused-import
 from base_projects.project_commands import test_command
+from base_projects.project_dispatch import ProjectCommandActions
+from base_projects.project_dispatch import WorkspaceCommandOptions
+from base_projects.project_dispatch import dispatch_projects_command
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_clone_command import clone_workspace_repo  # pylint: disable=unused-import
 from base_projects.workspace_clone_command import print_optional_clone_skip  # pylint: disable=unused-import
@@ -58,21 +59,6 @@ from base_setup.manifest_loader import ManifestError
 
 
 app = base_cli.App(name="base_projects")
-
-
-@dataclass(frozen=True)
-class WorkspaceCommandOptions:
-    workspace: str | None
-    output_format: str
-    workspace_manifest: str | None = None
-    workspace_manifest_source: str | None = None
-    workspace_config_path: str | None = None
-    workspace_owner: str | None = None
-    include_optional: bool = False
-    dry_run: bool = False
-
-
-ProjectCommandHandler = Callable[[base_cli.Context, tuple[str, ...], WorkspaceCommandOptions], int]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -123,247 +109,63 @@ def run(
                 include_optional=include_optional,
                 dry_run=dry_run,
             ),
+            project_command_actions(),
         )
     except ProjectUsageError as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.USAGE_ERROR
 
 
-def dispatch_projects_command(
-    ctx: base_cli.Context,
-    arguments: tuple[str, ...],
-    options: WorkspaceCommandOptions,
-) -> int:
-    command = arguments[0] if arguments else "list"
-    command_arguments = arguments[1:] if arguments else ()
-    handler = PROJECT_COMMAND_HANDLERS.get(command)
-    if handler is not None:
-        return handler(ctx, command_arguments, options)
-
-    ctx.log.error(
-        "Unknown projects command '%s'. Supported commands: %s.",
-        command,
-        ", ".join(SUPPORTED_PROJECT_COMMANDS),
+def project_command_actions() -> ProjectCommandActions:
+    return ProjectCommandActions(
+        list_projects=list_projects_command,
+        workspace_status=workspace_status_command,
+        workspace_check=workspace_check_command,
+        workspace_doctor=workspace_doctor_command,
+        workspace_clone=workspace_clone_command,
+        workspace_pull=workspace_pull_command,
+        workspace_init=workspace_init_project_command,
+        workspace_configure=workspace_configure_from_options,
+        current_project=current_project_command,
+        manifest_project=manifest_project_command,
+        resolve_project=resolve_project_command,
+        test_command_project=test_command_project_command,
+        demo_script_project=demo_script_project_command,
+        activation_sources_project=activation_sources_project_command,
+        run_command_project=run_command_project_command,
+        list_run_commands=list_run_commands_command,
+        build_targets=build_targets_project_command,
+        build_target_list=build_target_list_project_command,
     )
-    return base_cli.ExitCode.USAGE_ERROR
 
 
-def require_argument_count(command: str, arguments: tuple[str, ...], minimum: int, maximum: int) -> None:
-    if len(arguments) < minimum:
-        raise ProjectUsageError(f"Project command '{command}' requires at least {minimum} argument(s).")
-    if len(arguments) > maximum:
-        raise ProjectUsageError(f"Project command '{command}' accepts at most {maximum} argument(s).")
-
-
-def optional_project_argument(command: str, arguments: tuple[str, ...]) -> str | None:
-    require_argument_count(command, arguments, 0, 1)
-    return arguments[0] if arguments else None
-
-
-def list_projects_from_args(
+def workspace_init_project_command(
     ctx: base_cli.Context,
-    arguments: tuple[str, ...],
-    workspace: str | None,
-    output_format: str,
-) -> int:
-    require_argument_count("list", arguments, 0, 0)
-    return list_projects_command(ctx, workspace, output_format)
-
-
-def workspace_status_from_args(
-    ctx: base_cli.Context,
-    arguments: tuple[str, ...],
+    workspace_source: str,
     options: WorkspaceCommandOptions,
 ) -> int:
-    require_argument_count("status", arguments, 0, 0)
-    return workspace_status_command(ctx, options.workspace, options.output_format, options.workspace_manifest)
-
-
-def current_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
-    require_argument_count("current", arguments, 0, 0)
-    return current_project_command(ctx)
-
-
-def manifest_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...]) -> int:
-    require_argument_count("manifest", arguments, 0, 1)
-    return manifest_project_command(ctx, arguments[0] if arguments else None)
-
-
-def resolve_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
-    require_argument_count("resolve", arguments, 1, 1)
-    return resolve_project_command(ctx, arguments[0], workspace)
-
-
-def test_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
-    project = optional_project_argument("test-command", arguments)
-    return test_command_project_command(ctx, project, workspace)
-
-
-def demo_script_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
-    project = optional_project_argument("demo-script", arguments)
-    return demo_script_project_command(ctx, project, workspace)
-
-
-def activation_sources_project_from_args(
-    ctx: base_cli.Context,
-    arguments: tuple[str, ...],
-    workspace: str | None,
-) -> int:
-    require_argument_count("activation-sources", arguments, 1, 1)
-    return activation_sources_project_command(ctx, arguments[0], workspace)
-
-
-def run_command_project_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
-    require_argument_count("run-command", arguments, 2, 2)
-    return run_command_project_command(ctx, arguments[0], arguments[1], workspace)
-
-
-def list_run_commands_from_args(ctx: base_cli.Context, arguments: tuple[str, ...], workspace: str | None) -> int:
-    project = optional_project_argument("run-commands", arguments)
-    return list_run_commands_command(ctx, project, workspace)
-
-
-def workspace_init_from_args(
-    ctx: base_cli.Context,
-    arguments: tuple[str, ...],
-    options: WorkspaceCommandOptions,
-) -> int:
-    require_argument_count("init", arguments, 1, 1)
     return workspace_init_command(
         ctx,
-        arguments[0],
+        workspace_source,
         options,
         workspace_clone_command=workspace_clone_command,
     )
 
 
-def _handle_list(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return list_projects_from_args(ctx, arguments, options.workspace, options.output_format)
-
-
-def _handle_status(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return workspace_status_from_args(ctx, arguments, options)
-
-
-def _handle_check(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    require_argument_count("check", arguments, 0, 0)
-    return workspace_check_command(ctx, options.workspace, options.output_format, options.workspace_manifest)
-
-
-def _handle_doctor(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    require_argument_count("doctor", arguments, 0, 0)
-    return workspace_doctor_command(ctx, options.workspace, options.output_format, options.workspace_manifest)
-
-
-def _handle_clone(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    require_argument_count("clone", arguments, 0, 0)
-    return workspace_clone_command(ctx, options)
-
-
-def _handle_pull(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    require_argument_count("pull", arguments, 0, 0)
-    return workspace_pull_command(ctx, options)
-
-
-def _handle_init(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return workspace_init_from_args(ctx, arguments, options)
-
-
-def _handle_configure(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    require_argument_count("configure", arguments, 0, 0)
-    return workspace_configure_from_options(ctx, options)
-
-
-def _handle_current(ctx: base_cli.Context, arguments: tuple[str, ...], _options: WorkspaceCommandOptions) -> int:
-    return current_project_from_args(ctx, arguments)
-
-
-def _handle_manifest(ctx: base_cli.Context, arguments: tuple[str, ...], _options: WorkspaceCommandOptions) -> int:
-    return manifest_project_from_args(ctx, arguments)
-
-
-def _handle_resolve(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return resolve_project_from_args(ctx, arguments, options.workspace)
-
-
-def _handle_test_command(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return test_command_project_from_args(ctx, arguments, options.workspace)
-
-
-def _handle_demo_script(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return demo_script_project_from_args(ctx, arguments, options.workspace)
-
-
-def _handle_activation_sources(
+def build_targets_project_command(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
-    options: WorkspaceCommandOptions,
+    workspace: str | None,
 ) -> int:
-    return activation_sources_project_from_args(ctx, arguments, options.workspace)
+    return build_targets_project_from_args(ctx, arguments, workspace, resolve_named_project)
 
 
-def _handle_run_command(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return run_command_project_from_args(ctx, arguments, options.workspace)
-
-
-def _handle_run_commands(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return list_run_commands_from_args(ctx, arguments, options.workspace)
-
-
-def _handle_build_targets(ctx: base_cli.Context, arguments: tuple[str, ...], options: WorkspaceCommandOptions) -> int:
-    return build_targets_project_from_args(ctx, arguments, options.workspace, resolve_named_project)
-
-
-def _handle_build_target_list(
+def build_target_list_project_command(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
-    options: WorkspaceCommandOptions,
+    workspace: str | None,
 ) -> int:
-    return list_build_targets_from_args(ctx, arguments, options.workspace, resolve_named_project)
-
-
-SUPPORTED_PROJECT_COMMANDS = (
-    "list",
-    "current",
-    "manifest",
-    "resolve",
-    "status",
-    "check",
-    "doctor",
-    "clone",
-    "configure",
-    "init",
-    "test-command",
-    "demo-script",
-    "activation-sources",
-    "run-command",
-    "run-commands",
-    "build-targets",
-    "build-target-list",
-    "pull",
-)
-
-
-PROJECT_COMMAND_HANDLERS: dict[str, ProjectCommandHandler] = {
-    "list": _handle_list,
-    "status": _handle_status,
-    "check": _handle_check,
-    "doctor": _handle_doctor,
-    "clone": _handle_clone,
-    "pull": _handle_pull,
-    "init": _handle_init,
-    "configure": _handle_configure,
-    "current": _handle_current,
-    "manifest": _handle_manifest,
-    "resolve": _handle_resolve,
-    "test-command": _handle_test_command,
-    "demo-script": _handle_demo_script,
-    "activation-sources": _handle_activation_sources,
-    "run-command": _handle_run_command,
-    "run-commands": _handle_run_commands,
-    "build-targets": _handle_build_targets,
-    "build-target-list": _handle_build_target_list,
-}
+    return list_build_targets_from_args(ctx, arguments, workspace, resolve_named_project)
 
 
 def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import base_cli
+from base_projects.command_helpers import ProjectUsageError
+
+
+@dataclass(frozen=True)
+class WorkspaceCommandOptions:
+    workspace: str | None
+    output_format: str
+    workspace_manifest: str | None = None
+    workspace_manifest_source: str | None = None
+    workspace_config_path: str | None = None
+    workspace_owner: str | None = None
+    include_optional: bool = False
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class ProjectCommandActions:
+    list_projects: Callable[[base_cli.Context, str | None, str], int]
+    workspace_status: Callable[[base_cli.Context, str | None, str, str | None], int]
+    workspace_check: Callable[[base_cli.Context, str | None, str, str | None], int]
+    workspace_doctor: Callable[[base_cli.Context, str | None, str, str | None], int]
+    workspace_clone: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
+    workspace_pull: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
+    workspace_init: Callable[[base_cli.Context, str, WorkspaceCommandOptions], int]
+    workspace_configure: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
+    current_project: Callable[[base_cli.Context], int]
+    manifest_project: Callable[[base_cli.Context, str | None], int]
+    resolve_project: Callable[[base_cli.Context, str | None, str | None], int]
+    test_command_project: Callable[[base_cli.Context, str | None, str | None], int]
+    demo_script_project: Callable[[base_cli.Context, str | None, str | None], int]
+    activation_sources_project: Callable[[base_cli.Context, str | None, str | None], int]
+    run_command_project: Callable[[base_cli.Context, str | None, str | None, str | None], int]
+    list_run_commands: Callable[[base_cli.Context, str | None, str | None], int]
+    build_targets: Callable[[base_cli.Context, tuple[str, ...], str | None], int]
+    build_target_list: Callable[[base_cli.Context, tuple[str, ...], str | None], int]
+
+
+ProjectCommandHandler = Callable[
+    [base_cli.Context, tuple[str, ...], WorkspaceCommandOptions, ProjectCommandActions],
+    int,
+]
+
+
+def dispatch_projects_command(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    command = arguments[0] if arguments else "list"
+    command_arguments = arguments[1:] if arguments else ()
+    handler = PROJECT_COMMAND_HANDLERS.get(command)
+    if handler is not None:
+        return handler(ctx, command_arguments, options, actions)
+
+    ctx.log.error(
+        "Unknown projects command '%s'. Supported commands: %s.",
+        command,
+        ", ".join(SUPPORTED_PROJECT_COMMANDS),
+    )
+    return base_cli.ExitCode.USAGE_ERROR
+
+
+def require_argument_count(command: str, arguments: tuple[str, ...], minimum: int, maximum: int) -> None:
+    if len(arguments) < minimum:
+        raise ProjectUsageError(f"Project command '{command}' requires at least {minimum} argument(s).")
+    if len(arguments) > maximum:
+        raise ProjectUsageError(f"Project command '{command}' accepts at most {maximum} argument(s).")
+
+
+def optional_project_argument(command: str, arguments: tuple[str, ...]) -> str | None:
+    require_argument_count(command, arguments, 0, 1)
+    return arguments[0] if arguments else None
+
+
+def _handle_list(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("list", arguments, 0, 0)
+    return actions.list_projects(ctx, options.workspace, options.output_format)
+
+
+def _handle_status(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("status", arguments, 0, 0)
+    return actions.workspace_status(ctx, options.workspace, options.output_format, options.workspace_manifest)
+
+
+def _handle_check(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("check", arguments, 0, 0)
+    return actions.workspace_check(ctx, options.workspace, options.output_format, options.workspace_manifest)
+
+
+def _handle_doctor(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("doctor", arguments, 0, 0)
+    return actions.workspace_doctor(ctx, options.workspace, options.output_format, options.workspace_manifest)
+
+
+def _handle_clone(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("clone", arguments, 0, 0)
+    return actions.workspace_clone(ctx, options)
+
+
+def _handle_pull(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("pull", arguments, 0, 0)
+    return actions.workspace_pull(ctx, options)
+
+
+def _handle_init(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("init", arguments, 1, 1)
+    return actions.workspace_init(ctx, arguments[0], options)
+
+
+def _handle_configure(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("configure", arguments, 0, 0)
+    return actions.workspace_configure(ctx, options)
+
+
+def _handle_current(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    _options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("current", arguments, 0, 0)
+    return actions.current_project(ctx)
+
+
+def _handle_manifest(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    _options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("manifest", arguments, 0, 1)
+    return actions.manifest_project(ctx, arguments[0] if arguments else None)
+
+
+def _handle_resolve(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("resolve", arguments, 1, 1)
+    return actions.resolve_project(ctx, arguments[0], options.workspace)
+
+
+def _handle_test_command(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    project = optional_project_argument("test-command", arguments)
+    return actions.test_command_project(ctx, project, options.workspace)
+
+
+def _handle_demo_script(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    project = optional_project_argument("demo-script", arguments)
+    return actions.demo_script_project(ctx, project, options.workspace)
+
+
+def _handle_activation_sources(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("activation-sources", arguments, 1, 1)
+    return actions.activation_sources_project(ctx, arguments[0], options.workspace)
+
+
+def _handle_run_command(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("run-command", arguments, 2, 2)
+    return actions.run_command_project(ctx, arguments[0], arguments[1], options.workspace)
+
+
+def _handle_run_commands(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    project = optional_project_argument("run-commands", arguments)
+    return actions.list_run_commands(ctx, project, options.workspace)
+
+
+def _handle_build_targets(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    return actions.build_targets(ctx, arguments, options.workspace)
+
+
+def _handle_build_target_list(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    return actions.build_target_list(ctx, arguments, options.workspace)
+
+
+SUPPORTED_PROJECT_COMMANDS = (
+    "list",
+    "current",
+    "manifest",
+    "resolve",
+    "status",
+    "check",
+    "doctor",
+    "clone",
+    "configure",
+    "init",
+    "test-command",
+    "demo-script",
+    "activation-sources",
+    "run-command",
+    "run-commands",
+    "build-targets",
+    "build-target-list",
+    "pull",
+)
+
+
+PROJECT_COMMAND_HANDLERS: dict[str, ProjectCommandHandler] = {
+    "list": _handle_list,
+    "status": _handle_status,
+    "check": _handle_check,
+    "doctor": _handle_doctor,
+    "clone": _handle_clone,
+    "pull": _handle_pull,
+    "init": _handle_init,
+    "configure": _handle_configure,
+    "current": _handle_current,
+    "manifest": _handle_manifest,
+    "resolve": _handle_resolve,
+    "test-command": _handle_test_command,
+    "demo-script": _handle_demo_script,
+    "activation-sources": _handle_activation_sources,
+    "run-command": _handle_run_command,
+    "run-commands": _handle_run_commands,
+    "build-targets": _handle_build_targets,
+    "build-target-list": _handle_build_target_list,
+}

--- a/cli/python/base_projects/tests/test_engine_structure.py
+++ b/cli/python/base_projects/tests/test_engine_structure.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import unittest
 
 from base_projects import engine
+from base_projects import project_dispatch
 from base_projects import workspace_clone_command
 
 
@@ -16,3 +17,11 @@ class BaseProjectsEngineStructureTests(unittest.TestCase):
         self.assertNotIn("def workspace_clone_command", engine_source)
         self.assertNotIn("def clone_workspace_repo", engine_source)
         self.assertIs(engine.workspace_clone_command, workspace_clone_command.workspace_clone_command)
+
+    def test_project_command_dispatch_lives_outside_engine(self) -> None:
+        engine_source = Path(engine.__file__).read_text(encoding="utf-8")
+        dispatch_source = Path(project_dispatch.__file__).read_text(encoding="utf-8")
+
+        self.assertIn("def dispatch_projects_command", dispatch_source)
+        self.assertNotIn("def dispatch_projects_command", engine_source)
+        self.assertNotIn("PROJECT_COMMAND_HANDLERS", engine_source)

--- a/cli/python/base_projects/tests/test_workspace_init.py
+++ b/cli/python/base_projects/tests/test_workspace_init.py
@@ -94,8 +94,13 @@ class WorkspaceInitTests(unittest.TestCase):
     def test_workspace_init_command_is_extracted_from_engine(self) -> None:
         workspace_init = importlib.import_module("base_projects.workspace_init")
 
+        actions = engine.project_command_actions()
         self.assertIs(
-            engine.workspace_init_from_args.__globals__["workspace_init_command"],
+            actions.workspace_init,
+            engine.workspace_init_project_command,
+        )
+        self.assertIs(
+            engine.workspace_init_project_command.__globals__["workspace_init_command"],
             workspace_init.workspace_init_command,
         )
 


### PR DESCRIPTION
## Summary
- Move projects command names, argument validation, and handler dispatch into base_projects.project_dispatch.
- Keep command implementations in engine.py and pass them through a typed action set.
- Update structure coverage for dispatch and workspace-init wiring.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m py_compile cli/python/base_projects/engine.py cli/python/base_projects/project_dispatch.py
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest base_projects.tests.test_engine_structure base_projects.tests.test_workspace_init
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest discover -s cli/python/base_projects/tests
- git diff --cached --check

Fixes #1507