### PR TITLE
Type GitHub Project operations boundary

### DIFF
--- a/cli/python/base_github_projects/project_configure_command.py
+++ b/cli/python/base_github_projects/project_configure_command.py
@@ -2,25 +2,31 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
-from typing import Any
 
 import base_cli
 
+from .project_config import ProjectConfig
 from .project_configure import ConfigureDryRunPlan, ProjectReplacement
 from .project_configure import legacy_project_title, render_dry_run_configure, standard_template_view_errors
+from .project_model import OwnerInfo
+from .project_model import ProjectArguments
+from .project_model import ProjectField
+from .project_model import ProjectInfo
+from .project_model import ProjectSchema
+from .project_operations import ProjectOperations
 
 
 @dataclass(frozen=True)
 class ConfigureExecution:
     owner: str
-    owner_info: Any
-    args: Any
-    project: Any
+    owner_info: OwnerInfo
+    args: ProjectArguments
+    project: ProjectInfo | None
     replacement: ProjectReplacement | None
-    ops: Any
+    ops: ProjectOperations
 
 
-def configure_command(args: Any, ops: Any) -> int:
+def configure_command(args: ProjectArguments, ops: ProjectOperations) -> int:
     owner = ops.require_owner(args)
     if args.replace_project and not args.repo:
         raise ops.ProjectUsageError("--replace-project requires --repo.")
@@ -74,10 +80,10 @@ def configure_command(args: Any, ops: Any) -> int:
 
 
 def replacement_plan_for_args(
-    args: Any,
+    args: ProjectArguments,
     owner: str,
-    project: Any,
-    ops: Any,
+    project: ProjectInfo | None,
+    ops: ProjectOperations,
 ) -> ProjectReplacement | None:
     if not args.replace_project:
         return None
@@ -99,16 +105,16 @@ def replacement_plan_for_args(
 
 
 def fetch_existing_configure_fields(
-    project: Any,
+    project: ProjectInfo | None,
     replacement: ProjectReplacement | None,
-    ops: Any,
-) -> tuple[Any, ...]:
+    ops: ProjectOperations,
+) -> tuple[ProjectField, ...]:
     if project is None or replacement is not None:
         return ()
     return ops.fetch_project_fields(project.project_id)
 
 
