### PR TITLE
Add logs last failure tail

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -85,6 +85,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
 - `basectl logs` lists recent Base CLI runtime logs and can print, open, or tail
   the newest matching log file.
+- `basectl logs last` prints the latest failed command metadata and a bounded
+  redacted log tail, with optional JSON output for local automation.
 - `basectl history` lists recent structured Base command runs from the local
   history index and supports table, JSON, and privacy-conscious report output.
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -7,6 +7,7 @@ base_logs_subcommand_usage() {
     cat <<'EOF'
 Usage:
   basectl logs [options]
+  basectl logs last [--command <name>] [--lines <count>] [--format text|json]
 
 Options:
   --command <name>  Filter by basectl command or Python CLI name.
@@ -15,10 +16,12 @@ Options:
   --tail            Tail and follow the most recent matching log.
   --open            Open the most recent matching log in PAGER or EDITOR.
   --lines <count>   Line count to show before following with --tail. Defaults to 40.
+  --format <format> Output format for "logs last": text or json. Defaults to text.
   -v                Enable DEBUG logging for this subcommand.
   -h, --help        Show this help text.
 
 Surface recent Base CLI runtime logs from the Base cache root.
+"logs last" prints the latest failed command metadata and a bounded redacted log tail.
 EOF
 }
 
@@ -36,7 +39,7 @@ base_logs_subcommand_main() {
                 args+=(--debug)
                 shift
                 ;;
-            --command|--limit|--lines)
+            --command|--limit|--lines|--format)
                 [[ -n "${2:-}" ]] || {
                     base_logs_subcommand_usage >&2
                     print_error "Option '$1' requires an argument."
@@ -45,7 +48,7 @@ base_logs_subcommand_main() {
                 args+=("$1" "$2")
                 shift 2
                 ;;
-            --command=*|--limit=*|--lines=*|--path|--tail|--open)
+            --command=*|--limit=*|--lines=*|--format=*|--path|--tail|--open)
                 args+=("$1")
                 shift
                 ;;

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -187,6 +187,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "logs_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl logs l); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "logs_commands=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl history --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -288,7 +292,8 @@ EOF
     [[ "$output" == *"prompt_options=--output --help"* ]]
     [[ "$output" == *"docs_options=--show-url"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
-    [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
+    [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines --format"* ]]
+    [[ "$output" == *"logs_commands=last"* ]]
     [[ "$output" == *"history_options=--project --command --status --limit --format --report"* ]]
     [[ "$output" == *"trust_commands=status allow revoke"* ]]
     [[ "$output" == *"trust_projects=base demo"* ]]

--- a/cli/bash/commands/basectl/tests/logs.bats
+++ b/cli/bash/commands/basectl/tests/logs.bats
@@ -49,14 +49,37 @@ EOF
     [[ "$output" == *"ARGS=--debug --path"* ]]
 }
 
+@test "basectl logs last forwards action and format to the Python logs layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected logs python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run_basectl logs last --format json --lines 5
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ARGS=last --format json --lines 5"* ]]
+}
+
 @test "basectl logs prints help without requiring the Base Python venv" {
     run_basectl logs --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl logs [options]"* ]]
+    [[ "$output" == *"basectl logs last"* ]]
     [[ "$output" == *"--command <name>"* ]]
     [[ "$output" == *"--path"* ]]
+    [[ "$output" == *"--format <format>"* ]]
 }
 
 @test "basectl logs reports missing option arguments as usage errors" {
@@ -70,5 +93,11 @@ EOF
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"ERROR: Option '--limit' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl logs last --format
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--format' requires an argument."* ]]
     [[ "$output" != *"FATAL"* ]]
 }

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import shlex
 import shutil
 import subprocess
 import sys
+from collections import deque
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import base_cli
 from base_cli.history import HISTORY_PATH
@@ -18,10 +21,19 @@ from base_cli.history import optional_int
 from base_cli.history import optional_string
 from base_cli.history import parse_finished_history_record_line
 from base_cli.history import parse_positive_int
+from base_cli.history import redact_history_argv
+from base_cli.history import redact_history_text
 from base_cli.paths import base_cache_root
+from base_cli.redaction import REDACTED
+from base_cli.redaction import redact_text_value
 
 
 RUN_ID_RE = re.compile(r"^(?P<stamp>\d{8}T\d{6})_[A-Za-z0-9]+$")
+LOG_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?P<key>\b[A-Za-z_][A-Za-z0-9_.-]*)=(?P<value>[^\s,;]+)",
+    re.IGNORECASE,
+)
+SECRET_KEY_RE = re.compile(r"token|password|secret|api[-_]?key|authorization", re.IGNORECASE)
 
 app = base_cli.App(name="base_logs", log_to_file=False)
 
