### PR TITLE
Add devcontainer export preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `basectl workspace onboarding` to summarize first-day repository
   readiness, missing clone actions, and project setup/check/test commands from
   a workspace manifest without mutating repositories.
+- Added `basectl devcontainer` to preview or write `.devcontainer/devcontainer.json`
+  from Base project manifests, with JSON output that reports supported,
+  unsupported, and ambiguous manifest fields.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Current implemented commands include:
 - `basectl build <project> [target...]`
 - `basectl run <project> <command>`
 - `basectl export-context [project]`
+- `basectl devcontainer [project]`
 - `basectl docs`
 - `basectl onboard`
 - `basectl version`
@@ -839,6 +840,19 @@ Base-managed project. Markdown exports combine context Markdown files with
 stable source headings, using `.ai-context/INDEX.md` order when available and
 falling back to deterministic filename order for unlisted files. Zip exports
 contain only files from `.ai-context/` so they can be uploaded manually.
+
+Preview a Dev Containers configuration from a project manifest with:
+
+```bash
+basectl devcontainer example
+basectl devcontainer example --format json
+basectl devcontainer example --write
+```
+
+`basectl devcontainer` is dry-run by default and reports unsupported or
+ambiguous manifest fields instead of guessing container behavior. `--write`
+creates `.devcontainer/devcontainer.json` only when that file does not already
+exist.
 
 Open Base's documentation home page on GitHub with:
 

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -40,6 +40,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `config`
 - `doctor`
 - `docs`
+- `devcontainer`
 - `export-context`
 - `gh`
 - `onboard`
@@ -159,6 +160,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   directory for manual AI tool upload or copy/paste. Markdown exports include
   stable file headings and use `INDEX.md` ordering when available. Zip exports
   contain only files from `.ai-context`.
+- `basectl devcontainer [project]` previews a generated
+  `.devcontainer/devcontainer.json` from the resolved Base manifest. It is
+  dry-run by default, supports `--format json`, and writes only with `--write`,
+  refusing to replace an existing project-owned Dev Containers file.
 - `basectl docs` opens the Base documentation home page on GitHub. Use
   `--show-url` to print the URL without opening a browser.
 - `basectl prompt list` lists repo-owned Markdown prompts that Base can render

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -39,6 +39,8 @@ Commands:
     Run a project's declared test command.
   export-context [project] [options]
     Export a project's .ai-context directory as Markdown or Zip.
+  devcontainer [project] [options]
+    Preview or write .devcontainer/devcontainer.json from a Base manifest.
   build <project> [target...] [options]
     Run a project's declared build targets.
   demo [project] [options]
@@ -281,6 +283,11 @@ basectl_do_export_context() {
     base_export_context_subcommand_main "$@"
 }
 
+basectl_do_devcontainer() {
+    basectl_source_subcommand_module devcontainer || return 1
+    base_devcontainer_subcommand_main "$@"
+}
+
 basectl_do_build() {
     basectl_source_subcommand_module build || return 1
     base_build_subcommand_main "$@"
@@ -501,6 +508,7 @@ basectl_main() {
         check)            basectl_do_check "$@" ;;
         test)             basectl_do_test "$@" ;;
         export-context)   basectl_do_export_context "$@" ;;
+        devcontainer)     basectl_do_devcontainer "$@" ;;
         build)            basectl_do_build "$@" ;;
         demo)             basectl_do_demo "$@" ;;
         run)              basectl_do_run "$@" ;;

