### PR TITLE
Clean up release engine compatibility imports

### DIFF
--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -1,35 +1,26 @@
 from __future__ import annotations
 
-import subprocess  # pylint: disable=unused-import
 import sys
 
 import base_cli
-from base_setup import process  # pylint: disable=unused-import
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 
+from . import release_readiness
 from .release_model import ReleaseContext, ReleaseError, ReleaseFinding
 from .release_parser import ReleaseArguments
 from .release_parser import ReleaseUsageError
 from .release_parser import parse_release_args
 from .release_parser import print_usage
-# pylint: disable=unused-import
-from .release_publish import RELEASE_STEP_TIMEOUT_SECONDS
 from .release_publish import release_publish_recovery_guidance, require_interactive_publish_confirmation
 from .release_publish import run_release_step, write_temp_release_notes
-from .release_readiness import CHANGELOG_HEADER_RE, GIT_INSPECTION_TIMEOUT_SECONDS
-from .release_readiness import changelog_finding, current_git_branch, extract_changelog_section
-from .release_readiness import gh_cli_finding, git_branch_finding, git_status, git_worktree_finding
-from .release_readiness import github_release_finding, last_non_empty_line, local_tag_exists, local_tag_finding
-from .release_readiness import read_version_file, release_findings as _release_findings
-from .release_readiness import remote_tag_finding, version_file_finding
-# pylint: enable=unused-import
+from .release_readiness import extract_changelog_section, gh_cli_finding, github_release_finding
 
 app = base_cli.App(name="base_release")
-release_findings = lambda ctx: _release_findings(  # pylint: disable=unnecessary-lambda-assignment
-    ctx,
-    gh_cli_finding_func=gh_cli_finding,
-)
+
+
+def release_findings(ctx: ReleaseContext) -> tuple[ReleaseFinding, ...]:
+    return release_readiness.release_findings(ctx, gh_cli_finding_func=gh_cli_finding)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -11,7 +11,8 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_release import engine
+from base_release import release_publish
+from base_release import release_readiness
 from base_release.engine import ReleaseError
 from base_release.engine import ReleaseFinding
 from base_release.engine import main
@@ -547,21 +548,24 @@ class ReleaseHelperTests(unittest.TestCase):
     def test_run_release_step_uses_bounded_timeout(self) -> None:
         completed = subprocess.CompletedProcess(["git", "tag"], 0, stdout="")
 
-        with mock.patch("base_release.engine.subprocess.run", return_value=completed) as run:
-            engine.run_release_step(["git", "tag"], cwd=Path("/repo"))
+        with mock.patch("base_release.release_publish.process.run_capture", return_value=completed) as run_capture:
+            release_publish.run_release_step(["git", "tag"], cwd=Path("/repo"))
 
-        self.assertEqual(run.call_args.kwargs["timeout"], engine.RELEASE_STEP_TIMEOUT_SECONDS)
+        self.assertEqual(
+            run_capture.call_args.kwargs["timeout_seconds"],
+            release_publish.RELEASE_STEP_TIMEOUT_SECONDS,
+        )
 
     def test_run_release_step_uses_shared_capture_helper(self) -> None:
         completed = subprocess.CompletedProcess(["git", "tag"], 0, stdout="")
 
-        with mock.patch("base_release.engine.process.run_capture", return_value=completed) as run_capture:
-            engine.run_release_step(["git", "tag"], cwd=Path("/repo"))
+        with mock.patch("base_release.release_publish.process.run_capture", return_value=completed) as run_capture:
+            release_publish.run_release_step(["git", "tag"], cwd=Path("/repo"))
 
         run_capture.assert_called_once_with(
             ["git", "tag"],
             cwd=Path("/repo"),
-            timeout_seconds=engine.RELEASE_STEP_TIMEOUT_SECONDS,
+            timeout_seconds=release_publish.RELEASE_STEP_TIMEOUT_SECONDS,
             stderr=subprocess.STDOUT,
         )
 
@@ -569,59 +573,62 @@ class ReleaseHelperTests(unittest.TestCase):
         command = ["git", "push", "origin", "v1.2.3"]
 
         with mock.patch(
-            "base_release.engine.subprocess.run",
+            "base_release.release_publish.process.run_capture",
             side_effect=subprocess.TimeoutExpired(command, timeout=30),
         ):
             with self.assertRaisesRegex(ReleaseError, "timed out"):
