### PR TITLE
Extract Base runtime venv setup helper

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -22,10 +22,10 @@ import_base_lib str/lib_str.sh
 source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_check_results.sh"
 source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_linux_debian.sh"
 source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh"
+source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_venv.sh"
 
 _BASE_SETUP_VENV_DIR_CACHE=""
 _BASE_SETUP_PYTHONPATH_CACHE=""
-_BASE_SETUP_VENV_HEALTH_MESSAGE=""
 
 setup_refresh_cached_paths() {
     local base_pythonpath old_pythonpath
@@ -263,184 +263,12 @@ setup_notify_min_seconds() {
     printf '%s\n' "${BASE_SETUP_NOTIFY_MIN_SECONDS:-30}"
 }
 
-setup_recreate_venv_enabled() {
-    [[ "${BASE_SETUP_RECREATE_VENV:-false}" == true ]]
-}
-
-setup_base_recreate_venv_enabled() {
-    setup_recreate_venv_enabled || return 1
-    [[ -z "${BASE_SETUP_PROJECT_NAME:-}" || "${BASE_SETUP_PROJECT_NAME:-}" == base ]]
-}
-
-setup_project_recreate_venv_enabled() {
-    local project="$1"
-
-    setup_recreate_venv_enabled || return 1
-    [[ -n "$project" && "$project" != base ]]
-}
-
 setup_notifications_enabled() {
     [[ "${BASE_SETUP_NOTIFY:-true}" == true ]]
 }
 
 setup_notifications_forced() {
     [[ "${BASE_SETUP_NOTIFY_FORCE:-false}" == true ]]
-}
-
-setup_virtualenv_exists() {
-    local venv_dir
-
-    setup_ensure_cached_paths
-    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
-    [[ -f "$venv_dir/bin/activate" || -f "$venv_dir/pyvenv.cfg" ]]
-}
-
-setup_pyvenv_cfg_value() {
-    local key="$1"
-    local pyvenv_cfg="$2"
-    local line value
-
-    [[ -f "$pyvenv_cfg" ]] || return 1
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        case "$line" in
-            "$key = "*)
-                value="${line#"$key = "}"
-                printf '%s\n' "$value"
-                return 0
-                ;;
-        esac
-    done <"$pyvenv_cfg"
-    return 1
-}
-
-setup_virtualenv_home_has_python() {
-    local candidate home_path="$1"
-
-    [[ -d "$home_path" ]] || return 1
-    for candidate in "$home_path"/python*; do
-        [[ -x "$candidate" && ! -d "$candidate" ]] && return 0
-    done
-    return 1
-}
-
-setup_python_machine() {
-    local machine python_bin="$1"
-
-    [[ -x "$python_bin" ]] || return 1
-    machine="$("$python_bin" -c 'import platform; print(platform.machine() or "unknown")' 2>/dev/null || true)"
-    [[ -n "$machine" ]] || return 1
-    printf '%s\n' "$machine"
-}
-
-setup_virtualenv_homebrew_architecture_compatible() {
-    local executable_path home_path homebrew_prefix pyvenv_cfg python_bin python_machine venv_dir="$1"
-
-    [[ "$(setup_current_platform)" == macos ]] || return 0
-
-    homebrew_prefix="$(setup_homebrew_prefix 2>/dev/null || true)"
-    [[ "$homebrew_prefix" == "/opt/homebrew" ]] || return 0
-
-    pyvenv_cfg="$venv_dir/pyvenv.cfg"
-    python_bin="$venv_dir/bin/python"
-    python_machine="$(setup_python_machine "$python_bin" || true)"
-    executable_path="$(setup_pyvenv_cfg_value executable "$pyvenv_cfg" || true)"
-    home_path="$(setup_pyvenv_cfg_value home "$pyvenv_cfg" || true)"
-
-    if [[ "$python_machine" == "x86_64" ]]; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Base virtual environment Python is x86_64 but Homebrew prefix is '$homebrew_prefix'."
-        return 1
-    fi
-
-    if [[ "$executable_path" == /usr/local/* ]]; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Base virtual environment Python executable '$executable_path' is under /usr/local but Homebrew prefix is '$homebrew_prefix'."
-        return 1
-    fi
-
-    if [[ "$home_path" == /usr/local/* ]]; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Base virtual environment Python home '$home_path' is under /usr/local but Homebrew prefix is '$homebrew_prefix'."
-        return 1
-    fi
-
-    return 0
-}
-
-setup_virtualenv_healthy_path() {
-    local executable_path home_path pyvenv_cfg python_bin venv_dir="$1"
-
-    pyvenv_cfg="$venv_dir/pyvenv.cfg"
-    python_bin="$venv_dir/bin/python"
-    if [[ ! -d "$venv_dir" ]]; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is missing at '$venv_dir'."
-        return 1
-    fi
-    if [[ ! -f "$pyvenv_cfg" ]]; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is missing pyvenv.cfg at '$pyvenv_cfg'."
-        return 1
-    fi
-    if [[ ! -x "$python_bin" ]]; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is missing or not executable at '$python_bin'."
-        return 1
-    fi
-    if ! "$python_bin" --version >/dev/null 2>&1; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python failed to run at '$python_bin'."
-        return 1
-    fi
-
-    executable_path="$(setup_pyvenv_cfg_value executable "$pyvenv_cfg" || true)"
-    if [[ -n "$executable_path" && ! -x "$executable_path" ]]; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is broken because '$executable_path' no longer exists."
-        return 1
-    fi
-
-    home_path="$(setup_pyvenv_cfg_value home "$pyvenv_cfg" || true)"
-    if [[ -n "$home_path" ]] && ! setup_virtualenv_home_has_python "$home_path"; then
-        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is broken because home path '$home_path' no longer provides Python."
-        return 1
-    fi
-
-    setup_virtualenv_homebrew_architecture_compatible "$venv_dir" || return 1
-
-    _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is healthy at '$venv_dir'."
-    return 0
-}
-
-setup_virtualenv_healthy() {
-    setup_ensure_cached_paths
-    setup_virtualenv_healthy_path "$_BASE_SETUP_VENV_DIR_CACHE"
-}
-
-setup_venv_dir() {
-    setup_ensure_cached_paths
-    printf '%s\n' "$_BASE_SETUP_VENV_DIR_CACHE"
-}
-
-setup_backup_existing_venv_path() {
-    local backup_path description timestamp venv_dir
-
-    description="${1:-existing path}"
-    setup_ensure_cached_paths
-    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
-    [[ -e "$venv_dir" ]] || return 0
-
-    timestamp="$(setup_backup_timestamp)" || fatal_error "Unable to generate virtual environment backup timestamp."
-    backup_path="${venv_dir}.backup.${timestamp}"
-    [[ ! -e "$backup_path" ]] || fatal_error "Virtual environment backup path already exists at '$backup_path'."
-
-    if setup_is_dry_run; then
-        log_info "[DRY-RUN] Would move $description '$venv_dir' to '$backup_path'."
-        return 0
-    fi
-
-    log_info "Moving $description '$venv_dir' to '$backup_path'."
-    mv "$venv_dir" "$backup_path" || fatal_error "Unable to move $description '$venv_dir' to '$backup_path'."
-}
-
-setup_pyyaml_package() {
-    printf '%s\n' "${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
-}
-
-setup_click_package() {
-    printf '%s\n' "${BASE_SETUP_CLICK_PACKAGE:-click}"
 }
 
 setup_ci_runtime_only() {
@@ -528,20 +356,8 @@ setup_reject_test_hook_if_disallowed() {
     fatal_error "$variable_name is a test-only setup override. Set BASE_TEST_MODE=true or CI=true to use it."
 }
 
-setup_recovery_venv() {
-    printf "%s\n" "Run 'basectl setup --recreate-venv' to back up and recreate the Base virtual environment."
-}
-
-setup_recovery_base_python_package() {
-    printf "%s\n" "Run 'basectl setup' to install Base Python bootstrap packages."
-}
-
 setup_recovery_base_bash_libraries() {
     printf "%s\n" "Clone basefoundry/base-bash-libs next to Base, install it with 'brew install basefoundry/base/base-bash-libs', or set BASE_BASH_LIBS_DIR."
-}
-
-setup_recovery_ci_python() {
-    printf "%s\n" "Install Python 3.13 or set BASE_SETUP_PYTHON_BIN, then rerun with '--ci'."
 }
 
 setup_recovery_project_layer() {
@@ -687,130 +503,6 @@ setup_print_runtime_chain_summary() {
         gh_version="$(setup_gh_version_line 2>/dev/null || true)"
         gh_arch="$(setup_executable_architecture "$gh_bin" 2>/dev/null || true)"
         log_info "GitHub CLI: path=$gh_bin version=${gh_version:-unknown} arch=${gh_arch:-unknown}"
-    fi
-}
-
-setup_find_platform_python_bin() {
-    local platform
-
-    platform="$(setup_current_platform)" || return 1
-    case "$platform" in
-        linux-debian)
-            setup_find_linux_python_bin
-            ;;
-        *)
-            setup_find_python_bin
-            ;;
-    esac
-}
-
-setup_recovery_platform_python() {
-    local platform
-
-    platform="$(setup_current_platform)" || return 1
-    case "$platform" in
-        linux-debian)
-            setup_recovery_linux_python
-            ;;
-        *)
-            setup_recovery_python
-            ;;
-    esac
-}
-
-setup_create_virtualenv() {
-    local venv_dir python_bin
-
-    setup_ensure_cached_paths
-    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
-
-    if setup_virtualenv_exists && ! setup_base_recreate_venv_enabled; then
-        setup_virtualenv_healthy ||
-            fatal_error "$_BASE_SETUP_VENV_HEALTH_MESSAGE $(setup_recovery_venv)"
-        log_info "Virtual environment already exists at '$venv_dir'."
-        return 0
-    fi
-
-    if setup_virtualenv_exists; then
-        setup_backup_existing_venv_path "existing virtual environment"
-    else
-        setup_backup_existing_venv_path "existing non-venv path"
-    fi
-
-    if setup_is_dry_run; then
-        log_info "[DRY-RUN] Would create Python virtual environment at '$venv_dir'."
-        return 0
-    fi
-
-    python_bin="$(setup_find_platform_python_bin)" || fatal_error "Unable to locate a python3 executable after installation. $(setup_recovery_platform_python)"
-
-    safe_mkdir -p "$(dirname "$venv_dir")"
-    log_info "Creating Python virtual environment at '$venv_dir'."
-    "$python_bin" -m venv "$venv_dir"
-}
-
-setup_base_venv_python_bin() {
-    local venv_dir="$1"
-    local python_bin="$venv_dir/bin/python"
-
-    [[ -x "$python_bin" ]] || return 1
-    printf '%s\n' "$python_bin"
-}
-
-setup_base_python_package_installed() {
-    local package="$1"
-    local venv_dir python_bin
-
-    if setup_is_dry_run && setup_base_recreate_venv_enabled; then
-        return 1
-    fi
-
-    setup_ensure_cached_paths
-    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
-    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1
-    "$python_bin" -m pip show "$package" >/dev/null 2>&1
-}
-
-setup_install_base_python_package() {
-    local package="$1"
-    local venv_dir python_bin
-
-    setup_ensure_cached_paths
-    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
-
-    if setup_base_python_package_installed "$package"; then
-        log_info "Python package '$package' is already installed in the Base virtual environment."
-        return 0
-    fi
-
-    if setup_is_dry_run; then
-        log_info "[DRY-RUN] Would install Python package '$package' in the Base virtual environment."
-        return 0
-    fi
-
-    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
-
-    log_info "Installing Python package '$package' in the Base virtual environment."
-    "$python_bin" -m pip install --disable-pip-version-check "$package" ||
-        fatal_error "Unable to install Python package '$package' in the Base virtual environment."
-}
-
-setup_install_pyyaml() {
-    setup_install_base_python_package "$(setup_pyyaml_package)"
-}
-
-setup_install_click() {
-    setup_install_base_python_package "$(setup_click_package)"
-}
-
-setup_base_python_package_check_message() {
-    local package="$1"
-    local installed="$2"
-
-    if [[ "$installed" == true ]]; then
-        printf "Python package '%s' is installed in the Base virtual environment.\n" "$package"
-    else
-        printf "Python package '%s' is not installed in the Base virtual environment.\n" "$package"
     fi
 }
 
@@ -1586,43 +1278,6 @@ setup_run_base_dev_layer() {
     env BASE_PLATFORM="$platform" "$BASE_HOME/bin/base-wrapper" --project base base_dev "${args[@]}" "${profile_args[@]}"
 }
 
-setup_write_virtualenv_check_probe() {
-    local result_file="$1"
-
-    if setup_virtualenv_healthy; then
-        setup_write_check_result_file \
-            "$result_file" \
-            "base_virtualenv" \
-            true \
-            "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
-    else
-        setup_write_check_result_file \
-            "$result_file" \
-            "base_virtualenv" \
-            false \
-            "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
-            "$(setup_recovery_venv)"
-    fi
-}
-
-setup_write_python_package_check_probe() {
-    local ok=false
-    local package="$3"
-    local result_file="$1"
-    local result_name="$2"
-
-    if setup_base_python_package_installed "$package"; then
-        ok=true
-    fi
-
-    setup_write_check_result_file \
-        "$result_file" \
-        "$result_name" \
-        "$ok" \
-        "$(setup_base_python_package_check_message "$package" "$ok")" \
-        "$(setup_recovery_base_python_package)"
-}
-
 setup_wait_for_base_check_probes() {
     local failed=0
     local pid
@@ -1649,69 +1304,6 @@ setup_collect_platform_base_check_results() {
             fatal_error "$(setup_unsupported_platform_message "$platform")"
             ;;
     esac
-}
-
-setup_collect_ci_runtime_check_results() {
-    local click_package
-    local missing=0
-    local pyyaml_package
-    local python_bin
-
-    setup_clear_check_results
-    click_package="$(setup_click_package)"
-    pyyaml_package="$(setup_pyyaml_package)"
-    setup_ensure_cached_paths
-
-    if python_bin="$(setup_find_platform_python_bin)"; then
-        setup_add_check_result \
-            "python" \
-            true \
-            "Python is available for CI runtime checks." \
-            "" \
-            "Resolved Python binary: $python_bin"
-    else
-        setup_add_check_result \
-            "python" \
-            false \
-            "Python is not available for CI runtime checks." \
-            "$(setup_recovery_ci_python)"
-        missing=1
-    fi
-
-    if setup_virtualenv_healthy; then
-        setup_add_check_result "base_virtualenv" true "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
-    else
-        setup_add_check_result \
-            "base_virtualenv" \
-            false \
-            "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
-            "$(setup_recovery_venv)"
-        missing=1
-    fi
-
-    if setup_base_python_package_installed "$pyyaml_package"; then
-        setup_add_check_result "pyyaml" true "$(setup_base_python_package_check_message "$pyyaml_package" true)"
-    else
-        setup_add_check_result \
-            "pyyaml" \
-            false \
-            "$(setup_base_python_package_check_message "$pyyaml_package" false)" \
-            "$(setup_recovery_base_python_package)"
-        missing=1
-    fi
-
-    if setup_base_python_package_installed "$click_package"; then
-        setup_add_check_result "click" true "$(setup_base_python_package_check_message "$click_package" true)"
-    else
-        setup_add_check_result \
-            "click" \
-            false \
-            "$(setup_base_python_package_check_message "$click_package" false)" \
-            "$(setup_recovery_base_python_package)"
-        missing=1
-    fi
-
-    return "$missing"
 }
 
 setup_collect_base_check_results() {
@@ -1865,26 +1457,6 @@ setup_run_check_json() {
         args+=(--record-path "$(setup_project_check_record_path "$project")" --checked-at "$checked_at")
     fi
     setup_run_diagnostics_json "${args[@]}"
-}
-
-setup_run_ci_runtime_install() {
-    setup_create_virtualenv
-    setup_install_pyyaml
-    setup_install_click
-    if setup_profiles_enabled; then
-        if setup_is_dry_run; then
-            setup_run_base_dev_layer setup --dry-run || fatal_error "Python prerequisite profile layer failed."
-        else
-            setup_run_base_dev_layer setup || fatal_error "Python prerequisite profile layer failed."
-        fi
-    fi
-    setup_run_project_artifact_setup || return $?
-
-    if setup_is_dry_run; then
-        log_info "[DRY-RUN] Base CI setup check is complete."
-    else
-        log_info "Base CI setup is complete."
-    fi
 }
 
 setup_run_platform_install() {

--- a/cli/bash/commands/basectl/subcommands/setup_venv.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_venv.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+
+#
+# setup_venv.sh
+#     Base runtime virtualenv and Python bootstrap helpers for setup_common.sh.
+#
+# This file is sourced by setup_common.sh. It intentionally preserves the
+# existing setup_* function names so setup/check/doctor call sites remain
+# behavior-compatible while Base runtime ownership moves out of the shared file.
+#
+
+[[ -n "${_base_setup_venv_sourced:-}" ]] && return 0
+_base_setup_venv_sourced=1
+readonly _base_setup_venv_sourced
+
+_BASE_SETUP_VENV_HEALTH_MESSAGE=""
+
+setup_recreate_venv_enabled() {
+    [[ "${BASE_SETUP_RECREATE_VENV:-false}" == true ]]
+}
+
+setup_base_recreate_venv_enabled() {
+    setup_recreate_venv_enabled || return 1
+    [[ -z "${BASE_SETUP_PROJECT_NAME:-}" || "${BASE_SETUP_PROJECT_NAME:-}" == base ]]
+}
+
+setup_project_recreate_venv_enabled() {
+    local project="$1"
+
+    setup_recreate_venv_enabled || return 1
+    [[ -n "$project" && "$project" != base ]]
+}
+
+setup_virtualenv_exists() {
+    local venv_dir
+
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+    [[ -f "$venv_dir/bin/activate" || -f "$venv_dir/pyvenv.cfg" ]]
+}
+
+setup_pyvenv_cfg_value() {
+    local key="$1"
+    local pyvenv_cfg="$2"
+    local line value
+
+    [[ -f "$pyvenv_cfg" ]] || return 1
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        case "$line" in
+            "$key = "*)
+                value="${line#"$key = "}"
+                printf '%s\n' "$value"
+                return 0
+                ;;
+        esac
+    done <"$pyvenv_cfg"
+    return 1
+}
+
+setup_virtualenv_home_has_python() {
+    local candidate home_path="$1"
+
+    [[ -d "$home_path" ]] || return 1
+    for candidate in "$home_path"/python*; do
+        [[ -x "$candidate" && ! -d "$candidate" ]] && return 0
+    done
+    return 1
+}
+
+setup_python_machine() {
+    local machine python_bin="$1"
+
+    [[ -x "$python_bin" ]] || return 1
+    machine="$("$python_bin" -c 'import platform; print(platform.machine() or "unknown")' 2>/dev/null || true)"
+    [[ -n "$machine" ]] || return 1
+    printf '%s\n' "$machine"
+}
+
+setup_virtualenv_homebrew_architecture_compatible() {
+    local executable_path home_path homebrew_prefix pyvenv_cfg python_bin python_machine venv_dir="$1"
+
+    [[ "$(setup_current_platform)" == macos ]] || return 0
+
+    homebrew_prefix="$(setup_homebrew_prefix 2>/dev/null || true)"
+    [[ "$homebrew_prefix" == "/opt/homebrew" ]] || return 0
+
+    pyvenv_cfg="$venv_dir/pyvenv.cfg"
+    python_bin="$venv_dir/bin/python"
+    python_machine="$(setup_python_machine "$python_bin" || true)"
+    executable_path="$(setup_pyvenv_cfg_value executable "$pyvenv_cfg" || true)"
+    home_path="$(setup_pyvenv_cfg_value home "$pyvenv_cfg" || true)"
+
+    if [[ "$python_machine" == "x86_64" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Base virtual environment Python is x86_64 but Homebrew prefix is '$homebrew_prefix'."
+        return 1
+    fi
+
+    if [[ "$executable_path" == /usr/local/* ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Base virtual environment Python executable '$executable_path' is under /usr/local but Homebrew prefix is '$homebrew_prefix'."
+        return 1
+    fi
+
+    if [[ "$home_path" == /usr/local/* ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Base virtual environment Python home '$home_path' is under /usr/local but Homebrew prefix is '$homebrew_prefix'."
+        return 1
+    fi
+
+    return 0
+}
+
+setup_virtualenv_healthy_path() {
+    local executable_path home_path pyvenv_cfg python_bin venv_dir="$1"
+
+    pyvenv_cfg="$venv_dir/pyvenv.cfg"
+    python_bin="$venv_dir/bin/python"
+    if [[ ! -d "$venv_dir" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is missing at '$venv_dir'."
+        return 1
+    fi
+    if [[ ! -f "$pyvenv_cfg" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is missing pyvenv.cfg at '$pyvenv_cfg'."
+        return 1
+    fi
+    if [[ ! -x "$python_bin" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is missing or not executable at '$python_bin'."
+        return 1
+    fi
+    if ! "$python_bin" --version >/dev/null 2>&1; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python failed to run at '$python_bin'."
+        return 1
+    fi
+
+    executable_path="$(setup_pyvenv_cfg_value executable "$pyvenv_cfg" || true)"
+    if [[ -n "$executable_path" && ! -x "$executable_path" ]]; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is broken because '$executable_path' no longer exists."
+        return 1
+    fi
+
+    home_path="$(setup_pyvenv_cfg_value home "$pyvenv_cfg" || true)"
+    if [[ -n "$home_path" ]] && ! setup_virtualenv_home_has_python "$home_path"; then
+        _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment Python is broken because home path '$home_path' no longer provides Python."
+        return 1
+    fi
+
+    setup_virtualenv_homebrew_architecture_compatible "$venv_dir" || return 1
+
+    _BASE_SETUP_VENV_HEALTH_MESSAGE="Virtual environment is healthy at '$venv_dir'."
+    return 0
+}
+
+setup_virtualenv_healthy() {
+    setup_ensure_cached_paths
+    setup_virtualenv_healthy_path "$_BASE_SETUP_VENV_DIR_CACHE"
+}
+
+setup_venv_dir() {
+    setup_ensure_cached_paths
+    printf '%s\n' "$_BASE_SETUP_VENV_DIR_CACHE"
+}
+
+setup_backup_existing_venv_path() {
+    local backup_path description timestamp venv_dir
+
+    description="${1:-existing path}"
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+    [[ -e "$venv_dir" ]] || return 0
+
+    timestamp="$(setup_backup_timestamp)" || fatal_error "Unable to generate virtual environment backup timestamp."
+    backup_path="${venv_dir}.backup.${timestamp}"
+    [[ ! -e "$backup_path" ]] || fatal_error "Virtual environment backup path already exists at '$backup_path'."
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Would move $description '$venv_dir' to '$backup_path'."
+        return 0
+    fi
+
+    log_info "Moving $description '$venv_dir' to '$backup_path'."
+    mv "$venv_dir" "$backup_path" || fatal_error "Unable to move $description '$venv_dir' to '$backup_path'."
+}
+
+setup_pyyaml_package() {
+    printf '%s\n' "${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
+}
+
+setup_click_package() {
+    printf '%s\n' "${BASE_SETUP_CLICK_PACKAGE:-click}"
+}
+
+setup_recovery_venv() {
+    printf "%s\n" "Run 'basectl setup --recreate-venv' to back up and recreate the Base virtual environment."
+}
+
+setup_recovery_base_python_package() {
+    printf "%s\n" "Run 'basectl setup' to install Base Python bootstrap packages."
+}
+
+setup_recovery_ci_python() {
+    printf "%s\n" "Install Python 3.13 or set BASE_SETUP_PYTHON_BIN, then rerun with '--ci'."
+}
+
+setup_find_platform_python_bin() {
+    local platform
+
+    platform="$(setup_current_platform)" || return 1
+    case "$platform" in
+        linux-debian)
+            setup_find_linux_python_bin
+            ;;
+        *)
+            setup_find_python_bin
+            ;;
+    esac
+}
+
+setup_recovery_platform_python() {
+    local platform
+
+    platform="$(setup_current_platform)" || return 1
+    case "$platform" in
+        linux-debian)
+            setup_recovery_linux_python
+            ;;
+        *)
+            setup_recovery_python
+            ;;
+    esac
+}
+
+setup_create_virtualenv() {
+    local venv_dir python_bin
+
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+
+    if setup_virtualenv_exists && ! setup_base_recreate_venv_enabled; then
+        setup_virtualenv_healthy ||
+            fatal_error "$_BASE_SETUP_VENV_HEALTH_MESSAGE $(setup_recovery_venv)"
+        log_info "Virtual environment already exists at '$venv_dir'."
+        return 0
+    fi
+
+    if setup_virtualenv_exists; then
+        setup_backup_existing_venv_path "existing virtual environment"
+    else
+        setup_backup_existing_venv_path "existing non-venv path"
+    fi
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Would create Python virtual environment at '$venv_dir'."
+        return 0
+    fi
+
+    python_bin="$(setup_find_platform_python_bin)" || fatal_error "Unable to locate a python3 executable after installation. $(setup_recovery_platform_python)"
+
+    safe_mkdir -p "$(dirname "$venv_dir")"
+    log_info "Creating Python virtual environment at '$venv_dir'."
+    "$python_bin" -m venv "$venv_dir"
+}
+
+setup_base_venv_python_bin() {
+    local venv_dir="$1"
+    local python_bin="$venv_dir/bin/python"
+
+    [[ -x "$python_bin" ]] || return 1
+    printf '%s\n' "$python_bin"
+}
+
+setup_base_python_package_installed() {
+    local package="$1"
+    local venv_dir python_bin
+
+    if setup_is_dry_run && setup_base_recreate_venv_enabled; then
+        return 1
+    fi
+
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1
+    "$python_bin" -m pip show "$package" >/dev/null 2>&1
+}
+
+setup_install_base_python_package() {
+    local package="$1"
+    local venv_dir python_bin
+
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+
+    if setup_base_python_package_installed "$package"; then
+        log_info "Python package '$package' is already installed in the Base virtual environment."
+        return 0
+    fi
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Would install Python package '$package' in the Base virtual environment."
+        return 0
+    fi
+
+    python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
+
+    log_info "Installing Python package '$package' in the Base virtual environment."
+    "$python_bin" -m pip install --disable-pip-version-check "$package" ||
+        fatal_error "Unable to install Python package '$package' in the Base virtual environment."
+}
+
+setup_install_pyyaml() {
+    setup_install_base_python_package "$(setup_pyyaml_package)"
+}
+
+setup_install_click() {
+    setup_install_base_python_package "$(setup_click_package)"
+}
+
+setup_base_python_package_check_message() {
+    local package="$1"
+    local installed="$2"
+
+    if [[ "$installed" == true ]]; then
+        printf "Python package '%s' is installed in the Base virtual environment.\n" "$package"
+    else
+        printf "Python package '%s' is not installed in the Base virtual environment.\n" "$package"
+    fi
+}
+
+setup_write_virtualenv_check_probe() {
+    local result_file="$1"
+
+    if setup_virtualenv_healthy; then
+        setup_write_check_result_file \
+            "$result_file" \
+            "base_virtualenv" \
+            true \
+            "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+    else
+        setup_write_check_result_file \
+            "$result_file" \
+            "base_virtualenv" \
+            false \
+            "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
+            "$(setup_recovery_venv)"
+    fi
+}
+
+setup_write_python_package_check_probe() {
+    local ok=false
+    local package="$3"
+    local result_file="$1"
+    local result_name="$2"
+
+    if setup_base_python_package_installed "$package"; then
+        ok=true
+    fi
+
+    setup_write_check_result_file \
+        "$result_file" \
+        "$result_name" \
+        "$ok" \
+        "$(setup_base_python_package_check_message "$package" "$ok")" \
+        "$(setup_recovery_base_python_package)"
+}
+
+setup_collect_ci_runtime_check_results() {
+    local click_package
+    local missing=0
+    local pyyaml_package
+    local python_bin
+
+    setup_clear_check_results
+    click_package="$(setup_click_package)"
+    pyyaml_package="$(setup_pyyaml_package)"
+    setup_ensure_cached_paths
+
+    if python_bin="$(setup_find_platform_python_bin)"; then
+        setup_add_check_result \
+            "python" \
+            true \
+            "Python is available for CI runtime checks." \
+            "" \
+            "Resolved Python binary: $python_bin"
+    else
+        setup_add_check_result \
+            "python" \
+            false \
+            "Python is not available for CI runtime checks." \
+            "$(setup_recovery_ci_python)"
+        missing=1
+    fi
+
+    if setup_virtualenv_healthy; then
+        setup_add_check_result "base_virtualenv" true "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+    else
+        setup_add_check_result \
+            "base_virtualenv" \
+            false \
+            "$_BASE_SETUP_VENV_HEALTH_MESSAGE" \
+            "$(setup_recovery_venv)"
+        missing=1
+    fi
+
+    if setup_base_python_package_installed "$pyyaml_package"; then
+        setup_add_check_result "pyyaml" true "$(setup_base_python_package_check_message "$pyyaml_package" true)"
+    else
+        setup_add_check_result \
+            "pyyaml" \
+            false \
+            "$(setup_base_python_package_check_message "$pyyaml_package" false)" \
+            "$(setup_recovery_base_python_package)"
+        missing=1
+    fi
+
+    if setup_base_python_package_installed "$click_package"; then
+        setup_add_check_result "click" true "$(setup_base_python_package_check_message "$click_package" true)"
+    else
+        setup_add_check_result \
+            "click" \
+            false \
+            "$(setup_base_python_package_check_message "$click_package" false)" \
+            "$(setup_recovery_base_python_package)"
+        missing=1
+    fi
+
+    return "$missing"
+}
+
+setup_run_ci_runtime_install() {
+    setup_create_virtualenv
+    setup_install_pyyaml
+    setup_install_click
+    if setup_profiles_enabled; then
+        if setup_is_dry_run; then
+            setup_run_base_dev_layer setup --dry-run || fatal_error "Python prerequisite profile layer failed."
+        else
+            setup_run_base_dev_layer setup || fatal_error "Python prerequisite profile layer failed."
+        fi
+    fi
+    setup_run_project_artifact_setup || return $?
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Base CI setup check is complete."
+    else
+        log_info "Base CI setup is complete."
+    fi
+}

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -123,6 +123,28 @@ run_setup_common_script() {
     [[ "$output" == *"guard=1"* ]]
 }
 
+@test "setup_common sources venv helper idempotently" {
+    run_setup_common_script '
+        source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_venv.sh"
+        source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_venv.sh"
+        for helper in \
+            setup_virtualenv_healthy_path \
+            setup_create_virtualenv \
+            setup_base_python_package_installed \
+            setup_collect_ci_runtime_check_results \
+            setup_run_ci_runtime_install; do
+            declare -F "$helper" >/dev/null || {
+                printf "missing helper: %s\n" "$helper" >&2
+                exit 22
+            }
+        done
+        printf "guard=%s\n" "${_base_setup_venv_sourced:-}"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"guard=1"* ]]
+}
+
 @test "setup_common reports WSL2 host context without changing platform support" {
     run_setup_common_script '
         BASE_TEST_MODE=true

--- a/docs/setup-common-ownership.md
+++ b/docs/setup-common-ownership.md
@@ -1,9 +1,10 @@
 # `setup_common.sh` Ownership Reduction
 
 Status: active #1570 decomposition map. The first platform helpers,
-`setup_linux_debian.sh` and `setup_macos_homebrew.sh`, have been extracted from
-the shared 2,906-line baseline; `setup_common.sh` is now the shared
-orchestrator plus remaining unextracted domains.
+`setup_linux_debian.sh` and `setup_macos_homebrew.sh`, plus the Base runtime
+helper `setup_venv.sh`, have been extracted from the shared 2,906-line
+baseline; `setup_common.sh` is now the shared orchestrator plus remaining
+unextracted domains.
 
 `cli/bash/commands/basectl/subcommands/setup_common.sh` is intentionally shared
 by `basectl setup`, `basectl check`, `basectl doctor`, and
@@ -42,21 +43,21 @@ entry-point functions are the stable anchors for future edits.
 
 | File / span | Current responsibility | Entry-point anchors | Target owner |
 | --- | --- | --- | --- |
-| `setup_common.sh` 1-286 | Source guard, helper sourcing, shared cached paths, run state, profile flags, dry-run/debug/yes/CI toggles, Ubuntu/Debian consent prompts, and notification toggles. | `setup_refresh_cached_paths()`, `setup_enable_profile_argument()`, `setup_require_linux_debian_system_consent()` | Keep in shared shell orchestration until profile parsing can move independently. |
-| `setup_common.sh` 290-547 | Base virtualenv health checks, pyvenv inspection, architecture compatibility, package/config defaults, platform/host-env helpers, test-hook gates, and shared recovery text. | `setup_virtualenv_healthy_path()`, `setup_current_platform()`, `setup_recovery_venv()` | Candidate `setup_venv.sh` for virtualenv pieces only after platform Python finders and project-venv fallback dependencies are separated. |
-| `setup_common.sh` 551-589 | macOS completion notification behavior. | `setup_notify_completion()` | Candidate `setup_notifications.sh`; low risk but low value unless it still reduces ownership after platform helpers settle. |
-| `setup_common.sh` 593-689 | Shared command-path probes, executable architecture, Rosetta state, GitHub CLI version display, and runtime-chain summary rendering. | `setup_command_path()`, `setup_rosetta_translation_state()`, `setup_print_runtime_chain_summary()` | Keep shared because the summary combines platform helper data with cross-platform runtime state. |
-| `setup_common.sh` 693-806 | Platform Python dispatch, Base virtualenv creation, and Base bootstrap package install. | `setup_find_platform_python_bin()`, `setup_create_virtualenv()`, `setup_install_base_python_package()` | Candidate `setup_venv.sh`; keep the Linux/Debian and macOS Python finder calls as explicit helper dependencies. |
-| `setup_common.sh` 817-1008 | Base check finding metadata, base-bash-libs status, PYTHONPATH, and the diagnostics JSON bridge. | `setup_base_check_finding_id()`, `setup_diagnostics_python_bin()`, `setup_run_diagnostics_json()` | Finding metadata should eventually move to Python; the diagnostics bridge remains shared shell until check JSON assembly moves. |
-| `setup_common.sh` 1010-1158 | Project manifest resolution, project route dispatch, check-result recording, user config seeding, and legacy project-venv fallback helpers. | `setup_resolve_project_manifest()`, `setup_resolve_project_route()`, `setup_record_project_check_result()` | Continue moving structured route policy to Python; keep shell dispatch thin. |
-| `setup_common.sh` 1171-1253 | Doctor visual status and project virtualenv JSON snippets for pre-venv failure handling. | `setup_print_doctor_finding()`, `setup_print_project_venv_check_json()`, `setup_print_project_venv_doctor_json()` | Move structured JSON assembly to Python before considering command-local doctor formatting. |
-| `setup_common.sh` 1266-1554 | Project pre-venv, bootstrap, artifact setup/check/doctor, uv-manager, wrapper, and remote-network dispatch. | `setup_run_project_pre_venv_layer()`, `setup_run_project_bootstrap_layer()`, `setup_run_project_artifact_layer()` | Keep as shell dispatch; reduce by moving project policy and payload shape to Python. |
-| `setup_common.sh` 1562-1585 | `base_dev` prerequisite profile dispatch. | `setup_run_base_dev_layer()` | Candidate `setup_profiles.sh` once profile parsing, profile JSON keys, and profile dispatch can move together. |
-| `setup_common.sh` 1589-1654 | Shared parallel probe helpers plus platform and CI-runtime check-result dispatch. | `setup_write_virtualenv_check_probe()`, `setup_collect_platform_base_check_results()`, `setup_collect_ci_runtime_check_results()` | Keep shared until check JSON assembly and probe orchestration have clearer Python boundaries. |
-| `setup_common.sh` 1717-1868 | Base check text rendering, project check result status handling, top-level check orchestration, and check JSON argument assembly. | `setup_run_check()`, `setup_run_check_json()`, `setup_print_check_text_results()` | Move check JSON assembly to Python; keep human text rendering and exit orchestration in shell. |
-| `setup_common.sh` 1870-1914 | CI install, platform install dispatch, and top-level setup dispatch. | `setup_run_ci_runtime_install()`, `setup_run_platform_install()`, `setup_run_install()` | Keep shared dispatch in `setup_common.sh`; platform install bodies belong in platform helpers. |
+| `setup_common.sh` 1-274 | Source guard, helper sourcing, shared cached paths, run state, profile flags, dry-run/debug/yes/CI toggles, Ubuntu/Debian consent prompts, notification toggles, and CI mode detection. | `setup_refresh_cached_paths()`, `setup_enable_profile_argument()`, `setup_require_linux_debian_system_consent()` | Keep in shared shell orchestration until profile parsing can move independently. |
+| `setup_common.sh` 278-363 | Platform/host-env helpers, platform support messages, test-hook gates, and shared non-runtime recovery text. | `setup_current_platform()`, `setup_current_host_env()`, `setup_reject_test_hook_if_disallowed()` | Keep platform policy shared while OS-specific implementation remains in platform helpers. |
+| `setup_common.sh` 367-405 | macOS completion notification behavior. | `setup_notify_completion()` | Candidate `setup_notifications.sh`; low risk but low value unless it still reduces ownership after platform helpers settle. |
+| `setup_common.sh` 409-505 | Shared command-path probes, executable architecture, Rosetta state, GitHub CLI version display, and runtime-chain summary rendering. | `setup_command_path()`, `setup_rosetta_translation_state()`, `setup_print_runtime_chain_summary()` | Keep shared because the summary combines platform helper data with cross-platform runtime state. |
+| `setup_common.sh` 509-700 | Base check finding metadata, base-bash-libs status, PYTHONPATH, and the diagnostics JSON bridge. | `setup_base_check_finding_id()`, `setup_diagnostics_python_bin()`, `setup_run_diagnostics_json()` | Finding metadata should eventually move to Python; the diagnostics bridge remains shared shell until check JSON assembly moves. |
+| `setup_common.sh` 702-850 | Project manifest resolution, project route dispatch, check-result recording, user config seeding, and legacy project-venv fallback helpers. | `setup_resolve_project_manifest()`, `setup_resolve_project_route()`, `setup_record_project_check_result()` | Continue moving structured route policy to Python; keep shell dispatch thin. |
+| `setup_common.sh` 856-945 | Doctor visual status and project virtualenv JSON snippets for pre-venv failure handling. | `setup_print_doctor_finding()`, `setup_print_project_venv_check_json()`, `setup_print_project_venv_doctor_json()` | Move structured JSON assembly to Python before considering command-local doctor formatting. |
+| `setup_common.sh` 958-1246 | Project pre-venv, bootstrap, artifact setup/check/doctor, uv-manager, wrapper, and remote-network dispatch. | `setup_run_project_pre_venv_layer()`, `setup_run_project_bootstrap_layer()`, `setup_run_project_artifact_layer()` | Keep as shell dispatch; reduce by moving project policy and payload shape to Python. |
+| `setup_common.sh` 1254-1277 | `base_dev` prerequisite profile dispatch. | `setup_run_base_dev_layer()` | Candidate `setup_profiles.sh` once profile parsing, profile JSON keys, and profile dispatch can move together. |
+| `setup_common.sh` 1281-1309 | Shared probe waiting plus platform/base check dispatch. | `setup_wait_for_base_check_probes()`, `setup_collect_platform_base_check_results()`, `setup_collect_base_check_results()` | Keep dispatch shared until check JSON assembly and probe orchestration have clearer Python boundaries. |
+| `setup_common.sh` 1319-1459 | Base check text rendering, project check result status handling, top-level check orchestration, and check JSON argument assembly. | `setup_run_check()`, `setup_run_check_json()`, `setup_print_check_text_results()` | Move check JSON assembly to Python; keep human text rendering and exit orchestration in shell. |
+| `setup_common.sh` 1462-1486 | Platform install dispatch and top-level setup dispatch. | `setup_run_platform_install()`, `setup_run_install()` | Keep shared dispatch in `setup_common.sh`; install bodies belong in domain helpers. |
 | `setup_linux_debian.sh` 1-422 | Ubuntu/Debian recovery text, Python finder, runtime tool probes, check collector, apt prerequisites, GitHub CLI apt-repo setup, and Linux install body. | `setup_find_linux_python_bin()`, `setup_collect_linux_debian_base_check_results()`, `setup_run_linux_debian_install()` | Extracted OS/platform helper; keep future Ubuntu/Debian policy here unless it is structured data better owned by Python. |
 | `setup_macos_homebrew.sh` 1-601 | macOS/Homebrew recovery text, Homebrew discovery and installer policy, Xcode command-line tools, macOS Python finder, macOS host probes, and macOS install body. | `setup_find_brew_bin()`, `setup_install_homebrew()`, `setup_collect_macos_base_check_results()`, `setup_run_macos_install()` | Extracted OS/platform helper; keep future macOS/Homebrew policy here unless it is structured data better owned by Python. |
+| `setup_venv.sh` 1-444 | Base runtime virtualenv health, pyvenv inspection, recreate behavior, platform Python dispatch, Base bootstrap package checks/install, venv check probes, CI-runtime checks, and CI-runtime install body. | `setup_virtualenv_healthy_path()`, `setup_create_virtualenv()`, `setup_collect_ci_runtime_check_results()`, `setup_run_ci_runtime_install()` | Extracted Base runtime helper; keep future runtime bootstrap policy here unless structured check output moves to Python. |
 
 ## Decomposition Strategy
 
@@ -121,12 +122,27 @@ time.
 
 ### Phase 3: Base Runtime Virtualenv And Python Bootstrap
 
-Move the Base virtualenv and Python bootstrap surface only after platform Python
-finder boundaries are explicit. The candidate helper is `setup_venv.sh`.
+Implemented third as `setup_venv.sh`, after the Linux/Debian and macOS/Homebrew
+Python finder boundaries were explicit.
 
-Candidate functions include `setup_virtualenv_healthy_path()`,
-`setup_find_platform_python_bin()`, `setup_create_virtualenv()`,
-`setup_base_venv_python_bin()`, and `setup_install_base_python_package()`.
+The Base runtime helper owns:
+
+- virtualenv recreate and health policy:
+  `setup_recreate_venv_enabled()`, `setup_virtualenv_healthy_path()`, and
+  `setup_backup_existing_venv_path()`;
+- platform Python dispatch for runtime creation:
+  `setup_find_platform_python_bin()` and
+  `setup_recovery_platform_python()`;
+- Base bootstrap package checks and installs:
+  `setup_base_python_package_installed()`,
+  `setup_install_base_python_package()`, `setup_install_pyyaml()`, and
+  `setup_install_click()`;
+- venv and package probe writers:
+  `setup_write_virtualenv_check_probe()` and
+  `setup_write_python_package_check_probe()`;
+- CI-runtime setup and check body:
+  `setup_collect_ci_runtime_check_results()` and
+  `setup_run_ci_runtime_install()`.
 
 This matters because setup, check, CI runtime, and project dispatch all depend
 on Base runtime health. Extracting this too early would create hidden coupling;
@@ -191,10 +207,8 @@ Each sourced helper PR should follow this protocol:
 
 ## Recommended PR Sequence
 
-1. Complete the Linux/Debian and macOS/Homebrew platform helper extractions and
-   keep #1570 open for the remaining staged breakup.
-2. Move Base runtime virtualenv/Python bootstrap helpers after both platform
-   helpers are stable.
-3. Move profile and notification helpers if they still reduce ownership.
-4. Move structured check/doctor JSON assembly into Python-owned code, not into
+1. Complete the Linux/Debian, macOS/Homebrew, and Base runtime helper
+   extractions and keep #1570 open for the remaining staged breakup.
+2. Move profile and notification helpers if they still reduce ownership.
+3. Move structured check/doctor JSON assembly into Python-owned code, not into
    another shell helper.

--- a/tests/test_setup_common_ownership_docs.py
+++ b/tests/test_setup_common_ownership_docs.py
@@ -13,6 +13,9 @@ SETUP_LINUX_DEBIAN_SCRIPT = (
 SETUP_MACOS_HOMEBREW_SCRIPT = (
     REPO_ROOT / "cli" / "bash" / "commands" / "basectl" / "subcommands" / "setup_macos_homebrew.sh"
 )
+SETUP_VENV_SCRIPT = (
+    REPO_ROOT / "cli" / "bash" / "commands" / "basectl" / "subcommands" / "setup_venv.sh"
+)
 DOCS_README = REPO_ROOT / "docs" / "README.md"
 
 
@@ -31,6 +34,7 @@ def setup_shell_sources() -> str:
             SETUP_COMMON_SCRIPT,
             SETUP_LINUX_DEBIAN_SCRIPT,
             SETUP_MACOS_HOMEBREW_SCRIPT,
+            SETUP_VENV_SCRIPT,
         )
     )
 
@@ -96,3 +100,11 @@ def test_setup_common_sources_macos_homebrew_helper() -> None:
 
     assert 'source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh"' in common_source
     assert "_base_setup_macos_homebrew_sourced" in macos_homebrew_source
+
+
+def test_setup_common_sources_venv_helper() -> None:
+    common_source = setup_common_script()
+    venv_source = SETUP_VENV_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup_venv.sh"' in common_source
+    assert "_base_setup_venv_sourced" in venv_source


### PR DESCRIPTION
## Summary
- add `setup_venv.sh` for Base runtime virtualenv and Python bootstrap helpers
- keep existing public `setup_*` names while `setup_common.sh` retains shared setup/check dispatch
- move CI-runtime setup/check bodies and venv/package probe writers into the runtime helper
- refresh setup-common ownership docs and add source-guard coverage for the new helper

Refs #1570

## Validation
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_setup_common_ownership_docs.py tests/test_contract_hardening.py -q`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/setup-common.bats`
- `bash -n cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/setup_linux_debian.sh cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh cli/bash/commands/basectl/subcommands/setup_venv.sh`
- `shellcheck -S error cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/setup_linux_debian.sh cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh cli/bash/commands/basectl/subcommands/setup_venv.sh`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc tests/test_setup_common_ownership_docs.py`
- `git diff --check`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1570-venv-helper bin/basectl check --ci`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1570-venv-helper-full ./bin/base-test`