### PR TITLE
Guard docs current-version references

### DIFF
--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -265,7 +265,7 @@ Run everything locally with `basectl test base` or `bin/base-test`.
 
 ## Current Status
 
-Base **1.3.0** (June 2026) covers: first-mile `bootstrap.sh`
+Base **1.6.1** (July 2026) covers: first-mile `bootstrap.sh`
 installation, setup, check, doctor, project discovery, workspace
 status/check/doctor/clone/pull/init/configure, `basectl onboard`, project activation
 (subshell), test execution, build targets, named commands, demo scripts,
@@ -276,10 +276,13 @@ command history, manifest-declared PR policy, Base-managed artifact
 declarations, `--ci` mode for non-interactive CI, IDE bootstrapping (VS
 Code/Cursor), release readiness inspection, the `basectl docs` documentation
 shortcut, CI setup JSON output improvements, CI supply-chain policy enforcement,
-and pinned Homebrew installer variables for verified first-mile bootstrap.
+pinned Homebrew installer variables for verified first-mile bootstrap, and
+apt-backed Ubuntu/Debian setup support.
 
-Linux support is a design target but not yet an implemented or tested contract.
-Windows is out of scope.
+The setup/check/doctor platform contract is implemented for macOS and
+Ubuntu/Debian Linux. Broader Linux families, WSL, and native Windows remain
+outside the supported contract unless a later platform policy explicitly adds
+them.
 
 ## Where to Go Next
 

--- a/tests/test_docs_version.py
+++ b/tests/test_docs_version.py
@@ -1,0 +1,40 @@
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSION_FILE = REPO_ROOT / "VERSION"
+
+CURRENT_VERSION_REFERENCES = (
+    (
+        REPO_ROOT / "README.md",
+        r"!\[Version\]\(https://img\.shields\.io/badge/version-([0-9]+\.[0-9]+\.[0-9]+)-blue\)",
+    ),
+    (
+        REPO_ROOT / "README.md",
+        r"Base `([0-9]+\.[0-9]+\.[0-9]+)` is the current release\.",
+    ),
+    (
+        REPO_ROOT / "docs" / "technical-overview.md",
+        r"Base \*\*([0-9]+\.[0-9]+\.[0-9]+)\*\* \([^)]+\) covers:",
+    ),
+)
+
+
+def test_current_version_references_match_version_file() -> None:
+    version = VERSION_FILE.read_text(encoding="utf-8").strip()
+    mismatches: list[str] = []
+
+    for path, pattern in CURRENT_VERSION_REFERENCES:
+        text = path.read_text(encoding="utf-8")
+        match = re.search(pattern, text)
+        if match is None:
+            mismatches.append(f"{path.relative_to(REPO_ROOT)}: missing guarded current-version reference")
+            continue
+        documented_version = match.group(1)
+        if documented_version != version:
+            mismatches.append(
+                f"{path.relative_to(REPO_ROOT)}: expected current version {version}, found {documented_version}"
+            )
+
+    assert not mismatches, "\n".join(mismatches)


### PR DESCRIPTION
## Summary
- add a focused docs-version test for guarded current-release references
- refresh `docs/technical-overview.md` from stale 1.3.0 status to 1.6.1
- update the platform status text to match current macOS and Ubuntu/Debian support

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_docs_version.py -q`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_docs_version.py tests/test_base_cli_docs.py tests/test_contract_hardening.py -q`
- `git diff --check`

Fixes #1572