--- a/cli/bash/commands/basectl/subcommands/devcontainer.sh
+++ b/cli/bash/commands/basectl/subcommands/devcontainer.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_devcontainer_subcommand_sourced:-}" ]] && return 0
+_base_devcontainer_subcommand_sourced=1
+readonly _base_devcontainer_subcommand_sourced
+
+base_devcontainer_subcommand_usage() {
+    cat <<'EOF'
+Usage:
+  basectl devcontainer [project] [options]
+
+Options:
+  --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
+  --format <format>   Output format: text or json.
+  --write             Write .devcontainer/devcontainer.json. Refuses to replace an existing file.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Preview or write a Dev Containers configuration derived from a Base project manifest.
+The default mode is a dry-run preview; no files are written unless --write is present.
+EOF
+}
+
+base_devcontainer_usage_error() {
+    base_devcontainer_subcommand_usage >&2
+    print_error "$*"
+    return 2
+}
+
+base_devcontainer_subcommand_main() {
+    local project="" wrapper resolve_output resolved_name project_root manifest_path
+    local output_format="text" workspace_requested=0 write=0
+    local args=() setup_args=()
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_devcontainer_subcommand_usage
+                return 0
+                ;;
+            -v)
+                args+=(--debug)
+                shift
+                ;;
+            --workspace)
+                [[ -n "${2:-}" ]] || {
+                    base_devcontainer_usage_error "Option '--workspace' requires an argument."
+                    return $?
+                }
+                workspace_requested=1
+                args+=(--workspace "$2")
+                shift 2
+                ;;
+            --workspace=*)
+                workspace_requested=1
+                args+=("$1")
+                shift
+                ;;
+            --format)
+                [[ -n "${2:-}" ]] || {
+                    base_devcontainer_usage_error "Option '--format' requires an argument."
+                    return $?
+                }
+                output_format="$2"
+                shift 2
+                ;;
+            --format=*)
+                output_format="${1#--format=}"
+                shift
+                ;;
+            --write)
+                write=1
+                shift
+                ;;
+            -*)
+                base_devcontainer_usage_error "Unknown devcontainer option '$1'."
+                return $?
+                ;;
+            *)
+                if [[ -n "$project" ]]; then
+                    base_devcontainer_usage_error "The 'devcontainer' command accepts exactly one project name."
+                    return $?
+                fi
+                project="$1"
+                shift
+                ;;
+        esac
+    done
+
+    [[ "$output_format" == "text" || "$output_format" == "json" ]] || {
+        base_devcontainer_usage_error "Unsupported devcontainer format '$output_format'. Expected text or json."
+        return $?
+    }
+    [[ -n "$project" || "$workspace_requested" != "1" ]] || {
+        base_devcontainer_usage_error "Option '--workspace' requires an explicit project name."
+        return $?
+    }
+
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
+
+    if [[ -n "$project" ]]; then
+        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${args[@]}")" || return $?
+    else
+        resolve_output="$("$wrapper" --project base base_projects current)" || return $?
+    fi
+    IFS=$'\t' read -r resolved_name project_root manifest_path _ <<<"$resolve_output"
+
+    [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
+        fatal_error "Unable to resolve project for devcontainer export."
+    }
+
+    setup_args=(--manifest "$manifest_path" --action devcontainer --format "$output_format")
+    [[ "$write" != "1" ]] || setup_args+=(--write)
+    setup_args+=("$resolved_name")
+
+    "$wrapper" --project base base_setup "${setup_args[@]}"
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -91,6 +91,14 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "export_context_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl devcontainer ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "devcontainer_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl devcontainer demo --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "devcontainer_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl projects list --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -254,6 +262,8 @@ EOF
     [[ "$output" == *"build_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"run_options=--workspace --dry-run --list"* ]]
     [[ "$output" == *"export_context_options=--workspace --format --output --print --list-files"* ]]
+    [[ "$output" == *"devcontainer_projects=base demo"* ]]
+    [[ "$output" == *"devcontainer_options=--workspace --format --write"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
     [[ "$output" == *"workspace_commands=status check doctor onboarding clone pull init configure"* ]]
     [[ "$output" == *"workspace_status_options=--workspace --manifest --format"* ]]

--- a/cli/bash/commands/basectl/tests/devcontainer.bats
+++ b/cli/bash/commands/basectl/tests/devcontainer.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "basectl devcontainer delegates resolved manifest to base_setup export action" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local manifest_path="$workspace/demo/base_manifest.yaml"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected devcontainer python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest_path"
+    workspace="$(cd "$workspace" && pwd -P)"
+    manifest_path="$workspace/demo/base_manifest.yaml"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" devcontainer demo --workspace "$workspace" --format json --write
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=base"* ]]
+    [[ "$output" == *"ARGS=--manifest $manifest_path --action devcontainer --format json --write demo"* ]]
+}
+
+@test "basectl devcontainer prints help without requiring the Base Python venv" {
+    run_basectl devcontainer --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl devcontainer [project] [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--write"* ]]
+}
+
+@test "basectl devcontainer requires explicit project with workspace option" {
+    run_basectl devcontainer --workspace "$TEST_TMPDIR"
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--workspace' requires an explicit project name."* ]]
+}

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -13,6 +13,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"check [project] [options]"* ]]
     [[ "$output" == *"test [project] [options]"* ]]
     [[ "$output" == *"export-context [project] [options]"* ]]
+    [[ "$output" == *"devcontainer [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
     [[ "$output" == *"repo <init|clone|check|configure|agent-guidance|installer-template> [options]"* ]]
     [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
@@ -58,6 +59,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  config <path|show|doctor>' <<<"$output"
     grep -Fqx '  run <project> <command> [options]' <<<"$output"
     grep -Fqx '  export-context [project] [options]' <<<"$output"
+    grep -Fqx '  devcontainer [project] [options]' <<<"$output"
     grep -Fqx '  repo <init|clone|check|configure|agent-guidance|installer-template> [options]' <<<"$output"
     grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"

--- a/cli/python/base_setup/devcontainer_export.py
+++ b/cli/python/base_setup/devcontainer_export.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from base_setup.manifest_model import BaseManifest
+
+
+@dataclass(frozen=True)
+class DevcontainerFinding:
+    field: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DevcontainerExport:
+    project: str
+    manifest_path: Path
+    target_path: Path
+    target_exists: bool
+    write: bool
+    devcontainer: dict[str, Any]
+    supported: tuple[str, ...]
+    unsupported: tuple[DevcontainerFinding, ...]
+    ambiguous: tuple[DevcontainerFinding, ...]
+
+
+class DevcontainerExportError(RuntimeError):
+    pass
+
+
+def build_devcontainer_export(manifest: BaseManifest, *, write: bool = False) -> DevcontainerExport:
+    target_path = manifest.path.parent / ".devcontainer" / "devcontainer.json"
+    devcontainer: dict[str, Any] = {"name": manifest.project_name}
+    supported = ["project.name"]
+    unsupported: list[DevcontainerFinding] = []
+    ambiguous: list[DevcontainerFinding] = []
+
+    vscode = manifest.ide.get("vscode")
+    if vscode is not None:
+        vscode_customizations: dict[str, Any] = {}
+        if vscode.extensions:
+            vscode_customizations["extensions"] = list(vscode.extensions)
+            supported.append("ide.vscode.extensions")
+        if vscode.settings:
+            vscode_customizations["settings"] = vscode.settings
+            supported.append("ide.vscode.settings")
+        if vscode_customizations:
+            devcontainer["customizations"] = {"vscode": vscode_customizations}
+
+    for ide_name in sorted(set(manifest.ide) - {"vscode"}):
+        unsupported.append(
+            DevcontainerFinding(
+                field=f"ide.{ide_name}",
+                reason="Devcontainer export currently maps VS Code customizations only.",
+            )
+        )
+
+    add_unsupported_manifest_findings(manifest, unsupported)
+    add_ambiguous_manifest_findings(manifest, ambiguous)
+
+    return DevcontainerExport(
+        project=manifest.project_name,
+        manifest_path=manifest.path,
+        target_path=target_path,
+        target_exists=target_path.exists(),
+        write=write,
+        devcontainer=devcontainer,
+        supported=tuple(supported),
+        unsupported=tuple(unsupported),
+        ambiguous=tuple(ambiguous),
+    )
+
+
+def write_devcontainer_export(export: DevcontainerExport) -> None:
+    if export.target_path.exists():
+        raise DevcontainerExportError(
+            f"{export.target_path} already exists; refusing to replace project-owned devcontainer file."
+        )
+    export.target_path.parent.mkdir(parents=True, exist_ok=True)
+    export.target_path.write_text(dumps_devcontainer_json(export.devcontainer), encoding="utf-8")
+
+
+def add_unsupported_manifest_findings(manifest: BaseManifest, findings: list[DevcontainerFinding]) -> None:
+    if manifest.brewfile is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="brewfile",
+                reason="Brewfile installation is host-specific and is not translated to devcontainer features yet.",
+            )
+        )
+    if manifest.mise is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="mise",
+                reason=(
+                    "Project-owned mise configuration remains project-owned and is "
+                    "not embedded in devcontainer output."
+                ),
+            )
+        )
+    for index, artifact in enumerate(manifest.artifacts, start=1):
+        findings.append(
+            DevcontainerFinding(
+                field=f"artifacts[{index}]",
+                reason=(
+                    f"Base artifact {artifact.artifact_type}/{artifact.name} "
+                    "does not have a devcontainer feature mapping yet."
+                ),
+            )
+        )
+    if manifest.test is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="test",
+                reason=(
+                    "Project test commands remain Base/project commands and are not "
+                    "added to devcontainer lifecycle hooks."
+                ),
+            )
+        )
+    if manifest.health.required_env:
+        findings.append(
+            DevcontainerFinding(
+                field="health.required_env",
+                reason="Required environment variables are diagnostics, not container secrets.",
+            )
+        )
+    if manifest.health.required_ports:
+        findings.append(
+            DevcontainerFinding(
+                field="health.required_ports",
+                reason="Port health checks are diagnostics and are not translated to devcontainer port forwarding yet.",
+            )
+        )
+    if manifest.commands:
+        findings.append(
+            DevcontainerFinding(
+                field="commands",
+                reason=(
+                    "Project commands stay in Base/project manifests and are not "
+                    "copied into devcontainer lifecycle hooks."
+                ),
+            )
+        )
+    if manifest.activate.source:
+        findings.append(
+            DevcontainerFinding(
+                field="activate.source",
+                reason=(
+                    "Activation source scripts are interactive shell behavior and "
+                    "are not run by devcontainer export."
+                ),
+            )
+        )
+    if manifest.build is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="build",
+                reason="Build targets remain Base/project commands and are not translated to devcontainer tasks.",
+            )
+        )
+
+
+def add_ambiguous_manifest_findings(manifest: BaseManifest, findings: list[DevcontainerFinding]) -> None:
+    if manifest.python.manager is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="python.manager",
+                reason="Python manager selection may affect image choice, features, or post-create commands.",
+            )
+        )
+    if manifest.python.requires_python is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="python.requires_python",
+                reason="Python version constraints require an explicit image or feature policy before export.",
+            )
+        )
+
+
+def devcontainer_export_to_json(export: DevcontainerExport) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "project": export.project,
+        "manifest_path": str(export.manifest_path),
+        "target_path": str(export.target_path),
+        "target_exists": export.target_exists,
+        "write": export.write,
+        "devcontainer": export.devcontainer,
+        "supported": list(export.supported),
+        "unsupported": [finding_to_json(finding) for finding in export.unsupported],
+        "ambiguous": [finding_to_json(finding) for finding in export.ambiguous],
+    }
+
+
+def finding_to_json(finding: DevcontainerFinding) -> dict[str, str]:
+    return {"field": finding.field, "reason": finding.reason}
+
+
+def dumps_devcontainer_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def dumps_export_json(export: DevcontainerExport) -> str:
+    return dumps_devcontainer_json(devcontainer_export_to_json(export))
+
+
+def print_devcontainer_export_text(export: DevcontainerExport) -> None:
+    mode = "write" if export.write else "dry-run"
+    print(f"Devcontainer export for project '{export.project}'")
+    print(f"Manifest: {export.manifest_path}")
+    print(f"Target: {export.target_path}")
+    print(f"Mode: {mode}")
+    print()
+    if export.write:
+        print("Wrote devcontainer JSON.")
+    else:
+        print("Dry run: no files were written.")
+    print()
+    print("Generated devcontainer.json:")
+    print(dumps_devcontainer_json(export.devcontainer), end="")
+    print_devcontainer_findings("Unsupported fields", export.unsupported)
+    print_devcontainer_findings("Ambiguous fields", export.ambiguous)
+
+
+def print_devcontainer_findings(label: str, findings: tuple[DevcontainerFinding, ...]) -> None:
+    if not findings:
+        return
+    print()
+    print(f"{label}:")
+    for finding in findings:
+        print(f"- {finding.field}: {finding.reason}")

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -14,6 +14,11 @@ from .checks import checks_payload_to_json
 from .checks import checks_status
 from .checks import doctor_status
 from .checks import print_doctor_finding
