### PR TITLE
Add ensure-bash bootstrap path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `bootstrap.sh --ensure-bash` to verify or install only the Bash 4.2+
+  prerequisite on macOS and Ubuntu/Debian before the full Base setup path is
+  available.
+
 ### Changed
 
 - Clarified `basectl ci` help and docs so CI-safe setup/readiness/diagnostics

--- a/FAQ.md
+++ b/FAQ.md
@@ -14,6 +14,17 @@ The bootstrapper verifies macOS, ensures Homebrew is available, installs Git and
 a supported Bash when needed, installs or updates Base, and then prints the
 exact `basectl` commands needed to finish setup.
 
+If Base is already present but `basectl` cannot start because the current Bash
+is too old, use the narrower Bash repair path:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --dry-run
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --yes
+```
+
+On macOS this installs Homebrew Bash when needed. On Ubuntu/Debian it previews
+and then installs only the `bash` apt package.
+
 ### Why does bootstrap print commands instead of changing my shell automatically?
 
 `bootstrap.sh` is the first-mile handoff into Base. It intentionally avoids
@@ -35,6 +46,10 @@ bootstrap prints, typically:
 
 Use `bootstrap.sh` on a new or uncertain macOS machine. It handles missing
 first-mile prerequisites and then hands off to Base.
+
+Use `bootstrap.sh --ensure-bash` when the machine only needs a supported Bash
+before Base can continue. It does not clone Base, install Python, create virtual
+environments, or run project setup.
 
 Use Homebrew when you already have Homebrew and Bash and want Base managed like
 an ordinary installed tool:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ source checkout at `~/work/base`, and prints the exact `basectl setup` and
 `basectl update-profile` commands to finish the installation. It does not edit
 shell startup files automatically.
 
+If Base is already installed but `basectl` cannot start because Bash is too
+old, repair only that prerequisite:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --dry-run
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --yes
+```
+
 Choose an install mode explicitly when needed:
 
 ```bash
@@ -1174,6 +1182,9 @@ On Ubuntu/Debian Linux, `bootstrap.sh` does not run `sudo apt` automatically.
 It prints the manual source-checkout path, including the supported apt
 prerequisites, a sibling `base-bash-libs` checkout, `basectl setup --dry-run`,
 `basectl setup --yes`, and `basectl update-profile`.
+
+The focused `bootstrap.sh --ensure-bash --yes` path is intentionally narrower:
+it installs only Bash after a dry-run review.
 
 Base can be installed through its Homebrew tap:
 

--- a/bin/basectl
+++ b/bin/basectl
@@ -185,11 +185,13 @@ basectl_ensure_supported_bash() {
         printf 'ERROR: Base requires Bash 4.2 or newer; current version is %s.\n' "$display_version"
         printf 'A supported Bash was not found at /opt/homebrew/bin/bash or /usr/local/bin/bash.\n'
         printf '\n'
-        printf 'Run:\n'
-        printf '  basectl setup\n'
+        printf 'Run Base first-mile Bash setup:\n'
+        printf '  bootstrap.sh --ensure-bash --dry-run\n'
+        printf '  bootstrap.sh --ensure-bash --yes\n'
         printf '\n'
         printf 'Or install Bash manually:\n'
         printf '  brew install bash\n'
+        printf '  sudo apt-get install -y bash\n'
     } >&2
     exit 1
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,11 +12,13 @@ Usage:
 Options:
   --source                 Install or update Base from a Git checkout.
   --brew                   Install Base through Homebrew.
+  --ensure-bash            Verify or install Bash 4.2+ only.
   --install-dir <path>     Source checkout path. Defaults to ~/work/base.
   --repo-url <url>         Git repository URL for source mode.
   --branch <name>          Clone a specific branch for a new source checkout.
   --no-homebrew-install    Fail instead of installing Homebrew when missing.
   --dry-run                Print planned actions without making changes.
+  --yes                    Allow ensure-bash to make Ubuntu/Debian apt changes.
   -h, --help               Show this help text.
 
 Mode selection uses this precedence:
@@ -419,18 +421,49 @@ bootstrap_ensure_git() {
     bootstrap_git_usable || bootstrap_die "Git was installed, but 'git --version' still does not work."
 }
 
-bootstrap_bash_version_number() {
-    printf '%s\n' "${BASE_BOOTSTRAP_TEST_BASH_VERSION:-${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}}"
+bootstrap_bash_version_supported_parts() {
+    local major="$1"
+    local minor="$2"
+
+    [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+    ((major > 4 || (major == 4 && minor >= 2)))
+}
+
+bootstrap_current_bash_supported() {
+    local major
+    local minor
+    local test_version="${BASE_BOOTSTRAP_TEST_BASH_VERSION:-}"
+
+    if [[ -n "$test_version" ]]; then
+        major="${test_version:0:1}"
+        minor="${test_version:1}"
+        [[ -n "$minor" ]] || minor=0
+    else
+        major="${BASH_VERSINFO[0]:-0}"
+        minor="${BASH_VERSINFO[1]:-0}"
+    fi
+
+    bootstrap_bash_version_supported_parts "$major" "$minor"
+}
+
+bootstrap_bash_candidate_supported() {
+    local candidate="$1"
+    local major
+    local minor
+    local version_output
+
+    [[ -x "$candidate" ]] || return 1
+    version_output="$("$candidate" -c 'printf "%s %s\n" "${BASH_VERSINFO[0]:-0}" "${BASH_VERSINFO[1]:-0}"' 2>/dev/null)" || return 1
+    read -r major minor _ <<< "$version_output"
+    bootstrap_bash_version_supported_parts "${major:-0}" "${minor:-0}"
 }
 
 bootstrap_find_supported_bash() {
     local candidate
-    local candidates="${BASE_BOOTSTRAP_BASH_CANDIDATES:-/opt/homebrew/bin/bash:/usr/local/bin/bash}"
-    local current_version
+    local candidates="${1:-${BASE_BOOTSTRAP_BASH_CANDIDATES:-/opt/homebrew/bin/bash:/usr/local/bin/bash}}"
     local -a candidate_paths
 
-    current_version="$(bootstrap_bash_version_number)"
-    if [[ "$current_version" -ge 42 ]]; then
+    if bootstrap_current_bash_supported; then
         printf '%s\n' "${BASH:-bash}"
         return 0
     fi
@@ -438,7 +471,7 @@ bootstrap_find_supported_bash() {
     IFS=: read -ra candidate_paths <<< "$candidates"
     for candidate in "${candidate_paths[@]}"; do
         [[ -n "$candidate" ]] || continue
-        [[ -x "$candidate" ]] || continue
+        bootstrap_bash_candidate_supported "$candidate" || continue
         printf '%s\n' "$candidate"
         return 0
     done
@@ -461,6 +494,63 @@ bootstrap_ensure_supported_bash() {
     fi
 
     bootstrap_find_supported_bash >/dev/null 2>&1 || bootstrap_die "Bash was installed, but a supported Bash was not found."
+}
+
+bootstrap_linux_debian_bash_apt_update_command() {
+    printf '%s\n' "sudo apt-get update"
+}
+
+bootstrap_linux_debian_bash_apt_install_command() {
+    printf '%s\n' "sudo apt-get install -y bash"
+}
+
+bootstrap_ensure_linux_debian_bash() {
+    local yes="$1"
+
+    bootstrap_log "Bash 4.2+ is not available for Base."
+
+    if [[ "${BASE_BOOTSTRAP_DRY_RUN:-false}" == "true" ]]; then
+        bootstrap_log "[DRY-RUN] Would run: $(bootstrap_linux_debian_bash_apt_update_command)"
+        bootstrap_log "[DRY-RUN] Would run: $(bootstrap_linux_debian_bash_apt_install_command)"
+        return 0
+    fi
+
+    [[ "$yes" == "true" ]] ||
+        bootstrap_die "Installing Bash on Ubuntu/Debian requires --yes. Run 'bootstrap.sh --ensure-bash --dry-run' to review the apt commands, then rerun with '--yes'."
+
+    bootstrap_log "Installing Bash 4.2+ through apt."
+    sudo apt-get update || bootstrap_die "Failed to update apt package lists."
+    sudo apt-get install -y bash || bootstrap_die "Failed to install Bash through apt."
+    bootstrap_log "Bash install command completed; start a new shell or rerun bootstrap if the current shell is still too old."
+}
+
+bootstrap_run_ensure_bash() {
+    local allow_homebrew_install="$2"
+    local brew_bin=""
+    local linux_bash_candidates="${BASE_BOOTSTRAP_BASH_CANDIDATES:-/usr/bin/bash:/bin/bash}"
+    local platform="$1"
+    local yes="$3"
+
+    case "$platform" in
+        macos)
+            if bootstrap_find_supported_bash >/dev/null 2>&1; then
+                bootstrap_log "Bash 4.2+ is available for Base."
+                return 0
+            fi
+            bootstrap_ensure_homebrew "$allow_homebrew_install" brew_bin || return $?
+            bootstrap_ensure_supported_bash "$brew_bin"
+            ;;
+        linux-debian)
+            if bootstrap_find_supported_bash "$linux_bash_candidates" >/dev/null 2>&1; then
+                bootstrap_log "Bash 4.2+ is available for Base."
+                return 0
+            fi
+            bootstrap_ensure_linux_debian_bash "$yes"
+            ;;
+        *)
+            bootstrap_die "bootstrap.sh --ensure-bash currently supports macOS and Ubuntu/Debian Linux only."
+            ;;
+    esac
 }
 
 bootstrap_source_checkout_present() {
@@ -651,11 +741,13 @@ bootstrap_main() {
     local allow_homebrew_install="${BASE_BOOTSTRAP_HOMEBREW_INSTALL:-true}"
     local branch="${BASE_BOOTSTRAP_BRANCH:-}"
     local brew_bin=""
+    local ensure_bash_only=false
     local formula="${BASE_BOOTSTRAP_BREW_FORMULA:-basefoundry/base/base}"
     local install_dir="${BASE_BOOTSTRAP_INSTALL_DIR:-${BASE_HOME:-$HOME/work/base}}"
     local mode="${BASE_BOOTSTRAP_MODE:-}"
     local platform
     local repo_url="${BASE_BOOTSTRAP_REPO_URL:-https://github.com/basefoundry/base.git}"
+    local yes=false
 
     BASE_BOOTSTRAP_DRY_RUN="${BASE_BOOTSTRAP_DRY_RUN:-false}"
 
@@ -671,6 +763,10 @@ bootstrap_main() {
                 ;;
             --brew)
                 mode=brew
+                shift
+                ;;
+            --ensure-bash)
+                ensure_bash_only=true
                 shift
                 ;;
             --install-dir|--dir)
@@ -696,6 +792,10 @@ bootstrap_main() {
                 BASE_BOOTSTRAP_DRY_RUN=true
                 shift
                 ;;
+            --yes)
+                yes=true
+                shift
+                ;;
             *)
                 bootstrap_usage >&2
                 bootstrap_die "Unknown option '$1'."
@@ -703,11 +803,16 @@ bootstrap_main() {
         esac
     done
 
-    bootstrap_validate_mode "$mode" || return $?
     install_dir="$(bootstrap_expand_path "$install_dir")" || return $?
 
     bootstrap_log "Base bootstrap"
     platform="$(bootstrap_current_platform)" || return $?
+    if [[ "$ensure_bash_only" == "true" ]]; then
+        bootstrap_run_ensure_bash "$platform" "$allow_homebrew_install" "$yes"
+        return $?
+    fi
+
+    bootstrap_validate_mode "$mode" || return $?
     case "$platform" in
         macos)
             ;;

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -165,8 +165,10 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"Base requires Bash 4.2 or newer; current version is 3.2."* ]]
     [[ "$output" == *"A supported Bash was not found"* ]]
-    [[ "$output" == *"basectl setup"* ]]
+    [[ "$output" == *"bootstrap.sh --ensure-bash --dry-run"* ]]
+    [[ "$output" == *"bootstrap.sh --ensure-bash --yes"* ]]
     [[ "$output" == *"brew install bash"* ]]
+    [[ "$output" == *"sudo apt-get install -y bash"* ]]
 }
 
 @test "basectl rejects removed legacy commands" {

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -10,6 +10,10 @@ On Ubuntu/Debian Linux, `bootstrap.sh` stays conservative: it does not run
 manual source-checkout commands, including apt prerequisites and the
 `basectl setup --yes` handoff for unattended paste-and-run flows.
 
+When only the supported Bash prerequisite is missing, use the focused
+`--ensure-bash` path instead of the full install bootstrap. It verifies Bash
+4.2+ and installs only the platform Bash package when needed.
+
 ## Quick Start
 
 Run the bootstrapper from GitHub:
@@ -43,6 +47,16 @@ exec "$SHELL" -l
 `bootstrap.sh` does not edit shell startup files automatically. Shell profile
 integration remains an explicit `basectl update-profile` step so the user can
 see what was installed before Base changes future interactive shells.
+
+If `basectl` reports that the current Bash is too old, repair just that first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --dry-run
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --yes
+```
+
+On macOS this path uses Homebrew Bash. On Ubuntu/Debian it previews and then
+runs only `sudo apt-get update` and `sudo apt-get install -y bash`.
 
 On Ubuntu/Debian, inspect the manual path first:
 
