### PR TITLE
Add Agentic Coding Platform initiative

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -33,6 +33,9 @@ allows it. When an issue is tracked in the repo-named Project, move its status
 through `In Progress`, `In Review`, and `Done` as the work advances. Repo-named
 Project metadata uses five fields: `Status`, `Priority`, `Area`, `Size`, and
 `Initiative`.
+Use `Agentic Coding Platform` for GitHub-centered agentic workflow work such as
+agent-ready repo baselines, agent-readiness checks, issue-readiness gates,
+Copilot/cloud-agent readiness, and local handoff/context artifacts.
 Use the smallest accurate `Size` when creating issues: `T` for tiny obvious
 work, `S` for normal small work or unknown scope, `M` for interacting changes,
 and `L` only for work that should probably be split. The default remains `S`

--- a/.github/ISSUE_TEMPLATE/implementation.yml
+++ b/.github/ISSUE_TEMPLATE/implementation.yml
@@ -117,6 +117,7 @@ body:
         - v1.0 Readiness
         - Adoption Polish
         - Contract Hardening
+        - Agentic Coding Platform
     validations:
       required: true
   - type: dropdown

--- a/.github/base-project.yml
+++ b/.github/base-project.yml
@@ -20,6 +20,7 @@ project:
     - v1.0 Readiness
     - Adoption Polish
     - Contract Hardening
+    - Agentic Coding Platform
   issue_defaults:
     status: Backlog
     priority: P2

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -94,8 +94,15 @@ Project fields:
 - `Area`: `CLI`, `Setup`, `Workspace`, `Manifest`, `Runtime`, `Shell`,
   `Python`, `Docs`, `CI`, `Packaging`, `Security`, `Product`
 - `Size`: `T`, `S`, `M`, `L`
-- `Initiative`: `BanyanLabs Dogfood`, `Workspace Handling`, `pyproject/uv`,
-  `v1.0 Readiness`, `Adoption Polish`
+- `Initiative`: `BanyanLabs Dogfood`, `BanyanLabs Dogfooding`,
+  `Workspace Handling`, `pyproject/uv`, `v1.0 Readiness`, `Adoption Polish`,
+  `Contract Hardening`, `Agentic Coding Platform`
+
+Use `Agentic Coding Platform` for work that makes GitHub-centered agentic
+implementation more repeatable: agent-ready repo baselines, agent-readiness
+checks, issue-readiness gates, Copilot/cloud-agent readiness, and local
+handoff/context artifacts. Keep provider-specific runtime integrations out of
+this initiative unless the issue is about Base's GitHub-owned workflow contract.
 
 Use the smallest accurate `Size` when creating or triaging an issue:
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -356,8 +356,9 @@ the repo Project:
 - `Area`: `CLI`, `Setup`, `Workspace`, `Manifest`, `Runtime`, `Shell`,
   `Python`, `Docs`, `CI`, `Packaging`, `Security`, `Product`
 - `Size`: `T`, `S`, `M`, `L`
-- `Initiative`: `BanyanLabs Dogfood`, `Workspace Handling`, `pyproject/uv`,
-  `v1.0 Readiness`, `Adoption Polish`, plus values passed with
+- `Initiative`: `BanyanLabs Dogfood`, `BanyanLabs Dogfooding`,
+  `Workspace Handling`, `pyproject/uv`, `v1.0 Readiness`, `Adoption Polish`,
+  `Contract Hardening`, `Agentic Coding Platform`, plus values passed with
   `--initiative-option`
 
 `T` means a tiny, obvious issue with no design decision or cross-module

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -308,6 +308,25 @@ def test_implementation_issue_template_is_copilot_ready_and_project_aligned() ->
     assert "assign this issue to Copilot" in fields["agent_assignment"]["attributes"]["description"]
 
 
+def test_agentic_coding_platform_initiative_is_documented() -> None:
+    project_config = load_yaml_mapping(BASE_PROJECT_CONFIG)["project"]
+    implementation_template = load_yaml_mapping(IMPLEMENTATION_ISSUE_TEMPLATE)
+    workflow_docs = (REPO_ROOT / "docs" / "github-workflow.md").read_text(encoding="utf-8")
+    workflow_context = (REPO_ROOT / ".ai-context" / "WORKFLOWS.md").read_text(encoding="utf-8")
+    initiative_fields = [
+        field
+        for field in implementation_template["body"]
+        if isinstance(field, dict) and field.get("id") == "initiative"
+    ]
+
+    assert "Agentic Coding Platform" in project_config["initiatives"]
+    assert len(initiative_fields) == 1
+    assert "Agentic Coding Platform" in initiative_fields[0]["attributes"]["options"]
+    assert "Agentic Coding Platform" in workflow_docs
+    assert "agent-ready repo baselines" in workflow_docs
+    assert "agent-ready repo baselines" in workflow_context
+
+
 def test_python_tests_run_on_supported_minor_versions() -> None:
     workflow = load_workflow(WORKFLOW_DIR / "tests.yml")
     python_job = workflow["jobs"]["python"]


### PR DESCRIPTION
## Summary
- Add `Agentic Coding Platform` to Base Project config and the implementation issue template.
- Document when agentic-platform issues should use that Initiative.
- Update AI workflow context and repo-baseline Project metadata docs.

## Issue
Fixes #1557

## Validation
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py -q`
- `git diff --check`
- `gh project field-list 10 --owner basefoundry --format json --jq ...` confirmed the live Initiative option exists.

## Notes
Live Project metadata was configured with `basectl gh project configure --initiative-option "Agentic Coding Platform"`. Open agentic-platform issues #1558-#1562 were also moved onto the new Initiative.