@@ -45,6 +57,40 @@ class LogCommandOptions:
     tail: bool
     open_file: bool
     lines: int
+    output_format: str
+
+
+@dataclass(frozen=True)
+class LastFailureRecord:
+    payload: dict[str, Any]
+    run_id: str
+    command: str
+    raw_command: str | None
+    project: str | None
+    status: str
+    exit_code: int | None
+    ended_at: str
+    sort_time: datetime
+    log_path: str | None
+
+    @property
+    def log_file(self) -> Path | None:
+        if not self.log_path:
+            return None
+        return Path(self.log_path).expanduser()
+
+    @property
+    def log_exists(self) -> bool:
+        log_file = self.log_file
+        return log_file is not None and log_file.is_file()
+
+
+@dataclass(frozen=True)
+class LogTail:
+    lines: list[str]
+    requested_lines: int
+    truncated: bool
+    available: bool
 
 
 @dataclass(frozen=True)
@@ -71,19 +117,24 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--tail", is_flag=True, help="Tail and follow the most recent matching log.")
 @base_cli.option("--open", "open_file", is_flag=True, help="Open the most recent matching log in PAGER or EDITOR.")
 @base_cli.option("--lines", default="40", help="Line count to show before following.")
+@base_cli.option("--format", "output_format", default="text", help="Output format for logs last: text or json.")
+@base_cli.argument("action", required=False)
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
+    action: str | None,
     command_filter: str | None,
     limit: str,
     path_only: bool,
     tail: bool,
     open_file: bool,
     lines: str,
+    output_format: str,
 ) -> int:
     try:
         limit_value = parse_positive_int("--limit", limit)
         line_count = parse_positive_int("--lines", lines)
+        normalized_format = normalize_logs_format(output_format)
     except ValueError as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.USAGE_ERROR
@@ -95,18 +146,46 @@ def run(
         tail=tail,
         open_file=open_file,
         lines=line_count,
+        output_format=normalized_format,
     )
     selected_actions = sum(1 for selected in (path_only, tail, open_file) if selected)
-    if selected_actions > 1:
-        ctx.log.error("Choose only one of --path, --tail, or --open.")
+    validation_error = logs_command_validation_error(action, normalized_format, selected_actions)
+    if validation_error is not None:
+        ctx.log.error(validation_error)
         return base_cli.ExitCode.USAGE_ERROR
 
     cache_root = base_cache_root()
+    if action == "last":
+        return run_last_failure(ctx, cache_root, options)
+
+    return run_recent_logs(ctx, cache_root, options)
+
+
+def logs_command_validation_error(action: str | None, output_format: str, selected_actions: int) -> str | None:
+    if action is not None and action != "last":
+        return f"Unknown logs command '{action}'. Supported commands: last."
+    if action == "last" and selected_actions > 0:
+        return "`basectl logs last` does not accept --path, --tail, or --open."
+    if action is None and output_format != "text":
+        return "Option '--format' is only supported with `basectl logs last`."
+    if action is None and selected_actions > 1:
+        return "Choose only one of --path, --tail, or --open."
+    return None
+
+
+def run_recent_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandOptions) -> int:
     ctx.log.debug("Scanning Base cache root '%s'.", cache_root)
     entries = recent_logs(cache_root, command_filter=options.command_filter)
     if not entries:
         return report_no_logs(ctx, cache_root, options)
     return run_with_entries(entries, options)
