### PR TITLE
Add local history report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Added `basectl devenv-report` to classify Base manifest fields as supported,
   unsupported, lossy, or project-owned for Nix/devenv adoption planning without
   generating files or requiring Nix.
+- Added `basectl history --report` to generate local Markdown or JSON activity
+  summaries from recent command history and log metadata without dumping raw
+  logs or uploading telemetry.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -957,13 +957,19 @@ basectl history
 basectl history --project base
 basectl history --command check --status error
 basectl history --format json
+basectl history --report
+basectl history --report --format json
 ```
 
 `basectl history` reads the local history index at
 `<base-cache-root>/history/runs.jsonl`. History records are best-effort
 metadata for Python-backed Base commands with persistent logs; they point to raw
 logs instead of replacing them, and malformed history lines are ignored while
-listing recent runs. The broader local diagnostic report model is described in
+listing recent runs. `--report` prints a privacy-conscious local activity
+summary with recent commands, failure counts, common failing command families,
+and log file locations. Reports do not include raw log contents, compact home
+paths to `~`, and redact secret-looking arguments and URL credentials. The
+broader local diagnostic report model is described in
 [docs/observability.md](docs/observability.md).
 
 Inspect machine-local Base config with:

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -44,6 +44,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `devenv-report`
 - `export-context`
 - `gh`
+- `history`
+- `logs`
 - `onboard`
 - `prompt`
 - `repo init/clone/check/configure/agent-guidance/installer-template`
@@ -83,7 +85,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl logs` lists recent Base CLI runtime logs and can print, open, or tail
   the newest matching log file.
 - `basectl history` lists recent structured Base command runs from the local
-  history index and supports JSON output for scripts.
+  history index and supports table, JSON, and privacy-conscious report output.
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
 - `basectl trust status/allow/revoke <project>` manages local approval for
   manifest-declared project commands under `~/.base.d/trust/manifest-commands/`.

--- a/cli/bash/commands/basectl/subcommands/history.sh
+++ b/cli/bash/commands/basectl/subcommands/history.sh
@@ -14,7 +14,9 @@ Options:
   --status <ok|warn|error>
                         Filter by command status.
   --limit <count>       Number of recent history records to list. Defaults to 10.
-  --format <text|json>  Output format. Defaults to text.
+  --format <text|markdown|json>
+                        Output format. Defaults to text, or Markdown with --report.
+  --report              Print a privacy-conscious Markdown or JSON activity report.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
 
@@ -34,6 +36,10 @@ base_history_subcommand_main() {
                 ;;
             -v)
                 args+=(--debug)
+                shift
+                ;;
+            --report)
+                args+=("$1")
                 shift
                 ;;
             --project|--command|--status|--limit|--format)

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -289,7 +289,7 @@ EOF
     [[ "$output" == *"docs_options=--show-url"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
-    [[ "$output" == *"history_options=--project --command --status --limit --format"* ]]
+    [[ "$output" == *"history_options=--project --command --status --limit --format --report"* ]]
     [[ "$output" == *"trust_commands=status allow revoke"* ]]
     [[ "$output" == *"trust_projects=base demo"* ]]
     [[ "$output" == *"trust_status_options=--workspace --format"* ]]

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -26,6 +26,27 @@ EOF
     [[ "$output" == *"ARGS=--project demo --command check --status error --limit 3 --format json"* ]]
 }
 
+@test "basectl history forwards report mode to the Python history layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_history" ]]; then
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected history python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl history --report --limit 5 --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ARGS=--report --limit 5 --format json"* ]]
+}
+
 @test "basectl history forwards verbose flag to the Python history layer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
 
@@ -54,7 +75,8 @@ EOF
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl history [options]"* ]]
     [[ "$output" == *"--project <name>"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"--report"* ]]
