### PR TITLE
Add local finding explanations

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -94,6 +94,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
   manifest-declared project commands under `~/.base.d/trust/manifest-commands/`.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.
+- `basectl doctor explain <finding-id>` prints local, deterministic guidance
+  for selected stable finding IDs, with optional JSON output.
 - `basectl gh` manages GitHub issues, pull requests, branch naming, repository
   hygiene, and GitHub Project metadata using Base's opinionated workflow. It
   uses standard GitHub-style issue categories such as `bug`, `enhancement`,

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -12,6 +12,7 @@ base_doctor_subcommand_usage() {
     cat <<'EOF'
 Usage:
   basectl doctor [project] [options]
+  basectl doctor explain <finding-id> [--format text|json]
 
 Options:
   --ci                  Run diagnostics with CI-safe defaults.
@@ -33,6 +34,7 @@ Profiles:
 Purpose:
   Diagnose the local Base CLI environment and, when provided, project artifacts.
   Use doctor for finding IDs and fix hints; use check for a quick pass/fail result.
+  Use doctor explain for local, provider-neutral guidance about a stable finding ID.
 
 See also:
   basectl check [project] [options]
@@ -44,6 +46,98 @@ base_doctor_usage_error() {
     print_error "$*"
     printf "Run 'basectl doctor --help' for usage.\n" >&2
     return 2
+}
+
+base_doctor_explain_usage() {
+    cat <<'EOF'
+Usage:
+  basectl doctor explain <finding-id> [--format text|json]
+
+Options:
+  --format <text|json>  Select output format. Defaults to text.
+  -h, --help            Show this help text.
+
+Purpose:
+  Print local, deterministic guidance for a stable Base finding ID.
+EOF
+}
+
+base_doctor_explain_usage_error() {
+    print_error "$*"
+    printf "Run 'basectl doctor explain --help' for usage.\n" >&2
+    return 2
+}
+
+base_doctor_explain_finding() {
+    local finding_id="$1"
+    local output_format="$2"
+    local python_bin
+
+    python_bin="$(setup_diagnostics_python_bin)" ||
+        fatal_error "Python is required to render Base finding explanations."
+    setup_ensure_cached_paths
+    env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+        "$python_bin" -m base_setup.finding_explanations "$finding_id" --format "$output_format"
+}
+
+base_doctor_explain_main() {
+    local finding_id=""
+    local output_format="text"
+
+    while (($#)); do
+        case "$1" in
+            -h|--help|help)
+                base_doctor_explain_usage
+                return 0
+                ;;
+            --format)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    base_doctor_explain_usage_error "Option '--format' requires an argument."
+                    return $?
+                fi
+                case "$1" in
+                    text|json)
+                        output_format="$1"
+                        ;;
+                    *)
+                        base_doctor_explain_usage_error "Unsupported doctor explain output format '$1'."
+                        return $?
+                        ;;
+                esac
+                ;;
+            --format=*)
+                case "${1#--format=}" in
+                    text|json)
+                        output_format="${1#--format=}"
+                        ;;
+                    *)
+                        base_doctor_explain_usage_error "Unsupported doctor explain output format '${1#--format=}'."
+                        return $?
+                        ;;
+                esac
+                ;;
+            *)
+                if [[ "$1" == -* ]]; then
+                    base_doctor_explain_usage_error "Unknown option '$1'."
+                    return $?
+                fi
+                if [[ -n "$finding_id" ]]; then
+                    base_doctor_explain_usage_error "The 'doctor explain' command accepts exactly one finding ID."
+                    return $?
+                fi
+                finding_id="$1"
+                ;;
+        esac
+        shift
+    done
+
+    if [[ -z "$finding_id" ]]; then
+        base_doctor_explain_usage_error "The 'doctor explain' command requires a finding ID."
+        return $?
+    fi
+
+    base_doctor_explain_finding "$finding_id" "$output_format"
 }
 
 base_doctor_print_finding() {
@@ -181,6 +275,12 @@ base_doctor_subcommand_main() {
     local remote_network=false
 
     setup_clear_run_state
+
+    if [[ "${1:-}" == explain ]]; then
+        shift
+        base_doctor_explain_main "$@"
+        return $?
+    fi
 
     while (($#)); do
         case "$1" in

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -43,6 +43,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "doctor_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl doctor explain --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "doctor_explain_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl test ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -261,7 +265,8 @@ EOF
     [[ "$output" == *"activate_projects=base demo"* ]]
     [[ "$output" == *"activate_options=--workspace --no-cd"* ]]
     [[ "$output" == *"check_projects=base demo"* ]]
-    [[ "$output" == *"doctor_projects=base demo"* ]]
+    [[ "$output" == *"doctor_projects=base demo explain"* ]]
+    [[ "$output" == *"doctor_explain_options=--format"* ]]
     [[ "$output" == *"test_projects=base demo"* ]]
     [[ "$output" == *"build_projects=base demo"* ]]
     [[ "$output" == *"run_projects=base demo"* ]]

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -174,6 +174,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl doctor [project] [options]"* ]]
+    [[ "$output" == *"basectl doctor explain <finding-id>"* ]]
     [[ "$output" == *"--profile <list>"* ]]
     [[ "$output" == *"Profile lists are comma-separated, for example: --profile dev,sre."* ]]
     [[ "$output" == *"dev       - Base development tooling for this repository."* ]]
@@ -185,8 +186,61 @@ EOF
     [[ "$output" != *"--dev"* ]]
     [[ "$output" == *"Diagnose the local Base CLI environment"* ]]
     [[ "$output" == *"Use doctor for finding IDs and fix hints; use check for a quick pass/fail result."* ]]
+    [[ "$output" == *"Use doctor explain for local, provider-neutral guidance"* ]]
     [[ "$output" == *"See also:"* ]]
     [[ "$output" == *"basectl check [project] [options]"* ]]
+}
+
+@test "basectl doctor explain prints help without requiring diagnostics" {
+    run_basectl doctor explain --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl doctor explain <finding-id>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"Print local, deterministic guidance"* ]]
+}
+
+@test "basectl doctor explain delegates to the local explanation renderer" {
+    cat > "$TEST_MOCKBIN/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-c" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup.finding_explanations" ]]; then
+    printf 'ARGS=%s\n' "${*:3}"
+    exit 0
+fi
+printf 'unexpected doctor explain python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/python3"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor explain BASE-D001 --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ARGS=BASE-D001 --format json"* ]]
+}
+
+@test "basectl doctor explain reports usage errors before Python dispatch" {
+    run_basectl doctor explain
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: The 'doctor explain' command requires a finding ID."* ]]
+    [[ "$output" == *"Run 'basectl doctor explain --help' for usage."* ]]
+
+    run_basectl doctor explain --format
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--format' requires an argument."* ]]
+
+    run_basectl doctor explain BASE-D001 --format yaml
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unsupported doctor explain output format 'yaml'."* ]]
 }
 
 @test "basectl doctor uses visual status indicators on a color-capable tty" {

--- a/cli/python/base_setup/finding_explanations.py
+++ b/cli/python/base_setup/finding_explanations.py
@@ -1,0 +1,340 @@
+"""Local explanation catalog for stable Base finding IDs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+CATALOG_SCHEMA_VERSION = 1
+SUCCESS = 0
+FAILURE = 1
+USAGE_ERROR = 2
+FINDING_DOC_PATH = "docs/doctor-findings.md"
+
+
+@dataclass(frozen=True)
+class RelatedDoc:
+    label: str
+    path: str
+
+
+@dataclass(frozen=True)
+class FindingExplanation:
+    finding_id: str
+    title: str
+    summary: str
+    why_it_matters: str
+    likely_causes: tuple[str, ...]
+    fix_steps: tuple[str, ...]
+    related_commands: tuple[str, ...]
+    docs: tuple[RelatedDoc, ...]
+
+
+def catalog_by_id(explanations: tuple[FindingExplanation, ...]) -> dict[str, FindingExplanation]:
+    catalog: dict[str, FindingExplanation] = {}
+    for explanation in explanations:
+        if explanation.finding_id in catalog:
+            raise ValueError(f"Duplicate finding explanation ID {explanation.finding_id}.")
+        catalog[explanation.finding_id] = explanation
+    return catalog
+
+
+CATALOG = catalog_by_id(
+    (
+        FindingExplanation(
+            finding_id="BASE-D001",
+            title="Homebrew availability and PATH refresh",
+            summary="Base could not confirm that Homebrew is installed and available on PATH.",
+            why_it_matters=(
+                "Homebrew is the primary package manager Base uses for macOS runtime prerequisites. "
+                "When it is missing or not visible in PATH, setup and doctor cannot reliably install or "
+                "inspect macOS tools."
+            ),
+            likely_causes=(
+                "Homebrew is not installed on this machine.",
+                "Homebrew is installed but the current shell has not loaded its shellenv output.",
+                "The terminal is running under the wrong architecture for the installed Homebrew prefix.",
+            ),
+            fix_steps=(
+                "Run `basectl setup --dry-run` to preview the Homebrew bootstrap path.",
+                "Install or repair Homebrew, then restart the shell or source your profile.",
+                "Run `basectl doctor` again and confirm `BASE-D001` reports `ok`.",
+            ),
+            related_commands=("basectl setup --dry-run", "basectl doctor", "brew --prefix"),
+            docs=(RelatedDoc("Doctor Finding IDs", "docs/doctor-findings.md#base-runtime-findings"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-D004",
+            title="Base virtual environment integrity",
+            summary="Base could not verify the Python virtual environment used by Base itself.",
+            why_it_matters=(
+                "Base Python subcommands depend on this virtual environment for local CLI modules and "
+                "runtime packages. A broken environment can make setup, check, doctor, and project commands "
+                "fail before project-specific diagnostics can run."
+            ),
+            likely_causes=(
+                "The virtual environment under `~/.base.d/base/.venv` is missing or incomplete.",
+                "The Python executable inside the virtual environment no longer starts.",
+                "A macOS architecture change left the virtual environment pointing at an incompatible Python.",
+            ),
+            fix_steps=(
+                "Run `basectl setup --dry-run` to review the repair actions.",
+                "Run `basectl setup --recreate-venv` when the existing environment must be rebuilt.",
+                "Run `basectl doctor` again and confirm the Base virtualenv finding is healthy.",
+            ),
+            related_commands=("basectl setup --dry-run", "basectl setup --recreate-venv", "basectl doctor"),
+            docs=(RelatedDoc("Runtime Environment", "docs/runtime-environment.md"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-D007",
+            title="Base reusable Bash library source readiness",
+            summary="Base could not confirm that the reusable Bash library source is available.",
+            why_it_matters=(
+                "The Bash command layer imports shared libraries for GitHub, string, logging, and shell "
+                "behavior. If the library source is missing or mismatched, shell subcommands may fail before "
+                "they can reach Python diagnostics."
+            ),
+            likely_causes=(
+                "`BASE_BASH_LIBS_DIR` points at a missing or stale checkout.",
+                "A source checkout is missing its sibling `base-bash-libs` repository.",
+                "A Homebrew install cannot locate the packaged library path.",
+            ),
+            fix_steps=(
+                "Run `basectl doctor` to see the resolved Bash library source.",
+                "For source checkouts, place `base-bash-libs` next to `base` or set `BASE_BASH_LIBS_DIR`.",
+                "For installed Base, reinstall or upgrade the Base package that provides the libraries.",
+            ),
+            related_commands=("basectl doctor", "basectl check", "basectl setup --dry-run"),
+            docs=(RelatedDoc("Runtime Environment", "docs/runtime-environment.md"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-D011",
+            title="GitHub CLI availability on Ubuntu/Debian",
+            summary="Base could not find the GitHub CLI on an Ubuntu/Debian host.",
+            why_it_matters=(
+                "Several Base workflows use `gh` for repository, issue, pull request, and project automation. "
+                "On Linux, Base reports this as a diagnostic so setup can stay explicit about adding external "
+                "package repositories."
+            ),
+            likely_causes=(
+                "The `gh` executable is not installed.",
+                "The GitHub apt repository has not been added to the host.",
+                "`gh` is installed outside the PATH visible to the current shell.",
+            ),
+            fix_steps=(
+                "Run `basectl setup --dry-run` to review the Linux setup guidance.",
+                "Install GitHub CLI using GitHub's official Ubuntu/Debian instructions.",
+                "Run `gh auth status -h github.com` when GitHub-backed workflows need authentication.",
+            ),
+            related_commands=("basectl setup --dry-run", "basectl doctor --ci", "gh auth status -h github.com"),
+            docs=(RelatedDoc("Linux Support", "docs/linux-support.md"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-P050",
+            title="Project virtual environment readiness",
+            summary="Base could not verify the Base-managed Python virtual environment for the project.",
+            why_it_matters=(
+                "Project artifact checks and Python-package reconciliation depend on a working project "
+                "environment unless the manifest opts into another manager such as uv. A broken venv blocks "
+                "reliable project setup and command execution."
+            ),
+            likely_causes=(
+                "The project virtual environment has not been created yet.",
+                "The environment exists but its Python executable is missing or broken.",
+                "The project changed Python versions and the old virtual environment was not recreated.",
+            ),
+            fix_steps=(
+                "Run `basectl setup <project> --dry-run` to preview project environment actions.",
+                "Run `basectl setup <project>` to create missing project artifacts.",
+                "Use `--recreate-venv` when Base reports that the existing venv must be replaced.",
+            ),
+            related_commands=(
+                "basectl check <project>",
+                "basectl setup <project> --dry-run",
+                "basectl setup <project> --recreate-venv",
+            ),
+            docs=(RelatedDoc("Python Manifest", "docs/python-manifest.md"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-P080",
+            title="Project Git repository status",
+            summary="Base could not confirm that the project directory is inside a Git repository.",
+            why_it_matters=(
+                "Git context lets Base connect local project state to remotes, pull requests, and workspace "
+                "automation. Without it, source-control diagnostics and some GitHub-backed workflows cannot "
+                "make reliable claims."
+            ),
+            likely_causes=(
+                "The project directory was copied without its `.git` directory.",
+                "The manifest points outside the intended repository checkout.",
+                "The project is new and has not been initialized with Git yet.",
+            ),
+            fix_steps=(
+                "Run `git status` from the project root to confirm repository state.",
+                "Move into the intended checkout or initialize Git for the project.",
+                "Run `basectl doctor <project>` again after the repository state is corrected.",
+            ),
+            related_commands=("git status", "basectl doctor <project>", "basectl workspace status"),
+            docs=(RelatedDoc("Source Control And Forge Support", "docs/source-control-and-forge-support.md"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-P081",
+            title="Project Git origin remote status",
+            summary="Base could not parse or find the project's `origin` remote.",
+            why_it_matters=(
+                "The `origin` remote is the anchor Base uses for repository identity and GitHub-oriented "
+                "diagnostics. Missing or malformed remotes make project automation ambiguous."
+            ),
+            likely_causes=(
+                "The project has no `origin` remote configured.",
+                "`origin` points at a local path or unsupported URL shape.",
+                "The repository was cloned from a temporary or renamed remote.",
+            ),
+            fix_steps=(
+                "Run `git remote -v` from the project root.",
+                "Set or repair `origin` with the canonical repository URL.",
+                "Run `basectl doctor <project> --remote-network` only when you want an opt-in reachability probe.",
+            ),
+            related_commands=("git remote -v", "basectl doctor <project>", "basectl doctor <project> --remote-network"),
+            docs=(RelatedDoc("Source Control And Forge Support", "docs/source-control-and-forge-support.md"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-P150",
+            title="uv CLI availability for uv-managed projects or uv command runners",
+            summary="Base could not find `uv` where the project manifest expects uv-managed behavior.",
+            why_it_matters=(
+                "When a project declares uv-managed environments or uv command runners, Base needs the `uv` "
+                "CLI to inspect lockfiles and execute those commands consistently."
+            ),
+            likely_causes=(
+                "`uv` is not installed.",
+                "`uv` is installed but not on PATH for the current shell or CI runner.",
+                "The project manifest opted into uv before the host was prepared.",
+            ),
+            fix_steps=(
+                "Run `basectl setup <project> --dry-run` to preview the uv setup path.",
+                "Install uv using the project-supported package path.",
+                "Run `basectl check <project>` again before invoking uv-backed project commands.",
+            ),
+            related_commands=("basectl setup <project> --dry-run", "basectl check <project>", "uv --version"),
+            docs=(RelatedDoc("Python Manifest - Command Runners", "docs/python-manifest.md#command-runners"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-P160",
+            title="Manifest command executable availability",
+            summary="Base found an obvious missing executable in a manifest-declared command.",
+            why_it_matters=(
+                "Manifest commands are project-owned shell commands. Base checks for missing leading "
+                "executables so users see a fast, local warning before a test, run, build, or demo command "
+                "fails deeper in the workflow."
+            ),
+            likely_causes=(
+                "The tool named first in the command is not installed.",
+                "The command relies on a project script that has not been created yet.",
+                "The command is intended to run through a manager such as uv but the runner is not declared.",
+            ),
+            fix_steps=(
+                "Inspect the command in `base_manifest.yaml`.",
+                "Install the missing executable or update the command to use the intended runner.",
+                "Run `basectl check <project>` to confirm the advisory warning is gone.",
+            ),
+            related_commands=("basectl check <project>", "basectl run <project> <command> --dry-run"),
+            docs=(RelatedDoc("Python Manifest - Command Runners", "docs/python-manifest.md#command-runners"),),
+        ),
+    )
+)
+
+
+def normalize_finding_id(value: str) -> str:
+    return value.strip().upper()
+
+
+def explanation_to_json(explanation: FindingExplanation) -> dict[str, Any]:
+    return {
+        "schema_version": CATALOG_SCHEMA_VERSION,
+        "found": True,
+        "id": explanation.finding_id,
+        "title": explanation.title,
+        "summary": explanation.summary,
+        "why_it_matters": explanation.why_it_matters,
+        "likely_causes": list(explanation.likely_causes),
+        "fix_steps": list(explanation.fix_steps),
+        "related_commands": list(explanation.related_commands),
+        "docs": [{"label": doc.label, "path": doc.path} for doc in explanation.docs],
+    }
+
+
+def unknown_to_json(finding_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": CATALOG_SCHEMA_VERSION,
+        "found": False,
+        "id": finding_id,
+        "message": "No local explanation is available for this finding ID.",
+        "docs": FINDING_DOC_PATH,
+        "known_ids": sorted(CATALOG),
+    }
+
+
+def render_text(explanation: FindingExplanation) -> str:
+    lines = [
+        f"{explanation.finding_id} - {explanation.title}",
+        "",
+        "Summary:",
+        f"  {explanation.summary}",
+        "",
+        "Why it matters:",
+        f"  {explanation.why_it_matters}",
+        "",
+        "Likely causes:",
+    ]
+    lines.extend(f"  - {cause}" for cause in explanation.likely_causes)
+    lines.extend(("", "Fix steps:"))
+    lines.extend(f"  {index}. {step}" for index, step in enumerate(explanation.fix_steps, start=1))
+    if explanation.related_commands:
+        lines.extend(("", "Related commands:"))
+        lines.extend(f"  - {command}" for command in explanation.related_commands)
+    if explanation.docs:
+        lines.extend(("", "Docs:"))
+        lines.extend(f"  - {doc.label}: {doc.path}" for doc in explanation.docs)
+    return "\n".join(lines) + "\n"
+
+
+def render_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="base_setup.finding_explanations")
+    parser.add_argument("finding_id", help="Stable finding ID, such as BASE-D001 or BASE-P050.")
+    parser.add_argument("--format", choices=("text", "json"), default="text", help="Output format.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    finding_id = normalize_finding_id(args.finding_id)
+    explanation = CATALOG.get(finding_id)
+    if explanation is None:
+        if args.format == "json":
+            print(render_json(unknown_to_json(finding_id)), end="")
+        else:
+            print(
+                f"No local explanation is available for {finding_id}. "
+                f"See {FINDING_DOC_PATH} for documented finding IDs.",
+                file=sys.stderr,
+            )
+        return FAILURE
+    if args.format == "json":
+        print(render_json(explanation_to_json(explanation)), end="")
+    else:
+        print(render_text(explanation), end="")
+    return SUCCESS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_setup/tests/test_finding_explanations.py
+++ b/cli/python/base_setup/tests/test_finding_explanations.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import io
+import json
+import re
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from base_setup import finding_explanations
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DOCTOR_FINDINGS_DOC = REPO_ROOT / "docs" / "doctor-findings.md"
+
+
+def invoke(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        status = finding_explanations.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class FindingExplanationTests(unittest.TestCase):
+    def test_known_id_renders_local_text_explanation(self) -> None:
+        status, stdout, stderr = invoke(["base-p050"])
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("BASE-P050 - Project virtual environment readiness", stdout)
+        self.assertIn("Why it matters:", stdout)
+        self.assertIn("Fix steps:", stdout)
+        self.assertIn("basectl setup <project> --dry-run", stdout)
+        self.assertIn("docs/python-manifest.md", stdout)
+
+    def test_known_id_renders_stable_json_shape(self) -> None:
+        status, stdout, stderr = invoke(["BASE-D001", "--format", "json"])
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertTrue(payload["found"])
+        self.assertEqual(payload["id"], "BASE-D001")
+        self.assertEqual(payload["title"], "Homebrew availability and PATH refresh")
+        self.assertGreaterEqual(len(payload["likely_causes"]), 1)
+        self.assertGreaterEqual(len(payload["fix_steps"]), 1)
+        self.assertGreaterEqual(len(payload["related_commands"]), 1)
+        self.assertEqual(payload["docs"][0]["path"], "docs/doctor-findings.md#base-runtime-findings")
+
+    def test_unknown_id_fails_with_clear_text_guidance(self) -> None:
+        status, stdout, stderr = invoke(["BASE-X999"])
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("No local explanation is available for BASE-X999", stderr)
+        self.assertIn("docs/doctor-findings.md", stderr)
+
+    def test_unknown_id_json_is_machine_readable(self) -> None:
+        status, stdout, stderr = invoke(["BASE-X999", "--format", "json"])
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertFalse(payload["found"])
+        self.assertEqual(payload["id"], "BASE-X999")
+        self.assertIn("BASE-D001", payload["known_ids"])
+        self.assertEqual(payload["docs"], "docs/doctor-findings.md")
+
+    def test_catalog_entries_are_documented_finding_ids(self) -> None:
+        doc_text = DOCTOR_FINDINGS_DOC.read_text(encoding="utf-8")
+        documented_ids = set(re.findall(r"`(BASE-[DPHW][0-9]{3})`", doc_text))
+
+        self.assertTrue(set(finding_explanations.CATALOG).issubset(documented_ids))
+
+    def test_catalog_entries_have_actionable_sections(self) -> None:
+        for explanation in finding_explanations.CATALOG.values():
+            with self.subTest(finding_id=explanation.finding_id):
+                self.assertEqual(
+                    explanation.finding_id,
+                    finding_explanations.normalize_finding_id(explanation.finding_id),
+                )
+                self.assertTrue(explanation.summary)
+                self.assertTrue(explanation.why_it_matters)
+                self.assertTrue(explanation.likely_causes)
+                self.assertTrue(explanation.fix_steps)
+                self.assertTrue(explanation.related_commands)
+                self.assertTrue(explanation.docs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -77,6 +77,7 @@ inspect the resolved command contract first.
 | `basectl setup --ci <project>` | Run setup with CI-safe defaults. Does not run tests or create runners/VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv` |
 | `basectl check [project]` | Verify Base and optional project readiness without making changes. Project checks record the latest result under `~/.base.d/<project>/checks/last.json`. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
 | `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
+| `basectl doctor explain <finding-id>` | Print local, deterministic guidance for a stable finding ID. | `--format <text\|json>` |
 | `basectl ci setup\|check\|doctor <project>` | Compatibility alias for the corresponding `--ci` mode command. | Same options as the target command. |
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
 | `basectl logs last` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name>`, `--lines <count>`, `--format <text\|json>` |

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -26,6 +26,27 @@ machine-readable stdout.
 explicit, reviewable, and paired with dry-run behavior before Base offers it as
 part of the doctor workflow.
 
+## Local Explanations
+
+`basectl doctor explain <finding-id>` prints local, deterministic guidance for
+selected high-frequency finding IDs:
+
+```bash
+basectl doctor explain BASE-P050
+basectl doctor explain BASE-D001 --format json
+```
+
+The explanation catalog is provider-neutral and local-only. It includes a
+summary, why the finding matters, likely causes, concrete fix steps, related
+commands, and documentation links. Unknown IDs fail clearly and point back to
+this reference. The first catalog slice intentionally covers frequent Base
+runtime and project-readiness findings rather than every documented ID.
+
+Future AI-assisted doctor features should build on this local catalog as the
+ground truth. Optional provider amplification may add richer phrasing or
+context later, but it must not replace the local explanation data, require a
+provider for deterministic guidance, or change the stable finding-ID contract.
+
 ## Diagnostic JSON Contract
 
 Base diagnostic JSON uses `schema_version: 1` for object-shaped payloads. This

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -306,7 +306,16 @@ _base_basectl_completion() {
             fi
             ;;
         doctor)
-            _base_basectl_completion_project_profiles_or_options "$cur" "--ci --profile --format --manifest --remote-network --no-color -v -h --help"
+            if [[ "${COMP_WORDS[2]:-}" == explain ]]; then
+                _base_basectl_completion_compgen "--format -h --help" "$cur"
+            elif ((COMP_CWORD == 2)) && [[ "$cur" != -* ]]; then
+                _base_basectl_completion_project_candidates "$cur"
+                if [[ "explain" == "$cur"* ]]; then
+                    COMPREPLY+=("explain")
+                fi
+            else
+                _base_basectl_completion_project_profiles_or_options "$cur" "--ci --profile --format --manifest --remote-network --no-color -v -h --help"
+            fi
             ;;
         gh)
             case "${COMP_WORDS[2]:-}" in

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -465,18 +465,29 @@ _base_basectl_completion() {
             _arguments '1:config command:(path show doctor)'
             ;;
         doctor)
-            _arguments '--ci[Run diagnostics with CI-safe defaults]' \
-                '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
-                '--format[Output format]:format:(text json)' \
-                '--manifest[Use a specific manifest]:path:_files' \
-                '--remote-network[Opt in to bounded project Git origin reachability diagnostics]' \
-                '--no-color[Disable doctor status colors and symbols in text output]' \
-                '-v[Enable DEBUG logging]' \
-                '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
-            if [[ "$state" == projects ]]; then
-                _base_basectl_completion_describe_projects
-            fi
+            case "${words[3]:-}" in
+                explain)
+                    _arguments '--format[Output format]:format:(text json)' \
+                        '(-h --help)'{-h,--help}'[Show help text]' \
+                        '2:finding id:'
+                    ;;
+                *)
+                    _arguments '--ci[Run diagnostics with CI-safe defaults]' \
+                        '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
+                        '--format[Output format]:format:(text json)' \
+                        '--manifest[Use a specific manifest]:path:_files' \
+                        '--remote-network[Opt in to bounded project Git origin reachability diagnostics]' \
+                        '--no-color[Disable doctor status colors and symbols in text output]' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]' \
+                        '1:doctor command or project:->doctor_targets'
+                    if [[ "$state" == doctor_targets ]]; then
+                        _alternative \
+                            'commands:doctor command:(explain)' \
+                            'projects:Base project:_base_basectl_completion_describe_projects'
+                    fi
+                    ;;
+            esac
             ;;
         gh)
             case "${words[3]:-}" in


### PR DESCRIPTION
## Summary
- add a schema-versioned local explanation catalog for selected high-frequency doctor/check finding IDs
- expose `basectl doctor explain <finding-id>` with text and JSON output
- document the provider-neutral boundary and update shell completions/tests

Closes #1577

## Tests
- `python -m pytest cli/python/base_setup/tests/test_finding_explanations.py tests/test_doctor_findings_docs.py tests/test_stability_tiers_docs.py -q`
- `python -m pylint --rcfile=.pylintrc cli/python/base_setup/finding_explanations.py cli/python/base_setup/tests/test_finding_explanations.py`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/doctor.bats cli/bash/commands/basectl/tests/completions.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats`
- `bash -n cli/bash/commands/basectl/subcommands/doctor.sh lib/shell/completions/basectl_completion.sh`
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- `git diff --check`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bin/basectl doctor explain BASE-P050`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bin/basectl doctor explain BASE-D001 --format json`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bin/basectl doctor explain BASE-X999 --format json`