### PR TITLE
Extract devcontainer export package

### DIFF
--- a/cli/python/base_devcontainer/__init__.py
+++ b/cli/python/base_devcontainer/__init__.py
@@ -1,0 +1,3 @@
+"""Dev Containers export support for Base manifests."""
+
+from __future__ import annotations

--- a/cli/python/base_devcontainer/export.py
+++ b/cli/python/base_devcontainer/export.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from base_setup.manifest_model import BaseManifest
+
+
+__all__ = (
+    "DevcontainerExport",
+    "DevcontainerExportError",
+    "DevcontainerFinding",
+    "add_ambiguous_manifest_findings",
+    "add_unsupported_manifest_findings",
+    "build_devcontainer_export",
+    "devcontainer_export_to_json",
+    "dumps_devcontainer_json",
+    "dumps_export_json",
+    "finding_to_json",
+    "print_devcontainer_export_text",
+    "print_devcontainer_findings",
+    "write_devcontainer_export",
+)
+
+
+@dataclass(frozen=True)
+class DevcontainerFinding:
+    field: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DevcontainerExport:
+    project: str
+    manifest_path: Path
+    target_path: Path
+    target_exists: bool
+    write: bool
+    devcontainer: dict[str, Any]
+    supported: tuple[str, ...]
+    unsupported: tuple[DevcontainerFinding, ...]
+    ambiguous: tuple[DevcontainerFinding, ...]
+
+
+class DevcontainerExportError(RuntimeError):
+    pass
+
+
+def build_devcontainer_export(manifest: BaseManifest, *, write: bool = False) -> DevcontainerExport:
+    target_path = manifest.path.parent / ".devcontainer" / "devcontainer.json"
+    devcontainer: dict[str, Any] = {"name": manifest.project_name}
+    supported = ["project.name"]
+    unsupported: list[DevcontainerFinding] = []
+    ambiguous: list[DevcontainerFinding] = []
+
+    vscode = manifest.ide.get("vscode")
+    if vscode is not None:
+        vscode_customizations: dict[str, Any] = {}
+        if vscode.extensions:
+            vscode_customizations["extensions"] = list(vscode.extensions)
+            supported.append("ide.vscode.extensions")
+        if vscode.settings:
+            vscode_customizations["settings"] = vscode.settings
+            supported.append("ide.vscode.settings")
+        if vscode_customizations:
+            devcontainer["customizations"] = {"vscode": vscode_customizations}
+
+    for ide_name in sorted(set(manifest.ide) - {"vscode"}):
+        unsupported.append(
+            DevcontainerFinding(
+                field=f"ide.{ide_name}",
+                reason="Devcontainer export currently maps VS Code customizations only.",
+            )
+        )
+
+    add_unsupported_manifest_findings(manifest, unsupported)
+    add_ambiguous_manifest_findings(manifest, ambiguous)
+
+    return DevcontainerExport(
+        project=manifest.project_name,
+        manifest_path=manifest.path,
+        target_path=target_path,
+        target_exists=target_path.exists(),
+        write=write,
+        devcontainer=devcontainer,
+        supported=tuple(supported),
+        unsupported=tuple(unsupported),
+        ambiguous=tuple(ambiguous),
+    )
+
+
+def write_devcontainer_export(export: DevcontainerExport) -> None:
+    if export.target_path.exists():
+        raise DevcontainerExportError(
+            f"{export.target_path} already exists; refusing to replace project-owned devcontainer file."
+        )
+    export.target_path.parent.mkdir(parents=True, exist_ok=True)
+    export.target_path.write_text(dumps_devcontainer_json(export.devcontainer), encoding="utf-8")
+
+
+def add_unsupported_manifest_findings(manifest: BaseManifest, findings: list[DevcontainerFinding]) -> None:
+    if manifest.brewfile is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="brewfile",
+                reason="Brewfile installation is host-specific and is not translated to devcontainer features yet.",
+            )
+        )
+    if manifest.mise is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="mise",
+                reason=(
+                    "Project-owned mise configuration remains project-owned and is "
+                    "not embedded in devcontainer output."
+                ),
+            )
+        )
+    for index, artifact in enumerate(manifest.artifacts, start=1):
+        findings.append(
+            DevcontainerFinding(
+                field=f"artifacts[{index}]",
+                reason=(
+                    f"Base artifact {artifact.artifact_type}/{artifact.name} "
+                    "does not have a devcontainer feature mapping yet."
+                ),
+            )
+        )
+    if manifest.test is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="test",
+                reason=(
+                    "Project test commands remain Base/project commands and are not "
+                    "added to devcontainer lifecycle hooks."
+                ),
+            )
+        )
+    if manifest.health.required_env:
+        findings.append(
+            DevcontainerFinding(
+                field="health.required_env",
+                reason="Required environment variables are diagnostics, not container secrets.",
+            )
+        )
+    if manifest.health.required_ports:
+        findings.append(
+            DevcontainerFinding(
+                field="health.required_ports",
+                reason="Port health checks are diagnostics and are not translated to devcontainer port forwarding yet.",
+            )
+        )
+    if manifest.commands:
+        findings.append(
+            DevcontainerFinding(
+                field="commands",
+                reason=(
+                    "Project commands stay in Base/project manifests and are not "
+                    "copied into devcontainer lifecycle hooks."
+                ),
+            )
+        )
+    if manifest.activate.source:
+        findings.append(
+            DevcontainerFinding(
+                field="activate.source",
+                reason=(
+                    "Activation source scripts are interactive shell behavior and "
+                    "are not run by devcontainer export."
+                ),
+            )
+        )
+    if manifest.build is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="build",
+                reason="Build targets remain Base/project commands and are not translated to devcontainer tasks.",
+            )
+        )
+
+
+def add_ambiguous_manifest_findings(manifest: BaseManifest, findings: list[DevcontainerFinding]) -> None:
+    if manifest.python.manager is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="python.manager",
+                reason="Python manager selection may affect image choice, features, or post-create commands.",
+            )
+        )
+    if manifest.python.requires_python is not None:
+        findings.append(
+            DevcontainerFinding(
+                field="python.requires_python",
+                reason="Python version constraints require an explicit image or feature policy before export.",
+            )
+        )
+
+
+def devcontainer_export_to_json(export: DevcontainerExport) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "project": export.project,
+        "manifest_path": str(export.manifest_path),
+        "target_path": str(export.target_path),
+        "target_exists": export.target_exists,
+        "write": export.write,
+        "devcontainer": export.devcontainer,
+        "supported": list(export.supported),
+        "unsupported": [finding_to_json(finding) for finding in export.unsupported],
+        "ambiguous": [finding_to_json(finding) for finding in export.ambiguous],
+    }
+
+
+def finding_to_json(finding: DevcontainerFinding) -> dict[str, str]:
+    return {"field": finding.field, "reason": finding.reason}
+
+
+def dumps_devcontainer_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def dumps_export_json(export: DevcontainerExport) -> str:
+    return dumps_devcontainer_json(devcontainer_export_to_json(export))
+
+
+def print_devcontainer_export_text(export: DevcontainerExport) -> None:
+    mode = "write" if export.write else "dry-run"
+    print(f"Devcontainer export for project '{export.project}'")
+    print(f"Manifest: {export.manifest_path}")
+    print(f"Target: {export.target_path}")
+    print(f"Mode: {mode}")
+    print()
+    if export.write:
+        print("Wrote devcontainer JSON.")
+    else:
+        print("Dry run: no files were written.")
+    print()
+    print("Generated devcontainer.json:")
+    print(dumps_devcontainer_json(export.devcontainer), end="")
+    print_devcontainer_findings("Unsupported fields", export.unsupported)
+    print_devcontainer_findings("Ambiguous fields", export.ambiguous)
+
+
+def print_devcontainer_findings(label: str, findings: tuple[DevcontainerFinding, ...]) -> None:
+    if not findings:
+        return
+    print()
+    print(f"{label}:")
+    for finding in findings:
+        print(f"- {finding.field}: {finding.reason}")