-                engine.run_release_step(command)
+                release_publish.run_release_step(command)
 
     def test_run_release_step_reports_os_error_as_release_error(self) -> None:
         command = ["gh", "release", "create", "v1.2.3"]
 
-        with mock.patch("base_release.engine.subprocess.run", side_effect=OSError("network unavailable")):
+        with mock.patch(
+            "base_release.release_publish.process.run_capture",
+            side_effect=OSError("network unavailable"),
+        ):
             with self.assertRaisesRegex(ReleaseError, "Unable to run release command"):
-                engine.run_release_step(command)
+                release_publish.run_release_step(command)
 
     def test_run_release_step_quotes_spaced_arguments_in_errors(self) -> None:
         command = ["gh", "release", "create", "v1.2.3", "--title", "Demo Release"]
         completed = subprocess.CompletedProcess(command, 1, stdout="release failed\n")
 
-        with mock.patch("base_release.engine.subprocess.run", return_value=completed):
+        with mock.patch("base_release.release_publish.process.run_capture", return_value=completed):
             with self.assertRaisesRegex(
                 ReleaseError,
                 "gh release create v1.2.3 --title 'Demo Release'",
             ):
-                engine.run_release_step(command)
+                release_publish.run_release_step(command)
 
     def test_git_worktree_finding_warns_when_status_times_out(self) -> None:
         with mock.patch(
-            "base_release.engine.subprocess.run",
+            "base_release.release_readiness.subprocess.run",
             side_effect=subprocess.TimeoutExpired(["git", "status", "--porcelain"], timeout=10),
         ):
-            finding = engine.git_worktree_finding(Path("/repo"))
+            finding = release_readiness.git_worktree_finding(Path("/repo"))
 
         self.assertEqual(finding.status, "warn")
         self.assertIn("Unable to inspect Git worktree status", finding.message)
 
     def test_git_branch_finding_warns_when_branch_check_times_out(self) -> None:
         with mock.patch(
-            "base_release.engine.subprocess.run",
+            "base_release.release_readiness.subprocess.run",
             side_effect=subprocess.TimeoutExpired(["git", "branch", "--show-current"], timeout=10),
         ):
-            finding = engine.git_branch_finding(Path("/repo"))
+            finding = release_readiness.git_branch_finding(Path("/repo"))
 
         self.assertEqual(finding.status, "warn")
         self.assertIn("Unable to inspect current Git branch", finding.message)
 
     def test_local_tag_finding_warns_when_tag_check_times_out(self) -> None:
         with mock.patch(
-            "base_release.engine.subprocess.run",
+            "base_release.release_readiness.subprocess.run",
             side_effect=subprocess.TimeoutExpired(
                 ["git", "rev-parse", "--verify", "--quiet", "refs/tags/v1.2.3"],
                 timeout=10,
             ),
         ):
-            finding = engine.local_tag_finding(Path("/repo"), "v1.2.3")
+            finding = release_readiness.local_tag_finding(Path("/repo"), "v1.2.3")
 
         self.assertEqual(finding.status, "warn")
         self.assertIn("Unable to inspect local tag v1.2.3", finding.message)

--- a/cli/python/base_release/tests/test_engine_structure.py
+++ b/cli/python/base_release/tests/test_engine_structure.py
@@ -8,10 +8,12 @@ from base_release import engine
 def test_release_readiness_helpers_are_split_from_engine() -> None:
     engine_path = Path(engine.__file__)
     readiness_path = engine_path.with_name("release_readiness.py")
+    engine_source = engine_path.read_text(encoding="utf-8")
 
     assert readiness_path.exists()
     assert "def release_findings" in readiness_path.read_text(encoding="utf-8")
-    assert "def release_findings" not in engine_path.read_text(encoding="utf-8")
+    assert "release_findings = lambda" not in engine_source
+    assert "release_findings as _release_findings" not in engine_source
 
 
 def test_release_publish_helpers_are_split_from_engine() -> None:


### PR DESCRIPTION
## Summary
- Remove release engine imports kept only for old patch paths.
- Replace the release_findings lambda alias with an explicit patch seam function.
- Move helper tests to patch release_publish and release_readiness directly.

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m py_compile cli/python/base_release/engine.py cli/python/base_release/tests/test_engine.py cli/python/base_release/tests/test_engine_structure.py
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_release/tests -q
- git diff --cached --check

Fixes #1509