### PR TITLE
Extract repo GitHub settings helper

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -252,6 +252,22 @@ base_repo_load_agent_guidance() {
     source "$module_path"
 }
 
+base_repo_load_github_settings() {
+    local module_path
+
+    if declare -F base_repo_configure_github >/dev/null 2>&1; then
+        return 0
+    fi
+
+    module_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/repo_github_settings.sh" || return 1
+    [[ -f "$module_path" ]] || {
+        log_error "repo GitHub settings helper was not found at '$module_path'."
+        return 1
+    }
+    # shellcheck source=cli/bash/commands/basectl/subcommands/repo_github_settings.sh
+    source "$module_path"
+}
+
 base_repo_default_description() {
     local name="$1"
 
@@ -975,21 +991,6 @@ base_repo_require_gh() {
     gh_auth_status_diagnostics "Run 'gh auth login -h github.com' and retry."
 }
 
-base_repo_homebrew_gh_outdated() {
-    local output=""
-
-    command -v brew >/dev/null 2>&1 || return 1
-    HOMEBREW_NO_AUTO_UPDATE=1 brew list gh >/dev/null 2>&1 || return 1
-    output="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated gh 2>/dev/null || true)"
-    printf '%s\n' "$output" | awk '$1 == "gh" { found = 1 } END { exit found ? 0 : 1 }'
-}
-
-base_repo_warn_if_gh_outdated() {
-    if base_repo_homebrew_gh_outdated; then
-        log_warn "GitHub CLI 'gh' is outdated; run 'basectl setup --profile dev' to upgrade Base-managed developer prerequisites."
-    fi
-}
-
 base_repo_pretty_quote() {
     local value="$1"
 
@@ -1034,326 +1035,12 @@ base_repo_join_csv() {
     printf '%s' "$joined"
 }
 
-base_repo_configure_label() {
-    local color="$3"
-    local description="$4"
-    local dry_run="$1"
-    local label="$2"
-    local repo="$5"
-    local quoted_description
-
-    if [[ "$dry_run" == "1" ]]; then
-        quoted_description="$(base_repo_pretty_quote "$description")"
-        printf "[DRY-RUN] Would run: gh label create %s --repo %s --color %s --description %s --force\n" \
-            "$label" "$repo" "$color" "$quoted_description"
-        return 0
-    fi
-
-    gh label create "$label" --repo "$repo" --color "$color" --description "$description" --force || return 1
-    printf "  Label: %s (created or updated).\n" "$label"
-}
-
-base_repo_ensure_github_repo() {
-    local description="$3"
-    local dry_run="$1"
-    local repo="$2"
-    local visibility="$4"
-
-    if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would create %s GitHub repository '%s' if it does not already exist.\n" "$visibility" "$repo"
-        return 0
-    fi
-
-    base_repo_require_gh || return 1
-    if gh repo view "$repo" >/dev/null 2>&1; then
-        log_info "GitHub repository '$repo' already exists."
-        return 0
-    fi
-
-    log_info "Creating $visibility GitHub repository '$repo'."
-    gh repo create "$repo" "--$visibility" --description "$description"
-}
-
-base_repo_default_branch_ruleset_payload() {
-    cat <<'JSON'
-{"name":"Base default branch protection","target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},"rules":[{"type":"pull_request","parameters":{"allowed_merge_methods":["squash"],"dismiss_stale_reviews_on_push":false,"require_code_owner_review":false,"require_last_push_approval":false,"required_approving_review_count":0,"required_review_thread_resolution":false}},{"type":"deletion"},{"type":"non_fast_forward"}]}
-JSON
-}
-
-base_repo_rulesets_plan_gated_error() {
-    local message="$1"
-
-    [[ "$message" == *"Upgrade to GitHub Pro"* ]] &&
-        [[ "$message" == *"make this repository public"* ]] &&
-        [[ "$message" == *"(HTTP 403)"* ]]
-}
-
-base_repo_configure_default_branch_protection() {
-    local dry_run="$1"
-    local payload
-    local repo="$2"
-    local ruleset_lookup_output=""
-    local ruleset_id=""
-
-    payload="$(base_repo_default_branch_ruleset_payload)"
-
-    if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would create or update GitHub ruleset 'Base default branch protection' on '%s' targeting '~DEFAULT_BRANCH'.\n" "$repo"
-        printf "[DRY-RUN] Would run: gh api repos/%s/rulesets --jq %s\n" \
-            "$repo" \
-            "$(base_repo_pretty_quote 'map(select(.name == "Base default branch protection" and .source_type == "Repository")) | .[0].id // ""')"
-        printf "[DRY-RUN] Would run: gh api repos/%s/rulesets --method POST --input -\n" "$repo"
-        printf "[DRY-RUN] Payload: %s\n" "$payload"
-        return 0
-    fi
-
-    base_repo_require_gh || return 1
-    ruleset_lookup_output="$(gh api "repos/$repo/rulesets" \
-        --jq 'map(select(.name == "Base default branch protection" and .source_type == "Repository")) | .[0].id // ""' 2>&1)" || {
-        if base_repo_rulesets_plan_gated_error "$ruleset_lookup_output"; then
-            log_warn "Default branch protection skipped for '$repo'."
-            log_warn "$ruleset_lookup_output"
-            return 0
-        fi
-        [[ -z "$ruleset_lookup_output" ]] || log_error "$ruleset_lookup_output"
-        log_error "Unable to inspect GitHub rulesets for '$repo'."
-        return 1
-    }
-    ruleset_id="$ruleset_lookup_output"
-
-    if [[ -n "$ruleset_id" ]]; then
-        printf '%s\n' "$payload" | gh api "repos/$repo/rulesets/$ruleset_id" --method PUT --input - || {
-            log_error "Unable to update Base default branch protection ruleset for '$repo'."
-            return 1
-        }
-        printf "  Branch protection: updated 'Base default branch protection'.\n"
-    else
-        printf '%s\n' "$payload" | gh api "repos/$repo/rulesets" --method POST --input - || {
-            log_error "Unable to create Base default branch protection ruleset for '$repo'."
-            return 1
-        }
-        printf "  Branch protection: created 'Base default branch protection'.\n"
-    fi
-}
-
 base_repo_title_case_name() {
     local name="$1"
 
     printf '%s\n' "$name" |
         tr '._-' '   ' |
         awk '{ for (i = 1; i <= NF; i++) { $i = toupper(substr($i, 1, 1)) substr($i, 2) } print }'
-}
-
-base_repo_default_project_title() {
-    local repo="$1"
-
-    printf '%s\n' "${repo#*/}"
-}
-
-base_repo_project_owner_from_repo() {
-    local repo="$1"
-
-    printf '%s\n' "${repo%%/*}"
-}
-
-base_repo_project_config_path() {
-    local root="$1"
-    local path="$root/.github/base-project.yml"
-
-    if [[ -f "$path" ]]; then
-        printf '%s\n' "$path"
-    fi
-}
-
-base_repo_project_intake_secret_fix_command() {
-    local repo="$1"
-
-    printf 'gh auth token | gh secret set BASE_PROJECT_TOKEN --repo %s\n' "$repo"
-}
-
-base_repo_secret_list_has_project_token() {
-    awk '
-        $1 == "BASE_PROJECT_TOKEN" { found = 1 }
-        END { exit found ? 0 : 1 }
-    '
-}
-
-base_repo_check_project_intake_secret() {
-    local dry_run="$1"
-    local output=""
-    local repo="$2"
-
-    if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would verify GitHub Actions secret 'BASE_PROJECT_TOKEN' exists for '%s'.\n" "$repo"
-        return 0
-    fi
-
-    base_repo_require_gh || return 1
-    output="$(gh secret list --repo "$repo" 2>&1)" || {
-        log_warn "Unable to inspect GitHub Actions secrets for '$repo'."
-        [[ -z "$output" ]] || log_warn "$output"
-        log_warn "Project Intake may fail unless BASE_PROJECT_TOKEN is configured with user Project access."
-        log_warn "Fix: $(base_repo_project_intake_secret_fix_command "$repo")"
-        return 0
-    }
-
-    if printf '%s\n' "$output" | base_repo_secret_list_has_project_token; then
-        return 0
-    fi
-
-    log_warn "Project Intake secret 'BASE_PROJECT_TOKEN' is not configured for '$repo'."
-    log_warn "GitHub Actions default token cannot access user-level Projects."
-    log_warn "Fix: $(base_repo_project_intake_secret_fix_command "$repo")"
-}
-
-base_repo_configure_project_metadata() {
-    local dry_run="$1"
-    local config_path="$6"
-    local copy_fields_from_project="$7"
-    local replace_project="$8"
-    local option
-    local owner="$4"
-    local output=""
-    local project_title="$3"
-    local repo="$2"
-    local schema="$5"
-    local status=0
-    local wrapper="${BASE_REPO_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
-    shift 8
-
-    if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would configure GitHub Project '%s' for '%s'.\n" "$project_title" "$repo"
-        if [[ "$replace_project" == "1" ]]; then
-            printf "[DRY-RUN] Would replace nonstandard existing GitHub Project '%s' from 'base-project-template'.\n" "$project_title"
-        else
-            printf "[DRY-RUN] Would copy GitHub Project 'base-project-template' to '%s' if missing.\n" "$project_title"
-        fi
-        printf "[DRY-RUN] Would link GitHub Project '%s' to repository '%s'.\n" "$project_title" "$repo"
-        printf "[DRY-RUN] Would backfill issues from '%s' into GitHub Project '%s'.\n" "$repo" "$project_title"
-        if [[ -n "$config_path" ]]; then
-            printf "[DRY-RUN] Would read GitHub Project config from '%s'.\n" "$config_path"
-            printf "[DRY-RUN] Would apply issue defaults from '%s' to missing Project item fields.\n" "$config_path"
-        fi
-        if [[ -n "$copy_fields_from_project" ]]; then
-            printf "[DRY-RUN] Would copy missing Project item field values from '%s' into '%s'.\n" \
-                "$copy_fields_from_project" \
-                "$project_title"
-        fi
-        base_repo_check_project_intake_secret "$dry_run" "$repo"
-        printf "[DRY-RUN] Would run: %s --project base base_github_projects project configure --project %s --owner %s --repo %s --schema %s" \
-            "$wrapper" \
-            "$(base_repo_pretty_arg "$project_title")" \
-            "$owner" \
-            "$repo" \
-            "$schema"
-        if [[ -n "$config_path" ]]; then
-            printf " --config %s" "$(base_repo_pretty_arg "$config_path")"
-        fi
-        if [[ -n "$copy_fields_from_project" ]]; then
-            printf " --copy-fields-from %s" "$(base_repo_pretty_arg "$copy_fields_from_project")"
-        fi
-        if [[ "$replace_project" == "1" ]]; then
-            printf " --replace-project"
-        fi
-        for option in "$@"; do
-            printf " --initiative-option %s" "$(base_repo_pretty_arg "$option")"
-        done
-        printf "\n"
-        printf "[DRY-RUN] Project fields: Status, Priority, Area, Size, Initiative\n"
-        return 0
-    fi
-
-    [[ -x "$wrapper" ]] || {
-        log_error "Base Python wrapper '$wrapper' is missing or is not executable."
-        return 1
-    }
-    base_repo_check_project_intake_secret "$dry_run" "$repo" || return 1
-
-    local command=(
-        "$wrapper"
-        --project base
-        base_github_projects
-        project
-        configure
-        --project "$project_title"
-        --owner "$owner"
-        --repo "$repo"
-        --schema "$schema"
-    )
-    if [[ -n "$config_path" ]]; then
-        command+=(--config "$config_path")
-    fi
-    if [[ -n "$copy_fields_from_project" ]]; then
-        command+=(--copy-fields-from "$copy_fields_from_project")
-    fi
-    if [[ "$replace_project" == "1" ]]; then
-        command+=(--replace-project)
-    fi
-    for option in "$@"; do
-        command+=(--initiative-option "$option")
-    done
-
-    log_info "Configuring GitHub Project '$project_title' for '$repo'."
-    log_info "Running: $(base_repo_pretty_command "${command[@]}")"
-    output="$(BASE_CLI_DISPLAY_COMMAND="basectl gh" "${command[@]}" 2>&1)" || status=$?
-    if [[ "$status" -eq 0 ]]; then
-        [[ -z "$output" ]] || printf '%s\n' "$output"
-        printf "  GitHub Project '%s': Status, Priority, Area, Size, Initiative fields configured.\n" "$project_title"
-        return 0
-    fi
-    if [[ "$status" -eq 3 ]]; then
-        log_warn "GitHub Project metadata skipped for '$repo'."
-        [[ -z "$output" ]] || log_warn "$output"
-        return 0
-    fi
-
-    [[ -z "$output" ]] || log_error "$output"
-    log_error "Unable to configure GitHub Project metadata for '$repo'."
-    return 1
-}
-
-base_repo_configure_github() {
-    local applied_labels=()
-    local dry_run="$1"
-    local labels=()
-    local protect_default_branch="${3:-1}"
-    local repo="$2"
-    local status=0
-
-    if [[ "$dry_run" == "1" ]]; then
-        printf "[DRY-RUN] Would run: gh repo edit %s --enable-issues --enable-projects --enable-squash-merge --enable-merge-commit=false --enable-rebase-merge=false --delete-branch-on-merge --squash-merge-commit-message pr-title-description\n" "$repo"
-    else
-        base_repo_require_gh || return 1
-        base_repo_warn_if_gh_outdated
-        printf "Configuring GitHub repository '%s'...\n" "$repo"
-        gh repo edit "$repo" \
-            --enable-issues \
-            --enable-projects \
-            --enable-squash-merge \
-            --enable-merge-commit=false \
-            --enable-rebase-merge=false \
-            --delete-branch-on-merge \
-            --squash-merge-commit-message pr-title-description || return 1
-        printf "  Repository settings: applied.\n"
-    fi
-
-    base_repo_configure_label "$dry_run" bug "d73a4a" "Something is not working" "$repo" && applied_labels+=(bug) || status=1
-    base_repo_configure_label "$dry_run" enhancement "a2eeef" "New feature or product improvement" "$repo" && applied_labels+=(enhancement) || status=1
-    base_repo_configure_label "$dry_run" documentation "0075ca" "Documentation improvements" "$repo" && applied_labels+=(documentation) || status=1
-    base_repo_configure_label "$dry_run" ci "0e8a16" "Continuous integration, tests, automation, or release workflows" "$repo" && applied_labels+=(ci) || status=1
-    base_repo_configure_label "$dry_run" security "ee0701" "Security hardening or vulnerability work" "$repo" && applied_labels+=(security) || status=1
-    base_repo_configure_label "$dry_run" needs-demo "fbca04" "Change should update a project demo" "$repo" && applied_labels+=(needs-demo) || status=1
-    if [[ "$dry_run" != "1" && "${#applied_labels[@]}" -gt 0 ]]; then
-        labels=("${applied_labels[@]}")
-        printf "  Labels: "
-        base_repo_join_csv "${labels[@]}"
-        printf " (%d applied).\n" "${#labels[@]}"
-    fi
-    if [[ "$protect_default_branch" == "1" ]]; then
-        base_repo_configure_default_branch_protection "$dry_run" "$repo" || status=1
-    fi
-
-    return "$status"
 }
 
 base_repo_pr_branch_name() {
@@ -2242,6 +1929,7 @@ base_repo_init() {
             github_repo="$(base_repo_infer_github_repo "$root" || true)"
         fi
         if [[ -n "$github_repo" ]]; then
+            base_repo_load_github_settings || return 1
             base_repo_ensure_github_repo "$dry_run" "$github_repo" "$description" "$github_visibility" || return 1
             base_repo_configure_github "$dry_run" "$github_repo" "$protect_default_branch" || return 1
             if ((configure_project)); then
@@ -2657,6 +2345,7 @@ base_repo_configure() {
         base_repo_write_project_support_files "$dry_run" "$path" || return 1
     fi
 
+    base_repo_load_github_settings || return 1
     base_repo_configure_github "$dry_run" "$github_repo" "$protect_default_branch" || return 1
     if ((configure_project)); then
         [[ -n "$project_title" ]] || project_title="$(base_repo_default_project_title "$github_repo")"

--- a/cli/bash/commands/basectl/subcommands/repo_github_settings.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_github_settings.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_repo_github_settings_sourced:-}" ]] && return 0
+_base_repo_github_settings_sourced=1
+readonly _base_repo_github_settings_sourced
+
+base_repo_homebrew_gh_outdated() {
+    local output=""
+
+    command -v brew >/dev/null 2>&1 || return 1
+    HOMEBREW_NO_AUTO_UPDATE=1 brew list gh >/dev/null 2>&1 || return 1
+    output="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated gh 2>/dev/null || true)"
+    printf '%s\n' "$output" | awk '$1 == "gh" { found = 1 } END { exit found ? 0 : 1 }'
+}
+
+base_repo_warn_if_gh_outdated() {
+    if base_repo_homebrew_gh_outdated; then
+        log_warn "GitHub CLI 'gh' is outdated; run 'basectl setup --profile dev' to upgrade Base-managed developer prerequisites."
+    fi
+}
+
+base_repo_configure_label() {
+    local color="$3"
+    local description="$4"
+    local dry_run="$1"
+    local label="$2"
+    local repo="$5"
+    local quoted_description
+
+    if [[ "$dry_run" == "1" ]]; then
+        quoted_description="$(base_repo_pretty_quote "$description")"
+        printf "[DRY-RUN] Would run: gh label create %s --repo %s --color %s --description %s --force\n" \
+            "$label" "$repo" "$color" "$quoted_description"
+        return 0
+    fi
+
+    gh label create "$label" --repo "$repo" --color "$color" --description "$description" --force || return 1
+    printf "  Label: %s (created or updated).\n" "$label"
+}
+
+base_repo_ensure_github_repo() {
+    local description="$3"
+    local dry_run="$1"
+    local repo="$2"
+    local visibility="$4"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would create %s GitHub repository '%s' if it does not already exist.\n" "$visibility" "$repo"
+        return 0
+    fi
+
+    base_repo_require_gh || return 1
+    if gh repo view "$repo" >/dev/null 2>&1; then
+        log_info "GitHub repository '$repo' already exists."
+        return 0
+    fi
+
+    log_info "Creating $visibility GitHub repository '$repo'."
+    gh repo create "$repo" "--$visibility" --description "$description"
+}
+
+base_repo_default_branch_ruleset_payload() {
+    cat <<'JSON'
+{"name":"Base default branch protection","target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},"rules":[{"type":"pull_request","parameters":{"allowed_merge_methods":["squash"],"dismiss_stale_reviews_on_push":false,"require_code_owner_review":false,"require_last_push_approval":false,"required_approving_review_count":0,"required_review_thread_resolution":false}},{"type":"deletion"},{"type":"non_fast_forward"}]}
+JSON
+}
+
+base_repo_rulesets_plan_gated_error() {
+    local message="$1"
+
+    [[ "$message" == *"Upgrade to GitHub Pro"* ]] &&
+        [[ "$message" == *"make this repository public"* ]] &&
+        [[ "$message" == *"(HTTP 403)"* ]]
+}
+
+base_repo_configure_default_branch_protection() {
+    local dry_run="$1"
+    local payload
+    local repo="$2"
+    local ruleset_lookup_output=""
+    local ruleset_id=""
+
+    payload="$(base_repo_default_branch_ruleset_payload)"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would create or update GitHub ruleset 'Base default branch protection' on '%s' targeting '~DEFAULT_BRANCH'.\n" "$repo"
+        printf "[DRY-RUN] Would run: gh api repos/%s/rulesets --jq %s\n" \
+            "$repo" \
+            "$(base_repo_pretty_quote 'map(select(.name == "Base default branch protection" and .source_type == "Repository")) | .[0].id // ""')"
+        printf "[DRY-RUN] Would run: gh api repos/%s/rulesets --method POST --input -\n" "$repo"
+        printf "[DRY-RUN] Payload: %s\n" "$payload"
+        return 0
+    fi
+
+    base_repo_require_gh || return 1
+    ruleset_lookup_output="$(gh api "repos/$repo/rulesets" \
+        --jq 'map(select(.name == "Base default branch protection" and .source_type == "Repository")) | .[0].id // ""' 2>&1)" || {
+        if base_repo_rulesets_plan_gated_error "$ruleset_lookup_output"; then
+            log_warn "Default branch protection skipped for '$repo'."
+            log_warn "$ruleset_lookup_output"
+            return 0
+        fi
+        [[ -z "$ruleset_lookup_output" ]] || log_error "$ruleset_lookup_output"
+        log_error "Unable to inspect GitHub rulesets for '$repo'."
+        return 1
+    }
+    ruleset_id="$ruleset_lookup_output"
+
+    if [[ -n "$ruleset_id" ]]; then
+        printf '%s\n' "$payload" | gh api "repos/$repo/rulesets/$ruleset_id" --method PUT --input - || {
+            log_error "Unable to update Base default branch protection ruleset for '$repo'."
+            return 1
+        }
+        printf "  Branch protection: updated 'Base default branch protection'.\n"
+    else
+        printf '%s\n' "$payload" | gh api "repos/$repo/rulesets" --method POST --input - || {
+            log_error "Unable to create Base default branch protection ruleset for '$repo'."
+            return 1
+        }
+        printf "  Branch protection: created 'Base default branch protection'.\n"
+    fi
+}
+
+base_repo_default_project_title() {
+    local repo="$1"
+
+    printf '%s\n' "${repo#*/}"
+}
+
+base_repo_project_owner_from_repo() {
+    local repo="$1"
+
+    printf '%s\n' "${repo%%/*}"
+}
+
+base_repo_project_config_path() {
+    local root="$1"
+    local path="$root/.github/base-project.yml"
+
+    if [[ -f "$path" ]]; then
+        printf '%s\n' "$path"
+    fi
+}
+
+base_repo_project_intake_secret_fix_command() {
+    local repo="$1"
+
+    printf 'gh auth token | gh secret set BASE_PROJECT_TOKEN --repo %s\n' "$repo"
+}
+
+base_repo_secret_list_has_project_token() {
+    awk '
+        $1 == "BASE_PROJECT_TOKEN" { found = 1 }
+        END { exit found ? 0 : 1 }
+    '
+}
+
+base_repo_check_project_intake_secret() {
+    local dry_run="$1"
+    local output=""
+    local repo="$2"
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would verify GitHub Actions secret 'BASE_PROJECT_TOKEN' exists for '%s'.\n" "$repo"
+        return 0
+    fi
+
+    base_repo_require_gh || return 1
+    output="$(gh secret list --repo "$repo" 2>&1)" || {
+        log_warn "Unable to inspect GitHub Actions secrets for '$repo'."
+        [[ -z "$output" ]] || log_warn "$output"
+        log_warn "Project Intake may fail unless BASE_PROJECT_TOKEN is configured with user Project access."
+        log_warn "Fix: $(base_repo_project_intake_secret_fix_command "$repo")"
+        return 0
+    }
+
+    if printf '%s\n' "$output" | base_repo_secret_list_has_project_token; then
+        return 0
+    fi
+
+    log_warn "Project Intake secret 'BASE_PROJECT_TOKEN' is not configured for '$repo'."
+    log_warn "GitHub Actions default token cannot access user-level Projects."
+    log_warn "Fix: $(base_repo_project_intake_secret_fix_command "$repo")"
+}
+
+base_repo_configure_project_metadata() {
+    local dry_run="$1"
+    local config_path="$6"
+    local copy_fields_from_project="$7"
+    local replace_project="$8"
+    local option
+    local owner="$4"
+    local output=""
+    local project_title="$3"
+    local repo="$2"
+    local schema="$5"
+    local status=0
+    local wrapper="${BASE_REPO_PROJECT_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
+    shift 8
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would configure GitHub Project '%s' for '%s'.\n" "$project_title" "$repo"
+        if [[ "$replace_project" == "1" ]]; then
+            printf "[DRY-RUN] Would replace nonstandard existing GitHub Project '%s' from 'base-project-template'.\n" "$project_title"
+        else
+            printf "[DRY-RUN] Would copy GitHub Project 'base-project-template' to '%s' if missing.\n" "$project_title"
+        fi
+        printf "[DRY-RUN] Would link GitHub Project '%s' to repository '%s'.\n" "$project_title" "$repo"
+        printf "[DRY-RUN] Would backfill issues from '%s' into GitHub Project '%s'.\n" "$repo" "$project_title"
+        if [[ -n "$config_path" ]]; then
+            printf "[DRY-RUN] Would read GitHub Project config from '%s'.\n" "$config_path"
+            printf "[DRY-RUN] Would apply issue defaults from '%s' to missing Project item fields.\n" "$config_path"
+        fi
+        if [[ -n "$copy_fields_from_project" ]]; then
+            printf "[DRY-RUN] Would copy missing Project item field values from '%s' into '%s'.\n" \
+                "$copy_fields_from_project" \
+                "$project_title"
+        fi
+        base_repo_check_project_intake_secret "$dry_run" "$repo"
+        printf "[DRY-RUN] Would run: %s --project base base_github_projects project configure --project %s --owner %s --repo %s --schema %s" \
+            "$wrapper" \
+            "$(base_repo_pretty_arg "$project_title")" \
+            "$owner" \
+            "$repo" \
+            "$schema"
+        if [[ -n "$config_path" ]]; then
+            printf " --config %s" "$(base_repo_pretty_arg "$config_path")"
+        fi
+        if [[ -n "$copy_fields_from_project" ]]; then
+            printf " --copy-fields-from %s" "$(base_repo_pretty_arg "$copy_fields_from_project")"
+        fi
+        if [[ "$replace_project" == "1" ]]; then
+            printf " --replace-project"
+        fi
+        for option in "$@"; do
+            printf " --initiative-option %s" "$(base_repo_pretty_arg "$option")"
+        done
+        printf "\n"
+        printf "[DRY-RUN] Project fields: Status, Priority, Area, Size, Initiative\n"
+        return 0
+    fi
+
+    [[ -x "$wrapper" ]] || {
+        log_error "Base Python wrapper '$wrapper' is missing or is not executable."
+        return 1
+    }
+    base_repo_check_project_intake_secret "$dry_run" "$repo" || return 1
+
+    local command=(
+        "$wrapper"
+        --project base
+        base_github_projects
+        project
+        configure
+        --project "$project_title"
+        --owner "$owner"
+        --repo "$repo"
+        --schema "$schema"
+    )
+    if [[ -n "$config_path" ]]; then
+        command+=(--config "$config_path")
+    fi
+    if [[ -n "$copy_fields_from_project" ]]; then
+        command+=(--copy-fields-from "$copy_fields_from_project")
+    fi
+    if [[ "$replace_project" == "1" ]]; then
+        command+=(--replace-project)
+    fi
+    for option in "$@"; do
+        command+=(--initiative-option "$option")
+    done
+
+    log_info "Configuring GitHub Project '$project_title' for '$repo'."
+    log_info "Running: $(base_repo_pretty_command "${command[@]}")"
+    output="$(BASE_CLI_DISPLAY_COMMAND="basectl gh" "${command[@]}" 2>&1)" || status=$?
+    if [[ "$status" -eq 0 ]]; then
+        [[ -z "$output" ]] || printf '%s\n' "$output"
+        printf "  GitHub Project '%s': Status, Priority, Area, Size, Initiative fields configured.\n" "$project_title"
+        return 0
+    fi
+    if [[ "$status" -eq 3 ]]; then
+        log_warn "GitHub Project metadata skipped for '$repo'."
+        [[ -z "$output" ]] || log_warn "$output"
+        return 0
+    fi
+
+    [[ -z "$output" ]] || log_error "$output"
+    log_error "Unable to configure GitHub Project metadata for '$repo'."
+    return 1
+}
+
+base_repo_configure_github() {
+    local applied_labels=()
+    local dry_run="$1"
+    local labels=()
+    local protect_default_branch="${3:-1}"
+    local repo="$2"
+    local status=0
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf "[DRY-RUN] Would run: gh repo edit %s --enable-issues --enable-projects --enable-squash-merge --enable-merge-commit=false --enable-rebase-merge=false --delete-branch-on-merge --squash-merge-commit-message pr-title-description\n" "$repo"
+    else
+        base_repo_require_gh || return 1
+        base_repo_warn_if_gh_outdated
+        printf "Configuring GitHub repository '%s'...\n" "$repo"
+        gh repo edit "$repo" \
+            --enable-issues \
+            --enable-projects \
+            --enable-squash-merge \
+            --enable-merge-commit=false \
+            --enable-rebase-merge=false \
+            --delete-branch-on-merge \
+            --squash-merge-commit-message pr-title-description || return 1
+        printf "  Repository settings: applied.\n"
+    fi
+
+    base_repo_configure_label "$dry_run" bug "d73a4a" "Something is not working" "$repo" && applied_labels+=(bug) || status=1
+    base_repo_configure_label "$dry_run" enhancement "a2eeef" "New feature or product improvement" "$repo" && applied_labels+=(enhancement) || status=1
+    base_repo_configure_label "$dry_run" documentation "0075ca" "Documentation improvements" "$repo" && applied_labels+=(documentation) || status=1
+    base_repo_configure_label "$dry_run" ci "0e8a16" "Continuous integration, tests, automation, or release workflows" "$repo" && applied_labels+=(ci) || status=1
+    base_repo_configure_label "$dry_run" security "ee0701" "Security hardening or vulnerability work" "$repo" && applied_labels+=(security) || status=1
+    base_repo_configure_label "$dry_run" needs-demo "fbca04" "Change should update a project demo" "$repo" && applied_labels+=(needs-demo) || status=1
+    if [[ "$dry_run" != "1" && "${#applied_labels[@]}" -gt 0 ]]; then
+        labels=("${applied_labels[@]}")
+        printf "  Labels: "
+        base_repo_join_csv "${labels[@]}"
+        printf " (%d applied).\n" "${#labels[@]}"
+    fi
+    if [[ "$protect_default_branch" == "1" ]]; then
+        base_repo_configure_default_branch_protection "$dry_run" "$repo" || status=1
+    fi
+
+    return "$status"
+}

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -459,6 +459,26 @@ EOF
     fi
 }
 
+@test "basectl repo GitHub settings implementation is split from repo dispatcher" {
+    local dispatcher="$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/repo.sh"
+    local helper="$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/repo_github_settings.sh"
+
+    [ -f "$helper" ]
+    grep -Fq "repo_github_settings.sh" "$dispatcher"
+    grep -Eq '^base_repo_configure_github\(\)' "$helper"
+    grep -Eq '^base_repo_configure_default_branch_protection\(\)' "$helper"
+    grep -Eq '^base_repo_configure_project_metadata\(\)' "$helper"
+    if grep -Eq '^base_repo_configure_github\(\)' "$dispatcher"; then
+        fail "repo dispatcher should not define base_repo_configure_github"
+    fi
+    if grep -Eq '^base_repo_default_branch_ruleset_payload\(\)' "$dispatcher"; then
+        fail "repo dispatcher should not define Base ruleset payload helpers"
+    fi
+    if grep -Eq '^base_repo_configure_project_metadata\(\)' "$dispatcher"; then
+        fail "repo dispatcher should not define Project metadata delegation"
+    fi
+}
+
 @test "basectl repo init missing name shows focused usage and example" {
     run_basectl repo init --repo codeforester/bankbuddy --pr
 

--- a/docs/repo-command-ownership.md
+++ b/docs/repo-command-ownership.md
@@ -1,7 +1,7 @@
 # `basectl repo` Ownership Map
 
 Status: maintained implementation boundary map
-Last reviewed: 2026-06-27
+Last reviewed: 2026-07-14
 
 `basectl repo` has grown from local baseline generation into a mixed local and
 GitHub workflow surface. This page maps the current responsibilities so future
@@ -16,9 +16,9 @@ refactors can reduce `repo.sh` safely without changing public command behavior.
 | Local baseline file generation | `repo init`, `repo check` | Bash | Keep file writes in Bash for now; extract stable writer groups only when the file set is already well-covered by BATS. |
 | Agent guidance generation | `repo agent-guidance` | Bash helper | Extracted to `repo_agent_guidance.sh`; it still uses shared repo path, write, and PR helpers from `repo.sh`. |
 | Installer template generation | `repo installer-template` | Bash helper | Extracted to `repo_installer_template.sh`; it still uses shared repo path, write, and PR helpers from `repo.sh`. |
-| GitHub repository settings and labels | `repo init`, `repo configure` | Bash calling `gh` | Keep the orchestration in Bash short-term. Move structured payload construction behind Python only when behavior needs richer validation or reusable JSON construction. |
-| Default branch protection | `repo configure` | Bash calling `gh api` | Candidate for Python helper if ruleset payloads grow or need deeper schema tests. |
-| GitHub Project metadata | `repo init`, `repo configure` | Bash delegating to Python Project engine | Continue moving Project semantics into `base_github_projects`; Bash should only collect flags, locate repo config, and report wrapper output. |
+| GitHub repository settings and labels | `repo init`, `repo configure` | Bash helper | Extracted to `repo_github_settings.sh`; keep `gh` orchestration in Bash short-term and move structured payload construction behind Python only when behavior needs richer validation or reusable JSON construction. |
+| Default branch protection | `repo configure` | Bash helper calling `gh api` | Extracted to `repo_github_settings.sh`; still a Python candidate if ruleset payloads grow or need deeper schema tests. |
+| GitHub Project metadata | `repo init`, `repo configure` | Bash helper delegating to Python Project engine | `repo_github_settings.sh` owns wrapper handoff and messaging. Continue moving Project semantics into `base_github_projects`; Bash should only collect flags, locate repo config, and report wrapper output. |
 | PR branch and generated PR creation | `repo init --pr`, `repo agent-guidance --pr`, `repo installer-template --pr` | Bash | Keep shared PR worktree and branch mechanics in Bash while Git remains the underlying tool. Extract generated PR body helpers by command as each command moves out. |
 | Clone planning and `gh repo clone` handoff | `repo clone` | Bash | Keep in Bash unless clone config parsing moves into a general repo config parser. |
 
@@ -48,9 +48,15 @@ the generated guidance file content, command parsing, generated PR body, and
 agent-guidance PR finish path while still reusing shared repo path, Git,
 dry-run, logging, and PR worktree primitives from `repo.sh`.
 
+The third split moves GitHub repository settings, labels, Base-managed default
+branch protection ruleset handling, repository creation, and Project metadata
+delegation into `cli/bash/commands/basectl/subcommands/repo_github_settings.sh`.
+The helper still reuses shared repo formatting, `gh` readiness, path, and
+project-support file helpers from `repo.sh`; this keeps `repo init` and
+`repo configure` behavior unchanged while separating GitHub-side configuration
+from local baseline generation.
+
 Follow-up candidates:
 
-- Separate GitHub repository settings and branch-protection payload helpers
-  from local baseline generation.
 - Continue reducing Project-specific logic in Bash by delegating schema and
   field behavior to the Python Project engine.


### PR DESCRIPTION
## Summary
- move `basectl repo` GitHub-side repository settings, labels, ruleset handling, repo creation, and Project metadata delegation into `repo_github_settings.sh`
- keep shared path, formatting, `gh` readiness, PR, and local baseline primitives in `repo.sh`
- update the repo ownership map and add structural BATS coverage for the new helper boundary

Refs #1563

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats`
- `bash -n cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/repo_github_settings.sh`
- `shellcheck -S error cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/repo_github_settings.sh`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_base_cli_docs.py tests/test_contract_hardening.py -q`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1563-full ./bin/base-test`