-def prepare_configure_project(execution: ConfigureExecution) -> Any:
+def prepare_configure_project(execution: ConfigureExecution) -> ProjectInfo:
     if execution.replacement is not None:
         execution.ops.update_project(
             execution.replacement.legacy_project.project_id,
@@ -137,9 +143,9 @@ def prepare_configure_project(execution: ConfigureExecution) -> Any:
 
 def ensure_schema_fields(
     project_id: str,
-    fields: tuple[Any, ...],
-    schema: Any,
-    ops: Any,
+    fields: tuple[ProjectField, ...],
+    schema: ProjectSchema,
+    ops: ProjectOperations,
 ) -> None:
     by_name = {field.name: field for field in fields}
     for spec in schema.fields:
@@ -150,7 +156,7 @@ def ensure_schema_fields(
             ops.update_single_select_field(field, spec)
 
 
-def link_and_backfill_project(project_id: str, repo: str | None, ops: Any) -> None:
+def link_and_backfill_project(project_id: str, repo: str | None, ops: ProjectOperations) -> None:
     if not repo:
         return
     ops.link_project_to_repository(project_id, repo)
@@ -161,7 +167,7 @@ def link_and_backfill_project(project_id: str, repo: str | None, ops: Any) -> No
 def copy_replacement_project_fields(
     project_id: str,
     replacement: ProjectReplacement | None,
-    ops: Any,
+    ops: ProjectOperations,
 ) -> None:
     if replacement is None:
         return
@@ -174,7 +180,7 @@ def copy_replacement_project_fields(
         )
 
 
-def close_replacement_project(replacement: ProjectReplacement | None, ops: Any) -> None:
+def close_replacement_project(replacement: ProjectReplacement | None, ops: ProjectOperations) -> None:
     if replacement is None:
         return
     ops.update_project(replacement.legacy_project.project_id, closed=True)
@@ -185,7 +191,7 @@ def copy_project_fields_from_source(
     owner: str,
     target_project_id: str,
     source_project_title: str | None,
-    ops: Any,
+    ops: ProjectOperations,
 ) -> None:
     if not source_project_title:
         return
@@ -203,9 +209,9 @@ def copy_project_fields_from_source(
 
 def apply_project_config_defaults(
     target_project_id: str,
-    target_fields: tuple[Any, ...],
-    project_config: Any,
-    ops: Any,
+    target_fields: tuple[ProjectField, ...],
+    project_config: ProjectConfig,
+    ops: ProjectOperations,
 ) -> None:
     defaults = ops.project_field_defaults_for_config(project_config)
     if not defaults:

--- a/cli/python/base_github_projects/project_doctor_command.py
+++ b/cli/python/base_github_projects/project_doctor_command.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
-
 import base_cli
 
+from .project_model import ProjectArguments
+from .project_operations import ProjectOperations
 
-def doctor_command(args: Any, ops: Any) -> int:
+
+def doctor_command(args: ProjectArguments, ops: ProjectOperations) -> int:
     owner = ops.require_owner(args)
     owner_info = ops.find_owner_and_project(owner, args.project_title or "")
     if owner_info.project is None:

--- a/cli/python/base_github_projects/project_issue_fields_command.py
+++ b/cli/python/base_github_projects/project_issue_fields_command.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
-
 import base_cli
 
+from .project_model import ProjectArguments
+from .project_operations import ProjectOperations
 
-def issue_set_fields_command(args: Any, ops: Any) -> int:
+
+def issue_set_fields_command(args: ProjectArguments, ops: ProjectOperations) -> int:
     owner = ops.require_owner(args)
     repo = ops.require_repo(args)
     owner_info = ops.find_owner_and_project(owner, args.project_title or "")

--- a/cli/python/base_github_projects/project_operations.py
+++ b/cli/python/base_github_projects/project_operations.py
@@ -1,7 +1,87 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from .project_config import ProjectConfig
+from .project_item_fields import FieldCopySummary
+from .project_model import ConfigureAction
+from .project_model import FieldUpdate
+from .project_model import Finding
+from .project_model import OwnerInfo
+from .project_model import ProjectArguments
+from .project_model import ProjectField
+from .project_model import ProjectInfo
+from .project_model import ProjectSchema
+from .project_model import ProjectView
+from .project_model import SelectFieldSpec
 
 
-class ProjectOperations(SimpleNamespace):
-    """Explicit operations surface passed to GitHub Project command helpers."""
+class ConfigurationPlan(Protocol):
+    def __call__(
+        self,
+        *,
+        project_exists: bool,
+        fields: tuple[ProjectField, ...],
+        schema: ProjectSchema,
+    ) -> tuple[ConfigureAction, ...]:
+        """Plan Project configuration changes."""
+
+
+class ResolveIssueFieldUpdates(Protocol):
+    def __call__(
+        self,
+        fields: tuple[ProjectField, ...],
+        values: dict[str, str],
+        *,
+        project_title: str,
+    ) -> tuple[FieldUpdate, ...]:
+        """Resolve issue field updates from command arguments."""
+
+
+class UpdateProject(Protocol):
+    def __call__(
+        self,
+        project_id: str,
+        *,
+        title: str | None = None,
+        closed: bool | None = None,
+    ) -> None:
+        """Update mutable GitHub Project metadata."""
+
+
+@dataclass(frozen=True)
+class ProjectOperations:
+    """Typed operations surface passed to GitHub Project command helpers."""
+
+    ProjectError: type[Exception]
+    ProjectUsageError: type[Exception]
+    add_project_item: Callable[[str, str], str]
+    apply_missing_project_item_defaults: Callable[[str, tuple[ProjectField, ...], dict[str, str]], FieldCopySummary]
+    backfill_repository_issues: Callable[[str, str], int]
+    compare_schema: Callable[[tuple[ProjectField, ...], ProjectSchema], tuple[Finding, ...]]
+    configuration_plan: ConfigurationPlan
+    copy_missing_project_item_fields: Callable[[str, str], FieldCopySummary]
+    copy_template_project: Callable[[str, str, str], ProjectInfo]
+    create_project: Callable[[str, str], ProjectInfo]
+    create_single_select_field: Callable[[str, SelectFieldSpec], None]
+    fetch_issue_id: Callable[[str, str, int], str]
+    fetch_project_fields: Callable[[str], tuple[ProjectField, ...]]
+    fetch_project_views: Callable[[str], tuple[ProjectView, ...]]
+    find_owner_and_project: Callable[[str, str], OwnerInfo]
+    find_project_item_id: Callable[[str, str], str | None]
+    issue_field_values_for_args: Callable[[ProjectArguments], dict[str, str]]
+    link_project_to_repository: Callable[[str, str], None]
+    missing_option_names: Callable[[ProjectField, SelectFieldSpec], tuple[str, ...]]
+    project_config_for_args: Callable[[ProjectArguments], ProjectConfig]
+    project_field_defaults_for_config: Callable[[ProjectConfig], dict[str, str]]
+    require_owner: Callable[[ProjectArguments], str]
+    require_repo: Callable[[ProjectArguments], str]
+    resolve_issue_field_updates: ResolveIssueFieldUpdates
+    schema_for_args: Callable[[ProjectArguments], ProjectSchema]
+    split_repo: Callable[[str], tuple[str, str]]
+    update_item_field: Callable[[str, str, FieldUpdate], None]
+    update_project: UpdateProject
+    update_single_select_field: Callable[[ProjectField, SelectFieldSpec], None]
+    verify_standard_template_views: Callable[[tuple[ProjectView, ...]], None]

--- a/cli/python/base_github_projects/tests/test_engine_structure.py
+++ b/cli/python/base_github_projects/tests/test_engine_structure.py
@@ -44,7 +44,16 @@ def test_project_git_helpers_are_split_from_engine() -> None:
 def test_project_operations_are_explicit_instead_of_module_ops() -> None:
     engine_path = Path(engine.__file__)
     operations_path = engine_path.with_name("project_operations.py")
+    configure_command_path = engine_path.with_name("project_configure_command.py")
+    issue_fields_command_path = engine_path.with_name("project_issue_fields_command.py")
+    doctor_command_path = engine_path.with_name("project_doctor_command.py")
+    operations_source = operations_path.read_text(encoding="utf-8")
 
     assert operations_path.exists()
-    assert "class ProjectOperations" in operations_path.read_text(encoding="utf-8")
+    assert "class ProjectOperations" in operations_source
+    assert "@dataclass(frozen=True)" in operations_source
+    assert "SimpleNamespace" not in operations_source
+    assert "ops: Any" not in configure_command_path.read_text(encoding="utf-8")
+    assert "ops: Any" not in issue_fields_command_path.read_text(encoding="utf-8")
+    assert "ops: Any" not in doctor_command_path.read_text(encoding="utf-8")
     assert "sys.modules[__name__]" not in engine_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Replace the SimpleNamespace operations object with a frozen ProjectOperations dataclass.
- Add protocols for keyword-only operation call signatures.
- Update GitHub Project command helpers to accept ProjectArguments and ProjectOperations instead of Any.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m py_compile cli/python/base_github_projects/project_operations.py cli/python/base_github_projects/project_configure_command.py cli/python/base_github_projects/project_doctor_command.py cli/python/base_github_projects/project_issue_fields_command.py cli/python/base_github_projects/engine.py
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests -q
- git diff --cached --check

Fixes #1505