--- a/cli/python/base_devcontainer/tests/test_export.py
+++ b/cli/python/base_devcontainer/tests/test_export.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from base_devcontainer.export import build_devcontainer_export
+from base_devcontainer.export import write_devcontainer_export
+from base_setup.manifest import read_manifest
+
+
+def write_manifest(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+class DevcontainerExportTests(unittest.TestCase):
+    def test_build_devcontainer_export_uses_manifest_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "base_manifest.yaml"
+            write_manifest(
+                manifest_path,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "ide:",
+                        "  vscode:",
+                        "    extensions:",
+                        "      - ms-python.python",
+                        "artifacts: []",
+                        "",
+                    ]
+                ),
+            )
+
+            export = build_devcontainer_export(read_manifest(manifest_path))
+
+        self.assertEqual(export.project, "demo")
+        self.assertEqual(export.target_path, manifest_path.parent / ".devcontainer" / "devcontainer.json")
+        self.assertEqual(
+            export.devcontainer,
+            {
+                "customizations": {"vscode": {"extensions": ["ms-python.python"]}},
+                "name": "demo",
+            },
+        )
+        self.assertEqual(export.supported, ("project.name", "ide.vscode.extensions"))
+
+    def test_write_devcontainer_export_writes_stable_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "base_manifest.yaml"
+            write_manifest(manifest_path, "project:\n  name: demo\nartifacts: []\n")
+            export = build_devcontainer_export(read_manifest(manifest_path), write=True)
+
+            write_devcontainer_export(export)
+
+            payload = json.loads(export.target_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload, {"name": "demo"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/python/base_setup/devcontainer_export.py
+++ b/cli/python/base_setup/devcontainer_export.py
@@ -1,235 +1,34 @@
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
-
-from base_setup.manifest_model import BaseManifest
-
-
-@dataclass(frozen=True)
-class DevcontainerFinding:
-    field: str
-    reason: str
-
-
-@dataclass(frozen=True)
-class DevcontainerExport:
-    project: str
-    manifest_path: Path
-    target_path: Path
-    target_exists: bool
-    write: bool
-    devcontainer: dict[str, Any]
-    supported: tuple[str, ...]
-    unsupported: tuple[DevcontainerFinding, ...]
-    ambiguous: tuple[DevcontainerFinding, ...]
+from base_devcontainer.export import DevcontainerExport
+from base_devcontainer.export import DevcontainerExportError
+from base_devcontainer.export import DevcontainerFinding
+from base_devcontainer.export import add_ambiguous_manifest_findings
+from base_devcontainer.export import add_unsupported_manifest_findings
+from base_devcontainer.export import build_devcontainer_export
+from base_devcontainer.export import devcontainer_export_to_json
+from base_devcontainer.export import dumps_devcontainer_json
+from base_devcontainer.export import dumps_export_json
+from base_devcontainer.export import finding_to_json
+from base_devcontainer.export import print_devcontainer_export_text
+from base_devcontainer.export import print_devcontainer_findings
+from base_devcontainer.export import write_devcontainer_export
 
 
-class DevcontainerExportError(RuntimeError):
-    pass
-
-
-def build_devcontainer_export(manifest: BaseManifest, *, write: bool = False) -> DevcontainerExport:
-    target_path = manifest.path.parent / ".devcontainer" / "devcontainer.json"
-    devcontainer: dict[str, Any] = {"name": manifest.project_name}
-    supported = ["project.name"]
-    unsupported: list[DevcontainerFinding] = []
-    ambiguous: list[DevcontainerFinding] = []
-
-    vscode = manifest.ide.get("vscode")
-    if vscode is not None:
-        vscode_customizations: dict[str, Any] = {}
-        if vscode.extensions:
-            vscode_customizations["extensions"] = list(vscode.extensions)
-            supported.append("ide.vscode.extensions")
-        if vscode.settings:
-            vscode_customizations["settings"] = vscode.settings
-            supported.append("ide.vscode.settings")
-        if vscode_customizations:
-            devcontainer["customizations"] = {"vscode": vscode_customizations}
-
-    for ide_name in sorted(set(manifest.ide) - {"vscode"}):
-        unsupported.append(
-            DevcontainerFinding(
-                field=f"ide.{ide_name}",
-                reason="Devcontainer export currently maps VS Code customizations only.",
-            )
-        )
-
-    add_unsupported_manifest_findings(manifest, unsupported)
-    add_ambiguous_manifest_findings(manifest, ambiguous)
-
-    return DevcontainerExport(
-        project=manifest.project_name,
-        manifest_path=manifest.path,
-        target_path=target_path,
-        target_exists=target_path.exists(),
-        write=write,
-        devcontainer=devcontainer,
-        supported=tuple(supported),
-        unsupported=tuple(unsupported),
-        ambiguous=tuple(ambiguous),
-    )
-
-
-def write_devcontainer_export(export: DevcontainerExport) -> None:
-    if export.target_path.exists():
-        raise DevcontainerExportError(
-            f"{export.target_path} already exists; refusing to replace project-owned devcontainer file."
-        )
-    export.target_path.parent.mkdir(parents=True, exist_ok=True)
-    export.target_path.write_text(dumps_devcontainer_json(export.devcontainer), encoding="utf-8")
-
-
-def add_unsupported_manifest_findings(manifest: BaseManifest, findings: list[DevcontainerFinding]) -> None:
-    if manifest.brewfile is not None:
-        findings.append(
-            DevcontainerFinding(
-                field="brewfile",
-                reason="Brewfile installation is host-specific and is not translated to devcontainer features yet.",
-            )
-        )
-    if manifest.mise is not None:
-        findings.append(
-            DevcontainerFinding(
-                field="mise",
-                reason=(
-                    "Project-owned mise configuration remains project-owned and is "
-                    "not embedded in devcontainer output."
-                ),
-            )
-        )
-    for index, artifact in enumerate(manifest.artifacts, start=1):
-        findings.append(
-            DevcontainerFinding(
-                field=f"artifacts[{index}]",
-                reason=(
-                    f"Base artifact {artifact.artifact_type}/{artifact.name} "
-                    "does not have a devcontainer feature mapping yet."
-                ),
-            )
-        )
-    if manifest.test is not None:
-        findings.append(
-            DevcontainerFinding(
-                field="test",
-                reason=(
-                    "Project test commands remain Base/project commands and are not "
-                    "added to devcontainer lifecycle hooks."
-                ),
-            )
-        )
-    if manifest.health.required_env:
-        findings.append(
-            DevcontainerFinding(
-                field="health.required_env",
-                reason="Required environment variables are diagnostics, not container secrets.",
-            )
-        )
-    if manifest.health.required_ports:
-        findings.append(
-            DevcontainerFinding(
-                field="health.required_ports",
-                reason="Port health checks are diagnostics and are not translated to devcontainer port forwarding yet.",
-            )
-        )
-    if manifest.commands:
-        findings.append(
-            DevcontainerFinding(
-                field="commands",
-                reason=(
-                    "Project commands stay in Base/project manifests and are not "
-                    "copied into devcontainer lifecycle hooks."
-                ),
-            )
-        )
-    if manifest.activate.source:
-        findings.append(
-            DevcontainerFinding(
-                field="activate.source",
-                reason=(
-                    "Activation source scripts are interactive shell behavior and "
-                    "are not run by devcontainer export."
-                ),
-            )
-        )
-    if manifest.build is not None:
-        findings.append(
-            DevcontainerFinding(
-                field="build",
-                reason="Build targets remain Base/project commands and are not translated to devcontainer tasks.",
-            )
-        )
-
-
-def add_ambiguous_manifest_findings(manifest: BaseManifest, findings: list[DevcontainerFinding]) -> None:
-    if manifest.python.manager is not None:
-        findings.append(
-            DevcontainerFinding(
-                field="python.manager",
-                reason="Python manager selection may affect image choice, features, or post-create commands.",
-            )
-        )
-    if manifest.python.requires_python is not None:
-        findings.append(
-            DevcontainerFinding(
-                field="python.requires_python",
-                reason="Python version constraints require an explicit image or feature policy before export.",
-            )
-        )
-
-
-def devcontainer_export_to_json(export: DevcontainerExport) -> dict[str, Any]:
-    return {
-        "schema_version": 1,
-        "project": export.project,
-        "manifest_path": str(export.manifest_path),
-        "target_path": str(export.target_path),
-        "target_exists": export.target_exists,
-        "write": export.write,
-        "devcontainer": export.devcontainer,
-        "supported": list(export.supported),
-        "unsupported": [finding_to_json(finding) for finding in export.unsupported],
-        "ambiguous": [finding_to_json(finding) for finding in export.ambiguous],
-    }
-
-
-def finding_to_json(finding: DevcontainerFinding) -> dict[str, str]:
-    return {"field": finding.field, "reason": finding.reason}
-
-
-def dumps_devcontainer_json(payload: dict[str, Any]) -> str:
-    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
-
-
-def dumps_export_json(export: DevcontainerExport) -> str:
-    return dumps_devcontainer_json(devcontainer_export_to_json(export))
-
-
-def print_devcontainer_export_text(export: DevcontainerExport) -> None:
-    mode = "write" if export.write else "dry-run"
-    print(f"Devcontainer export for project '{export.project}'")
-    print(f"Manifest: {export.manifest_path}")
-    print(f"Target: {export.target_path}")
-    print(f"Mode: {mode}")
-    print()
-    if export.write:
-        print("Wrote devcontainer JSON.")
-    else:
-        print("Dry run: no files were written.")
-    print()
-    print("Generated devcontainer.json:")
-    print(dumps_devcontainer_json(export.devcontainer), end="")
-    print_devcontainer_findings("Unsupported fields", export.unsupported)
-    print_devcontainer_findings("Ambiguous fields", export.ambiguous)
-
-
-def print_devcontainer_findings(label: str, findings: tuple[DevcontainerFinding, ...]) -> None:
-    if not findings:
-        return
-    print()
-    print(f"{label}:")
-    for finding in findings:
-        print(f"- {finding.field}: {finding.reason}")
+# Compatibility exports for callers that imported Dev Containers helpers from
+# base_setup before the focused base_devcontainer package existed.
+__all__ = (
+    "DevcontainerExport",
+    "DevcontainerExportError",
+    "DevcontainerFinding",
+    "add_ambiguous_manifest_findings",
+    "add_unsupported_manifest_findings",
+    "build_devcontainer_export",
+    "devcontainer_export_to_json",
+    "dumps_devcontainer_json",
+    "dumps_export_json",
+    "finding_to_json",
+    "print_devcontainer_export_text",
+    "print_devcontainer_findings",
+    "write_devcontainer_export",
+)

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -8,17 +8,17 @@ from pathlib import Path
 import base_cli
 from base_cli.config import UserConfig
 from base_cli.paths import discover_manifest
+from base_devcontainer.export import DevcontainerExportError
+from base_devcontainer.export import build_devcontainer_export
+from base_devcontainer.export import dumps_export_json
+from base_devcontainer.export import print_devcontainer_export_text
+from base_devcontainer.export import write_devcontainer_export
 
 from .checks import check_to_json
 from .checks import checks_payload_to_json
 from .checks import checks_status
 from .checks import doctor_status
 from .checks import print_doctor_finding
-from .devcontainer_export import DevcontainerExportError
-from .devcontainer_export import build_devcontainer_export
-from .devcontainer_export import dumps_export_json
-from .devcontainer_export import print_devcontainer_export_text
-from .devcontainer_export import write_devcontainer_export
 from .devenv_report import build_devenv_report
 from .devenv_report import dumps_devenv_report_json
 from .devenv_report import print_devenv_report_text

--- a/cli/python/base_setup/tests/test_compatibility_facades.py
+++ b/cli/python/base_setup/tests/test_compatibility_facades.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 import unittest
 
+from base_devcontainer import export as devcontainer_export_impl
 from base_setup import git_remote
 from base_setup import ide
+from base_setup import devcontainer_export
+from base_setup import engine as setup_engine
 from base_setup import manifest_checks
 from base_setup import setup_reconcile
 from base_trust import trust_store
@@ -23,6 +26,13 @@ class CompatibilityFacadeTests(unittest.TestCase):
         self.assertIn("reconcile_ide_settings", ide.__all__)
         self.assertIn("IdeDiagnosticSnapshot", ide.__all__)
 
+    def test_devcontainer_export_declares_compatibility_exports(self) -> None:
+        self.assertIn("build_devcontainer_export", devcontainer_export.__all__)
+        self.assertIn("write_devcontainer_export", devcontainer_export.__all__)
+        self.assertIn("DevcontainerExportError", devcontainer_export.__all__)
+        self.assertIs(devcontainer_export.build_devcontainer_export, devcontainer_export_impl.build_devcontainer_export)
+        self.assertIs(devcontainer_export.write_devcontainer_export, devcontainer_export_impl.write_devcontainer_export)
+
     def test_setup_callers_use_focused_ide_modules(self) -> None:
         manifest_checks_source = Path(manifest_checks.__file__).read_text(encoding="utf-8")
         setup_reconcile_source = Path(setup_reconcile.__file__).read_text(encoding="utf-8")
@@ -40,6 +50,17 @@ class CompatibilityFacadeTests(unittest.TestCase):
         self.assertIn("from .ide_extensions import reconcile_ide_extensions", setup_reconcile_source)
         self.assertIn("from .ide_installs import reconcile_ide_installs", setup_reconcile_source)
         self.assertIn("from .ide_settings import reconcile_ide_settings", setup_reconcile_source)
+
+    def test_setup_engine_uses_focused_devcontainer_package(self) -> None:
+        setup_engine_source = Path(setup_engine.__file__).read_text(encoding="utf-8")
+        facade_source = Path(devcontainer_export.__file__).read_text(encoding="utf-8")
+
+        self.assertIn("from base_devcontainer.export import build_devcontainer_export", setup_engine_source)
+        self.assertIn("from base_devcontainer.export import write_devcontainer_export", setup_engine_source)
+        self.assertNotIn("from .devcontainer_export import", setup_engine_source)
+        self.assertIn("from base_devcontainer.export import build_devcontainer_export", facade_source)
+        self.assertNotIn("def build_devcontainer_export", facade_source)
+        self.assertNotIn("@dataclass", facade_source)
 
     def test_trust_store_uses_focused_git_modules(self) -> None:
         trust_store_source = Path(trust_store.__file__).read_text(encoding="utf-8")

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,8 @@ reference. The filename should answer "what is this about?"
   repository workflows.
 - [Tool Boundaries](tool-boundaries.md) records ecosystem decisions for tools
   such as `mise`, `direnv`, Homebrew, IDEs, Docker, and dotfile managers.
+- [Python Package Ownership](python-package-ownership.md) maps focused
+  `cli/python/` package boundaries and compatibility facade expectations.
 
 ## Presentations
 

--- a/docs/python-package-ownership.md
+++ b/docs/python-package-ownership.md
@@ -1,0 +1,23 @@
+# Python Package Ownership
+
+Base keeps Python code in focused packages under `cli/python/` and shared runtime
+helpers under `lib/python/`. Package boundaries should follow product
+responsibility, not file size.
+
+## Current Boundaries
+
+| Package | Primary responsibility | Notes |
+| --- | --- | --- |
+| `base_setup` | Setup reconciliation, manifest parsing, project diagnostics, project routing, and compatibility facades for older imports. | Keep setup/check/doctor behavior here. Do not add adapter-specific schema generation here when a focused package can own it. |
+| `base_devcontainer` | Dev Containers export from Base manifests. | Owns generated `devcontainer.json` shape, unsupported/ambiguous field reporting, guarded writes, and text/JSON export rendering through `base_devcontainer.export`. |
+| `base_devenv` | Not extracted yet. | #1576 should move Nix/devenv compatibility reporting here or to an equivalent focused package in a later slice. |
+
+## Extraction Rules
+
+- Preserve public `basectl` command behavior while moving implementation
+  ownership.
+- Keep compatibility facades in `base_setup` when existing internal callers may
+  still import historical module names.
+- Keep shared manifest models and loaders in `base_setup` until there is a
+  broader manifest package boundary.
+- Add structure tests when a package becomes the primary owner for a surface.


### PR DESCRIPTION
## Summary
- Move Dev Containers export ownership from base_setup into a focused base_devcontainer package.
- Keep base_setup.devcontainer_export as an explicit compatibility facade for historical imports.
- Update base_setup command dispatch to use the focused package directly.
- Add package-boundary tests and a Python package ownership doc for the staged #1576 extraction.

Refs #1576

## Validation
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_devcontainer/tests/test_export.py cli/python/base_setup/tests/test_devcontainer_export.py cli/python/base_setup/tests/test_compatibility_facades.py -q
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_base_cli_docs.py tests/test_contract_hardening.py -q
- BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/devcontainer.bats cli/bash/commands/basectl/tests/devenv-report.bats
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_setup/tests/test_devenv_report.py -q
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_devcontainer/tests/test_export.py cli/python/base_setup/tests/test_devcontainer_export.py cli/python/base_setup/tests/test_compatibility_facades.py lib/python/base_cli/tests/test_public_command_lifecycle.py -q
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_devcontainer cli/python/base_setup/devcontainer_export.py cli/python/base_setup/engine.py cli/python/base_setup/tests/test_compatibility_facades.py
- git diff --check
- env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1576-devcontainer-full ./bin/base-test