+from .devcontainer_export import DevcontainerExportError
+from .devcontainer_export import build_devcontainer_export
+from .devcontainer_export import dumps_export_json
+from .devcontainer_export import print_devcontainer_export_text
+from .devcontainer_export import write_devcontainer_export
 from .errors import ArtifactError
 from .manifest import BaseManifest, ManifestError, read_manifest
 from .manifest_checks import empty_user_config  # pylint: disable=unused-import
@@ -37,6 +42,7 @@ class ManifestAction:
     action: str
     dry_run: bool
     output_format: str
+    write: bool = False
     remote_network: bool = False
 
 
@@ -49,6 +55,7 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--manifest", help="Path to base_manifest.yaml.")
 @base_cli.option("--start-dir", default=".", help="Directory where manifest discovery should start.")
 @base_cli.option("--dry-run", is_flag=True, help="Log planned changes without making them.")
+@base_cli.option("--write", is_flag=True, help="Write actions that default to dry-run output.")
 @base_cli.option(
     "--action",
     default="setup",
@@ -67,6 +74,7 @@ def run(
     manifest: str | None,
     start_dir: str,
     dry_run: bool,
+    write: bool,
     action: str,
     output_format: str,
     remote_network: bool,
@@ -82,9 +90,11 @@ def run(
     try:
         base_manifest = read_manifest(manifest_path)
         validate_project_name(base_manifest, project)
-        manifest_action = ManifestAction(action, dry_run, output_format, remote_network)
+        manifest_action = ManifestAction(action, dry_run, output_format, write, remote_network)
         if action == "route":
             status = route_manifest(ctx, manifest_action, base_manifest)
+        elif action == "devcontainer":
+            status = devcontainer_manifest(ctx, manifest_action, base_manifest)
         else:
             default_manifest = read_default_manifest(ctx)
             status = run_manifest_action(
@@ -100,6 +110,9 @@ def run(
         ctx.log.error(str(exc))
         status = base_cli.ExitCode.FAILURE
     except ArtifactError as exc:
+        ctx.log.error(str(exc))
+        status = base_cli.ExitCode.FAILURE
+    except DevcontainerExportError as exc:
         ctx.log.error(str(exc))
         status = base_cli.ExitCode.FAILURE
     return status
@@ -150,11 +163,35 @@ def run_manifest_action(
     else:
         ctx.log.error(
             "Unsupported base_setup action '%s'. Expected setup, bootstrap, check, doctor, "
-            "route, precheck, or predoctor.",
+            "route, devcontainer, precheck, or predoctor.",
             action,
         )
         status = base_cli.ExitCode.USAGE_ERROR
     return status
+
+
+def devcontainer_manifest(
+    ctx: base_cli.Context,
+    manifest_action: ManifestAction,
+    manifest: BaseManifest,
+) -> int:
+    if manifest_action.output_format not in ("text", "json"):
+        ctx.log.error(
+            "Unsupported devcontainer output format '%s'. Expected text or json.",
+            manifest_action.output_format,
+        )
+        return base_cli.ExitCode.USAGE_ERROR
+
+    export = build_devcontainer_export(manifest, write=manifest_action.write)
+    if manifest_action.write:
+        write_devcontainer_export(export)
+        export = build_devcontainer_export(manifest, write=True)
+
+    if manifest_action.output_format == "json":
+        print(dumps_export_json(export), end="")
+    else:
+        print_devcontainer_export_text(export)
+    return base_cli.ExitCode.SUCCESS
 
 
 def route_manifest(

--- a/cli/python/base_setup/tests/test_devcontainer_export.py
+++ b/cli/python/base_setup/tests/test_devcontainer_export.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from base_setup.tests.helpers import run_engine
+
+
+def write_manifest(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+class DevcontainerExportTests(unittest.TestCase):
+    def test_devcontainer_export_defaults_to_stable_json_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "base_manifest.yaml"
+            write_manifest(
+                manifest_path,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "ide:",
+                        "  vscode:",
+                        "    extensions:",
+                        "      - ms-python.python",
+                        "    settings:",
+                        "      python.defaultInterpreterPath: .venv/bin/python",
+                        "artifacts: []",
+                        "",
+                    ]
+                ),
+            )
+
+            status, stdout, stderr = run_engine(
+                ["--manifest", str(manifest_path), "--action", "devcontainer", "--format", "json", "demo"]
+            )
+
+            target_path = manifest_path.resolve().parent / ".devcontainer" / "devcontainer.json"
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertTrue(stdout.startswith("{\n"))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertFalse(payload["write"])
+        self.assertFalse(payload["target_exists"])
+        self.assertEqual(payload["target_path"], str(target_path))
+        self.assertFalse(target_path.exists())
+        self.assertEqual(
+            payload["devcontainer"],
+            {
+                "customizations": {
+                    "vscode": {
+                        "extensions": ["ms-python.python"],
+                        "settings": {"python.defaultInterpreterPath": ".venv/bin/python"},
+                    }
+                },
+                "name": "demo",
+            },
+        )
+        self.assertEqual(payload["supported"], ["project.name", "ide.vscode.extensions", "ide.vscode.settings"])
+        self.assertEqual(payload["unsupported"], [])
+        self.assertEqual(payload["ambiguous"], [])
+
+    def test_devcontainer_export_reports_unsupported_and_ambiguous_manifest_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "base_manifest.yaml"
+            (root / "Brewfile").write_text("brew 'jq'\n", encoding="utf-8")
+            write_manifest(
+                manifest_path,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "brewfile: Brewfile",
+                        "mise: .mise.toml",
+                        "python:",
+                        "  manager: uv",
+                        "  requires_python: '>=3.12'",
+                        "ide:",
+                        "  vscode:",
+                        "    extensions:",
+                        "      - ms-python.python",
+                        "  cursor:",
+                        "    extensions:",
+                        "      - github.copilot",
+                        "artifacts:",
+                        "  - type: tool",
+                        "    name: terraform",
+                        "    version: latest",
+                        "test:",
+                        "  command: pytest",
+                        "health:",
+                        "  required_env:",
+                        "    - API_TOKEN",
+                        "",
+                    ]
+                ),
+            )
+
+            status, stdout, stderr = run_engine(
+                ["--manifest", str(manifest_path), "--action", "devcontainer", "--format", "json", "demo"]
+            )
+
+        payload = json.loads(stdout)
+        unsupported_fields = {item["field"] for item in payload["unsupported"]}
+        ambiguous_fields = {item["field"] for item in payload["ambiguous"]}
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["devcontainer"]["customizations"]["vscode"]["extensions"], ["ms-python.python"])
+        self.assertLessEqual(
+            {"brewfile", "mise", "ide.cursor", "artifacts[1]", "test", "health.required_env"},
+            unsupported_fields,
+        )
+        self.assertEqual({"python.manager", "python.requires_python"}, ambiguous_fields)
+
+    def test_devcontainer_write_refuses_to_replace_existing_project_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "base_manifest.yaml"
+            target_path = root / ".devcontainer" / "devcontainer.json"
+            target_path.parent.mkdir()
+            target_path.write_text('{"name":"project-owned"}\n', encoding="utf-8")
+            write_manifest(
+                manifest_path,
+                "project:\n  name: demo\nartifacts: []\n",
+            )
+
+            status, stdout, stderr = run_engine(
+                [
+                    "--manifest",
+                    str(manifest_path),
+                    "--action",
+                    "devcontainer",
+                    "--format",
+                    "json",
+                    "--write",
+                    "demo",
+                ]
+            )
+            target_content = target_path.read_text(encoding="utf-8")
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("already exists; refusing to replace project-owned devcontainer file", stderr)
+        self.assertEqual(target_content, '{"name":"project-owned"}\n')
+
+    def test_devcontainer_write_creates_target_only_with_write_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "base_manifest.yaml"
+            target_path = root / ".devcontainer" / "devcontainer.json"
+            write_manifest(
+                manifest_path,
+                "project:\n  name: demo\nartifacts: []\n",
+            )
+
+            status, stdout, stderr = run_engine(
+                [
+                    "--manifest",
+                    str(manifest_path),
+                    "--action",
+                    "devcontainer",
+                    "--format",
+                    "json",
+                    "--write",
+                    "demo",
+                ]
+            )
+            target_payload = json.loads(target_path.read_text(encoding="utf-8"))
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertTrue(payload["write"])
+        self.assertEqual(target_payload, {"name": "demo"})

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,9 @@ reference. The filename should answer "what is this about?"
 - [Python Manifest Section](python-manifest.md) records the structured Python
   manifest shape, uv adoption paths, and its relationship to `python-package`
   artifacts.
+- [Devcontainer Export](devcontainer-export.md) documents the read-only
+  Dev Containers export preview, guarded write path, and unsupported field
+  reporting.
 - [Repository Baseline](repo-baseline.md) documents `basectl repo init`,
   `basectl repo check`, `basectl repo configure`, and the optional
   `basectl repo agent-guidance` layer for standardizing new Base-managed

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -48,6 +48,7 @@ full compatibility contract.
 | `basectl build <project> [target...]` | Run declared build targets, or `build.default` when no target is provided. | `--workspace <path>`, `--dry-run`, `-- <args>` |
 | `basectl build <project> --list` | List build targets declared by a project manifest. | `--workspace <path>` |
 | `basectl demo [project]` | Run a project-owned demo script. | `--workspace <path>`, `--dry-run`, `-- <args>` |
+| `basectl devcontainer [project]` | Preview or write `.devcontainer/devcontainer.json` from a Base manifest. Dry-run is the default. | `--workspace <path>`, `--format <text\|json>`, `--write` |
 | `basectl trust status <project>` | Show local manifest command trust status. | `--workspace <path>`, `--format <text\|json>` |
 | `basectl trust allow <project>` | Approve the current manifest command contract on this machine. | `--workspace <path>`, `--manifest-sha256 <sha256>` |
 | `basectl trust revoke <project>` | Remove local manifest command approval. | `--workspace <path>` |

--- a/docs/devcontainer-export.md
+++ b/docs/devcontainer-export.md
@@ -1,0 +1,54 @@
+# Devcontainer Export
+
+`basectl devcontainer [project]` derives a minimal Dev Containers configuration
+from a Base project manifest. The default mode is a dry-run preview: it reads
+`base_manifest.yaml`, prints the generated `.devcontainer/devcontainer.json`
+content, and reports which manifest fields were supported, unsupported, or
+ambiguous.
+
+```bash
+basectl devcontainer demo
+basectl devcontainer demo --format json
+```
+
+Use `--workspace <path>` when resolving a named project outside the configured
+workspace. Use `--write` only after reviewing the preview:
+
+```bash
+basectl devcontainer demo --format json
+basectl devcontainer demo --write
+```
+
+When writing, Base creates `.devcontainer/devcontainer.json` under the project
+root and refuses to replace an existing file. There is no force flag; project
+owned Dev Containers files remain project owned.
+
+## Supported Fields
+
+The current export supports:
+
+- `project.name` as `name`
+- `ide.vscode.extensions` as `customizations.vscode.extensions`
+- `ide.vscode.settings` as `customizations.vscode.settings`
+
+The JSON report includes the generated `devcontainer` object and the target path.
+This makes the dry-run output stable enough for review and automation without
+requiring a container runtime.
+
+## Unsupported And Ambiguous Fields
+
+Base deliberately does not guess container behavior for manifest fields that
+carry host setup, project commands, diagnostics, or runtime policy. The export
+reports those fields instead of silently dropping them.
+
+Examples include:
+
+- `brewfile`, `mise`, `artifacts`, `test`, `commands`, `build`, and activation
+  sources as unsupported
+- `python.manager` and `python.requires_python` as ambiguous until Base has an
+  explicit image or feature policy
+- non-VS Code IDE customizations as unsupported
+
+This command does not build images, start containers, install packages, execute
+project hooks, or replace Dev Containers as the owner of containerized
+development behavior.

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -165,6 +165,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | `basectl build <project> [targets] [--list\|--dry-run]` | Run build targets |
 | `basectl demo [project] [--non-interactive]` | Run project demo script |
 | `basectl export-context [project]` | Generate AI context pack from `.ai-context/` |
+| `basectl devcontainer [project]` | Preview or write `.devcontainer/devcontainer.json` from manifest metadata |
 | `basectl prompt <list\|name>` | List or render repo-owned AI workflow prompts |
 
 ### Diagnostics

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -132,7 +132,7 @@ _base_basectl_completion_project_profiles_or_options() {
 
 _base_basectl_completion() {
     local command cur
-    local commands="activate setup check test export-context build demo run repo ci release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
+    local commands="activate setup check test export-context devcontainer build demo run repo ci release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -216,6 +216,9 @@ _base_basectl_completion() {
             ;;
         export-context)
             _base_basectl_completion_project_or_options "--workspace --format --output --print --list-files -v -h --help" "$cur"
+            ;;
+        devcontainer)
+            _base_basectl_completion_project_or_options "--workspace --format --write -v -h --help" "$cur"
             ;;
         build)
             _base_basectl_completion_project_or_options "--workspace --dry-run --list -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -85,6 +85,7 @@ _base_basectl_completion() {
         'check:Verify the local Base CLI environment'
         'test:Run a project test command'
         'export-context:Export a project AI context bundle'
+        'devcontainer:Preview or write a Dev Containers configuration'
         'build:Run project build targets'
         'demo:Run a project interactive demo'
         'run:Run a project command'
@@ -243,6 +244,16 @@ _base_basectl_completion() {
                 '--output[Output path]:path:_files' \
                 '--print[Print the Markdown export to stdout]' \
                 '--list-files[List files in export order]' \
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                _base_basectl_completion_describe_projects
+            fi
+            ;;
+        devcontainer)
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--format[Output format]:format:(text json)' \
+                '--write[Write .devcontainer/devcontainer.json]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '1:Base project:->projects'
             if [[ "$state" == projects ]]; then

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -210,6 +210,7 @@ assert_bash_completion_options_match_help() {
 @test "Bash option completions match command help" {
     assert_bash_completion_options_match_help check check
     assert_bash_completion_options_match_help doctor doctor
+    assert_bash_completion_options_match_help devcontainer devcontainer
     assert_bash_completion_options_match_help repo-init repo init
     assert_bash_completion_options_match_help repo-configure repo configure
     assert_bash_completion_options_match_help repo-installer-template repo installer-template


### PR DESCRIPTION
## Summary
- Add `basectl devcontainer` as a dry-run-first project manifest export for `.devcontainer/devcontainer.json`.
- Generate stable JSON with supported, unsupported, and ambiguous manifest-field reporting.
- Add guarded `--write` behavior that refuses to replace an existing project-owned devcontainer file.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/devcontainer.bats cli/bash/commands/basectl/tests/help.bats`
- `bash -n cli/bash/commands/basectl/subcommands/devcontainer.sh`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_setup`
- `git diff --check`

Fixes #1536