+
+
+def normalize_logs_format(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"text", "json"}:
+        raise ValueError(f"Unsupported output format '{value}'. Expected one of: text, json.")
+    return normalized
 
 
 def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandOptions) -> int:
@@ -129,6 +208,220 @@ def run_with_entries(entries: list[LogEntry], options: LogCommandOptions) -> int
 
     print_log_table(entries[: options.limit])
     return base_cli.ExitCode.SUCCESS
+
+
+def run_last_failure(ctx: base_cli.Context, cache_root: Path, options: LogCommandOptions) -> int:
+    record = latest_failed_history_record(cache_root, command_filter=options.command_filter, logger=ctx.log)
+    history_path = cache_root / HISTORY_PATH
+    if record is None:
+        if options.output_format == "json":
+            print(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "found": False,
+                        "history_path": redact_history_text(str(history_path)),
+                        "message": "No failed Base command history found.",
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"No failed Base command history found under {history_path}.")
+        return base_cli.ExitCode.SUCCESS
+
+    tail = last_failure_tail(record, options.lines)
+    if options.output_format == "json":
+        print(json.dumps(last_failure_to_json(record, tail), indent=2, sort_keys=True))
+    else:
+        print_last_failure_text(record, tail)
+    return base_cli.ExitCode.SUCCESS
+
+
+def latest_failed_history_record(
+    cache_root: Path,
+    command_filter: str | None = None,
+    logger: Any | None = None,
+) -> LastFailureRecord | None:
+    records = read_failed_history_records(cache_root, logger=logger)
+    if command_filter:
+        normalized = normalize_command_filter(command_filter)
+        records = [
+            record
+            for record in records
+            if normalize_command_filter(record.command) == normalized
+            or (
+                record.raw_command is not None
+                and normalize_command_filter(record.raw_command) == normalized
+            )
+        ]
+    if not records:
+        return None
+    return sorted(records, key=lambda record: (record.sort_time, record.run_id), reverse=True)[0]
+
+
+def read_failed_history_records(cache_root: Path, logger: Any | None = None) -> list[LastFailureRecord]:
+    path = cache_root / HISTORY_PATH
+    if not path.is_file():
+        return []
+
+    records: list[LastFailureRecord] = []
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            record = parse_last_failure_history_line(line)
+            if record is None:
+                if logger is not None:
+                    logger.debug("Ignoring malformed or non-failing history line %s in '%s'.", line_number, path)
+                continue
+            records.append(record)
+    return records
+
+
+def parse_last_failure_history_line(line: str) -> LastFailureRecord | None:
+    payload = parse_finished_history_record_line(line)
+    if payload is None:
+        return None
+
+    run_id = optional_string(payload.get("run_id"))
+    command = optional_string(payload.get("command"))
+    status = optional_string(payload.get("status"))
+    if not run_id or not command or not status:
+        return None
+
+    exit_code = optional_int(payload.get("exit_code"))
+    if not history_payload_failed(status, exit_code):
+        return None
+
+    ended_at = optional_string(payload.get("ended_at")) or optional_string(payload.get("started_at")) or ""
+    return LastFailureRecord(
+        payload=payload,
+        run_id=run_id,
+        command=command,
+        raw_command=optional_string(payload.get("raw_command")),
+        project=optional_string(payload.get("project")),
+        status=status,
+        exit_code=exit_code,
+        ended_at=ended_at,
+        sort_time=parse_history_timestamp(ended_at),
+        log_path=optional_string(payload.get("log_path")),
+    )
+
+
+def history_payload_failed(status: str, exit_code: int | None) -> bool:
+    return status == "error" or (exit_code is not None and exit_code != 0)
+
+
+def parse_history_timestamp(value: str) -> datetime:
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def last_failure_tail(record: LastFailureRecord, line_count: int) -> LogTail:
+    log_file = record.log_file
+    if log_file is None or not log_file.is_file():
+        return LogTail(lines=[], requested_lines=line_count, truncated=False, available=False)
+    return read_redacted_tail(log_file, line_count)
+
+
+def read_redacted_tail(path: Path, line_count: int) -> LogTail:
+    buffered: deque[str] = deque(maxlen=line_count + 1)
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            buffered.append(redact_log_line(line.rstrip("\n")))
+    truncated = len(buffered) > line_count
+    lines = list(buffered)
+    if truncated:
+        lines = lines[1:]
+    return LogTail(lines=lines, requested_lines=line_count, truncated=truncated, available=True)
+
+
+def redact_log_line(value: str) -> str:
+    text = redact_text_value(value)
+    return LOG_SECRET_ASSIGNMENT_RE.sub(redact_log_secret_assignment, text)
+
+
+def redact_log_secret_assignment(match: re.Match[str]) -> str:
+    key = match.group("key")
+    if SECRET_KEY_RE.search(key):
+        return f"{key}={REDACTED}"
+    return match.group(0)
+
+
+def print_last_failure_text(record: LastFailureRecord, tail: LogTail) -> None:
+    print("Latest failed Base command")
+    print(f"Time: {display_last_value(record.ended_at)}")
+    print(f"Command: {redact_history_text(record.command)}")
+    print(f"Project: {redact_history_text(record.project) if record.project else '-'}")
+    print(f"Status: {redact_history_text(record.status)}")
+    print(f"Exit: {record.exit_code if record.exit_code is not None else '-'}")
+    print(f"Run ID: {redact_history_text(record.run_id)}")
+    print(f"Log: {display_last_log_path(record)}")
+    argv = redacted_last_argv(record)
+    if argv:
+        print(f"Argv: {' '.join(argv)}")
+
+    if record.log_path is None:
+        print()
+        print("No log path was recorded for this failed run. Use `basectl history --status error` for metadata.")
+        return
+    if not tail.available:
+        print()
+        print("The recorded log file is missing or was cleaned. Use `basectl history --status error` for metadata.")
+        return
+
+    print()
+    suffix = " (truncated)" if tail.truncated else ""
+    print(f"Log tail (last {tail.requested_lines} lines{suffix}):")
+    for line in tail.lines:
+        print(line)
+
+
+def display_last_value(value: str) -> str:
+    return redact_history_text(value) if value else "-"
+
+
+def display_last_log_path(record: LastFailureRecord) -> str:
+    if not record.log_path:
+        return "-"
+    suffix = "" if record.log_exists else " (missing)"
+    return f"{redact_history_text(record.log_path)}{suffix}"
+
+
+def redacted_last_argv(record: LastFailureRecord) -> list[str]:
+    value = record.payload.get("argv")
+    if not isinstance(value, list):
+        return []
+    return redact_history_argv([str(arg) for arg in value], sensitive_options=set())
+
+
+def last_failure_to_json(record: LastFailureRecord, tail: LogTail) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "found": True,
+        "run": {
+            "run_id": redact_history_text(record.run_id),
+            "command": redact_history_text(record.command),
+            "raw_command": redact_history_text(record.raw_command) if record.raw_command else None,
+            "project": redact_history_text(record.project) if record.project else None,
+            "status": redact_history_text(record.status),
+            "exit_code": record.exit_code,
+            "ended_at": redact_history_text(record.ended_at),
+            "log_path": redact_history_text(record.log_path) if record.log_path else None,
+            "log_exists": record.log_exists,
+            "argv": redacted_last_argv(record),
+        },
+        "tail": {
+            "available": tail.available,
+            "requested_lines": tail.requested_lines,
+            "truncated": tail.truncated,
+            "lines": tail.lines,
+        },
+    }
 
 
 def recent_logs(cache_root: Path, command_filter: str | None = None) -> list[LogEntry]:

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -27,6 +27,36 @@ def write_history_line(cache_root: Path, payload: dict | str) -> None:
         handle.write(f"{text}\n")
 
 