@@ -86,12 +100,15 @@ bootstrap.sh --install-dir ~/work/base
 bootstrap.sh --repo-url https://github.com/basefoundry/base.git
 bootstrap.sh --branch <name>
 bootstrap.sh --no-homebrew-install
+bootstrap.sh --ensure-bash
 bootstrap.sh --dry-run
+bootstrap.sh --yes
 ```
 
 Use `--dry-run` to inspect the planned prerequisite installs and Base install
 route without changing the machine. On Ubuntu/Debian, the bootstrapper always
-prints manual commands rather than mutating apt state itself.
+prints manual commands rather than mutating apt state itself, except for the
+focused `--ensure-bash --yes` path that installs only Bash.
 
 ## Contributor Path
 

--- a/docs/linux-support.md
+++ b/docs/linux-support.md
@@ -151,6 +151,24 @@ want to paste the reviewed command sequence into an unattended shell; an
 interactive user can run `basectl setup` after reviewing `--dry-run` and confirm
 the Ubuntu/Debian system-change prompt.
 
+The focused Bash prerequisite repair path is the one exception. When Base is
+already present but the current shell is too old for `basectl`, review and run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --dry-run
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --ensure-bash --yes
+```
+
+On Ubuntu/Debian, `--ensure-bash` previews and then runs only:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y bash
+```
+
+It does not clone Base, install Python, create virtual environments, install
+developer tools, or run project setup.
+
 Ubuntu/Debian setup can install the simple apt prerequisites that Base knows
 how to own. The mutation path is intentionally explicit: `basectl setup
 --dry-run` prints the apt commands, interactive `basectl setup` prompts before

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -83,12 +83,24 @@ EOF
     chmod +x "$TEST_MOCKBIN/brew"
 }
 
+create_sudo_stub() {
+    cat > "$TEST_MOCKBIN/sudo" <<'EOF'
+#!/bin/sh
+printf 'sudo %s\n' "$*" >> "${BASE_BOOTSTRAP_TEST_COMMAND_LOG:?}"
+exit 0
+EOF
+    chmod +x "$TEST_MOCKBIN/sudo"
+}
+
 create_supported_bash_candidate() {
     local bash_path="$1"
 
     mkdir -p "$(dirname "$bash_path")"
     cat > "$bash_path" <<'EOF'
 #!/bin/sh
+if [ "${1:-}" = "-c" ]; then
+    printf '42\n'
+fi
 exit 0
 EOF
     chmod +x "$bash_path"
@@ -119,6 +131,8 @@ sha256_file() {
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"--source"* ]]
     [[ "$output" == *"--brew"* ]]
+    [[ "$output" == *"--ensure-bash"* ]]
+    [[ "$output" == *"--yes"* ]]
 }
 
 @test "bootstrap avoids shell strict mode" {
@@ -178,6 +192,43 @@ sha256_file() {
     [[ "$output" == *"$install_dir/bin/basectl setup"* ]]
     [[ "$output" == *"$install_dir/bin/basectl update-profile"* ]]
     [[ "$output" == *"exec \"\$SHELL\" -l"* ]]
+}
+
+@test "bootstrap ensure-bash no-ops when current Bash is supported" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_OS=Darwin \
+        BASE_BOOTSTRAP_TEST_BASH_VERSION=42 \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --ensure-bash --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base bootstrap"* ]]
+    [[ "$output" == *"Bash 4.2+ is available for Base."* ]]
+    [[ "$output" != *"Install mode:"* ]]
+    [[ "$output" != *"git clone"* ]]
+    [[ "$output" != *"basectl setup"* ]]
+}
+
+@test "bootstrap ensure-bash macOS dry-run installs Homebrew Bash only" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_OS=Darwin \
+        BASE_BOOTSTRAP_TEST_BASH_VERSION=32 \
+        BASE_BOOTSTRAP_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        BASE_BOOTSTRAP_BREW_CANDIDATES="$TEST_TMPDIR/missing-brew" \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --ensure-bash --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing Homebrew."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: /bin/bash -c <Homebrew installer from https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh>"* ]]
+    [[ "$output" == *"Installing Bash 4.2+ through Homebrew."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: brew install bash"* ]]
+    [[ "$output" != *"Installing Git through Homebrew."* ]]
+    [[ "$output" != *"Install mode:"* ]]
+    [[ "$output" != *"git clone"* ]]
+    [[ "$output" != *"basectl setup"* ]]
 }
 
 @test "bootstrap dry-run reports pinned Homebrew installer verification" {
@@ -381,6 +432,62 @@ sha256_file() {
     [[ "$output" != *"Xcode"* ]]
 }
 
+@test "bootstrap ensure-bash linux-debian dry-run prints Bash apt commands only" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_PLATFORM=linux-debian \
+        BASE_BOOTSTRAP_TEST_BASH_VERSION=32 \
+        BASE_BOOTSTRAP_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --ensure-bash --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Bash 4.2+ is not available for Base."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get update"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get install -y bash"* ]]
+    [[ "$output" != *"git python3"* ]]
+    [[ "$output" != *"git clone"* ]]
+    [[ "$output" != *"basectl setup"* ]]
+}
+
+@test "bootstrap ensure-bash linux-debian requires yes before apt mutation" {
+    create_sudo_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_PLATFORM=linux-debian \
+        BASE_BOOTSTRAP_TEST_BASH_VERSION=32 \
+        BASE_BOOTSTRAP_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        BASE_BOOTSTRAP_TEST_COMMAND_LOG="$TEST_COMMAND_LOG" \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --ensure-bash
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Installing Bash on Ubuntu/Debian requires --yes."* ]]
+    [ ! -e "$TEST_COMMAND_LOG" ]
+}
+
+@test "bootstrap ensure-bash linux-debian yes runs Bash apt commands" {
+    create_sudo_stub
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_PLATFORM=linux-debian \
+        BASE_BOOTSTRAP_TEST_BASH_VERSION=32 \
+        BASE_BOOTSTRAP_BASH_CANDIDATES="$TEST_TMPDIR/missing-bash" \
+        BASE_BOOTSTRAP_TEST_COMMAND_LOG="$TEST_COMMAND_LOG" \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --ensure-bash --yes
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing Bash 4.2+ through apt."* ]]
+    [[ "$output" == *"Bash install command completed; start a new shell or rerun bootstrap if the current shell is still too old."* ]]
+    grep -Fqx "sudo apt-get update" "$TEST_COMMAND_LOG"
+    grep -Fqx "sudo apt-get install -y bash" "$TEST_COMMAND_LOG"
+    [[ "$output" != *"git clone"* ]]
+    [[ "$output" != *"basectl setup"* ]]
+}
+
 @test "bootstrap linux-debian rejects Homebrew mode" {
     run env \
         HOME="$TEST_HOME" \
@@ -432,4 +539,15 @@ sha256_file() {
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"bootstrap.sh currently supports macOS and Ubuntu/Debian Linux only"* ]]
+}
+
+@test "bootstrap ensure-bash rejects unsupported platforms" {
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_BOOTSTRAP_TEST_PLATFORM=unsupported \
+        "$BASH" "$BASE_REPO_ROOT/bootstrap.sh" --ensure-bash --dry-run
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bootstrap.sh --ensure-bash currently supports macOS and Ubuntu/Debian Linux only."* ]]
 }

--- a/tests/test_bootstrap_docs.py
+++ b/tests/test_bootstrap_docs.py
@@ -17,6 +17,8 @@ def test_readme_first_mile_section_surfaces_verified_homebrew_installer_path() -
     first_mile = section(text, "### New Or Uncertain Machine?", "### Team Or Security-Conscious Rollout")
 
     assert "curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash" in first_mile
+    assert "--ensure-bash --dry-run" in first_mile
+    assert "--ensure-bash --yes" in first_mile
     assert "BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL" in first_mile
     assert "BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256" in first_mile
     assert "BASE_HOMEBREW_INSTALLER_URL" in first_mile
@@ -28,6 +30,8 @@ def test_bootstrap_quick_start_surfaces_verified_homebrew_installer_path() -> No
     quick_start = section(text, "## Quick Start", "## Install Mode")
 
     assert "curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash" in quick_start
+    assert "--ensure-bash --dry-run" in quick_start
+    assert "--ensure-bash --yes" in quick_start
     assert "BASE_BOOTSTRAP_HOMEBREW_INSTALLER_URL" in quick_start
     assert "BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256" in quick_start
     assert "BASE_HOMEBREW_INSTALLER_URL" in quick_start


### PR DESCRIPTION
## Summary
- Add `bootstrap.sh --ensure-bash` for a focused Bash 4.2+ prerequisite repair path.
- Keep macOS on the existing first-mile Homebrew helper and add Ubuntu/Debian dry-run plus explicit `--yes` apt mutation.
- Update basectl recovery guidance and bootstrap/Linux docs.

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/bootstrap.bats cli/bash/commands/basectl/tests/runtime-dispatch.bats`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_bootstrap_docs.py -q`
- `bash -n bootstrap.sh`
- `bash -n bin/basectl`
- `git diff --check origin/main`

Fixes #1542