### PR TITLE
Add workspace onboarding summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `bootstrap.sh --ensure-bash` to verify or install only the Bash 4.2+
   prerequisite on macOS and Ubuntu/Debian before the full Base setup path is
   available.
+- Added `basectl workspace onboarding` to summarize first-day repository
+  readiness, missing clone actions, and project setup/check/test commands from
+  a workspace manifest without mutating repositories.
 
 ### Changed
 

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -57,6 +57,23 @@ Fetch and validate a canonical workspace manifest before updating the local mani
 EOF
 }
 
+base_workspace_onboarding_usage() {
+    cat <<'EOF'
+Usage:
+  basectl workspace onboarding [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --manifest <path>   Local workspace manifest describing expected repositories.
+                      Overrides workspace.manifest from ~/.base.d/config.yaml.
+  --format <format>   Output format for the onboarding summary: text or json.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Summarize first-day workspace onboarding from a workspace manifest without cloning or setup.
+EOF
+}
+
 base_workspace_init_usage() {
     cat <<'EOF'
 Usage:
@@ -98,6 +115,9 @@ base_workspace_subcommand_usage() {
         status|check|doctor)
             base_workspace_report_usage
             ;;
+        onboarding)
+            base_workspace_onboarding_usage
+            ;;
         clone)
             base_workspace_clone_usage
             ;;
@@ -113,12 +133,13 @@ base_workspace_subcommand_usage() {
         *)
             cat <<'EOF'
 Usage:
-  basectl workspace <status|check|doctor|clone|pull|init|configure> [options]
+  basectl workspace <status|check|doctor|onboarding|clone|pull|init|configure> [options]
 
 Commands:
   status     Show workspace status. Supports --format text|json.
   check      Run workspace checks. Supports --format text|json.
   doctor     Run workspace diagnostics. Supports --format text|json.
+  onboarding Show first-day onboarding summary. Supports --format text|json.
   clone      Clone or validate expected repositories from a workspace manifest.
   pull       Fetch and validate a canonical workspace manifest source.
   init       Initialize a workspace from a workspace configuration repository.
@@ -146,7 +167,7 @@ base_workspace_subcommand_main() {
             base_workspace_subcommand_usage
             return 0
             ;;
-        status|check|doctor|clone|pull|init|configure)
+        status|check|doctor|onboarding|clone|pull|init|configure)
             shift
             ;;
         *)

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -255,7 +255,7 @@ EOF
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"export_context_options=--workspace --format --output --print --list-files"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
-    [[ "$output" == *"workspace_commands=status check doctor clone pull init configure"* ]]
+    [[ "$output" == *"workspace_commands=status check doctor onboarding clone pull init configure"* ]]
     [[ "$output" == *"workspace_status_options=--workspace --manifest --format"* ]]
     [[ "$output" == *"workspace_clone_options=--workspace --manifest --include-optional --dry-run"* ]]
     [[ "$output" == *"workspace_pull_options=--source --manifest --dry-run"* ]]
@@ -342,6 +342,6 @@ EOF
             printf "options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"commands=status check doctor clone pull init configure"* ]]
+    [[ "$output" == *"commands=status check doctor onboarding clone pull init configure"* ]]
     [[ "$output" == *"options=--workspace --manifest --dry-run"* ]]
 }

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -84,7 +84,7 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull|init|configure> [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor|onboarding|clone|pull|init|configure> [options]"* ]]
     [[ "$output" != *"Usage: basectl [options] <command> [args...]"* ]]
 
     run_basectl help release

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -86,6 +86,34 @@ EOF
     [ "$output" = "ARGS=--workspace $workspace --format json" ]
 }
 
+@test "basectl workspace onboarding delegates to the Python projects layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local manifest="$TEST_TMPDIR/workspace.yaml"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    touch "$manifest"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "onboarding" ]]; then
+    printf 'ARGS=%s\n' "${*:4}"
+    exit 0
+fi
+printf 'unexpected workspace onboarding python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace onboarding --workspace "$workspace" --manifest "$manifest" --format json
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS=--workspace $workspace --manifest $manifest --format json" ]
+}
+
 @test "basectl workspace clone delegates to the Python projects layer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