+    [[ "$output" == *"--format <text|markdown|json>"* ]]
 }
 
 @test "basectl history reports missing option arguments as usage errors" {

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -12,6 +14,8 @@ from base_cli.history import optional_int
 from base_cli.history import optional_string
 from base_cli.history import parse_finished_history_record_line
 from base_cli.history import parse_positive_int
+from base_cli.history import redact_history_argv
+from base_cli.history import redact_history_text
 from base_cli.paths import base_cache_root
 
 
@@ -49,6 +53,24 @@ class HistoryOptions:
     status: str | None
     limit: int
     output_format: str
+    report: bool
+
+
+@dataclass(frozen=True)
+class CommandFamilySummary:
+    command: str
+    count: int
+    failures: int
+
+
+@dataclass(frozen=True)
+class HistoryReport:
+    cache_root: Path
+    history_path: Path
+    records: list[HistoryRecord]
+    status_counts: dict[str, int]
+    command_families: list[CommandFamilySummary]
+    failures: list[HistoryRecord]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -60,7 +82,8 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--command", "command_filter", help="Filter by basectl command name.")
 @base_cli.option("--status", "status_filter", help="Filter by status: ok, warn, or error.")
 @base_cli.option("--limit", default="10", help="Maximum history records to list.")
-@base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
+@base_cli.option("--format", "output_format", default="text", help="Output format: text, markdown, or json.")
+@base_cli.option("--report", is_flag=True, help="Print a privacy-conscious local activity report.")
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
@@ -69,6 +92,7 @@ def run(
     status_filter: str | None,
     limit: str,
     output_format: str,
+    report: bool,
 ) -> int:
     try:
         options = HistoryOptions(
@@ -76,18 +100,28 @@ def run(
             command=command_filter,
             status=normalize_optional_filter(status_filter),
             limit=parse_positive_int("--limit", limit),
-            output_format=normalize_format(output_format),
+            output_format=normalize_report_format(output_format) if report else normalize_format(output_format),
+            report=report,
         )
     except ValueError as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.USAGE_ERROR
 
-    records = recent_history(base_cache_root(), options=options, logger=ctx.log)
+    cache_root = base_cache_root()
+    records = recent_history(cache_root, options=options, logger=ctx.log)
+    if options.report:
+        history_report = build_history_report(cache_root, records)
+        if options.output_format == "json":
+            print(json.dumps(history_report_to_json(history_report), indent=2, sort_keys=True))
+        else:
+            print_history_report_markdown(history_report)
+        return base_cli.ExitCode.SUCCESS
+
     if options.output_format == "json":
         print(json.dumps([record.to_json() for record in records], indent=2))
         return base_cli.ExitCode.SUCCESS
     if not records:
-        print(f"No Base command history found under {base_cache_root() / HISTORY_PATH}.")
+        print(f"No Base command history found under {cache_root / HISTORY_PATH}.")
         return base_cli.ExitCode.SUCCESS
     print_history_table(records)
     return base_cli.ExitCode.SUCCESS
@@ -103,6 +137,15 @@ def normalize_format(value: str) -> str:
     normalized = value.strip().lower()
     if normalized not in {"text", "json"}:
         raise ValueError(f"Unsupported output format '{value}'. Expected one of: text, json.")
+    return normalized
+
+
+def normalize_report_format(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized == "text":
+        return "markdown"
+    if normalized not in {"markdown", "json"}:
+        raise ValueError(f"Unsupported report output format '{value}'. Expected one of: markdown, json.")
     return normalized
 
 
@@ -214,3 +257,211 @@ def display_log_path(record: HistoryRecord) -> str:
         return "-"
     suffix = "" if record.log_exists else " (missing)"
     return f"{record.log_path}{suffix}"
+
+
+def build_history_report(cache_root: Path, records: list[HistoryRecord]) -> HistoryReport:
+    return HistoryReport(
+        cache_root=cache_root,
+        history_path=cache_root / HISTORY_PATH,
+        records=records,
+        status_counts=build_status_counts(records),
+        command_families=build_command_family_summaries(records),
+        failures=[record for record in records if is_failure(record)],
+    )
+
+
+def build_status_counts(records: list[HistoryRecord]) -> dict[str, int]:
+    counts = Counter(record.status for record in records)
+    return {status: counts.get(status, 0) for status in ("error", "ok", "warn")}
+
+
+def build_command_family_summaries(records: list[HistoryRecord]) -> list[CommandFamilySummary]:
+    counts: dict[str, int] = {}
+    failures: dict[str, int] = {}
+    for record in records:
+        command = command_family(record.command)
+        counts[command] = counts.get(command, 0) + 1
+        if is_failure(record):
+            failures[command] = failures.get(command, 0) + 1
+    summaries = [
+        CommandFamilySummary(command=command, count=count, failures=failures.get(command, 0))
+        for command, count in counts.items()
+    ]
+    return sorted(summaries, key=lambda item: (-item.failures, -item.count, item.command))
+
+
+def command_family(command: str) -> str:
+    return command.split()[0] if command.split() else command
+
+
+def is_failure(record: HistoryRecord) -> bool:
+    if record.status == "error":
+        return True
+    return record.exit_code is not None and record.exit_code != 0
+
+
+def history_report_to_json(report: HistoryReport) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "cache_root": sanitize_report_path(str(report.cache_root)),
+        "history_path": sanitize_report_path(str(report.history_path)),
+        "summary": {
+            "record_count": len(report.records),
+            "failure_count": len(report.failures),
+            "status_counts": report.status_counts,
+        },
+        "command_families": [
+            {"command": family.command, "count": family.count, "failures": family.failures}
+            for family in report.command_families
+        ],
+        "failures": [report_record_to_json(record) for record in report.failures],
+        "recent": [report_record_to_json(record) for record in report.records],
+        "privacy": {
+            "raw_logs_included": False,
+            "redaction_rules": [
+                "Raw log contents are not included by default.",
+                "Home directory paths are compacted to '~'.",
+                "Secret-looking option values, environment assignments, and URL credentials are redacted.",
+            ],
+        },
+    }
+
+
+def report_record_to_json(record: HistoryRecord) -> dict[str, Any]:
+    return {
+        "run_id": sanitize_report_text(record.run_id),
+        "command": sanitize_report_text(record.command),
+        "project": sanitize_report_text(record.project) if record.project else None,
+        "status": sanitize_report_text(record.status),
+        "exit_code": record.exit_code,
+        "ended_at": sanitize_report_text(record.ended_at),
+        "log_path": sanitize_report_path(record.log_path) if record.log_path else None,
+        "log_exists": record.log_exists,
+        "argv": sanitize_report_argv(record.payload.get("argv")),
+    }
+
+
+def sanitize_report_argv(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    redacted = redact_history_argv([str(arg) for arg in value], sensitive_options=set())
+    return [compact_report_home_text(arg) for arg in redacted]
+
+
+def sanitize_report_path(value: str) -> str:
+    text = sanitize_report_text(value)
+    if text.startswith("/") or text.startswith("~"):
+        return redact_history_text(str(Path(text).expanduser().resolve(strict=False)))
+    return text
+
+
+def sanitize_report_text(value: str) -> str:
+    return compact_report_home_text(redact_history_text(value))
+
+
+def compact_report_home_text(value: str) -> str:
+    home = os.environ.get("HOME")
+    if not home:
+        return value
+    raw_home = str(Path(home).expanduser())
+    resolved_home = str(Path(home).expanduser().resolve(strict=False))
+    candidates = {raw_home, resolved_home}
+    for candidate in (raw_home, resolved_home):
+        if candidate.startswith("/var/"):
+            candidates.add(f"/private{candidate}")
+        if candidate.startswith("/private/var/"):
+            candidates.add(candidate.removeprefix("/private"))
+    for candidate in sorted(candidates, key=len, reverse=True):
+        if value == candidate:
+            return "~"
+        if value.startswith(f"{candidate}/"):
+            return f"~/{value[len(candidate) + 1:]}"
+    return value
+
+
+def print_history_report_markdown(report: HistoryReport) -> None:
+    print("# Base Local Activity Report")
+    print()
+    print(f"- History index: `{sanitize_report_path(str(report.history_path))}`")
+    print(f"- Cache root: `{sanitize_report_path(str(report.cache_root))}`")
+    print(f"- History records: {len(report.records)}")
+    print(f"- Failures: {len(report.failures)}")
+    print(f"- Warnings: {report.status_counts.get('warn', 0)}")
+    print()
+
+    if not report.records:
+        print("No command history records found.")
+        print()
+        print_report_privacy_section()
+        return
+
+    print("## Status Summary")
+    print()
+    for status in ("ok", "warn", "error"):
+        print(f"- {status}: {report.status_counts.get(status, 0)}")
+    print()
+
+    print("## Common Failing Command Families")
+    print()
+    failing_families = [family for family in report.command_families if family.failures > 0]
+    if not failing_families:
+        print("No failing command families found in the selected recent history.")
+    else:
+        for family in failing_families:
+            print(f"- `{family.command}`: {family.failures} failures across {family.count} runs")
+    print()
+
+    print("## Recent Commands")
+    print()
+    print("| Time | Command | Project | Status | Exit | Log |")
+    print("| --- | --- | --- | --- | --- | --- |")
+    for record in report.records:
+        print(
+            "| "
+            f"{markdown_cell(display_time(record))} | "
+            f"`{markdown_cell(record.command)}` | "
+            f"{markdown_cell(display_project(record))} | "
+            f"{markdown_cell(record.status)} | "
+            f"{markdown_cell(display_exit_code(record))} | "
+            f"{markdown_cell(display_report_log_path(record))} |"
+        )
+    print()
+
+    if report.failures:
+        print("## Failure Details")
+        print()
+        for record in report.failures:
+            print(f"- `{sanitize_report_text(record.command)}` at {display_time(record)}")
+            print(f"  - status: {sanitize_report_text(record.status)}")
+            print(f"  - exit: {display_exit_code(record)}")
+            print(f"  - log: {display_report_log_path(record)}")
+            argv = sanitize_report_argv(record.payload.get("argv"))
+            if argv:
+                print(f"  - argv: `{markdown_inline(' '.join(argv))}`")
+        print()
+
+    print_report_privacy_section()
+
+
+def display_report_log_path(record: HistoryRecord) -> str:
+    if not record.log_path:
+        return "-"
+    path = sanitize_report_path(record.log_path)
+    suffix = "" if record.log_exists else " (missing)"
+    return f"`{path}`{suffix}"
+
+
+def print_report_privacy_section() -> None:
+    print("## Privacy")
+    print()
+    print("- Raw log contents are not included by default.")
+    print("- Home directory paths are compacted to `~`.")
+    print("- Secret-looking option values, environment assignments, and URL credentials are shown as `[REDACTED]`.")
+
+
+def markdown_cell(value: str) -> str:
+    return sanitize_report_text(value).replace("|", "\\|")
+
+
+def markdown_inline(value: str) -> str:
+    return sanitize_report_text(value).replace("`", "\\`")

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -30,6 +30,7 @@ def history_record(
     exit_code: int = 0,
     ended_at: str = "2026-06-10T10:15:00Z",
     log_path: str = "~/logs/run.log",
+    argv: list[str] | None = None,
 ) -> dict:
     return {
         "schema_version": 1,
@@ -37,7 +38,7 @@ def history_record(
         "event": "finished",
         "command": command,
         "raw_command": f"base_{command}",
-        "argv": ["basectl", command],
+        "argv": argv or ["basectl", command],
         "project": project,
         "ended_at": ended_at,
         "exit_code": exit_code,
@@ -157,16 +158,151 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn("No Base command history found", stdout)
 
+    def test_markdown_report_handles_empty_history(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            status, stdout, stderr = invoke(["--report"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("# Base Local Activity Report", stdout)
+        self.assertIn("History records: 0", stdout)
+        self.assertIn("No command history records found.", stdout)
+        self.assertIn(str(cache_root / "history" / "runs.jsonl"), stdout)
+
+    def test_report_json_summarizes_successful_history(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            log_path = cache_root / "cli" / "base_setup" / "logs" / "run-ok.log"
+            log_path.parent.mkdir(parents=True)
+            log_path.write_text("ok\n", encoding="utf-8")
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-ok",
+                    "check",
+                    status="ok",
+                    exit_code=0,
+                    log_path=str(log_path),
+                ),
+            )
+
+            status, stdout, stderr = invoke(["--report", "--format", "json"], cache_root)
+            payload = json.loads(stdout)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(
+            payload["history_path"],
+            str((cache_root / "history" / "runs.jsonl").resolve(strict=False)),
+        )
+        self.assertEqual(payload["summary"]["record_count"], 1)
+        self.assertEqual(payload["summary"]["failure_count"], 0)
+        self.assertEqual(payload["summary"]["status_counts"], {"error": 0, "ok": 1, "warn": 0})
+        self.assertEqual(payload["command_families"], [{"command": "check", "count": 1, "failures": 0}])
+        self.assertEqual(payload["failures"], [])
+        self.assertEqual(payload["recent"][0]["log_exists"], True)
+
+    def test_markdown_report_lists_failures_and_common_failing_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-error-new",
+                    "check",
+                    status="error",
+                    exit_code=2,
+                    ended_at="2026-06-10T10:20:00Z",
+                    log_path=str(cache_root / "cli" / "base_setup" / "logs" / "run-error-new.log"),
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-error-old",
+                    "check",
+                    status="error",
+                    exit_code=1,
+                    ended_at="2026-06-10T10:10:00Z",
+                    log_path=str(cache_root / "cli" / "base_setup" / "logs" / "run-error-old.log"),
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-warn",
+                    "setup",
+                    status="warn",
+                    exit_code=0,
+                    ended_at="2026-06-10T10:15:00Z",
+                ),
+            )
+
+            status, stdout, stderr = invoke(["--report"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("Failures: 2", stdout)
+        self.assertIn("- `check`: 2 failures across 2 runs", stdout)
+        self.assertIn("run-error-new.log", stdout)
+        self.assertIn("run-error-old.log", stdout)
+        self.assertIn("## Privacy", stdout)
+        self.assertIn("Raw log contents are not included", stdout)
+
+    def test_report_redacts_arguments_and_home_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache"
+            home = Path(tmpdir) / "home"
+            home.mkdir()
+            secret = "super-secret-value"
+            write_history_line(
+                cache_root,
+                history_record(
+                    "run-secret",
+                    "setup",
+                    status="error",
+                    exit_code=1,
+                    log_path=str(home / ".cache" / "base" / "cli" / "base_setup" / "logs" / "run-secret.log"),
+                    argv=[
+                        "basectl",
+                        "setup",
+                        "--token",
+                        secret,
+                        f"DATABASE_PASSWORD={secret}",
+                        str(home / "work" / "demo"),
+                        f"https://user:{secret}@example.com/private.git",
+                    ],
+                ),
+            )
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+                status, stdout, stderr = invoke(["--report", "--format", "json"], cache_root)
+            payload = json.loads(stdout)
+            encoded = json.dumps(payload)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertNotIn(secret, encoded)
+        self.assertNotIn(str(home), encoded)
+        self.assertIn("[REDACTED]", encoded)
+        self.assertIn("~/work/demo", encoded)
+        self.assertTrue(payload["recent"][0]["log_path"].startswith("~/.cache/base/cli/base_setup/logs/"))
+
     def test_invalid_options_report_usage_errors(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             status, stdout, stderr = invoke(["--limit", "0"], Path(tmpdir))
             format_status, _format_stdout, format_stderr = invoke(["--format", "yaml"], Path(tmpdir))
+            report_status, _report_stdout, report_stderr = invoke(["--report", "--format", "yaml"], Path(tmpdir))
 
         self.assertEqual(status, 2)
         self.assertEqual(stdout, "")
         self.assertIn("Option '--limit' must be greater than zero", stderr)
         self.assertEqual(format_status, 2)
         self.assertIn("Unsupported output format 'yaml'", format_stderr)
+        self.assertEqual(report_status, 2)
+        self.assertIn("Unsupported report output format 'yaml'", report_stderr)
 
     def test_click_usage_errors_use_delegated_display_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,9 +74,9 @@ reference. The filename should answer "what is this about?"
 - [GitHub Bash Helper Boundary](github-bash-helper-boundary.md) records what
   GitHub CLI shell behavior can move to `base-bash-libs` and what must stay in
   Base or Python.
-- [Local Observability](observability.md) defines the shipped local command
-  history index plus the future last-error explanation and report model beyond
-  raw runtime logs.
+- [Local Observability](observability.md) defines runtime logs, the shipped
+  local command history index, `basectl history --report`, and future diagnostic
+  report work beyond raw runtime logs.
 - [Release Process](release-process.md) defines the Base release ceremony,
   version-file policy, GitHub Release flow, and Homebrew tap follow-up.
 - [Homebrew Upgrade Rehearsal](homebrew-upgrade-rehearsal.md) defines the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -641,8 +641,9 @@ Doctor findings use stable identifiers documented in
 on those IDs instead of human-readable messages.
 
 Base should also remain locally observable. `basectl logs` exposes recent Base
-CLI runtime logs from the Base cache root, and `basectl history` lists the
-structured local command-history index without sending telemetry anywhere.
+CLI runtime logs from the Base cache root, `basectl history` lists the
+structured local command-history index, and `basectl history --report`
+summarizes recent local activity without sending telemetry anywhere.
 Useful command metadata includes the command, target project or workspace,
 start and end time, exit code, manifest version where relevant, external tools
 invoked, and log file paths.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -70,9 +70,10 @@ inspect the resolved command contract first.
 | `basectl ci doctor <project>` | Run diagnostics with CI-safe defaults. Does not launch GitHub Actions or Ubuntu VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>` |
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
 | `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |
+| `basectl history` | List recent structured Base command history records. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--format <text\|json>` |
+| `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>` |
 | `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name>` |
 | `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name>`, `--lines <count>` |
-| `basectl history` | List recent structured Base command runs. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--format <text\|json>` |
 | `basectl clean` | Remove old Base runtime logs, temp files, and cache entries. | `--older-than <age>`, `--keep-last <count>`, `--dry-run` |
 | `basectl config path` | Print the local Base config path. | none |
 | `basectl config show` | Show local Base config as redacted JSON. | none |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,15 +1,17 @@
 # Local Observability Model
 
-> **STATUS** — `basectl history` and the local history index are implemented as
-> the first slice. `basectl explain last-error`, `basectl report`, and history
+> **STATUS** — `basectl history`, the local history index, and
+> `basectl history --report` are implemented as local-only slices.
+> `basectl explain last-error`, a broader `basectl report` bundle, and history
 > cleanup integration are tracked but not scheduled longer-term future work.
 
 Tracker: [#396](https://github.com/basefoundry/base/issues/396)
 
-Base currently exposes raw runtime logs through `basectl logs` and structured
-local command metadata through `basectl history`. This document defines the
-local observability layer: shipped command history, future last-error
-explanation, and future report generation.
+Base currently exposes raw runtime logs through `basectl logs`, structured
+local command metadata through `basectl history`, and a redacted local activity
+summary through `basectl history --report`. This document defines the local
+observability layer: shipped command history and activity reports, future
+last-error explanation, and broader future report generation.
 
 ## Goals
 
@@ -18,8 +20,10 @@ explanation, and future report generation.
   to scan without opening individual log files.
 - Allow a future `basectl explain last-error` command to summarize the latest
   failed Base run from local evidence.
-- Allow a future `basectl report` command to create a redacted local diagnostic
-  bundle for bug reports or support handoff.
+- Generate redacted local activity reports from history and log metadata for
+  bug reports or support handoff.
+- Allow a future broader `basectl report` command to create an explicit
+  diagnostic bundle when Base has more local evidence surfaces to combine.
 - Keep all data local by default, with no telemetry and no automatic upload.
 
 ## Non-Goals
@@ -164,9 +168,25 @@ Expected options:
 - `--status <ok|warn|error>` filters by status.
 - `--limit <count>` limits the number of rows.
 - `--format json` prints structured records for scripts.
+- `--report` prints a Markdown activity report by default.
+- `--report --format json` prints the same report as deterministic JSON.
 
 `basectl logs` should remain the command for opening or tailing raw log files.
 `basectl history` should point to logs, not replace them.
+
+The report mode summarizes selected recent history records with:
+
+- total records, warnings, and failures
+- status counts
+- common failing command families
+- recent command rows
+- failure details with redacted argv values
+- log file locations and missing-log markers
+
+Report mode does not include raw log contents, upload data, or collect
+background telemetry. It compacts home-directory paths to `~` and re-applies
+secret-looking argument and URL credential redaction defensively before
+rendering Markdown or JSON.
 
 ## Planned Commands
 
@@ -186,10 +206,11 @@ The explanation should be rule-based. It should not call external services.
 If the history record is missing its log file, the command should still report
 the metadata and explain that raw evidence has been cleaned or moved.
 
-### `basectl report`
+### Broader `basectl report`
 
-`basectl report` should generate a local diagnostic artifact, preferably a
-Markdown report by default with an optional JSON format for automation.
+A future broader `basectl report` should generate a local diagnostic artifact,
+preferably a Markdown report by default with an optional JSON format for
+automation.
 
 The report should include:
 
@@ -208,13 +229,16 @@ should never upload the report.
 The shipped first slice is:
 
 1. Add history recording and `basectl history`. **Shipped.**
+2. Add `basectl history --report` for local history/log activity summaries.
+   **Shipped.**
 
 ### Unscheduled Future Work
 
 The following items remain tracked but are not scheduled:
 
 - Add `basectl explain last-error` after history records exist.
-- Add `basectl report` after history and explanation have stable local data.
+- Add broader `basectl report` after history and explanation have stable local
+  data.
 - Extend `basectl clean` to compact or prune history records once the history
   format is stable.
 
@@ -229,5 +253,6 @@ starts producing summaries or shareable diagnostic artifacts.
   same redaction and best-effort guarantees.
 - `basectl history` marks missing log files directly in text output and exposes
   `log_exists` in JSON output.
-- Future report generation should require an explicit option before embedding
+- `basectl history --report` does not include raw log excerpts; any future
+  broader report mode should still require an explicit option before embedding
   raw log excerpts.

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -177,6 +177,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | `basectl doctor [project] [--profile]` | Human-readable findings + fix commands |
 | `basectl logs [--tail\|--command\|--path\|--open]` | Inspect runtime logs |
 | `basectl history [--format json]` | Inspect structured local command history |
+| `basectl history --report [--format json]` | Summarize local command history and log metadata without raw log dumps |
 | `basectl config path\|show\|doctor` | Machine-local config |
 | `basectl clean [--older-than\|--keep-last]` | Prune cache/logs |
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -294,7 +294,7 @@ _base_basectl_completion() {
             _base_basectl_completion_compgen "--command --limit --path --tail --open --lines -v -h --help" "$cur"
             ;;
         history)
-            _base_basectl_completion_compgen "--project --command --status --limit --format -v -h --help" "$cur"
+            _base_basectl_completion_compgen "--project --command --status --limit --format --report -v -h --help" "$cur"
             ;;
         config)
             if ((COMP_CWORD == 2)); then


### PR DESCRIPTION
## Summary
- Add `basectl history --report` for local Markdown activity summaries and `--report --format json` for deterministic machine-readable output.
- Summarize recent command history, failure counts, failing command families, and relevant log locations without dumping raw logs.
- Reapply privacy redaction for secret-looking argv values, environment-style assignments, URL credentials, and home paths.

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_history/tests cli/python/base_logs/tests -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_history/tests/test_engine.py lib/python/base_cli/tests/test_python_standards.py -q`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/history.bats cli/bash/commands/basectl/tests/completions.bats lib/shell/completions/tests/completions.bats cli/bash/commands/basectl/tests/help.bats`
- `bash -n cli/bash/commands/basectl/subcommands/history.sh`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_history`
- `git diff --check`

Fixes #1538