### PR TITLE
Preserve manifest fields during user config merging

### DIFF
--- a/cli/python/base_setup/setup_reconcile.py
+++ b/cli/python/base_setup/setup_reconcile.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import base_cli
 from base_cli.config import UserConfig
 
@@ -95,24 +97,7 @@ def project_runtime_argument(manifest: BaseManifest) -> ProjectRuntimeConfig:
 
 
 def effective_manifest_with_user_config(manifest: BaseManifest, user_config: UserConfig) -> BaseManifest:
-    return BaseManifest(
-        path=manifest.path,
-        project_name=manifest.project_name,
-        brewfile=manifest.brewfile,
-        artifacts=manifest.artifacts,
-        ide=effective_ide_config(manifest.ide, user_config),
-        mise=manifest.mise,
-        test=manifest.test,
-        schema_version=manifest.schema_version,
-        health=manifest.health,
-        commands=manifest.commands,
-        activate=manifest.activate,
-        python=manifest.python,
-        github=manifest.github,
-        demo=manifest.demo,
-        build=manifest.build,
-        release=manifest.release,
-    )
+    return replace(manifest, ide=effective_ide_config(manifest.ide, user_config))
 
 
 def setup_artifacts(default_manifest: BaseManifest, manifest: BaseManifest) -> tuple:

--- a/cli/python/base_setup/tests/test_user_ide_preferences.py
+++ b/cli/python/base_setup/tests/test_user_ide_preferences.py
@@ -4,16 +4,59 @@ import json
 import os
 import tempfile
 import unittest
+from dataclasses import fields
+from dataclasses import replace
 from pathlib import Path
 from unittest import mock
 
 from base_cli.config import UserConfig, UserIdeConfig, UserIdePreference
 from base_setup import engine, ide
 from base_setup.github_manifest import GithubConfig, GithubPrConfig
-from base_setup.manifest import BaseManifest, IdeConfig
+from base_setup.manifest import BaseManifest, IdeConfig, read_manifest
 from base_setup.tests.helpers import fake_context
 
 class UserIdePreferenceMergeTests(unittest.TestCase):
+
+    def test_effective_manifest_preserves_parsed_project_languages(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "base_manifest.yaml"
+            manifest_path.write_text(
+                "project:\n"
+                "  name: demo\n"
+                "  languages:\n"
+                "    - python\n"
+                "    - golang\n"
+                "artifacts: []\n",
+                encoding="utf-8",
+            )
+            manifest = read_manifest(manifest_path)
+
+        user_config = UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))
+
+        effective = engine.effective_manifest_with_user_config(manifest, user_config)
+
+        self.assertEqual(effective.project_languages, ("python", "go"))
+
+    def test_effective_manifest_preserves_every_non_ide_field(self) -> None:
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+        preserved_fields = {
+            field.name: object()
+            for field in fields(BaseManifest)
+            if field.name != "ide"
+        }
+        manifest = replace(manifest, **preserved_fields)
+        user_config = UserConfig(raw={}, ide=UserIdeConfig(enabled=None, preferences={}))
+
+        effective = engine.effective_manifest_with_user_config(manifest, user_config)
+
+        for field_name, expected in preserved_fields.items():
+            with self.subTest(field=field_name):
+                self.assertIs(getattr(effective, field_name), expected)
 
     def test_effective_ide_config_adds_user_extensions_and_settings(self) -> None:
         manifest = BaseManifest(


### PR DESCRIPTION
## Summary

- Preserve every non-IDE BaseManifest field when applying user-local IDE preferences.
- Replace brittle whole-object reconstruction with an immutable dataclasses.replace update.
- Add regression coverage for parsed project.languages and a future-field preservation invariant.

## Issue

Fixes #1607

## Validation

- Focused setup reconciliation and manifest parsing tests: 64 passed, 123 subtests passed.
- Full Python suite: 891 passed, 1 skipped.
- Pylint passed for both touched Python files.
- git diff --check origin/main...HEAD passed.

## Demo Impact

None.

## Notes

.ai-context/ is unchanged because this fixes preservation inside an existing merge boundary without changing the manifest schema, command surface, architecture, or public behavior contract.

## Checklist

- [x] Branch name follows the repository convention.
- [x] PR is scoped to one issue.
- [x] Validation ran from the issue worktree.
- [x] Regression proof and the full Python suite pass.
- [x] Documentation changes are not required.
- [x] AI context applicability is explained.
- [x] PR includes Fixes #1607.
- [x] Demo impact is stated.