+def history_record(  # pylint: disable=too-many-arguments
+    run_id: str,
+    *,
+    command: str = "check",
+    raw_command: str = "base_setup",
+    status: str = "error",
+    exit_code: int = 1,
+    ended_at: str = "2026-06-01T01:00:00Z",
+    project: str | None = "demo",
+    log_path: str | None = "~/logs/run.log",
+    argv: list[str] | None = None,
+) -> dict:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "event": "finished",
+        "command": command,
+        "raw_command": raw_command,
+        "ended_at": ended_at,
+        "exit_code": exit_code,
+        "status": status,
+        "argv": argv if argv is not None else [command],
+    }
+    if project is not None:
+        payload["project"] = project
+    if log_path is not None:
+        payload["log_path"] = log_path
+    return payload
+
+
 def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -39,7 +69,7 @@ def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
     return status, stdout.getvalue(), stderr.getvalue()
 
 
-class BaseLogsTests(unittest.TestCase):
+class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_delegated_unknown_option_usage_uses_basectl_logs(self) -> None:
         stderr = io.StringIO()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -237,6 +267,190 @@ class BaseLogsTests(unittest.TestCase):
         self.assertEqual(filter_stderr, "")
         self.assertEqual(filter_stdout.strip(), str(older))
 
+    def test_last_prints_latest_failed_history_record_with_redacted_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            older_log = write_log(cache_root, "base_setup", "20260601T010000_aaaaaaaa", "old failure\n")
+            newer_log = write_log(
+                cache_root,
+                "base_setup",
+                "20260601T010200_bbbbbbbb",
+                "\n".join(
+                    [
+                        "line 1",
+                        "line 2",
+                        "token=secret-token",
+                        "fetch https://user:pass@example.com/repo.git",
+                    ]
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010000_aaaaaaaa",
+                    ended_at="2026-06-01T01:00:00Z",
+                    log_path=str(older_log),
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010100_okokokok",
+                    status="ok",
+                    exit_code=0,
+                    ended_at="2026-06-01T01:01:00Z",
+                    log_path=str(cache_root / "cli" / "base_setup" / "logs" / "ok.log"),
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010200_bbbbbbbb",
+                    ended_at="2026-06-01T01:02:00Z",
+                    log_path=str(newer_log),
+                    argv=["check", "--github-token", "token-secret", "url=https://user:pass@example.com/repo.git"],
+                ),
+            )
+
+            status, stdout, stderr = invoke(["last", "--lines", "2"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("Latest failed Base command", stdout)
+        self.assertIn("Command: check", stdout)
+        self.assertIn("Project: demo", stdout)
+        self.assertIn("Exit: 1", stdout)
+        self.assertIn("Log tail (last 2 lines (truncated)):", stdout)
+        self.assertNotIn("line 1", stdout)
+        self.assertNotIn("secret-token", stdout)
+        self.assertNotIn("token-secret", stdout)
+        self.assertNotIn("user:pass", stdout)
+        self.assertIn("token=[REDACTED]", stdout)
+        self.assertIn("https://[REDACTED]@example.com/repo.git", stdout)
+        self.assertIn("--github-token [REDACTED]", stdout)
+
+    def test_last_reports_no_failure_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010000_aaaaaaaa",
+                    status="ok",
+                    exit_code=0,
+                    log_path=str(cache_root / "cli" / "base_setup" / "logs" / "ok.log"),
+                ),
+            )
+
+            status, stdout, stderr = invoke(["last"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("No failed Base command history found", stdout)
+
+    def test_last_reports_missing_log_with_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            missing_log = cache_root / "cli" / "base_setup" / "logs" / "missing.log"
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010000_aaaaaaaa",
+                    log_path=str(missing_log),
+                    argv=["check", "API_KEY=plain-secret"],
+                ),
+            )
+
+            status, stdout, stderr = invoke(["last"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("Log:", stdout)
+        self.assertIn("(missing)", stdout)
+        self.assertIn("recorded log file is missing or was cleaned", stdout)
+        self.assertNotIn("plain-secret", stdout)
+        self.assertIn("API_KEY=[REDACTED]", stdout)
+
+    def test_last_json_output_has_stable_shape_and_redacted_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            log_path = write_log(
+                cache_root,
+                "base_setup",
+                "20260601T010000_aaaaaaaa",
+                "ok\npassword=db-secret\n",
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010000_aaaaaaaa",
+                    log_path=str(log_path),
+                    argv=["check", "--token=token-secret"],
+                ),
+            )
+
+            status, stdout, stderr = invoke(["last", "--format", "json", "--lines", "1"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertTrue(payload["found"])
+        self.assertEqual(payload["run"]["command"], "check")
+        self.assertEqual(payload["run"]["project"], "demo")
+        self.assertTrue(payload["run"]["log_exists"])
+        self.assertEqual(payload["run"]["argv"], ["check", "--token=[REDACTED]"])
+        self.assertEqual(payload["tail"]["requested_lines"], 1)
+        self.assertTrue(payload["tail"]["truncated"])
+        self.assertEqual(payload["tail"]["lines"], ["password=[REDACTED]"])
+        self.assertNotIn("db-secret", stdout)
+        self.assertNotIn("token-secret", stdout)
+
+    def test_last_json_reports_no_failure_without_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = invoke(["last", "--format", "json"], Path(tmpdir))
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertFalse(payload["found"])
+        self.assertIn("history_path", payload)
+
+    def test_last_can_filter_failures_by_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            check_log = write_log(cache_root, "base_setup", "20260601T010000_aaaaaaaa", "check failed\n")
+            release_log = write_log(cache_root, "base_release", "20260601T010100_bbbbbbbb", "release failed\n")
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010000_aaaaaaaa",
+                    command="check",
+                    raw_command="base_setup",
+                    ended_at="2026-06-01T01:00:00Z",
+                    log_path=str(check_log),
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "20260601T010100_bbbbbbbb",
+                    command="release",
+                    raw_command="base_release",
+                    ended_at="2026-06-01T01:01:00Z",
+                    log_path=str(release_log),
+                ),
+            )
+
+            status, stdout, stderr = invoke(["last", "--command", "check"], cache_root)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("Command: check", stdout)
+        self.assertIn("check failed", stdout)
+        self.assertNotIn("release failed", stdout)
+
     def test_empty_log_set_is_not_an_error_for_table_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             status, stdout, stderr = invoke([], Path(tmpdir))
@@ -274,6 +488,30 @@ class BaseLogsTests(unittest.TestCase):
         self.assertEqual(status, 2)
         self.assertEqual(stdout, "")
         self.assertIn("Choose only one", stderr)
+
+    def test_last_rejects_file_actions_and_unknown_formats(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            status, stdout, stderr = invoke(["last", "--path"], cache_root)
+            format_status, format_stdout, format_stderr = invoke(["last", "--format", "xml"], cache_root)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("does not accept --path", stderr)
+        self.assertEqual(format_status, 2)
+        self.assertEqual(format_stdout, "")
+        self.assertIn("Unsupported output format 'xml'", format_stderr)
+
+    def test_json_format_is_only_supported_for_last(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
+
+            status, stdout, stderr = invoke(["--format", "json"], cache_root)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("only supported with `basectl logs last`", stderr)
 
     def test_invalid_count_options_report_usage_errors(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -79,6 +79,7 @@ inspect the resolved command contract first.
 | `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
 | `basectl ci setup\|check\|doctor <project>` | Compatibility alias for the corresponding `--ci` mode command. | Same options as the target command. |
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
+| `basectl logs last` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name>`, `--lines <count>`, `--format <text\|json>` |
 | `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |
 | `basectl history` | List recent structured Base command history records. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--format <text\|json>` |
 | `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>` |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,17 +1,19 @@
 # Local Observability Model
 
-> **STATUS** — `basectl history`, the local history index, and
-> `basectl history --report` are implemented as local-only slices.
+> **STATUS** — `basectl history`, the local history index,
+> `basectl history --report`, and `basectl logs last` are implemented as
+> local-only slices.
 > `basectl explain last-error`, a broader `basectl report` bundle, and history
 > cleanup integration are tracked but not scheduled longer-term future work.
 
 Tracker: [#396](https://github.com/basefoundry/base/issues/396)
 
-Base currently exposes raw runtime logs through `basectl logs`, structured
-local command metadata through `basectl history`, and a redacted local activity
-summary through `basectl history --report`. This document defines the local
-observability layer: shipped command history and activity reports, future
-last-error explanation, and broader future report generation.
+Base currently exposes raw runtime logs through `basectl logs`, latest-failure
+evidence through `basectl logs last`, structured local command metadata through
+`basectl history`, and a redacted local activity summary through
+`basectl history --report`. This document defines the local observability
+layer: shipped command history and activity reports, future last-error
+explanation, and broader future report generation.
 
 ## Goals
 
@@ -174,6 +176,13 @@ Expected options:
 `basectl logs` should remain the command for opening or tailing raw log files.
 `basectl history` should point to logs, not replace them.
 
+`basectl logs last` bridges those surfaces for the common failure case. It reads
+the local history index, finds the latest failed run, prints command metadata,
+and includes a bounded redacted tail of the recorded log when the log still
+exists. It also supports `--format json` for local automation. If the log path
+is missing or the file was cleaned, it still reports the available history
+metadata and says that the recorded log file is missing.
+
 The report mode summarizes selected recent history records with:
 
 - total records, warnings, and failures
@@ -192,9 +201,9 @@ rendering Markdown or JSON.
 
 ### `basectl explain last-error`
 
-`basectl explain last-error` should find the latest failed history record,
-inspect its linked log file if present, and print a deterministic local
-summary:
+`basectl explain last-error` should build on the local evidence surfaced by
+`basectl logs last`. It should find the latest failed history record, inspect
+its linked log file if present, and print a deterministic local summary:
 
 - command, project, exit code, and time
 - likely failing subsystem when detectable
@@ -231,6 +240,8 @@ The shipped first slice is:
 1. Add history recording and `basectl history`. **Shipped.**
 2. Add `basectl history --report` for local history/log activity summaries.
    **Shipped.**
+3. Add `basectl logs last` for latest-failure metadata and bounded redacted log
+   tails. **Shipped.**
 
 ### Unscheduled Future Work
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -291,7 +291,11 @@ _base_basectl_completion() {
             _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"
             ;;
         logs)
-            _base_basectl_completion_compgen "--command --limit --path --tail --open --lines -v -h --help" "$cur"
+            if ((COMP_CWORD == 2)) && [[ "$cur" != -* ]]; then
+                _base_basectl_completion_compgen "last" "$cur"
+            else
+                _base_basectl_completion_compgen "--command --limit --path --tail --open --lines --format -v -h --help" "$cur"
+            fi
             ;;
         history)
             _base_basectl_completion_compgen "--project --command --status --limit --format --report -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -443,12 +443,14 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         logs)
-            _arguments '--command[Filter by command]:command:' \
+            _arguments '1:logs command:(last)' \
+                '--command[Filter by command]:command:' \
                 '--limit[Number of entries]:count:' \
                 '--path[Print most recent log path]' \
                 '--tail[Tail and follow most recent log]' \
                 '--open[Open most recent log]' \
                 '--lines[Lines to show before following]:count:' \
+                '--format[Output format for logs last]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         history)


### PR DESCRIPTION
## Summary
- add `basectl logs last` for latest failed command metadata and bounded redacted log tails
- support `--format json`, command filtering, missing-log handling, and completions
- document the new observability surface and command reference entry

Closes #1571

## Tests
- `python -m pytest cli/python/base_logs/tests/test_engine.py tests/test_observability_docs.py -q`
- `python -m pytest tests/test_stability_tiers_docs.py tests/test_observability_docs.py -q`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/completions.bats`
- `bash -n cli/bash/commands/basectl/subcommands/logs.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `git diff --check`
- `BASE_CACHE_DIR=/private/tmp/base-1571-smoke bin/basectl logs last`
- `BASE_CACHE_DIR=/private/tmp/base-1571-smoke bin/basectl logs last --format json`