### PR TITLE
Add reusable Base check workflow

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -1,0 +1,174 @@
+name: Reusable Base Check
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: Base project name to check.
+        required: true
+        type: string
+      manifest-path:
+        description: Path to base_manifest.yaml relative to the caller repository root.
+        required: false
+        default: base_manifest.yaml
+        type: string
+      setup-mode:
+        description: Use source-checkout to prepare Base from source, or preinstalled to use basectl from PATH.
+        required: false
+        default: source-checkout
+        type: string
+      base-ref:
+        description: Optional Base ref override for source-checkout mode. Empty uses the workflow commit.
+        required: false
+        default: ""
+        type: string
+      profiles:
+        description: Optional comma-separated Base prerequisite profiles.
+        required: false
+        default: ""
+        type: string
+      output-format:
+        description: basectl check output format.
+        required: false
+        default: json
+        type: string
+      python-version:
+        description: Python version used to prepare Base source-checkout mode.
+        required: false
+        default: "3.13"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.project }}
+  cancel-in-progress: true
+
+jobs:
+  base-check:
+    name: Base check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Validate inputs
+        env:
+          BASE_CHECK_OUTPUT_FORMAT: ${{ inputs.output-format }}
+          BASE_CHECK_PROJECT: ${{ inputs.project }}
+          BASE_CHECK_SETUP_MODE: ${{ inputs.setup-mode }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$BASE_CHECK_PROJECT" ]]; then
+            printf 'The project input is required.\n' >&2
+            exit 2
+          fi
+
+          case "$BASE_CHECK_SETUP_MODE" in
+            source-checkout|preinstalled) ;;
+            *)
+              printf 'Unsupported setup-mode: %s\n' "$BASE_CHECK_SETUP_MODE" >&2
+              printf 'Expected one of: source-checkout, preinstalled.\n' >&2
+              exit 2
+              ;;
+          esac
+
+          case "$BASE_CHECK_OUTPUT_FORMAT" in
+            text|json) ;;
+            *)
+              printf 'Unsupported output-format: %s\n' "$BASE_CHECK_OUTPUT_FORMAT" >&2
+              printf 'Expected one of: text, json.\n' >&2
+              exit 2
+              ;;
+          esac
+
+      - name: Checkout caller repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          path: workspace
+
+      - name: Checkout Base source
+        if: ${{ inputs.setup-mode == 'source-checkout' }}
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base
+          ref: ${{ inputs.base-ref || github.workflow_sha }}
+          path: .base/source
+
+      - name: Checkout Base Bash libraries
+        if: ${{ inputs.setup-mode == 'source-checkout' }}
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-bash-libs
+          ref: 424ef9fe61bc8a462ba9980ea63b38dd202ec242
+          path: .base/base-bash-libs
+
+      - name: Set up Python
+        if: ${{ inputs.setup-mode == 'source-checkout' }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Remove flaky hosted-runner apt sources
+        if: ${{ inputs.setup-mode == 'source-checkout' }}
+        run: |
+          sudo rm -f \
+            /etc/apt/sources.list.d/azure-cli.sources \
+            /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/microsoft-prod.sources \
+            /etc/apt/sources.list.d/microsoft-prod.list
+
+      - name: Install source-checkout prerequisites
+        if: ${{ inputs.setup-mode == 'source-checkout' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ca-certificates \
+            python3-venv \
+            python3-pip
+
+      - name: Prepare Base source runtime
+        if: ${{ inputs.setup-mode == 'source-checkout' }}
+        working-directory: .base/source
+        run: |
+          python -m venv "$HOME/.base.d/base/.venv"
+          "$HOME/.base.d/base/.venv/bin/python" -m pip install --upgrade pip
+          "$HOME/.base.d/base/.venv/bin/python" -m pip install -r requirements-dev.txt
+
+      - name: Run basectl check --ci
+        env:
+          BASE_CHECK_MANIFEST_PATH: ${{ inputs.manifest-path }}
+          BASE_CHECK_OUTPUT_FORMAT: ${{ inputs.output-format }}
+          BASE_CHECK_PROFILES: ${{ inputs.profiles }}
+          BASE_CHECK_PROJECT: ${{ inputs.project }}
+          BASE_CHECK_SETUP_MODE: ${{ inputs.setup-mode }}
+        run: |
+          set -euo pipefail
+
+          workspace_dir="$GITHUB_WORKSPACE/workspace"
+          case "$BASE_CHECK_SETUP_MODE" in
+            source-checkout)
+              base_command="$GITHUB_WORKSPACE/.base/source/bin/basectl"
+              export BASE_BASH_LIBS_DIR="$GITHUB_WORKSPACE/.base/base-bash-libs/lib/bash"
+              ;;
+            preinstalled)
+              base_command="basectl"
+              ;;
+          esac
+
+          args=(check --ci "$BASE_CHECK_PROJECT" --format "$BASE_CHECK_OUTPUT_FORMAT")
+          if [[ -n "$BASE_CHECK_MANIFEST_PATH" ]]; then
+            case "$BASE_CHECK_MANIFEST_PATH" in
+              /*) manifest_path="$BASE_CHECK_MANIFEST_PATH" ;;
+              *) manifest_path="$workspace_dir/$BASE_CHECK_MANIFEST_PATH" ;;
+            esac
+            args+=(--manifest "$manifest_path")
+          fi
+          if [[ -n "$BASE_CHECK_PROFILES" ]]; then
+            args+=(--profile "$BASE_CHECK_PROFILES")
+          fi
+
+          printf 'Running %s %s\n' "$base_command" "${args[*]}"
+          cd "$workspace_dir"
+          "$base_command" "${args[@]}"

--- a/docs/basectl-ci.md
+++ b/docs/basectl-ci.md
@@ -139,3 +139,62 @@ checkout CI job that prepares `~/.base.d/base/.venv` manually must install the
 same bootstrap packages that Base uses to read manifests and run Python command
 entry points. Add project-specific packages separately when the target project's
 manifest requires them.
+
+## Reusable GitHub Actions Workflow
+
+Base also publishes a reusable workflow for repositories that want the standard
+`basectl check --ci` readiness contract without copying the setup steps into
+every repository:
+
+```yaml
+name: Base check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  base-check:
+    permissions:
+      contents: read
+    uses: basefoundry/base/.github/workflows/base-check.yml@<base-ref-or-sha>
+    with:
+      project: my-project
+      manifest-path: base_manifest.yaml
+```
+
+For production repositories, pin the reusable workflow ref to a reviewed Base
+release tag or commit SHA. The default `source-checkout` mode checks out the
+caller repository, checks out Base source at the same commit as the reusable
+workflow, checks out `base-bash-libs`, prepares the Base Python runtime, and
+runs:
+
+```bash
+basectl check --ci <project> --format json --manifest <caller-manifest>
+```
+
+Supported inputs:
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `project` | required | Base project name to pass to `basectl check --ci`. |
+| `manifest-path` | `base_manifest.yaml` | Manifest path relative to the caller repository root. |
+| `setup-mode` | `source-checkout` | `source-checkout` prepares Base from source; `preinstalled` uses `basectl` already on `PATH`. |
+| `base-ref` | workflow commit | Optional Base ref override for `source-checkout` mode. Leave empty to use the pinned reusable workflow commit. |
+| `profiles` | empty | Optional comma-separated prerequisite profiles, such as `dev` or `sre`. |
+| `output-format` | `json` | `basectl check` output format: `json` or `text`. |
+| `python-version` | `3.13` | Python used to prepare the Base source runtime. |
+
+The workflow's `base-bash-libs` checkout is pinned inside the workflow file to
+match Base's CI supply-chain policy. Update that pin through a Base workflow-pin
+maintenance PR, not from caller workflow inputs.
+
+Use a repository-local workflow instead of the reusable workflow when the job
+must start services, install project-specific system packages, run tests, use
+secrets, or perform setup that must happen before `basectl check --ci`. In that
+case, keep the direct command step and follow the CI supply-chain policy for
+pinned actions and dependency installation.

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 COPILOT_INSTRUCTIONS = REPO_ROOT / ".github" / "copilot-instructions.md"
 COPILOT_SETUP_WORKFLOW = WORKFLOW_DIR / "copilot-setup-steps.yml"
+BASE_CHECK_WORKFLOW = WORKFLOW_DIR / "base-check.yml"
 BASE_PROJECT_CONFIG = REPO_ROOT / ".github" / "base-project.yml"
 IMPLEMENTATION_ISSUE_TEMPLATE = REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "implementation.yml"
 FULL_COMMIT_SHA_ACTION_REF = re.compile(r"^[^@]+@[0-9a-f]{40}$")
@@ -245,6 +246,42 @@ def test_all_workflow_action_uses_are_pinned_to_full_commit_sha() -> None:
     unpinned = workflow_action_references_without_full_sha()
 
     assert not unpinned, unpinned
+
+
+def test_reusable_base_check_workflow_contract() -> None:
+    workflow = load_workflow(BASE_CHECK_WORKFLOW)
+    ci_docs = (REPO_ROOT / "docs" / "basectl-ci.md").read_text(encoding="utf-8")
+    triggers = workflow.get("on") or workflow.get(True)
+    workflow_call = triggers["workflow_call"]
+    inputs = workflow_call["inputs"]
+    job = workflow["jobs"]["base-check"]
+    steps = job["steps"]
+    run_commands = "\n".join(step.get("run", "") for step in steps if isinstance(step, dict))
+
+    assert workflow["name"] == "Reusable Base Check"
+    assert workflow["permissions"] == {"contents": "read"}
+    assert "concurrency" in workflow
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 20
+    assert inputs["project"] == {
+        "description": "Base project name to check.",
+        "required": True,
+        "type": "string",
+    }
+    assert inputs["manifest-path"]["default"] == "base_manifest.yaml"
+    assert inputs["setup-mode"]["default"] == "source-checkout"
+    assert inputs["base-ref"]["default"] == ""
+    assert "base-bash-libs-ref" not in inputs
+    assert inputs["output-format"]["default"] == "json"
+    assert inputs["python-version"]["default"] == "3.13"
+    assert "source-checkout|preinstalled" in run_commands
+    assert "args=(check --ci \"$BASE_CHECK_PROJECT\" --format \"$BASE_CHECK_OUTPUT_FORMAT\")" in run_commands
+    assert "BASE_BASH_LIBS_DIR" in run_commands
+    assert "basefoundry/base-bash-libs" in str(steps)
+    assert "424ef9fe61bc8a462ba9980ea63b38dd202ec242" in str(steps)
+    assert "${{ inputs.base-ref || github.workflow_sha }}" in str(steps)
+    assert "uses: basefoundry/base/.github/workflows/base-check.yml@<base-ref-or-sha>" in ci_docs
+    assert "| `setup-mode` | `source-checkout` |" in ci_docs
 
 
 def test_copilot_repository_instructions_stay_anchored_to_base_guidance() -> None:


### PR DESCRIPTION
## Summary
- add `.github/workflows/base-check.yml` as a reusable `workflow_call` wrapper for `basectl check --ci`
- support source-checkout and preinstalled setup modes with minimal permissions and pinned actions
- document caller usage, supported inputs, and when to keep a repo-local workflow

Closes #1575

## Tests
- `python -m pytest tests/test_github_workflows.py -q`
- `python -m pylint --rcfile=.pylintrc tests/test_github_workflows.py`
- `python -m pytest tests/test_contract_hardening.py tests/test_linux_support_docs.py -q`
- `git diff --check`