@@ -221,6 +249,14 @@ EOF
     [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
     [[ "$output" == *"--format <format>"* ]]
 
+    run_basectl workspace onboarding --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl workspace onboarding [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--manifest <path>"* ]]
+    [[ "$output" == *"--format <format>"* ]]
+
     run_basectl workspace clone --help
 
     [ "$status" -eq 0 ]
@@ -264,7 +300,7 @@ EOF
     run_basectl workspace help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl workspace <status|check|doctor|clone|pull|init|configure> [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor|onboarding|clone|pull|init|configure> [options]"* ]]
     [[ "$output" != *"Project virtual environment Python was not found"* ]]
 }
 

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -41,12 +41,15 @@ from base_projects.workspace_context import resolve_workspace_manifest
 from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_init import workspace_init_command
 from base_projects.workspace_pull_command import workspace_pull_command
+from base_projects.workspace_onboarding import workspace_onboarding_summary
 from base_projects.workspace_report_json import dumps_json
 from base_projects.workspace_report_json import workspace_check_to_json
 from base_projects.workspace_report_json import workspace_doctor_to_json
+from base_projects.workspace_report_json import workspace_onboarding_to_json
 from base_projects.workspace_report_json import workspace_status_to_json
 from base_projects.workspace_report_text import print_workspace_check
 from base_projects.workspace_report_text import print_workspace_doctor
+from base_projects.workspace_report_text import print_workspace_onboarding
 from base_projects.workspace_report_text import print_workspace_status
 from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_projects.workspace_checks import workspace_error_count
@@ -122,6 +125,7 @@ def project_command_actions() -> ProjectCommandActions:
         workspace_status=workspace_status_command,
         workspace_check=workspace_check_command,
         workspace_doctor=workspace_doctor_command,
+        workspace_onboarding=workspace_onboarding_command,
         workspace_clone=workspace_clone_command,
         workspace_pull=workspace_pull_command,
         workspace_init=workspace_init_project_command,
@@ -276,6 +280,34 @@ def workspace_doctor_command(
         print_workspace_doctor(workspace_root, results, manifest)
 
     return min(workspace_error_count(results), 125)
+
+
+def workspace_onboarding_command(
+    ctx: base_cli.Context,
+    workspace: str | None,
+    output_format: str = "text",
+    workspace_manifest: str | None = None,
+) -> int:
+    if output_format not in ("text", "json"):
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
+
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, workspace_manifest))
+        if manifest is None:
+            ctx.log.error("Workspace onboarding requires a workspace manifest. Use --manifest or workspace.manifest.")
+            return base_cli.ExitCode.USAGE_ERROR
+        summary = workspace_onboarding_summary(workspace_root, manifest)
+    except (ProjectDiscoveryError, ManifestError, WorkspaceManifestError) as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    if output_format == "json":
+        print(dumps_json(workspace_onboarding_to_json(summary)))
+    else:
+        print_workspace_onboarding(summary)
+    return base_cli.ExitCode.SUCCESS
 
 
 def log_workspace_status_discovery(

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -25,6 +25,7 @@ class ProjectCommandActions:
     workspace_status: Callable[[base_cli.Context, str | None, str, str | None], int]
     workspace_check: Callable[[base_cli.Context, str | None, str, str | None], int]
     workspace_doctor: Callable[[base_cli.Context, str | None, str, str | None], int]
+    workspace_onboarding: Callable[[base_cli.Context, str | None, str, str | None], int]
     workspace_clone: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
     workspace_pull: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
     workspace_init: Callable[[base_cli.Context, str, WorkspaceCommandOptions], int]
@@ -117,6 +118,16 @@ def _handle_doctor(
 ) -> int:
     require_argument_count("doctor", arguments, 0, 0)
     return actions.workspace_doctor(ctx, options.workspace, options.output_format, options.workspace_manifest)
+
+
+def _handle_onboarding(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("onboarding", arguments, 0, 0)
+    return actions.workspace_onboarding(ctx, options.workspace, options.output_format, options.workspace_manifest)
 
 
 def _handle_clone(
@@ -265,6 +276,7 @@ SUPPORTED_PROJECT_COMMANDS = (
     "status",
     "check",
     "doctor",
+    "onboarding",
     "clone",
     "configure",
     "init",
@@ -284,6 +296,7 @@ PROJECT_COMMAND_HANDLERS: dict[str, ProjectCommandHandler] = {
     "status": _handle_status,
     "check": _handle_check,
     "doctor": _handle_doctor,
+    "onboarding": _handle_onboarding,
     "clone": _handle_clone,
     "pull": _handle_pull,
     "init": _handle_init,

--- a/cli/python/base_projects/tests/test_workspace_onboarding.py
+++ b/cli/python/base_projects/tests/test_workspace_onboarding.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_projects import engine
+
+
+def write_project_manifest(project_root: Path, name: str, test_command: str | None = None) -> None:
+    project_root.mkdir(parents=True)
+    lines = [
+        "project:",
+        f"  name: {name}",
+    ]
+    if test_command is not None:
+        lines.extend(
+            [
+                "test:",
+                f"  command: {test_command}",
+            ]
+        )
+    lines.extend(["artifacts: []", ""])
+    (project_root / "base_manifest.yaml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_ready_python_bin(home: Path, project: str) -> None:
+    python_bin = home / ".base.d" / project / ".venv" / "bin" / "python"
+    python_bin.parent.mkdir(parents=True)
+    python_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    python_bin.chmod(0o755)
+
+
+def write_workspace_manifest(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "schema_version: 1",
+                "workspace:",
+                "  name: demo-suite",
+                "repos:",
+                "  - name: base",
+                "    url: git@github.com:basefoundry/base.git",
+                "    default_branch: main",
+                "  - name: docs",
+                "  - name: api",
+                "    url: git@github.com:example/api.git",
+                "  - name: optional-tool",
+                "    url: git@github.com:example/optional-tool.git",
+                "    required: false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    env = {
+        "HOME": str(home),
+        "BASE_HOME": str(base_home),
+        "BASE_PROJECT": "",
+        "BASE_PROJECT_MANIFEST": "",
+    }
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class WorkspaceOnboardingTests(unittest.TestCase):
+    def test_workspace_onboarding_json_reports_complete_manifest_repositories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_workspace_manifest(manifest_path)
+            write_project_manifest(workspace / "base", "base", "./bin/base-test")
+            write_project_manifest(workspace / "docs", "docs")
+            write_project_manifest(workspace / "api", "api", "pytest tests/")
+            write_project_manifest(workspace / "optional-tool", "optional-tool")
+            for project in ("base", "docs", "api", "optional-tool"):
+                write_ready_python_bin(home, project)
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "onboarding",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(manifest_path),
+                    "--format",
+                    "json",
+                ],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        repositories = {item["repository"]: item for item in payload["repositories"]}
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["workspace"], str(workspace.resolve()))
+        self.assertEqual(payload["workspace_manifest"]["name"], "demo-suite")
+        self.assertEqual(payload["repository_count"], 4)
+        self.assertEqual(repositories["base"]["status"], "ready")
+        self.assertEqual(repositories["base"]["discovery_status"], "present")
+        self.assertEqual(repositories["base"]["path"], str((workspace / "base").resolve()))
+        self.assertEqual(repositories["base"]["setup_command"], f"cd {(workspace / 'base').resolve()} && basectl setup")
+        self.assertEqual(
+            repositories["base"]["validation_command"],
+            f"cd {(workspace / 'base').resolve()} && basectl check",
+        )
+        self.assertEqual(repositories["base"]["test_command"], "./bin/base-test")
+        self.assertIsNone(repositories["base"]["clone_command"])
+        self.assertEqual(repositories["docs"]["test_command"], None)
+        self.assertEqual(repositories["optional-tool"]["required"], False)
+
+    def test_workspace_onboarding_text_reports_missing_required_and_optional_repositories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_workspace_manifest(manifest_path)
+            write_project_manifest(workspace / "base", "base", "./bin/base-test")
+            write_ready_python_bin(home, "base")
+
+            status, stdout, stderr = invoke_engine(
+                ["onboarding", "--workspace", str(workspace), "--manifest", str(manifest_path)],
+                base_home,
+                home,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace onboarding: {workspace.resolve()} (demo-suite)", stdout)
+        self.assertIn(f"Workspace manifest: {manifest_path.resolve()}", stdout)
+        self.assertIn("base                 yes      ready", stdout)
+        self.assertIn("api                  yes      missing_required", stdout)
+        self.assertIn("optional-tool        no       missing_optional", stdout)
+        self.assertIn(f"clone: git clone git@github.com:example/api.git {(workspace / 'api').resolve()}", stdout)
+        self.assertIn("optional repository is missing; clone it only if this role needs it", stdout)
+        self.assertIn(f"validate: cd {(workspace / 'base').resolve()} && basectl check", stdout)
+        self.assertIn("test: ./bin/base-test", stdout)
+
+    def test_workspace_onboarding_json_reports_partial_non_base_repositories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_workspace_manifest(manifest_path)
+            write_project_manifest(workspace / "base", "base")
+            (workspace / "docs").mkdir(parents=True)
+            write_ready_python_bin(home, "base")
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "onboarding",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(manifest_path),
+                    "--format",
+                    "json",
+                ],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        repositories = {item["repository"]: item for item in payload["repositories"]}
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(repositories["docs"]["status"], "present_without_manifest")
+        self.assertEqual(repositories["docs"]["discovery_status"], "present")
+        self.assertEqual(repositories["docs"]["manifest"], "missing")
+        self.assertEqual(repositories["docs"]["setup_command"], None)
+        self.assertEqual(repositories["docs"]["validation_command"], None)
+        self.assertEqual(
+            repositories["docs"]["next_action"],
+            f"Add or verify {(workspace / 'docs' / 'base_manifest.yaml').resolve()} before Base setup.",
+        )

--- a/cli/python/base_projects/workspace_onboarding.py
+++ b/cli/python/base_projects/workspace_onboarding.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+from base_projects.project_commands import test_command as manifest_test_command
+from base_projects.workspace_manifest import WorkspaceManifest
+from base_projects.workspace_statuses import WorkspaceProjectStatus
+from base_projects.workspace_statuses import workspace_manifest_project_statuses
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
+
+
+@dataclass(frozen=True)
+class WorkspaceOnboardingRepository:
+    repository: str
+    path: Path
+    required: bool
+    status: str
+    discovery_status: str
+    manifest: str
+    venv: str
+    next_action: str
+    manifest_path: Path | None = None
+    url: str | None = None
+    default_branch: str | None = None
+    setup_command: str | None = None
+    validation_command: str | None = None
+    test_command: str | None = None
+    clone_command: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceOnboardingSummary:
+    workspace_root: Path
+    workspace_manifest: WorkspaceManifest
+    repositories: tuple[WorkspaceOnboardingRepository, ...]
+
+
+def workspace_onboarding_summary(
+    workspace_root: Path,
+    workspace_manifest: WorkspaceManifest,
+) -> WorkspaceOnboardingSummary:
+    statuses = workspace_manifest_project_statuses(workspace_root, workspace_manifest)
+    repositories = tuple(
+        onboarding_repository_from_status(status)
+        for status in statuses
+        if status.expected
+    )
+    return WorkspaceOnboardingSummary(
+        workspace_root=workspace_root,
+        workspace_manifest=workspace_manifest,
+        repositories=repositories,
+    )
+
+
+def onboarding_repository_from_status(status: WorkspaceProjectStatus) -> WorkspaceOnboardingRepository:
+    repository = status.repository or status.root.name
+    status_name = onboarding_status(status)
+    setup_command = setup_command_for_status(status)
+    validation_command = validation_command_for_status(status)
+    clone_command = clone_command_for_status(status)
+    test_command = test_command_for_status(status)
+
+    return WorkspaceOnboardingRepository(
+        repository=repository,
+        path=status.root,
+        required=status.required,
+        status=status_name,
+        discovery_status="missing" if status.repo == "missing" else "present",
+        manifest=status.manifest,
+        venv=status.venv,
+        next_action=next_action_for_status(status, status_name),
+        manifest_path=status.manifest_path,
+        url=status.url,
+        default_branch=status.default_branch,
+        setup_command=setup_command,
+        validation_command=validation_command,
+        test_command=test_command,
+        clone_command=clone_command,
+    )
+
+
+def onboarding_status(status: WorkspaceProjectStatus) -> str:
+    if status.repo == "missing":
+        return "missing_required" if status.required else "missing_optional"
+    if status.manifest == "missing":
+        return "present_without_manifest"
+    if status.manifest == "invalid":
+        return "invalid_manifest"
+    if status.venv == "ready":
+        return "ready"
+    return "needs_setup"
+
+
+def setup_command_for_status(status: WorkspaceProjectStatus) -> str | None:
+    if status.manifest != "valid":
+        return None
+    return f"cd {shlex.quote(str(status.root))} && basectl setup"
+
+
+def validation_command_for_status(status: WorkspaceProjectStatus) -> str | None:
+    if status.manifest != "valid":
+        return None
+    return f"cd {shlex.quote(str(status.root))} && basectl check"
+
+
+def clone_command_for_status(status: WorkspaceProjectStatus) -> str | None:
+    if status.repo != "missing" or status.url is None:
+        return None
+    return shlex.join(["git", "clone", status.url, str(status.root)])
+
+
+def test_command_for_status(status: WorkspaceProjectStatus) -> str | None:
+    if status.manifest != "valid" or status.manifest_path is None:
+        return None
+    try:
+        manifest = read_manifest(status.manifest_path)
+    except ManifestError:
+        return None
+    if manifest.test is None:
+        return None
+    return manifest_test_command(manifest.test).command
+
+
+def next_action_for_status(status: WorkspaceProjectStatus, status_name: str) -> str:
+    if status_name == "missing_required":
+        return missing_required_next_action(status)
+    if status_name == "missing_optional":
+        return "optional repository is missing; clone it only if this role needs it."
+    if status_name == "present_without_manifest":
+        return f"Add or verify {(status.root / 'base_manifest.yaml').resolve()} before Base setup."
+    if status_name == "invalid_manifest":
+        return f"Fix {status.manifest_path} before Base setup."
+    if status_name == "ready":
+        return "Run validation command."
+    return "Run setup command, then validation command."
+
+
+def missing_required_next_action(status: WorkspaceProjectStatus) -> str:
+    if status.url is not None:
+        return f"Clone {status.url} into {status.root}, then run setup."
+    repository = status.repository or status.root.name
+    return f"Create or clone repository '{repository}' into {status.root}, then run setup."

--- a/cli/python/base_projects/workspace_report_json.py
+++ b/cli/python/base_projects/workspace_report_json.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Any
 
 from base_projects.workspace_manifest import WorkspaceManifest
+from base_projects.workspace_onboarding import WorkspaceOnboardingRepository
+from base_projects.workspace_onboarding import WorkspaceOnboardingSummary
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.checks import check_to_json
@@ -60,6 +62,43 @@ def workspace_doctor_to_json(
     workspace_manifest: WorkspaceManifest | None = None,
 ) -> dict[str, Any]:
     return workspace_checks_to_json(workspace_root, results, workspace_manifest=workspace_manifest)
+
+
+def workspace_onboarding_to_json(summary: WorkspaceOnboardingSummary) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "workspace": str(summary.workspace_root),
+        "workspace_manifest": {
+            "path": str(summary.workspace_manifest.path),
+            "name": summary.workspace_manifest.name,
+            "schema_version": summary.workspace_manifest.schema_version,
+        },
+        "repository_count": len(summary.repositories),
+        "repositories": [workspace_onboarding_item_to_json(repository) for repository in summary.repositories],
+    }
+
+
+def workspace_onboarding_item_to_json(repository: WorkspaceOnboardingRepository) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "repository": repository.repository,
+        "required": repository.required,
+        "status": repository.status,
+        "discovery_status": repository.discovery_status,
+        "path": str(repository.path),
+        "manifest_path": str(repository.manifest_path) if repository.manifest_path is not None else None,
+        "manifest": repository.manifest,
+        "venv": repository.venv,
+        "next_action": repository.next_action,
+        "setup_command": repository.setup_command,
+        "validation_command": repository.validation_command,
+        "test_command": repository.test_command,
+        "clone_command": repository.clone_command,
+    }
+    if repository.url is not None:
+        payload["url"] = repository.url
+    if repository.default_branch is not None:
+        payload["default_branch"] = repository.default_branch
+    return payload
 
 
 def workspace_checks_to_json(

--- a/cli/python/base_projects/workspace_report_text.py
+++ b/cli/python/base_projects/workspace_report_text.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Any
 
 from base_projects.workspace_manifest import WorkspaceManifest
+from base_projects.workspace_onboarding import WorkspaceOnboardingRepository
+from base_projects.workspace_onboarding import WorkspaceOnboardingSummary
 from base_setup.checks import doctor_status
 from base_setup.checks import print_doctor_finding
 
@@ -94,6 +96,40 @@ def print_workspace_check(
     if workspace_manifest is not None:
         print(f"Workspace manifest: {workspace_manifest.path} ({workspace_manifest.name})")
     print_workspace_check_results(results, workspace_manifest)
+
+
+def print_workspace_onboarding(summary: WorkspaceOnboardingSummary) -> None:
+    print(f"Workspace onboarding: {summary.workspace_root} ({summary.workspace_manifest.name})")
+    print(f"Workspace manifest: {summary.workspace_manifest.path}")
+    print()
+    if not summary.repositories:
+        print("No repositories reported by the workspace manifest.")
+        return
+
+    print(f"{'REPOSITORY':<20} {'REQUIRED':<8} {'STATUS':<24} PATH")
+    for repository in summary.repositories:
+        print(
+            f"{repository.repository:<20} "
+            f"{yes_no(repository.required):<8} "
+            f"{repository.status:<24} "
+            f"{repository.path}"
+        )
+
+    print("\nNext actions:")
+    for repository in summary.repositories:
+        print_workspace_onboarding_action(repository)
+
+
+def print_workspace_onboarding_action(repository: WorkspaceOnboardingRepository) -> None:
+    print(f"- {repository.repository}: {repository.next_action}")
+    if repository.clone_command is not None:
+        print(f"  clone: {repository.clone_command}")
+    if repository.setup_command is not None:
+        print(f"  setup: {repository.setup_command}")
+    if repository.validation_command is not None:
+        print(f"  validate: {repository.validation_command}")
+    if repository.test_command is not None:
+        print(f"  test: {repository.test_command}")
 
 
 def print_workspace_doctor(

--- a/cli/python/base_projects/workspace_reports.py
+++ b/cli/python/base_projects/workspace_reports.py
@@ -15,6 +15,9 @@ from base_projects.workspace_checks import workspace_project_check_results
 from base_projects.workspace_checks import workspace_repo_presence_check
 from base_projects.workspace_context import resolve_workspace_manifest
 from base_projects.workspace_manifest import WorkspaceManifest
+from base_projects.workspace_onboarding import WorkspaceOnboardingRepository
+from base_projects.workspace_onboarding import WorkspaceOnboardingSummary
+from base_projects.workspace_onboarding import workspace_onboarding_summary
 from base_projects.workspace_report_common import ProjectLastCheck
 from base_projects.workspace_report_common import missing_repo_fix
 from base_projects.workspace_report_common import missing_repo_message
@@ -26,9 +29,11 @@ from base_projects.workspace_report_common import workspace_repo_check_details
 from base_projects.workspace_report_json import dumps_json
 from base_projects.workspace_report_json import workspace_check_to_json
 from base_projects.workspace_report_json import workspace_doctor_to_json
+from base_projects.workspace_report_json import workspace_onboarding_to_json
 from base_projects.workspace_report_json import workspace_status_to_json
 from base_projects.workspace_report_text import print_workspace_check
 from base_projects.workspace_report_text import print_workspace_doctor
+from base_projects.workspace_report_text import print_workspace_onboarding
 from base_projects.workspace_report_text import print_workspace_status
 from base_projects.workspace_statuses import WorkspaceProjectStatus
 from base_projects.workspace_statuses import attach_status_repo_metadata
@@ -43,6 +48,8 @@ from base_projects.workspace_statuses import workspace_project_statuses
 __all__ = (
     "ProjectLastCheck",
     "WorkspaceManifest",
+    "WorkspaceOnboardingRepository",
+    "WorkspaceOnboardingSummary",
     "WorkspaceProjectCheckResult",
     "WorkspaceProjectStatus",
     "attach_check_result_repo_metadata",
@@ -54,6 +61,7 @@ __all__ = (
     "most_severe_status",
     "print_workspace_check",
     "print_workspace_doctor",
+    "print_workspace_onboarding",
     "print_workspace_status",
     "project_last_check",
     "project_venv_check",
@@ -71,6 +79,8 @@ __all__ = (
     "workspace_manifest_project_check_results",
     "workspace_manifest_project_statuses",
     "workspace_non_base_repo_check",
+    "workspace_onboarding_summary",
+    "workspace_onboarding_to_json",
     "workspace_project_check_result",
     "workspace_project_check_results",
     "workspace_project_status",

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -68,6 +68,23 @@ With `--manifest <path>`, the same commands also report expected repositories,
 missing required and optional repositories, and discovered Base-managed
 projects outside the manifest.
 
+`basectl workspace onboarding --manifest <path>` is the first-day summary for a
+new teammate. It reads the same manifest and local repository state, then shows
+each expected repository, the expected local path, whether it is present,
+whether Base can read `base_manifest.yaml`, and the next action. JSON output is
+available for onboarding scripts or docs generators:
+
+```bash
+basectl workspace onboarding --manifest ~/work/base-workspace/workspace.yaml
+basectl workspace onboarding --manifest ~/work/base-workspace/workspace.yaml --format json
+```
+
+The onboarding report is read-only. It prints clone commands for missing
+repositories when the manifest provides `repos[].url`, and it prints the
+standard Base setup and validation commands for repositories with valid project
+manifests. It does not clone repositories, run setup, create virtual
+environments, or execute project tests.
+
 `basectl workspace clone --manifest <path>` uses the expected repository list
 as an explicit clone plan. It clones missing required GitHub repositories by
 default, reports missing optional repositories without cloning them, and
@@ -89,6 +106,7 @@ It should let Base answer:
 - which repositories are expected in this workspace
 - which expected repositories are already present
 - which expected repositories are missing
+- what a new teammate should do next for each expected repository
 - which discovered repositories are outside the expected set
 - which repositories are required versus optional
 - what clone URL and default branch should be shown in reports, and what

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -179,10 +179,13 @@ _base_basectl_completion() {
             ;;
         workspace)
             if ((COMP_CWORD == 2)); then
-                _base_basectl_completion_compgen "status check doctor clone pull init configure" "$cur"
+                _base_basectl_completion_compgen "status check doctor onboarding clone pull init configure" "$cur"
             else
                 case "${COMP_WORDS[2]:-}" in
                     status|check|doctor)
+                        _base_basectl_completion_compgen "--workspace --manifest --format -v -h --help" "$cur"
+                        ;;
+                    onboarding)
                         _base_basectl_completion_compgen "--workspace --manifest --format -v -h --help" "$cur"
                         ;;
                     clone)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -164,14 +164,14 @@ _base_basectl_completion() {
         workspace)
             case "${words[3]:-}" in
                 status|check|doctor)
-                    _arguments '1:workspace command:(status check doctor clone pull init configure)' \
+                    _arguments '1:workspace command:(status check doctor onboarding clone pull init configure)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--format[Output format]:format:(text json)' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 clone)
-                    _arguments '1:workspace command:(status check doctor clone pull init configure)' \
+                    _arguments '1:workspace command:(status check doctor onboarding clone pull init configure)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--include-optional[Include optional manifest repositories when cloning]' \
@@ -179,14 +179,14 @@ _base_basectl_completion() {
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 pull)
-                    _arguments '1:workspace command:(status check doctor clone pull init configure)' \
+                    _arguments '1:workspace command:(status check doctor onboarding clone pull init configure)' \
                         '--source[Canonical workspace manifest source]:url-or-path:' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--dry-run[Show planned workspace pull work without writing]' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 init)
-                    _arguments '1:workspace command:(status check doctor clone pull init configure)' \
+                    _arguments '1:workspace command:(status check doctor onboarding clone pull init configure)' \
                         '2:workspace source:' \
                         '--owner[GitHub owner for short workspace repository names]:owner:' \
                         '--path[Workspace configuration repository checkout path]:path:_files' \
@@ -197,14 +197,14 @@ _base_basectl_completion() {
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 configure)
-                    _arguments '1:workspace command:(status check doctor clone pull init configure)' \
+                    _arguments '1:workspace command:(status check doctor onboarding clone pull init configure)' \
                         '--workspace[Workspace directory to configure]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--dry-run[Show planned workspace configuration without applying repo changes]' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)
-                    _arguments '1:workspace command:(status check doctor clone pull init configure)'
+                    _arguments '1:workspace command:(status check doctor onboarding clone pull init configure)'
                     ;;
             esac
             ;;


### PR DESCRIPTION
## Summary
- Add `basectl workspace onboarding` for a read-only first-day summary from a workspace manifest.
- Emit both text and JSON with expected paths, discovery status, next actions, clone guidance, and setup/check/test commands.
- Document the onboarding workflow and keep the Bash wrapper help/delegation in sync.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_workspace_onboarding.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/workspace.bats`
- `bash -n cli/bash/commands/basectl/subcommands/workspace.sh`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_projects`
- `git diff --check`

Fixes #1535