### PR TITLE
Replace tab-delimited Python-to-Bash command metadata with a structured protocol

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -54,6 +54,16 @@ an explicit Bash script, or an interactive Base runtime shell.
 with the selected project virtual environment and a `PYTHONPATH` that includes
 Base's `lib/python` and `cli/python`.
 
+When Bash needs metadata from `base_projects` or the `base_setup` route action,
+it requests the internal versioned `command-protocol` format. Records have
+explicit schemas, field names, string/boolean/null types, and hex-framed UTF-8
+strings, so tabs, spaces, Unicode, newlines, and control bytes cannot change
+field boundaries. Bash validates the full record before use and never falls
+back to positional TSV parsing. Human-facing default text output remains
+unchanged. The runtime decoder is pure Bash and needs neither `jq` nor a second
+Python process; standalone Bash and Zsh completion have narrow readers for the
+same `project-list-entry` records, with the Bash reader remaining Bash-3-safe.
+
 ## Environment Layers
 
 Base separates shell startup from runtime activation:

--- a/.ai-context/DECISIONS.md
+++ b/.ai-context/DECISIONS.md
@@ -36,6 +36,10 @@ architecture discussion.
   reusable CLI behavior.
 - Python CLIs run through `base-wrapper` so venv and `PYTHONPATH` behavior is
   consistent.
+- Python-to-Bash command metadata uses the strict versioned
+  `BASE_COMMAND_PROTOCOL_V1` transport with named typed fields. Bash callers
+  request it explicitly, validate it without `jq`, and do not fall back to
+  positional tab-delimited parsing; default text output remains human-facing.
 - Base shell code should use explicit error handling and should not rely on
   `set -e`, `set -u`, or `set -o pipefail`.
 - Base treats remote-installer consent and integrity as separate decisions.

--- a/base_init.sh
+++ b/base_init.sh
@@ -286,6 +286,18 @@ base_init_source_stdlib() {
     source "$stdlib_path"
 }
 
+base_init_source_command_protocol() {
+    local protocol_path="$BASE_HOME/lib/bash/runtime/command_protocol.sh"
+
+    [[ -f "$protocol_path" ]] || {
+        base_init_error "Base command protocol helper '$protocol_path' was not found."
+        return 1
+    }
+
+    # shellcheck source=/dev/null
+    source "$protocol_path"
+}
+
 import_base_lib() {
     local relative_path="${1:-}"
     local lib_path
@@ -310,6 +322,7 @@ base_init_main() {
     base_init_require_bash || return 1
     base_init_export_contract || return 1
     base_init_source_stdlib "$@" || return 1
+    base_init_source_command_protocol || return 1
 
     add_to_path -p "$BASE_BIN_DIR"
     export PATH

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -13,12 +13,19 @@ BASECTL_REQUIRED_HOME_FILES=(
     lib/shell/bashrc
     lib/shell/baserc_guard.sh
     lib/bash/runtime/bashrc
+    lib/bash/runtime/command_protocol.sh
     lib/bash/version/lib_version.sh
     bin/basectl
     bin/base-wrapper
     cli/bash/commands/basectl/basectl.sh
 )
 readonly BASECTL_REQUIRED_HOME_FILES
+
+if ! declare -F base_command_protocol_decode_one >/dev/null 2>&1 &&
+    [[ -n "${BASE_HOME:-}" && -f "$BASE_HOME/lib/bash/runtime/command_protocol.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$BASE_HOME/lib/bash/runtime/command_protocol.sh"
+fi
 
 basectl_error() {
     printf 'ERROR: %s\n' "$*" >&2
@@ -421,8 +428,9 @@ basectl_default_activate_project() {
     local resolve_output project_name
 
     if [[ -x "$wrapper" ]]; then
-        if resolve_output="$("$wrapper" --project base base_projects current 2>/dev/null)"; then
-            IFS=$'\t' read -r project_name _ <<<"$resolve_output"
+        if resolve_output="$("$wrapper" --project base base_projects current --format command-protocol 2>/dev/null)" &&
+            base_command_protocol_decode_one project-reference "$resolve_output" 2>/dev/null; then
+            project_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
             if [[ -n "$project_name" ]]; then
                 printf '%s\n' "$project_name"
                 return 0

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -33,16 +33,16 @@ base_activate_resolve_project() {
     local wrapper="$2"
     shift 2
 
-    env -u BASE_PROJECT_VENV_DIR "$wrapper" --project base base_projects resolve "$project" "$@"
+    env -u BASE_PROJECT_VENV_DIR \
+        "$wrapper" --project base base_projects resolve "$project" "$@" --format command-protocol
 }
 
 base_activate_project_venv_dir() {
     local project="$1"
     local project_root="${2:-}"
-    local manifest_path="${3:-}"
-    shift 3
+    local route_venv_dir="${3:-}"
 
-    base_project_venv_dir "$project" "$project_root" "$manifest_path" "$@"
+    base_project_venv_dir "$project" "$project_root" "$route_venv_dir"
 }
 
 base_activate_shell_is_bash() {
@@ -54,10 +54,9 @@ base_activate_shell_is_bash() {
 
 base_activate_subcommand_main() {
     local project="" wrapper resolve_output activate_shell venv_fix
-    local resolved_name project_root manifest_path venv_dir shell_rc
+    local resolved_name project_root manifest_path venv_dir shell_rc route_venv_dir uses_uv_manager trust_required
     local preserve_cwd="${BASE_ACTIVATE_PRESERVE_CWD:-0}"
     local args=()
-    local resolve_fields=()
 
     while (($# > 0)); do
         case "$1" in
@@ -109,19 +108,24 @@ base_activate_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     resolve_output="$(base_activate_resolve_project "$project" "$wrapper" "${args[@]}")" || return $?
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_name="${resolve_fields[0]:-}"
-    project_root="${resolve_fields[1]:-}"
-    manifest_path="${resolve_fields[2]:-}"
+    base_command_protocol_decode_one project-route "$resolve_output" || {
+        fatal_error "Unable to resolve project '$project'."
+    }
+    resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+    route_venv_dir="${BASE_COMMAND_PROTOCOL_FIELDS[project_venv_dir]}"
+    uses_uv_manager="${BASE_COMMAND_PROTOCOL_FIELDS[uses_uv_manager]}"
+    trust_required="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_command_trust_required]}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
         fatal_error "Unable to resolve project '$project'."
     }
 
-    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:3}" || return $?
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
 
-    venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root" "$manifest_path" "${resolve_fields[@]:3}")"
-    venv_fix="$(base_project_venv_fix "$resolved_name" "$project_root" "$venv_dir" "${resolve_fields[@]:3}")"
+    venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root" "$route_venv_dir")"
+    venv_fix="$(base_project_venv_fix "$resolved_name" "$project_root" "$venv_dir" "$uses_uv_manager")"
     [[ -x "$venv_dir/bin/python" ]] || {
         fatal_error "Project virtual environment Python was not found at '$venv_dir/bin/python'. $venv_fix"
     }

--- a/cli/bash/commands/basectl/subcommands/build.sh
+++ b/cli/bash/commands/basectl/subcommands/build.sh
@@ -33,56 +33,82 @@ base_build_usage_error() {
     return 2
 }
 
+base_build_print_target_record() {
+    local display_text
+    local resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    local target_name="${BASE_COMMAND_PROTOCOL_FIELDS[target_name]}"
+    local working_dir="${BASE_COMMAND_PROTOCOL_FIELDS[working_dir]}"
+    local build_command="${BASE_COMMAND_PROTOCOL_FIELDS[command]}"
+    local description="${BASE_COMMAND_PROTOCOL_FIELDS[description]}"
+    local command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
+
+    if ((printed_header == 0)); then
+        printf "Build targets for project '%s'\n\n" "$resolved_name"
+        printed_header=1
+    fi
+    if [[ -n "$description" ]]; then
+        display_text="$description"
+        if [[ -n "$command_runner" ]]; then
+            display_text+=" [runner: $command_runner]"
+        fi
+    else
+        display_text="$(base_display_command_with_runner "$command_runner" "$build_command")" || return $?
+    fi
+    printf '%-20s %-40s %s\n' "$target_name" "$working_dir" "$display_text"
+}
+
+base_build_run_target_record() {
+    local resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    local project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    local manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+    local route_venv_dir="${BASE_COMMAND_PROTOCOL_FIELDS[project_venv_dir]}"
+    local uses_uv_manager="${BASE_COMMAND_PROTOCOL_FIELDS[uses_uv_manager]}"
+    local trust_required="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_command_trust_required]}"
+    local target_name="${BASE_COMMAND_PROTOCOL_FIELDS[target_name]}"
+    local working_dir="${BASE_COMMAND_PROTOCOL_FIELDS[working_dir]}"
+    local build_command="${BASE_COMMAND_PROTOCOL_FIELDS[command]}"
+    local command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
+    local command_to_run display_command
+
+    command_to_run="$(base_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
+    display_command="$(base_display_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
+
+    if [[ "$dry_run" == "1" ]]; then
+        printf '[DRY-RUN] Would build target %q for project %q in %q: %s\n' \
+            "$target_name" "$resolved_name" "$working_dir" "$display_command"
+        return 0
+    fi
+
+    if ((environment_prepared == 0)); then
+        base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
+        base_project_activate_environment \
+            "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "$route_venv_dir" "$uses_uv_manager" >/dev/null
+        environment_prepared=1
+    fi
+
+    log_info "Building target '$target_name' for project '$resolved_name': $display_command"
+    base_validate_command_runner "$command_runner"
+    base_project_run_shell_command "$working_dir" "$command_to_run" basectl-build "${extra_args[@]}"
+}
+
 base_build_list_targets() {
     local project="$1"
     shift
     local args=("$@")
     local wrapper="$BASE_HOME/bin/base-wrapper"
-    local list_output line resolved_name project_root manifest_path target_name working_dir build_command description command_runner
-    local display_text
+    local list_output
     local printed_header=0
-    local target_fields=()
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
-    list_output="$("$wrapper" --project base base_projects build-target-list "$project" "${args[@]}")" || return $?
-    while IFS= read -r line; do
-        [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r -a target_fields <<<"$line"
-        resolved_name="${target_fields[0]:-}"
-        project_root="${target_fields[1]:-}"
-        manifest_path="${target_fields[2]:-}"
-        target_name="${target_fields[3]:-}"
-        working_dir="${target_fields[4]:-}"
-        build_command="${target_fields[5]:-}"
-        description="${target_fields[6]:-}"
-        command_runner="$(base_project_command_runner_from_field "${target_fields[7]:-}" || true)"
-        [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" ]] || {
-            fatal_error "Unable to parse build targets for project '$project'."
-        }
-        if ((printed_header == 0)); then
-            printf "Build targets for project '%s'\n\n" "$resolved_name"
-            printed_header=1
-        fi
-        command_runner="${command_runner:-}"
-        if [[ -n "$description" ]]; then
-            display_text="$description"
-            if [[ -n "$command_runner" ]]; then
-                display_text+=" [runner: $command_runner]"
-            fi
-        else
-            display_text="$(base_display_command_with_runner "$command_runner" "$build_command")" || return $?
-        fi
-        printf '%-20s %-40s %s\n' "$target_name" "$working_dir" "$display_text"
-    done <<<"$list_output"
+    list_output="$("$wrapper" --project base base_projects build-target-list "$project" "${args[@]}" --format command-protocol)" || return $?
+    base_command_protocol_each build-target "$list_output" base_build_print_target_record
 }
 
 base_build_subcommand_main() {
-    local project="" wrapper resolve_output line resolved_name project_root manifest_path target_name working_dir build_command description command_runner
-    local command_to_run display_command
+    local project="" wrapper resolve_output
     local dry_run=0 list_targets=0 workspace_requested=0 environment_prepared=0
     local args=() extra_args=() targets=()
-    local target_fields=()
 
     while (($#)); do
         case "$1" in
@@ -161,43 +187,8 @@ base_build_subcommand_main() {
     wrapper="$BASE_HOME/bin/base-wrapper"
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
-    resolve_output="$("$wrapper" --project base base_projects build-targets "$project" "${targets[@]}" "${args[@]}")" || return $?
+    resolve_output="$("$wrapper" --project base base_projects build-targets "$project" "${targets[@]}" "${args[@]}" --format command-protocol)" || return $?
     [[ -n "$resolve_output" ]] || fatal_error "Unable to resolve build targets for project '$project'."
 
-    resolved_name=""
-    while IFS= read -r line; do
-        [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r -a target_fields <<<"$line"
-        resolved_name="${target_fields[0]:-}"
-        project_root="${target_fields[1]:-}"
-        manifest_path="${target_fields[2]:-}"
-        target_name="${target_fields[3]:-}"
-        working_dir="${target_fields[4]:-}"
-        build_command="${target_fields[5]:-}"
-        description="${target_fields[6]:-}"
-        command_runner="$(base_project_command_runner_from_field "${target_fields[7]:-}" || true)"
-        [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$target_name" && -n "$working_dir" && -n "$build_command" ]] || {
-            fatal_error "Unable to parse build target '$target_name' for project '$project'."
-        }
-
-        command_runner="${command_runner:-}"
-        command_to_run="$(base_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
-        display_command="$(base_display_command_with_runner "$command_runner" "$build_command" "${extra_args[@]}")" || return $?
-
-        if [[ "$dry_run" == "1" ]]; then
-            printf '[DRY-RUN] Would build target %q for project %q in %q: %s\n' \
-                "$target_name" "$resolved_name" "$working_dir" "$display_command"
-            continue
-        fi
-
-        if ((environment_prepared == 0)); then
-            base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${target_fields[@]:7}" || return $?
-            base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${target_fields[@]:7}" >/dev/null
-            environment_prepared=1
-        fi
-
-        log_info "Building target '$target_name' for project '$resolved_name': $display_command"
-        base_validate_command_runner "$command_runner"
-        base_project_run_shell_command "$working_dir" "$command_to_run" basectl-build "${extra_args[@]}" || return $?
-    done <<<"$resolve_output"
+    base_command_protocol_each build-target "$resolve_output" base_build_run_target_record
 }

--- a/cli/bash/commands/basectl/subcommands/demo.sh
+++ b/cli/bash/commands/basectl/subcommands/demo.sh
@@ -35,7 +35,7 @@ base_demo_subcommand_main() {
     local quoted_demo_script command_to_run display_command
     local dry_run=0 workspace_requested=0
     local args=() extra_args=() project_args=()
-    local resolve_fields=()
+    local route_venv_dir uses_uv_manager trust_required
 
     while (($#)); do
         case "$1" in
@@ -95,13 +95,18 @@ base_demo_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     [[ -n "$project" ]] && project_args+=("$project")
-    resolve_output="$("$wrapper" --project base base_projects demo-script "${project_args[@]}" "${args[@]}")" || return $?
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_name="${resolve_fields[0]:-}"
-    project_root="${resolve_fields[1]:-}"
-    manifest_path="${resolve_fields[2]:-}"
-    demo_script="${resolve_fields[3]:-}"
-    command_runner="$(base_project_command_runner_from_field "${resolve_fields[4]:-}" || true)"
+    resolve_output="$("$wrapper" --project base base_projects demo-script "${project_args[@]}" "${args[@]}" --format command-protocol)" || return $?
+    base_command_protocol_decode_one demo "$resolve_output" || {
+        fatal_error "Unable to resolve demo script for project '${project:-current project}'."
+    }
+    resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+    route_venv_dir="${BASE_COMMAND_PROTOCOL_FIELDS[project_venv_dir]}"
+    uses_uv_manager="${BASE_COMMAND_PROTOCOL_FIELDS[uses_uv_manager]}"
+    trust_required="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_command_trust_required]}"
+    demo_script="${BASE_COMMAND_PROTOCOL_FIELDS[demo_script]}"
+    command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$demo_script" ]] || {
         fatal_error "Unable to resolve demo script for project '${project:-current project}'."
@@ -118,8 +123,9 @@ base_demo_subcommand_main() {
         return 0
     fi
 
-    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:4}" || return $?
-    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
+    base_project_activate_environment \
+        "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "$route_venv_dir" "$uses_uv_manager" >/dev/null
 
     log_info "Running demo for project '$resolved_name': $display_command"
     if [[ -z "$command_runner" ]]; then

--- a/cli/bash/commands/basectl/subcommands/devcontainer.sh
+++ b/cli/bash/commands/basectl/subcommands/devcontainer.sh
@@ -100,11 +100,19 @@ base_devcontainer_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     if [[ -n "$project" ]]; then
-        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${args[@]}")" || return $?
+        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${args[@]}" --format command-protocol)" || return $?
+        base_command_protocol_decode_one project-route "$resolve_output" || {
+            fatal_error "Unable to resolve project for devcontainer export."
+        }
     else
-        resolve_output="$("$wrapper" --project base base_projects current)" || return $?
+        resolve_output="$("$wrapper" --project base base_projects current --format command-protocol)" || return $?
+        base_command_protocol_decode_one project-reference "$resolve_output" || {
+            fatal_error "Unable to resolve project for devcontainer export."
+        }
     fi
-    IFS=$'\t' read -r resolved_name project_root manifest_path _ <<<"$resolve_output"
+    resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
         fatal_error "Unable to resolve project for devcontainer export."

--- a/cli/bash/commands/basectl/subcommands/devenv_report.sh
+++ b/cli/bash/commands/basectl/subcommands/devenv_report.sh
@@ -94,11 +94,19 @@ base_devenv_report_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     if [[ -n "$project" ]]; then
-        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${args[@]}")" || return $?
+        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${args[@]}" --format command-protocol)" || return $?
+        base_command_protocol_decode_one project-route "$resolve_output" || {
+            fatal_error "Unable to resolve project for devenv-report."
+        }
     else
-        resolve_output="$("$wrapper" --project base base_projects current)" || return $?
+        resolve_output="$("$wrapper" --project base base_projects current --format command-protocol)" || return $?
+        base_command_protocol_decode_one project-reference "$resolve_output" || {
+            fatal_error "Unable to resolve project for devenv-report."
+        }
     fi
-    IFS=$'\t' read -r resolved_name project_root manifest_path _ <<<"$resolve_output"
+    resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
         fatal_error "Unable to resolve project for devenv-report."

--- a/cli/bash/commands/basectl/subcommands/export_context.sh
+++ b/cli/bash/commands/basectl/subcommands/export_context.sh
@@ -35,7 +35,6 @@ base_export_context_subcommand_main() {
     local project="" wrapper resolve_output resolved_name project_root manifest_path
     local output_format="markdown" output_path="" print_bundle=0 list_files=0 workspace_requested=0
     local resolve_args=() exporter_args=()
-    local resolve_fields=()
     local arg
     # shellcheck disable=SC2034 # Passed by name to cli_parse_options.
     local -a option_specs=(
@@ -114,14 +113,19 @@ base_export_context_subcommand_main() {
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     if [[ -n "$project" ]]; then
-        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${resolve_args[@]}")" || return $?
+        resolve_output="$("$wrapper" --project base base_projects resolve "$project" "${resolve_args[@]}" --format command-protocol)" || return $?
+        base_command_protocol_decode_one project-route "$resolve_output" || {
+            fatal_error "Unable to resolve project for export-context."
+        }
     else
-        resolve_output="$("$wrapper" --project base base_projects current)" || return $?
+        resolve_output="$("$wrapper" --project base base_projects current --format command-protocol)" || return $?
+        base_command_protocol_decode_one project-reference "$resolve_output" || {
+            fatal_error "Unable to resolve project for export-context."
+        }
     fi
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_name="${resolve_fields[0]:-}"
-    project_root="${resolve_fields[1]:-}"
-    manifest_path="${resolve_fields[2]:-}"
+    resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
         fatal_error "Unable to resolve project for export-context."

--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -4,54 +4,16 @@
 _base_project_command_helpers_sourced=1
 readonly _base_project_command_helpers_sourced
 
-base_project_route_value() {
-    local marker="$1" field
-    shift
-
-    for field in "$@"; do
-        case "$field" in
-            "$marker"*)
-                printf '%s\n' "${field#"$marker"}"
-                return 0
-                ;;
-        esac
-    done
-    return 1
-}
-
-base_project_route_venv_dir() {
-    base_project_route_value "__base_project_venv_dir=" "$@"
-}
-
-base_project_route_uses_uv_manager() {
-    [[ "$(base_project_route_value "__base_uses_uv_manager=" "$@" || true)" == "true" ]]
-}
-
-base_project_route_manifest_command_trust_required() {
-    [[ "$(base_project_route_value "__base_manifest_command_trust_required=" "$@" || true)" == "true" ]]
-}
-
-base_project_command_runner_from_field() {
-    local candidate="${1:-}"
-
-    [[ -n "$candidate" ]] || return 1
-    [[ "$candidate" != __base_* ]] || return 1
-    printf '%s\n' "$candidate"
-}
-
 base_project_venv_dir() {
     local project="$1"
     local project_root="${2:-}"
-    local manifest_path="${3:-}"
-    local route_fields=("${@:4}")
-    local route_venv_dir=""
+    local route_venv_dir="${3:-}"
 
     if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
         printf '%s\n' "$BASE_PROJECT_VENV_DIR"
         return 0
     fi
 
-    route_venv_dir="$(base_project_route_venv_dir "${route_fields[@]}" || true)"
     if [[ -n "$route_venv_dir" ]]; then
         printf '%s\n' "$route_venv_dir"
         return 0
@@ -77,9 +39,9 @@ base_project_venv_fix() {
     local project="$1"
     local project_root="${2:-}"
     local venv_dir="${3:-}"
-    shift 3
+    local uses_uv_manager="${4:-false}"
 
-    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_project_route_uses_uv_manager "$@"; then
+    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" && "$uses_uv_manager" == true ]]; then
         printf "Run 'uv sync' in '%s' first." "$project_root"
         return 0
     fi
@@ -93,10 +55,10 @@ base_project_venv_fix() {
 base_project_require_manifest_command_trust() {
     local project="$1"
     local manifest_path="$2"
+    local trust_required="${3:-false}"
     local wrapper="$BASE_HOME/bin/base-wrapper"
-    shift 2
 
-    base_project_route_manifest_command_trust_required "$@" || return 0
+    [[ "$trust_required" == true ]] || return 0
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
     "$wrapper" --project base base_trust require "$project" --manifest "$manifest_path"
@@ -107,11 +69,12 @@ base_project_activate_environment() {
     local project_root="$2"
     local manifest_path="$3"
     local dry_run="${4:-0}"
-    local route_fields=("${@:5}")
+    local route_venv_dir="${5:-}"
+    local uses_uv_manager="${6:-false}"
     local venv_dir venv_fix
 
-    venv_dir="$(base_project_venv_dir "$project" "$project_root" "$manifest_path" "${route_fields[@]}")"
-    venv_fix="$(base_project_venv_fix "$project" "$project_root" "$venv_dir" "${route_fields[@]}")"
+    venv_dir="$(base_project_venv_dir "$project" "$project_root" "$route_venv_dir")"
+    venv_fix="$(base_project_venv_fix "$project" "$project_root" "$venv_dir" "$uses_uv_manager")"
     export BASE_PROJECT="$project"
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"

--- a/cli/bash/commands/basectl/subcommands/run.sh
+++ b/cli/bash/commands/basectl/subcommands/run.sh
@@ -32,33 +32,35 @@ base_run_usage_error() {
     return 2
 }
 
+base_run_print_command_record() {
+    local display_text
+    local resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    local command_name="${BASE_COMMAND_PROTOCOL_FIELDS[command_name]}"
+    local command_text="${BASE_COMMAND_PROTOCOL_FIELDS[command]}"
+    local command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
+
+    if ((printed_header == 0)); then
+        printf "Commands for project '%s'\n\n" "$resolved_name"
+        printed_header=1
+    fi
+    display_text="$(base_display_command_with_runner "$command_runner" "$command_text")" || return $?
+    printf '%-20s %s\n' "$command_name" "$display_text"
+}
+
 base_run_list_commands() {
     local project="$1"
     shift
     local args=("$@")
     local wrapper="$BASE_HOME/bin/base-wrapper"
     local command_args=(run-commands)
-    local list_output line resolved_name project_root manifest_path command_name command_text command_runner display_text
+    local list_output
     local printed_header=0
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
     [[ -z "$project" ]] || command_args+=("$project")
 
-    list_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}")" || return $?
-    while IFS= read -r line; do
-        [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r resolved_name project_root manifest_path command_name command_text command_runner <<<"$line"
-        [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$command_name" ]] || {
-            fatal_error "Unable to parse runnable commands for project '$project'."
-        }
-        if ((printed_header == 0)); then
-            printf "Commands for project '%s'\n\n" "$resolved_name"
-            printed_header=1
-        fi
-        command_runner="${command_runner:-}"
-        display_text="$(base_display_command_with_runner "$command_runner" "$command_text")" || return $?
-        printf '%-20s %s\n' "$command_name" "$display_text"
-    done <<<"$list_output"
+    list_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}" --format command-protocol)" || return $?
+    base_command_protocol_each named-command "$list_output" base_run_print_command_record
 }
 
 base_run_subcommand_main() {
@@ -66,7 +68,7 @@ base_run_subcommand_main() {
     local command_to_run display_command
     local dry_run=0 list_commands=0 workspace_requested=0
     local args=() extra_args=()
-    local resolve_fields=()
+    local route_venv_dir uses_uv_manager trust_required
 
     while (($#)); do
         case "$1" in
@@ -152,13 +154,18 @@ base_run_subcommand_main() {
     wrapper="$BASE_HOME/bin/base-wrapper"
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
 
-    resolve_output="$("$wrapper" --project base base_projects run-command "$project" "$command_name" "${args[@]}")" || return $?
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_name="${resolve_fields[0]:-}"
-    project_root="${resolve_fields[1]:-}"
-    manifest_path="${resolve_fields[2]:-}"
-    run_command="${resolve_fields[3]:-}"
-    command_runner="$(base_project_command_runner_from_field "${resolve_fields[4]:-}" || true)"
+    resolve_output="$("$wrapper" --project base base_projects run-command "$project" "$command_name" "${args[@]}" --format command-protocol)" || return $?
+    base_command_protocol_decode_one project-command "$resolve_output" || {
+        fatal_error "Unable to resolve command '$command_name' for project '$project'."
+    }
+    resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+    route_venv_dir="${BASE_COMMAND_PROTOCOL_FIELDS[project_venv_dir]}"
+    uses_uv_manager="${BASE_COMMAND_PROTOCOL_FIELDS[uses_uv_manager]}"
+    trust_required="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_command_trust_required]}"
+    run_command="${BASE_COMMAND_PROTOCOL_FIELDS[command]}"
+    command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$run_command" ]] || {
         fatal_error "Unable to resolve command '$command_name' for project '$project'."
@@ -174,8 +181,9 @@ base_run_subcommand_main() {
         return 0
     fi
 
-    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:4}" || return $?
-    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
+    base_project_activate_environment \
+        "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "$route_venv_dir" "$uses_uv_manager" >/dev/null
 
     log_info "Running command '$command_name' for project '$resolved_name': $display_command"
     base_validate_command_runner "$command_runner"

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -634,44 +634,53 @@ setup_base_check_metadata() {
 }
 
 setup_resolve_project_manifest() {
-    local project="$1"
+    local requested_project="$1"
     local python_bin="$2"
-    local resolve_fields=()
-    local resolve_output resolved_manifest resolved_name resolved_root
+    local output_name_var="$3"
+    local output_root_var="$4"
+    local output_manifest_var="$5"
+    local protocol_output result_manifest result_name result_root
 
     if [[ -n "${BASE_SETUP_MANIFEST:-}" ]]; then
-        if [[ -z "$project" ]]; then
+        if [[ -z "$requested_project" ]]; then
             setup_ensure_cached_paths
-            env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-                "$python_bin" -m base_projects manifest "$BASE_SETUP_MANIFEST"
-            return $?
+            protocol_output="$(
+                env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+                    "$python_bin" -m base_projects manifest "$BASE_SETUP_MANIFEST" --format command-protocol
+            )" || return $?
+            base_command_protocol_decode_one project-reference "$protocol_output" || return 1
+            result_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+            result_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+            result_manifest="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+        else
+            result_name="$requested_project"
+            result_manifest="$BASE_SETUP_MANIFEST"
+            result_root="$(setup_project_root_from_manifest "$result_manifest")" || return 1
         fi
-        printf '%s\n' "$BASE_SETUP_MANIFEST"
-        return 0
+    else
+        [[ -n "$requested_project" ]] || requested_project=base
+        if [[ "$requested_project" == base ]]; then
+            result_name=base
+            result_root="$BASE_HOME"
+            result_manifest="$BASE_HOME/base_manifest.yaml"
+        else
+            setup_ensure_cached_paths
+            protocol_output="$(
+                env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
+                    "$python_bin" -m base_projects resolve "$requested_project" --format command-protocol
+            )" || return 1
+            base_command_protocol_decode_one project-route "$protocol_output" || return 1
+            result_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+            result_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+            result_manifest="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+            [[ "$result_name" == "$requested_project" ]] || return 1
+        fi
     fi
 
-    if [[ -z "$project" ]]; then
-        project=base
-    fi
-
-    if [[ "$project" == base ]]; then
-        printf '%s\n' "$BASE_HOME/base_manifest.yaml"
-        return 0
-    fi
-
-    setup_ensure_cached_paths
-    resolve_output="$(
-        env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-            "$python_bin" -m base_projects resolve "$project"
-    )" || return 1
-
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_name="${resolve_fields[0]:-}"
-    resolved_root="${resolve_fields[1]:-}"
-    resolved_manifest="${resolve_fields[2]:-}"
-    [[ "$resolved_name" == "$project" && -n "$resolved_root" && -n "$resolved_manifest" ]] || return 1
-
-    printf '%s\t%s\t%s\n' "$resolved_name" "$resolved_root" "$resolved_manifest"
+    [[ -n "$result_name" && -n "$result_root" && -n "$result_manifest" ]] || return 1
+    printf -v "$output_name_var" '%s' "$result_name"
+    printf -v "$output_root_var" '%s' "$result_root"
+    printf -v "$output_manifest_var" '%s' "$result_manifest"
 }
 
 setup_project_venv_dir() {
@@ -697,7 +706,7 @@ setup_resolve_project_route() {
 
     setup_ensure_cached_paths
     env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-        "$python_bin" -m base_setup --manifest "$manifest_path" --action route "$project"
+        "$python_bin" -m base_setup --manifest "$manifest_path" --action route --format command-protocol "$project"
 }
 
 setup_project_check_record_path() {
@@ -994,10 +1003,9 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path platform precheck_json project project_uses_uv_manager project_venv_dir python_bin remote_network resolved_name resolved_root resolve_output route_output venv_dir
+    local exit_code manifest_path platform precheck_json project project_uses_uv_manager project_venv_dir python_bin remote_network resolved_root route_output venv_dir
     local args=()
     local project_env_args=()
-    local resolve_fields=()
 
     if setup_is_dry_run && ! setup_base_python_package_installed "$(setup_pyyaml_package)"; then
         log_info "[DRY-RUN] Would run Python project setup layer after PyYAML is installed."
@@ -1008,17 +1016,12 @@ setup_run_project_artifact_layer() {
     setup_ensure_cached_paths
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
-    resolve_output="$(setup_resolve_project_manifest "$project" "$python_bin")" || {
+    setup_resolve_project_manifest "$project" "$python_bin" project resolved_root manifest_path || {
         log_error "Unable to resolve Base project '$project'."
         log_error "Run 'basectl projects list' to see projects Base can discover."
         return 1
     }
-    if [[ "$resolve_output" == *$'\t'* ]]; then
-        IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-        resolved_name="${resolve_fields[0]:-}"
-        resolved_root="${resolve_fields[1]:-}"
-        manifest_path="${resolve_fields[2]:-}"
-        project="$resolved_name"
+    if [[ "$project" != base ]]; then
         if [[ "$output_format" != json ]]; then
             if [[ "$action" == setup ]]; then
                 log_info "Resolved project '$project' at '$resolved_root'."
@@ -1026,18 +1029,20 @@ setup_run_project_artifact_layer() {
                 log_debug "Resolved project '$project' at '$resolved_root'."
             fi
         fi
-    else
-        if [[ -z "$project" ]]; then
-            project=base
-        fi
-        manifest_path="$resolve_output"
-        resolved_root="$(setup_project_root_from_manifest "$manifest_path")" || return 1
     fi
     route_output="$(setup_resolve_project_route "$project" "$manifest_path" "$python_bin")" || {
         log_error "Unable to resolve Base project environment for '$project'."
         return 1
     }
-    IFS=$'\t' read -r project resolved_root manifest_path project_venv_dir project_uses_uv_manager <<<"$route_output"
+    base_command_protocol_decode_one project-route "$route_output" || {
+        log_error "Python project routing returned invalid metadata for '$project'."
+        return 1
+    }
+    project="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    resolved_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+    project_venv_dir="${BASE_COMMAND_PROTOCOL_FIELDS[project_venv_dir]}"
+    project_uses_uv_manager="${BASE_COMMAND_PROTOCOL_FIELDS[uses_uv_manager]}"
     if [[ -z "$project" || -z "$resolved_root" || -z "$manifest_path" || -z "$project_venv_dir" ]]; then
         log_error "Python project routing returned incomplete metadata for '$project'."
         return 1

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -35,7 +35,7 @@ base_test_subcommand_main() {
     local command_to_run display_command
     local dry_run=0 workspace_requested=0
     local args=() extra_args=()
-    local resolve_fields=()
+    local route_venv_dir uses_uv_manager trust_required
 
     while (($#)); do
         case "$1" in
@@ -95,13 +95,18 @@ base_test_subcommand_main() {
 
     local command_args=(test-command)
     [[ -z "$project" ]] || command_args+=("$project")
-    resolve_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}")" || return $?
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_name="${resolve_fields[0]:-}"
-    project_root="${resolve_fields[1]:-}"
-    manifest_path="${resolve_fields[2]:-}"
-    test_command="${resolve_fields[3]:-}"
-    command_runner="$(base_project_command_runner_from_field "${resolve_fields[4]:-}" || true)"
+    resolve_output="$("$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}" --format command-protocol)" || return $?
+    base_command_protocol_decode_one project-command "$resolve_output" || {
+        fatal_error "Unable to resolve test command for project '$project'."
+    }
+    resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+    project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+    manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+    route_venv_dir="${BASE_COMMAND_PROTOCOL_FIELDS[project_venv_dir]}"
+    uses_uv_manager="${BASE_COMMAND_PROTOCOL_FIELDS[uses_uv_manager]}"
+    trust_required="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_command_trust_required]}"
+    test_command="${BASE_COMMAND_PROTOCOL_FIELDS[command]}"
+    command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" && -n "$test_command" ]] || {
         fatal_error "Unable to resolve test command for project '$project'."
@@ -116,8 +121,9 @@ base_test_subcommand_main() {
         return 0
     fi
 
-    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "${resolve_fields[@]:4}" || return $?
-    base_project_activate_environment "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "${resolve_fields[@]:4}" >/dev/null
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
+    base_project_activate_environment \
+        "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "$route_venv_dir" "$uses_uv_manager" >/dev/null
 
     log_info "Running tests for project '$resolved_name': $display_command"
     base_validate_command_runner "$command_runner"

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -368,8 +368,10 @@ base_update_run_setup() {
 base_update_resolve_project() {
     local base_home="$1"
     local project="$2"
+    local output_name_var="$3"
+    local output_root_var="$4"
+    local output_manifest_var="$5"
     local wrapper="$base_home/bin/base-wrapper"
-    local resolve_fields=()
     local resolve_output resolved_name resolved_root resolved_manifest
 
     if [[ -z "$project" ]]; then
@@ -377,26 +379,29 @@ base_update_resolve_project() {
     fi
 
     if [[ "$project" == base ]]; then
-        printf '%s\t%s\t%s\n' base "$base_home" "$base_home/base_manifest.yaml"
-        return 0
+        resolved_name=base
+        resolved_root="$base_home"
+        resolved_manifest="$base_home/base_manifest.yaml"
+    else
+        [[ -x "$wrapper" ]] || {
+            log_error "Base Python wrapper '$wrapper' is missing or is not executable."
+            return 1
+        }
+
+        resolve_output="$("$wrapper" --project base base_projects resolve "$project" --format command-protocol)" || return $?
+        base_command_protocol_decode_one project-route "$resolve_output" || return 1
+        resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
+        resolved_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
+        resolved_manifest="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
+        [[ "$resolved_name" == "$project" && -n "$resolved_root" && -n "$resolved_manifest" ]] || {
+            log_error "Unable to resolve Base project '$project'."
+            return 1
+        }
     fi
 
-    [[ -x "$wrapper" ]] || {
-        log_error "Base Python wrapper '$wrapper' is missing or is not executable."
-        return 1
-    }
-
-    resolve_output="$("$wrapper" --project base base_projects resolve "$project")" || return $?
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_name="${resolve_fields[0]:-}"
-    resolved_root="${resolve_fields[1]:-}"
-    resolved_manifest="${resolve_fields[2]:-}"
-    [[ "$resolved_name" == "$project" && -n "$resolved_root" && -n "$resolved_manifest" ]] || {
-        log_error "Unable to resolve Base project '$project'."
-        return 1
-    }
-
-    printf '%s\t%s\t%s\n' "$resolved_name" "$resolved_root" "$resolved_manifest"
+    printf -v "$output_name_var" '%s' "$resolved_name"
+    printf -v "$output_root_var" '%s' "$resolved_root"
+    printf -v "$output_manifest_var" '%s' "$resolved_manifest"
 }
 
 base_update_head_revision() {
@@ -413,8 +418,6 @@ base_update_subcommand_main() {
     local project=base
     local project_arg=""
     local repo
-    local resolve_fields=()
-    local resolve_output
     local resolved_project
     local update_branch
     local dry_run=0
@@ -447,11 +450,7 @@ base_update_subcommand_main() {
         shift
     done
 
-    resolve_output="$(base_update_resolve_project "$base_home" "$project")" || return $?
-    IFS=$'\t' read -r -a resolve_fields <<<"$resolve_output"
-    resolved_project="${resolve_fields[0]:-}"
-    repo="${resolve_fields[1]:-}"
-    manifest_path="${resolve_fields[2]:-}"
+    base_update_resolve_project "$base_home" "$project" resolved_project repo manifest_path || return $?
     [[ -n "$resolved_project" && -n "$repo" && -n "$manifest_path" ]] || {
         log_error "Unable to resolve Base project '$project'."
         return 1

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -14,10 +14,8 @@ load ./basectl_helpers.bash
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=false\n' \
-        "${BASE_TEST_PROJECT_ROOT:?}" \
-        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -65,10 +63,8 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=false\n' \
-        "${BASE_TEST_PROJECT_ROOT:?}" \
-        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -106,10 +102,8 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=true\n' \
-        "${BASE_TEST_PROJECT_ROOT:?}" \
-        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" true false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -149,10 +143,8 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=false\n' \
-        "${BASE_TEST_PROJECT_ROOT:?}" \
-        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -191,10 +183,8 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=true\n' \
-        "${BASE_TEST_PROJECT_ROOT:?}" \
-        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" true false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -229,7 +219,8 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "base" ]]; then
-    printf 'base\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route base "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${HOME:?}/.base.d/base/.venv" false false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -274,7 +265,8 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2
@@ -328,7 +320,8 @@ EOF
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 printf 'unexpected activate resolver args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/basectl_helpers.bash
+++ b/cli/bash/commands/basectl/tests/basectl_helpers.bash
@@ -10,6 +10,7 @@ setup() {
     TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
     TEST_STATE_DIR="$TEST_TMPDIR/state"
     mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
+    export BASH_ENV="$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash"
 }
 
 run_basectl() {

--- a/cli/bash/commands/basectl/tests/build.bats
+++ b/cli/bash/commands/basectl/tests/build.bats
@@ -40,8 +40,16 @@ load ./basectl_helpers.bash
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'printf "api:%s:%s:%s:%s:%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" >> "$BASE_TEST_BUILD_STATE"' 'Build API'
-    printf 'demo\t%s\t%s\tworker\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/worker" 'printf "worker:%s:%s\n" "$BASE_PROJECT" "$PWD" >> "$BASE_TEST_BUILD_STATE"' 'Build worker'
+    base_test_protocol_begin build-target 2
+    base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/api" \
+        'printf "api:%s:%s:%s:%s:%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" >> "$BASE_TEST_BUILD_STATE"' 'Build API' ""
+    base_test_protocol_build_target_record 1 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false worker \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/worker" \
+        'printf "worker:%s:%s\n" "$BASE_PROJECT" "$PWD" >> "$BASE_TEST_BUILD_STATE"' 'Build worker' ""
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected build python args: %s\n' "$*" >&2
@@ -73,7 +81,11 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'python -m build' 'Build API' uv
+    base_test_protocol_begin build-target 1
+    base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'python -m build' 'Build API' uv
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected build python args: %s\n' "$*" >&2
@@ -113,7 +125,11 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" && "${5:-}" == "api" ]]; then
-    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'fake-build ./cmd/api' 'Build API'
+    base_test_protocol_begin build-target 1
+    base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'fake-build ./cmd/api' 'Build API' ""
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected build python args: %s\n' "$*" >&2
@@ -147,7 +163,11 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'touch "$BASE_TEST_BUILD_STATE"; exit 7' 'Build API'
+    base_test_protocol_begin build-target 1
+    base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'touch "$BASE_TEST_BUILD_STATE"; exit 7' 'Build API' ""
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected build python args: %s\n' "$*" >&2
@@ -170,6 +190,38 @@ EOF
     [ ! -e "$state_file" ]
 }
 
+@test "basectl build preserves delegated command failures without reporting protocol errors" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api" "$workspace/demo/.venv/bin"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" ]]; then
+    base_test_protocol_begin build-target 1
+    base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'printf "build failed\n" >&2; exit 23' 'Build API' ""
+    base_test_protocol_end
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" build demo
+
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"build failed"* ]]
+    [[ "$output" != *"Invalid Base command protocol"* ]]
+    [[ "$output" != *"Unable to parse build targets"* ]]
+}
+
 @test "basectl build --list prints project build targets" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
@@ -178,7 +230,11 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-target-list" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'go build ./cmd/api' 'Build API'
+    base_test_protocol_begin build-target 1
+    base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'go build ./cmd/api' 'Build API' ""
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected build python args: %s\n' "$*" >&2
@@ -208,7 +264,11 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-target-list" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'python -m build' 'Build API' uv
+    base_test_protocol_begin build-target 1
+    base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+        "${BASE_TEST_PROJECT_ROOT:?}/services/api" 'python -m build' 'Build API' uv
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected build python args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/command-protocol.bats
+++ b/cli/bash/commands/basectl/tests/command-protocol.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+
+load ./basectl_helpers.bash
+
+
+@test "command protocol preserves field boundaries and nullable values" {
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
+        source "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash"
+        source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+        value=$'"'"'tabs\t spaces λ\nline\x01'"'"'
+        payload="$(base_test_protocol_project_command \
+            "$value" "/tmp/root with spaces" "/tmp/base_manifest.yaml" "/tmp/.venv" \
+            true false "$value" "")"
+        base_command_protocol_decode_one project-command "$payload" || exit
+        [[ "${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}" == "$value" ]]
+        [[ "${BASE_COMMAND_PROTOCOL_FIELDS[command]}" == "$value" ]]
+        [[ "${BASE_COMMAND_PROTOCOL_FIELDS[runner]}" == "" ]]
+        [[ "${BASE_COMMAND_PROTOCOL_NULL_FIELDS[runner]:-}" == 1 ]]
+        printf "decoded\n"
+    '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = decoded ]
+}
+
+@test "command protocol distinguishes an empty string from null" {
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
+        source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+        payload="BASE_COMMAND_PROTOCOL_V1
+record_type=project-command
+record_count=1
+record=0
+field.project_name:string=64656d6f
+field.project_root:string=2f746d702f64656d6f
+field.manifest_path:string=2f746d702f64656d6f2f626173655f6d616e69666573742e79616d6c
+field.project_venv_dir:string=2f746d702f64656d6f2f2e76656e76
+field.uses_uv_manager:boolean=false
+field.manifest_command_trust_required:boolean=true
+field.command:string=7072696e7466206f6b
+field.runner:string=
+end_record=0
+end_protocol="
+        base_command_protocol_decode_one project-command "$payload" || exit
+        [[ "${BASE_COMMAND_PROTOCOL_FIELDS[runner]}" == "" ]]
+        [[ -z "${BASE_COMMAND_PROTOCOL_NULL_FIELDS[runner]+present}" ]]
+    '
+
+    [ "$status" -eq 0 ]
+}
+
+@test "command protocol iterates multiple explicitly named records" {
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
+        source "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash"
+        source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+        collect() { names+="${names:+,}${BASE_COMMAND_PROTOCOL_FIELDS[command_name]}"; }
+        names=""
+        payload="$(
+            base_test_protocol_begin named-command 2
+            base_test_protocol_named_command_record 0 demo /tmp/demo /tmp/demo/base_manifest.yaml test "pytest tests/" ""
+            base_test_protocol_named_command_record 1 demo /tmp/demo /tmp/demo/base_manifest.yaml dev "uvicorn app:app" uv
+            base_test_protocol_end
+        )"
+        base_command_protocol_each named-command "$payload" collect || exit
+        printf "%s\n" "$names"
+    '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = test,dev ]
+}
+
+@test "command protocol validates every record before invoking callbacks" {
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
+        source "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash"
+        source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+        collect() { ((callback_count += 1)); }
+        callback_count=0
+        payload="$(
+            base_test_protocol_begin named-command 2
+            base_test_protocol_named_command_record 0 demo /tmp/demo /tmp/demo/base_manifest.yaml test "pytest tests/" ""
+            base_test_protocol_named_command_record 1 demo /tmp/demo /tmp/demo/base_manifest.yaml dev "uvicorn app:app" uv
+            base_test_protocol_end
+        )"
+        payload="${payload/field.command_name:string=646576/field.unknown:string=646576}"
+        if base_command_protocol_each named-command "$payload" collect; then
+            exit 1
+        fi
+        printf "callbacks=%s\n" "$callback_count"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unknown field 'unknown'"* ]]
+    [[ "$output" == *"callbacks=0"* ]]
+}
+
+@test "command protocol rejects unsupported versions and record types" {
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
+        source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+        payload="BASE_COMMAND_PROTOCOL_V2
+record_type=project-reference
+record_count=0
+end_protocol="
+        ! base_command_protocol_parse project-reference "$payload"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unsupported protocol header"* ]]
+
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
+        source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+        payload="BASE_COMMAND_PROTOCOL_V1
+record_type=project-route
+record_count=0
+end_protocol="
+        ! base_command_protocol_parse project-reference "$payload"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"expected record_type 'project-reference', got 'project-route'"* ]]
+}
+
+@test "command protocol rejects noncanonical and overflowing record counts" {
+    local count
+
+    for count in 01 1000001 18446744073709551616; do
+        run env BASE_REPO_ROOT="$BASE_REPO_ROOT" COUNT="$count" "$BASH" -c '
+            source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+            payload="BASE_COMMAND_PROTOCOL_V1
+record_type=project-reference
+record_count=$COUNT
+end_protocol="
+            ! base_command_protocol_parse project-reference "$payload"
+        '
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"record_count"* ]]
+    done
+}
+
+@test "command protocol rejects missing unknown duplicate and mistyped fields" {
+    local manifest_line valid
+    valid=$'BASE_COMMAND_PROTOCOL_V1\nrecord_type=project-reference\nrecord_count=1\nrecord=0\nfield.project_name:string=64656d6f\nfield.project_root:string=2f746d702f64656d6f\nfield.manifest_path:string=2f746d702f64656d6f2f626173655f6d616e69666573742e79616d6c\nend_record=0\nend_protocol='
+    manifest_line=$'field.manifest_path:string=2f746d702f64656d6f2f626173655f6d616e69666573742e79616d6c\n'
+
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" PAYLOAD="${valid/"$manifest_line"/}" \
+        "$BASH" -c 'source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"; ! base_command_protocol_decode_one project-reference "$PAYLOAD"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing field 'manifest_path'"* ]]
+
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" PAYLOAD="${valid/field.manifest_path/field.unknown}" \
+        "$BASH" -c 'source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"; ! base_command_protocol_decode_one project-reference "$PAYLOAD"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unknown field 'unknown'"* ]]
+
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" PAYLOAD="${valid/field.manifest_path:string=2f746d702f64656d6f2f626173655f6d616e69666573742e79616d6c/field.project_name:string=6f74686572}" \
+        "$BASH" -c 'source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"; ! base_command_protocol_decode_one project-reference "$PAYLOAD"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"duplicates field 'project_name'"* ]]
+
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" PAYLOAD="${valid/field.project_name:string/field.project_name:boolean}" \
+        "$BASH" -c 'source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"; ! base_command_protocol_decode_one project-reference "$PAYLOAD"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wire type 'boolean'"* ]]
+}
+
+@test "command protocol rejects malformed hexadecimal UTF-8 NUL and framing" {
+    local valid
+    valid=$'BASE_COMMAND_PROTOCOL_V1\nrecord_type=project-reference\nrecord_count=1\nrecord=0\nfield.project_name:string=64656d6f\nfield.project_root:string=2f746d702f64656d6f\nfield.manifest_path:string=2f746d702f64656d6f2f626173655f6d616e69666573742e79616d6c\nend_record=0\nend_protocol='
+
+    for replacement in abc c080 00; do
+        run env BASE_REPO_ROOT="$BASE_REPO_ROOT" PAYLOAD="${valid/64656d6f/$replacement}" \
+            "$BASH" -c 'source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"; ! base_command_protocol_decode_one project-reference "$PAYLOAD"'
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Invalid Base command protocol"* ]]
+    done
+
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" PAYLOAD="$valid"$'\nunexpected=true' \
+        "$BASH" -c 'source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"; ! base_command_protocol_decode_one project-reference "$PAYLOAD"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unexpected data after end_protocol"* ]]
+}

--- a/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
+++ b/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
@@ -1,0 +1,153 @@
+# Test-only builders for Base command-protocol fixtures emitted by fake Python commands.
+
+base_test_protocol_hex() {
+    local LC_ALL=C
+    local value="$1"
+    local byte index
+
+    for ((index = 0; index < ${#value}; index += 1)); do
+        printf -v byte '%d' "'${value:index:1}"
+        ((byte >= 0)) || byte=$((byte + 256))
+        printf '%02x' "$byte"
+    done
+}
+
+base_test_protocol_begin() {
+    printf 'BASE_COMMAND_PROTOCOL_V1\nrecord_type=%s\nrecord_count=%s\n' "$1" "$2"
+}
+
+base_test_protocol_string() {
+    printf 'field.%s:string=' "$1"
+    base_test_protocol_hex "$2"
+    printf '\n'
+}
+
+base_test_protocol_boolean() {
+    printf 'field.%s:boolean=%s\n' "$1" "$2"
+}
+
+base_test_protocol_nullable_string() {
+    if [[ -n "$2" ]]; then
+        base_test_protocol_string "$1" "$2"
+    else
+        printf 'field.%s:null=\n' "$1"
+    fi
+}
+
+base_test_protocol_end() {
+    printf 'end_protocol=\n'
+}
+
+base_test_protocol_project_reference_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    base_test_protocol_string manifest_path "$4"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_project_route_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    base_test_protocol_string manifest_path "$4"
+    base_test_protocol_string project_venv_dir "$5"
+    base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean manifest_command_trust_required "$7"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_project_command_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    base_test_protocol_string manifest_path "$4"
+    base_test_protocol_string project_venv_dir "$5"
+    base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean manifest_command_trust_required "$7"
+    base_test_protocol_string command "$8"
+    base_test_protocol_nullable_string runner "${9:-}"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_named_command_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    base_test_protocol_string manifest_path "$4"
+    base_test_protocol_string command_name "$5"
+    base_test_protocol_string command "$6"
+    base_test_protocol_nullable_string runner "${7:-}"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_build_target_record() {
+    local record_index="$1"
+    local command="${10}"
+    local description="${11:-}"
+    local runner="${12:-}"
+
+    printf 'record=%s\n' "$record_index"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    base_test_protocol_string manifest_path "$4"
+    base_test_protocol_string project_venv_dir "$5"
+    base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean manifest_command_trust_required "$7"
+    base_test_protocol_string target_name "$8"
+    base_test_protocol_string working_dir "$9"
+    base_test_protocol_string command "$command"
+    base_test_protocol_nullable_string description "$description"
+    base_test_protocol_nullable_string runner "$runner"
+    printf 'end_record=%s\n' "$record_index"
+}
+
+base_test_protocol_demo_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    base_test_protocol_string manifest_path "$4"
+    base_test_protocol_string project_venv_dir "$5"
+    base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean manifest_command_trust_required "$7"
+    base_test_protocol_string demo_script "$8"
+    base_test_protocol_nullable_string runner "${9:-}"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_activation_source_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string source_path "$2"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_project_list_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_project_reference() {
+    base_test_protocol_begin project-reference 1
+    base_test_protocol_project_reference_record 0 "$@"
+    base_test_protocol_end
+}
+
+base_test_protocol_project_route() {
+    base_test_protocol_begin project-route 1
+    base_test_protocol_project_route_record 0 "$@"
+    base_test_protocol_end
+}
+
+base_test_protocol_project_command() {
+    base_test_protocol_begin project-command 1
+    base_test_protocol_project_command_record 0 "$@"
+    base_test_protocol_end
+}
+
+base_test_protocol_demo() {
+    base_test_protocol_begin demo 1
+    base_test_protocol_demo_record 0 "$@"
+    base_test_protocol_end
+}

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -10,8 +10,10 @@ load ./setup_helpers.bash
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
-    printf 'base\t/Users/test/base\n'
-    printf 'demo\t/Users/test/demo\n'
+    base_test_protocol_begin project-list-entry 2
+    base_test_protocol_project_list_record 0 base /Users/test/base
+    base_test_protocol_project_list_record 1 demo /Users/test/demo
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected completion python args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -20,7 +20,9 @@ load ./basectl_helpers.bash
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo/demo.sh"
+    base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        "${BASE_TEST_PROJECT_ROOT:?}/demo/demo.sh" ""
     exit 0
 fi
 printf 'unexpected demo python args: %s\n' "$*" >&2
@@ -72,7 +74,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo/demo.sh" uv
+    base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        "${BASE_TEST_PROJECT_ROOT:?}/demo/demo.sh" uv
     exit 0
 fi
 printf 'unexpected demo python args: %s\n' "$*" >&2
@@ -112,8 +116,10 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && -z "${4:-}" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo.sh"
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "--format" ]]; then
+    base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        "${BASE_TEST_PROJECT_ROOT:?}/demo.sh" ""
     exit 0
 fi
 printf 'unexpected demo python args: %s\n' "$*" >&2
@@ -152,7 +158,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" && "${5:-}" == "--workspace" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/demo.sh"
+    base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        "${BASE_TEST_PROJECT_ROOT:?}/demo.sh" ""
     exit 0
 fi
 printf 'unexpected demo python args: %s\n' "$*" >&2
@@ -270,7 +278,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "base" ]]; then
-    printf 'base\t%s\t%s\t%s\n' "${BASE_REPO_ROOT:?}" "${BASE_REPO_ROOT:?}/base_manifest.yaml" "${BASE_REPO_ROOT:?}/demo/demo.sh"
+    base_test_protocol_demo base "${BASE_REPO_ROOT:?}" \
+        "${BASE_REPO_ROOT:?}/base_manifest.yaml" "${HOME:?}/.base.d/base/.venv" false false \
+        "${BASE_REPO_ROOT:?}/demo/demo.sh" ""
     exit 0
 fi
 printf 'unexpected self-demo python args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/devcontainer.bats
+++ b/cli/bash/commands/basectl/tests/devcontainer.bats
@@ -12,7 +12,8 @@ load ./basectl_helpers.bash
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then

--- a/cli/bash/commands/basectl/tests/devenv-report.bats
+++ b/cli/bash/commands/basectl/tests/devenv-report.bats
@@ -12,7 +12,8 @@ load ./basectl_helpers.bash
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -928,12 +928,14 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     esac
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
         exit 0
     fi
     printf 'ok     demo-artifact               Project artifact check passed.\n'
@@ -1016,12 +1018,14 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     esac
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
         exit 0
     fi
     printf '%s\n' "$@" > "${BASE_TEST_PROJECT_ARGS:?}"
@@ -1102,12 +1106,14 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     esac
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
         exit 0
     fi
     printf '[{"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"}]\n'
@@ -1186,12 +1192,14 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     esac
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'demo\t%s\t%s\t%s\tfalse\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
         exit 0
     fi
     printf '%s\n' "$@" > "${BASE_TEST_PROJECT_ARGS:?}"

--- a/cli/bash/commands/basectl/tests/export-context.bats
+++ b/cli/bash/commands/basectl/tests/export-context.bats
@@ -44,7 +44,8 @@ load ./basectl_helpers.bash
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "current" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_reference \
+        demo "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_export_context" ]]; then
@@ -86,7 +87,8 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" && "${5:-}" == "--workspace" ]]; then
-    printf 'demo\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_export_context" ]]; then

--- a/cli/bash/commands/basectl/tests/manifest-command-trust.bats
+++ b/cli/bash/commands/basectl/tests/manifest-command-trust.bats
@@ -31,64 +31,52 @@ TRUST
 fi
 
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" ]]; then
-    route_fields="__base_project_venv_dir=${BASE_TEST_PROJECT_ROOT:?}/.venv	__base_uses_uv_manager=false	__base_manifest_command_trust_required=true"
     case "${3:-}" in
         test-command)
-            printf 'demo\t%s\t%s\t%s\t%s\n' \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
-                "$route_fields"
+            base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false true \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7' ""
             exit 0
             ;;
         run-command)
-            printf 'demo\t%s\t%s\t%s\t%s\n' \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
-                "$route_fields"
+            base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false true \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7' ""
             exit 0
             ;;
         run-commands)
-            printf 'demo\t%s\t%s\tdev\t%s\n' \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-                'touch "$BASE_TEST_TRUST_STATE"; exit 7'
+            base_test_protocol_begin named-command 1
+            base_test_protocol_named_command_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" dev \
+                'touch "$BASE_TEST_TRUST_STATE"; exit 7' ""
+            base_test_protocol_end
             exit 0
             ;;
         build-targets)
-            printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
-                'Build API' \
-                "$route_fields"
+            base_test_protocol_begin build-target 1
+            base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false true api \
+                "${BASE_TEST_PROJECT_ROOT:?}" 'touch "$BASE_TEST_TRUST_STATE"; exit 7' 'Build API' ""
+            base_test_protocol_end
             exit 0
             ;;
         build-target-list)
-            printf 'demo\t%s\t%s\tapi\t%s\t%s\t%s\t%s\n' \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                'touch "$BASE_TEST_TRUST_STATE"; exit 7' \
-                'Build API' \
-                "$route_fields"
+            base_test_protocol_begin build-target 1
+            base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false api \
+                "${BASE_TEST_PROJECT_ROOT:?}" 'touch "$BASE_TEST_TRUST_STATE"; exit 7' 'Build API' ""
+            base_test_protocol_end
             exit 0
             ;;
         demo-script)
-            printf 'demo\t%s\t%s\t%s\t%s\n' \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-                "${BASE_TEST_PROJECT_ROOT:?}/demo.sh" \
-                "$route_fields"
+            base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false true \
+                "${BASE_TEST_PROJECT_ROOT:?}/demo.sh" ""
             exit 0
             ;;
         resolve)
-            printf 'demo\t%s\t%s\t%s\n' \
-                "${BASE_TEST_PROJECT_ROOT:?}" \
-                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-                "$route_fields"
+            base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+                "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false true
             exit 0
             ;;
     esac

--- a/cli/bash/commands/basectl/tests/project-command-helpers.bats
+++ b/cli/bash/commands/basectl/tests/project-command-helpers.bats
@@ -17,7 +17,7 @@ source_project_command_helpers() {
     [ "$status" -eq 0 ]
     [ "$output" = "$TEST_HOME/.base.d/demo/.venv" ]
 
-    run base_project_venv_dir demo "$TEST_TMPDIR/demo" "$TEST_TMPDIR/demo/base_manifest.yaml"
+    run base_project_venv_dir demo "$TEST_TMPDIR/demo" "$TEST_TMPDIR/demo/.venv"
 
     [ "$status" -eq 0 ]
     [ "$output" = "$TEST_TMPDIR/demo/.venv" ]
@@ -41,7 +41,7 @@ source_project_command_helpers() {
     HOME="$TEST_HOME"
     unset BASE_PROJECT_VENV_DIR
 
-    run base_project_venv_dir demo "$project_root" "$manifest_path" "__base_project_venv_dir=$project_root/.venv"
+    run base_project_venv_dir demo "$project_root" "$project_root/.venv"
 
     [ "$status" -eq 0 ]
     [ "$output" = "$project_root/.venv" ]
@@ -58,7 +58,7 @@ source_project_command_helpers() {
     HOME="$TEST_HOME"
     unset BASE_PROJECT_VENV_DIR
 
-    run base_project_venv_dir demo "$project_root" "$manifest_path" "__base_project_venv_dir=$project_root/.venv"
+    run base_project_venv_dir demo "$project_root" "$project_root/.venv"
 
     [ "$status" -eq 0 ]
     [ "$output" = "$project_root/.venv" ]
@@ -79,7 +79,7 @@ source_project_command_helpers() {
             HOME="$1"
             PATH="/usr/bin:/bin"
             unset BASE_PROJECT BASE_PROJECT_ROOT BASE_PROJECT_MANIFEST BASE_PROJECT_VENV_DIR
-            base_project_activate_environment demo "$2" "$3" 0 "__base_project_venv_dir=$4"
+            base_project_activate_environment demo "$2" "$3" 0 "$4" false
             printf "BASE_PROJECT=%s\n" "$BASE_PROJECT"
             printf "BASE_PROJECT_ROOT=%s\n" "$BASE_PROJECT_ROOT"
             printf "BASE_PROJECT_MANIFEST=%s\n" "$BASE_PROJECT_MANIFEST"
@@ -109,7 +109,7 @@ source_project_command_helpers() {
             source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/project_command_helpers.sh"
             HOME="$1"
             log_warn() { printf "WARN:%s\n" "$*"; }
-            base_project_activate_environment demo "$2" "$3" 0 "__base_project_venv_dir=$4"
+            base_project_activate_environment demo "$2" "$3" 0 "$4" false
         ' bash "$TEST_HOME" "$project_root" "$manifest_path" "$venv_dir"
 
     [ "$status" -eq 0 ]
@@ -122,7 +122,7 @@ source_project_command_helpers() {
             source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/project_command_helpers.sh"
             HOME="$1"
             log_warn() { printf "WARN:%s\n" "$*"; }
-            base_project_activate_environment demo "$2" "$3" 1 "__base_project_venv_dir=$4"
+            base_project_activate_environment demo "$2" "$3" 1 "$4" false
         ' bash "$TEST_HOME" "$project_root" "$manifest_path" "$venv_dir"
 
     [ "$status" -eq 0 ]

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -12,7 +12,9 @@ load ./basectl_helpers.bash
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "project=%s\nroot=%s\nmanifest=%s\nvenv=%s\npwd=%s\npath=%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" "$PATH" > "$BASE_TEST_RUN_STATE"; exit 7'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'printf "project=%s\nroot=%s\nmanifest=%s\nvenv=%s\npwd=%s\npath=%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" "$PATH" > "$BASE_TEST_RUN_STATE"; exit 7' ""
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -48,7 +50,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "audit" ]]; then
-    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'pytest tests/audit' uv
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'pytest tests/audit' uv
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -88,11 +92,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
-    printf 'demo\t%s\t%s\t%s\t__base_project_venv_dir=%s\t__base_uses_uv_manager=true\n' \
-        "${BASE_TEST_PROJECT_ROOT:?}" \
-        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" \
-        'printf "venv=%s\npath=%s\n" "$BASE_PROJECT_VENV_DIR" "$PATH" > "$BASE_TEST_RUN_STATE"' \
-        "${BASE_TEST_PROJECT_ROOT:?}/.venv"
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" true false \
+        'printf "venv=%s\npath=%s\n" "$BASE_PROJECT_VENV_DIR" "$PATH" > "$BASE_TEST_RUN_STATE"' ""
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -124,7 +126,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "audit" ]]; then
-    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'pytest tests/audit' uv
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'pytest tests/audit' uv
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -153,7 +157,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'touch "$BASE_TEST_RUN_STATE"; exit 7'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'touch "$BASE_TEST_RUN_STATE"; exit 7' ""
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -185,7 +191,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "lint" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'fake-lint src/'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'fake-lint src/' ""
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -219,7 +227,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'mise run dev'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'mise run dev' ""
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -252,7 +262,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "test" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "test-contract\n"'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'printf "test-contract\n"' ""
     exit 0
 fi
 printf 'unexpected run python args: %s\n' "$*" >&2
@@ -280,8 +292,12 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-commands" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" test 'pytest tests/'
-    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" dev 'uvicorn app:app --reload'
+    base_test_protocol_begin named-command 2
+    base_test_protocol_named_command_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" test 'pytest tests/' ""
+    base_test_protocol_named_command_record 1 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" dev 'uvicorn app:app --reload' ""
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected run list python args: %s\n' "$*" >&2
@@ -310,8 +326,11 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-commands" && -z "${4:-}" ]]; then
-    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" dev 'uvicorn app:app --reload'
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-commands" && "${4:-}" == "--format" ]]; then
+    base_test_protocol_begin named-command 1
+    base_test_protocol_named_command_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" dev 'uvicorn app:app --reload' ""
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected run list python args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -17,7 +17,7 @@ load ./basectl_helpers.bash
     cat > "$fake_base_home/bin/base-wrapper" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "--project" && "${2:-}" == "base" && "${3:-}" == "base_projects" && "${4:-}" == "current" ]]; then
-    printf 'brew\t/tmp/work/brew\t/tmp/work/brew/base_manifest.yaml\n'
+    base_test_protocol_project_reference brew /tmp/work/brew /tmp/work/brew/base_manifest.yaml
     exit 0
 fi
 printf 'unexpected args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/runtime-shell.bats
+++ b/cli/bash/commands/basectl/tests/runtime-shell.bats
@@ -93,6 +93,8 @@ EOF
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
+    base_test_protocol_begin activation-source 0
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected base_projects args: %s\n' "$*" >&2
@@ -134,7 +136,9 @@ EOF
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
-    printf '%s\n' "${BASE_TEST_ACTIVATION_SOURCE:?}"
+    base_test_protocol_begin activation-source 1
+    base_test_protocol_activation_source_record 0 "${BASE_TEST_ACTIVATION_SOURCE:?}"
+    base_test_protocol_end
     exit 0
 fi
 printf 'unexpected base_projects args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -304,7 +304,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -405,7 +406,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -13,6 +13,7 @@ setup() {
     unset OSTYPE_OVERRIDE
 
     mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
+    export BASH_ENV="$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash"
     create_uname_stub
 }
 
@@ -178,7 +179,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -380,7 +382,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -431,7 +434,8 @@ VENVEOF
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -545,7 +549,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -596,7 +601,8 @@ VENVEOF
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -733,7 +739,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" ==
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        printf 'base\t%s\t%s\t%s\tfalse\n' "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" "$HOME/.base.d/base/.venv"
+        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -849,6 +856,9 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
         if [[ "$output_format" == "json" ]]; then
             printf '{"schema_version":1,"project":"%s","project_root":"%s","manifest_path":"%s","project_venv_dir":"%s","uses_uv_manager":%s}\n' \
                 "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager"
+        elif [[ "$output_format" == "command-protocol" ]]; then
+            base_test_protocol_project_route \
+                "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager" false
         else
             printf '%s\t%s\t%s\t%s\t%s\n' "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager"
         fi
@@ -907,7 +917,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" ]
     project_root="${BASE_SETUP_TEST_WORKSPACE:?}/$project"
     manifest_path="$project_root/base_manifest.yaml"
     if [[ -f "$manifest_path" ]]; then
-        printf '%s\t%s\t%s\n' "$project" "$project_root" "$manifest_path"
+        base_test_protocol_project_route \
+            "$project" "$project_root" "$manifest_path" "$project_root/.venv" false false
         exit 0
     fi
     printf 'Project not found: %s\n' "$project" >&2
@@ -918,7 +929,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "manifest" 
     if [[ -f "$manifest_path" ]]; then
         project="$(awk '/^[[:space:]]*name:/ { print $2; exit }' "$manifest_path")"
         project_root="$(cd -- "$(dirname -- "$manifest_path")" && pwd -P)"
-        printf '%s\t%s\t%s\n' "$project" "$project_root" "$manifest_path"
+        base_test_protocol_project_reference "$project" "$project_root" "$manifest_path"
         exit 0
     fi
     printf 'Manifest not found: %s\n' "$manifest_path" >&2

--- a/cli/bash/commands/basectl/tests/test.bats
+++ b/cli/bash/commands/basectl/tests/test.bats
@@ -12,7 +12,9 @@ load ./basectl_helpers.bash
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "project=%s\nroot=%s\nmanifest=%s\nvenv=%s\npwd=%s\npath=%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" "$PATH" > "$BASE_TEST_TEST_STATE"; exit 7'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'printf "project=%s\nroot=%s\nmanifest=%s\nvenv=%s\npwd=%s\npath=%s\n" "$BASE_PROJECT" "$BASE_PROJECT_ROOT" "$BASE_PROJECT_MANIFEST" "$BASE_PROJECT_VENV_DIR" "$PWD" "$PATH" > "$BASE_TEST_TEST_STATE"; exit 7' ""
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2
@@ -48,7 +50,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'pytest tests/' uv
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'pytest tests/' uv
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2
@@ -88,7 +92,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'touch "$BASE_TEST_TEST_STATE"; exit 7'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'touch "$BASE_TEST_TEST_STATE"; exit 7' ""
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2
@@ -120,7 +126,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'fake-test tests/'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'fake-test tests/' ""
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2
@@ -153,7 +161,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'pytest tests/'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'pytest tests/' ""
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2
@@ -182,7 +192,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'mise run unit'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'mise run unit' ""
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2
@@ -215,7 +227,9 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "ran-test\n"'
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'printf "ran-test\n"' ""
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2
@@ -245,8 +259,10 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && -z "${4:-}" ]]; then
-    printf 'demo\t%s\t%s\t%s\n' "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" 'printf "current-project-test\n"'
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "--format" ]]; then
+    base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
+        'printf "current-project-test\n"' ""
     exit 0
 fi
 printf 'unexpected test python args: %s\n' "$*" >&2

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -56,7 +56,11 @@ assert_status() {
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
-            base_update_resolve_project() { printf "demo\t%s\t%s\n" "$BASE_TEST_PROJECT_ROOT" "$BASE_TEST_PROJECT_ROOT/base_manifest.yaml"; }
+            base_update_resolve_project() {
+                printf -v "$3" "%s" demo
+                printf -v "$4" "%s" "$BASE_TEST_PROJECT_ROOT"
+                printf -v "$5" "%s" "$BASE_TEST_PROJECT_ROOT/base_manifest.yaml"
+            }
             base_update_current_branch() { printf "%s\n" main; }
             base_update_default_branch() { printf "%s\n" main; }
             base_update_worktree_clean() { return 0; }
@@ -492,7 +496,11 @@ EOF
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
-            base_update_resolve_project() { printf "demo\t%s\t%s\n" "$BASE_TEST_PROJECT_ROOT" "$BASE_TEST_PROJECT_ROOT/base_manifest.yaml"; }
+            base_update_resolve_project() {
+                printf -v "$3" "%s" demo
+                printf -v "$4" "%s" "$BASE_TEST_PROJECT_ROOT"
+                printf -v "$5" "%s" "$BASE_TEST_PROJECT_ROOT/base_manifest.yaml"
+            }
             base_update_current_branch() { printf "%s\n" main; }
             base_update_default_branch() { printf "%s\n" main; }
             base_update_worktree_clean() { return 0; }

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Protocol
 
 import base_cli
+from base_cli.command_protocol import dumps_records
+from base_projects.project_commands import route_metadata_record
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 from base_setup.manifest_model import BaseManifest, BuildTargetConfig
@@ -29,11 +31,19 @@ def build_targets_project_from_args(
     arguments: tuple[str, ...],
     workspace: str | None,
     resolve_project: ProjectResolver,
+    output_format: str = "text",
 ) -> int:
     if len(arguments) < 1:
         ctx.log.error("Command 'build-targets' requires at least 1 argument (project name); got %d.", len(arguments))
         return base_cli.ExitCode.USAGE_ERROR
-    return build_targets_project_command(ctx, arguments[0], arguments[1:], workspace, resolve_project)
+    return build_targets_project_command(
+        ctx,
+        arguments[0],
+        arguments[1:],
+        workspace,
+        resolve_project,
+        output_format,
+    )
 
 
 def list_build_targets_from_args(
@@ -41,19 +51,21 @@ def list_build_targets_from_args(
     arguments: tuple[str, ...],
     workspace: str | None,
     resolve_project: ProjectResolver,
+    output_format: str = "text",
 ) -> int:
     if len(arguments) != 1:
         ctx.log.error("Command 'build-target-list' requires exactly 1 argument (project name); got %d.", len(arguments))
         return base_cli.ExitCode.USAGE_ERROR
-    return list_build_targets_command(ctx, arguments[0], workspace, resolve_project)
+    return list_build_targets_command(ctx, arguments[0], workspace, resolve_project, output_format)
 
 
-def build_targets_project_command(
+def build_targets_project_command(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     ctx: base_cli.Context,
     project_name: str | None,
     target_names: tuple[str, ...],
     workspace: str | None,
     resolve_project: ProjectResolver,
+    output_format: str = "text",
 ) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
@@ -67,15 +79,32 @@ def build_targets_project_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    for target_name, target_config, working_dir in targets:
-        print_build_target(
-            project,
-            manifest,
-            target_name,
-            target_config,
-            working_dir,
-            manifest_command_trust_required=True,
-        )
+    if output_format == "command-protocol":
+        records = [
+            build_target_record(
+                project,
+                manifest,
+                target_name,
+                target_config,
+                working_dir,
+                manifest_command_trust_required=True,
+            )
+            for target_name, target_config, working_dir in targets
+        ]
+        print(dumps_records("build-target", records))
+    elif output_format == "text":
+        for target_name, target_config, working_dir in targets:
+            print_build_target(
+                project,
+                manifest,
+                target_name,
+                target_config,
+                working_dir,
+                manifest_command_trust_required=True,
+            )
+    else:
+        ctx.log.error("Unsupported build-targets output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
@@ -84,6 +113,7 @@ def list_build_targets_command(
     project_name: str | None,
     workspace: str | None,
     resolve_project: ProjectResolver,
+    output_format: str = "text",
 ) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
@@ -97,16 +127,58 @@ def list_build_targets_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    for target_name, target_config, working_dir in targets:
-        print_build_target(
-            project,
-            manifest,
-            target_name,
-            target_config,
-            working_dir,
-            manifest_command_trust_required=False,
-        )
+    if output_format == "command-protocol":
+        records = [
+            build_target_record(
+                project,
+                manifest,
+                target_name,
+                target_config,
+                working_dir,
+                manifest_command_trust_required=False,
+            )
+            for target_name, target_config, working_dir in targets
+        ]
+        print(dumps_records("build-target", records))
+    elif output_format == "text":
+        for target_name, target_config, working_dir in targets:
+            print_build_target(
+                project,
+                manifest,
+                target_name,
+                target_config,
+                working_dir,
+                manifest_command_trust_required=False,
+            )
+    else:
+        ctx.log.error("Unsupported build-target-list output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
+
+
+def build_target_record(  # pylint: disable=too-many-arguments
+    project: ProjectLike,
+    manifest: BaseManifest,
+    target_name: str,
+    target_config: BuildTargetConfig,
+    working_dir: Path,
+    *,
+    manifest_command_trust_required: bool,
+) -> dict[str, str | bool | None]:
+    return {
+        "project_name": project.name,
+        "project_root": str(project.root),
+        "manifest_path": str(project.manifest_path),
+        **route_metadata_record(
+            manifest,
+            manifest_command_trust_required=manifest_command_trust_required,
+        ),
+        "target_name": target_name,
+        "working_dir": str(working_dir),
+        "command": target_config.command,
+        "description": target_config.description,
+        "runner": target_config.runner,
+    }
 
 
 def print_build_target(  # pylint: disable=too-many-arguments

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 
 import base_cli
+from base_cli.command_protocol import dumps_record
+from base_cli.command_protocol import dumps_records
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
 from base_projects.command_helpers import ProjectUsageError
@@ -17,11 +19,15 @@ from base_projects.project_commands import CommandConfig  # pylint: disable=unus
 from base_projects.project_commands import ProjectCommandError
 from base_projects.project_commands import TestConfig  # pylint: disable=unused-import
 from base_projects.project_commands import activation_source_paths
+from base_projects.project_commands import command_record
 from base_projects.project_commands import command_output as _command_output
+from base_projects.project_commands import demo_record
 from base_projects.project_commands import demo_output as _demo_output
+from base_projects.project_commands import named_command_record
 from base_projects.project_commands import named_command_output as _named_command_output
 from base_projects.project_commands import project_command
 from base_projects.project_commands import project_commands
+from base_projects.project_commands import project_record
 from base_projects.project_commands import project_output as _project_output
 from base_projects.project_commands import resolve_activation_source_path  # pylint: disable=unused-import
 from base_projects.project_commands import test_command
@@ -160,21 +166,23 @@ def build_targets_project_command(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
     workspace: str | None,
+    output_format: str = "text",
 ) -> int:
-    return build_targets_project_from_args(ctx, arguments, workspace, resolve_named_project)
+    return build_targets_project_from_args(ctx, arguments, workspace, resolve_named_project, output_format)
 
 
 def build_target_list_project_command(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
     workspace: str | None,
+    output_format: str = "text",
 ) -> int:
-    return list_build_targets_from_args(ctx, arguments, workspace, resolve_named_project)
+    return list_build_targets_from_args(ctx, arguments, workspace, resolve_named_project, output_format)
 
 
 def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
-    if output_format not in ("text", "json"):
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+    if output_format not in ("text", "json", "command-protocol"):
+        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json, command-protocol.", output_format)
         return base_cli.ExitCode.USAGE_ERROR
 
     try:
@@ -189,6 +197,20 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_f
             json.dumps(
                 [{"name": project.name, "path": str(project.root)} for project in projects],
                 separators=(",", ":"),
+            )
+        )
+        return base_cli.ExitCode.SUCCESS
+    if output_format == "command-protocol":
+        print(
+            dumps_records(
+                "project-list-entry",
+                [
+                    {
+                        "project_name": project.name,
+                        "project_root": str(project.root),
+                    }
+                    for project in projects
+                ],
             )
         )
         return base_cli.ExitCode.SUCCESS
@@ -352,7 +374,12 @@ def workspace_manifest_source_label(ctx: base_cli.Context, workspace_manifest: s
     return "none"
 
 
-def resolve_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+def resolve_project_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    workspace: str | None,
+    output_format: str = "text",
+) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
         return base_cli.ExitCode.USAGE_ERROR
@@ -364,11 +391,23 @@ def resolve_project_command(ctx: base_cli.Context, project_name: str | None, wor
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    print(_project_output(project.name, project.root, project.manifest_path, manifest))
+    if output_format == "command-protocol":
+        record = project_record(project.name, project.root, project.manifest_path, manifest)
+        print(dumps_record("project-route", record))
+    elif output_format == "text":
+        print(_project_output(project.name, project.root, project.manifest_path, manifest))
+    else:
+        ctx.log.error("Unsupported resolve output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
-def test_command_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+def test_command_project_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    workspace: str | None,
+    output_format: str = "text",
+) -> int:
     try:
         if project_name:
             project = resolve_named_project(ctx, project_name, workspace)
@@ -388,11 +427,27 @@ def test_command_project_command(ctx: base_cli.Context, project_name: str | None
         return base_cli.ExitCode.FAILURE
 
     command_config = test_command(manifest.test)
-    print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
+    if output_format == "command-protocol":
+        print(
+            dumps_record(
+                "project-command",
+                command_record(project.name, project.root, project.manifest_path, command_config, manifest),
+            )
+        )
+    elif output_format == "text":
+        print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
+    else:
+        ctx.log.error("Unsupported test-command output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
-def demo_script_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+def demo_script_project_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    workspace: str | None,
+    output_format: str = "text",
+) -> int:
     try:
         if project_name:
             project = resolve_named_project(ctx, project_name, workspace)
@@ -411,11 +466,27 @@ def demo_script_project_command(ctx: base_cli.Context, project_name: str | None,
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    print(_demo_output(project.name, project.root, project.manifest_path, demo_script, manifest))
+    if output_format == "command-protocol":
+        print(
+            dumps_record(
+                "demo",
+                demo_record(project.name, project.root, project.manifest_path, demo_script, manifest),
+            )
+        )
+    elif output_format == "text":
+        print(_demo_output(project.name, project.root, project.manifest_path, demo_script, manifest))
+    else:
+        ctx.log.error("Unsupported demo-script output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
-def activation_sources_project_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+def activation_sources_project_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    workspace: str | None,
+    output_format: str = "text",
+) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
         return base_cli.ExitCode.USAGE_ERROR
@@ -428,8 +499,14 @@ def activation_sources_project_command(ctx: base_cli.Context, project_name: str 
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    for source in sources:
-        print(source)
+    if output_format == "command-protocol":
+        print(dumps_records("activation-source", [{"source_path": str(source)} for source in sources]))
+    elif output_format == "text":
+        for source in sources:
+            print(source)
+    else:
+        ctx.log.error("Unsupported activation-sources output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
@@ -438,6 +515,7 @@ def run_command_project_command(
     project_name: str | None,
     command_name: str | None,
     workspace: str | None,
+    output_format: str = "text",
 ) -> int:
     if not project_name:
         ctx.log.error("Project name is required.")
@@ -454,11 +532,27 @@ def run_command_project_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
+    if output_format == "command-protocol":
+        print(
+            dumps_record(
+                "project-command",
+                command_record(project.name, project.root, project.manifest_path, command_config, manifest),
+            )
+        )
+    elif output_format == "text":
+        print(_command_output(project.name, project.root, project.manifest_path, command_config, manifest))
+    else:
+        ctx.log.error("Unsupported run-command output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
-def list_run_commands_command(ctx: base_cli.Context, project_name: str | None, workspace: str | None) -> int:
+def list_run_commands_command(
+    ctx: base_cli.Context,
+    project_name: str | None,
+    workspace: str | None,
+    output_format: str = "text",
+) -> int:
     try:
         if project_name:
             project = resolve_named_project(ctx, project_name, workspace)
@@ -474,23 +568,66 @@ def list_run_commands_command(ctx: base_cli.Context, project_name: str | None, w
         ctx.log.error("Project '%s' does not declare runnable commands in '%s'.", project.name, project.manifest_path)
         return base_cli.ExitCode.FAILURE
 
-    for command_name, command_config in commands.items():
-        print(_named_command_output(project.name, project.root, project.manifest_path, command_name, command_config))
+    if output_format == "command-protocol":
+        print(
+            dumps_records(
+                "named-command",
+                [
+                    named_command_record(
+                        project.name,
+                        project.root,
+                        project.manifest_path,
+                        command_name,
+                        command_config,
+                    )
+                    for command_name, command_config in commands.items()
+                ],
+            )
+        )
+    elif output_format == "text":
+        for command_name, command_config in commands.items():
+            print(
+                _named_command_output(
+                    project.name,
+                    project.root,
+                    project.manifest_path,
+                    command_name,
+                    command_config,
+                )
+            )
+    else:
+        ctx.log.error("Unsupported run-commands output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
-def current_project_command(ctx: base_cli.Context) -> int:
+def current_project_command(ctx: base_cli.Context, output_format: str = "text") -> int:
     try:
         project = current_project()
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    if output_format == "command-protocol":
+        print(
+            dumps_record(
+                "project-reference",
+                {
+                    "project_name": project.name,
+                    "project_root": str(project.root),
+                    "manifest_path": str(project.manifest_path),
+                },
+            )
+        )
+    elif output_format == "text":
+        print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    else:
+        ctx.log.error("Unsupported current output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
-def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int:
+def manifest_project_command(ctx: base_cli.Context, manifest: str | None, output_format: str = "text") -> int:
     if not manifest:
         ctx.log.error("Manifest path is required.")
         return base_cli.ExitCode.USAGE_ERROR
@@ -501,7 +638,22 @@ def manifest_project_command(ctx: base_cli.Context, manifest: str | None) -> int
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    if output_format == "command-protocol":
+        print(
+            dumps_record(
+                "project-reference",
+                {
+                    "project_name": project.name,
+                    "project_root": str(project.root),
+                    "manifest_path": str(project.manifest_path),
+                },
+            )
+        )
+    elif output_format == "text":
+        print(f"{project.name}\t{project.root}\t{project.manifest_path}")
+    else:
+        ctx.log.error("Unsupported manifest output format '%s'.", output_format)
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 

--- a/cli/python/base_projects/project_commands.py
+++ b/cli/python/base_projects/project_commands.py
@@ -56,6 +56,89 @@ def route_metadata_fields(manifest: BaseManifest, *, manifest_command_trust_requ
     ]
 
 
+def route_metadata_record(
+    manifest: BaseManifest,
+    *,
+    manifest_command_trust_required: bool = False,
+) -> dict[str, str | bool]:
+    route = route_for_manifest(manifest)
+    return {
+        "project_venv_dir": str(route.project_venv_dir),
+        "uses_uv_manager": route.uses_uv_manager,
+        "manifest_command_trust_required": manifest_command_trust_required,
+    }
+
+
+def project_record(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    manifest: BaseManifest,
+) -> dict[str, str | bool]:
+    return {
+        "project_name": project_name,
+        "project_root": str(project_root),
+        "manifest_path": str(manifest_path),
+        **route_metadata_record(
+            manifest,
+            manifest_command_trust_required=bool(manifest.activate.source),
+        ),
+    }
+
+
+def command_record(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    command: CommandConfig,
+    manifest: BaseManifest,
+) -> dict[str, str | bool | None]:
+    return {
+        "project_name": project_name,
+        "project_root": str(project_root),
+        "manifest_path": str(manifest_path),
+        **route_metadata_record(manifest, manifest_command_trust_required=True),
+        "command": command.command,
+        "runner": command.runner,
+    }
+
+
+def named_command_record(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    command_name: str,
+    command: CommandConfig,
+) -> dict[str, str | None]:
+    return {
+        "project_name": project_name,
+        "project_root": str(project_root),
+        "manifest_path": str(manifest_path),
+        "command_name": command_name,
+        "command": command.command,
+        "runner": command.runner,
+    }
+
+
+def demo_record(
+    project_name: str,
+    project_root: Path,
+    manifest_path: Path,
+    demo_script: Path,
+    manifest: BaseManifest,
+) -> dict[str, str | bool | None]:
+    if manifest.demo is None:
+        raise ProjectCommandError(f"Project '{project_name}' does not declare a demo in '{manifest_path}'.")
+    return {
+        "project_name": project_name,
+        "project_root": str(project_root),
+        "manifest_path": str(manifest_path),
+        **route_metadata_record(manifest, manifest_command_trust_required=True),
+        "demo_script": str(demo_script),
+        "runner": manifest.demo.runner,
+    }
+
+
 def project_output(project_name: str, project_root: Path, manifest_path: Path, manifest: BaseManifest) -> str:
     return "\t".join(
         [

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -30,16 +30,16 @@ class ProjectCommandActions:
     workspace_pull: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
     workspace_init: Callable[[base_cli.Context, str, WorkspaceCommandOptions], int]
     workspace_configure: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
-    current_project: Callable[[base_cli.Context], int]
-    manifest_project: Callable[[base_cli.Context, str | None], int]
-    resolve_project: Callable[[base_cli.Context, str | None, str | None], int]
-    test_command_project: Callable[[base_cli.Context, str | None, str | None], int]
-    demo_script_project: Callable[[base_cli.Context, str | None, str | None], int]
-    activation_sources_project: Callable[[base_cli.Context, str | None, str | None], int]
-    run_command_project: Callable[[base_cli.Context, str | None, str | None, str | None], int]
-    list_run_commands: Callable[[base_cli.Context, str | None, str | None], int]
-    build_targets: Callable[[base_cli.Context, tuple[str, ...], str | None], int]
-    build_target_list: Callable[[base_cli.Context, tuple[str, ...], str | None], int]
+    current_project: Callable[[base_cli.Context, str], int]
+    manifest_project: Callable[[base_cli.Context, str | None, str], int]
+    resolve_project: Callable[[base_cli.Context, str | None, str | None, str], int]
+    test_command_project: Callable[[base_cli.Context, str | None, str | None, str], int]
+    demo_script_project: Callable[[base_cli.Context, str | None, str | None, str], int]
+    activation_sources_project: Callable[[base_cli.Context, str | None, str | None, str], int]
+    run_command_project: Callable[[base_cli.Context, str | None, str | None, str | None, str], int]
+    list_run_commands: Callable[[base_cli.Context, str | None, str | None, str], int]
+    build_targets: Callable[[base_cli.Context, tuple[str, ...], str | None, str], int]
+    build_target_list: Callable[[base_cli.Context, tuple[str, ...], str | None, str], int]
 
 
 ProjectCommandHandler = Callable[
@@ -173,21 +173,21 @@ def _handle_configure(
 def _handle_current(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
-    _options: WorkspaceCommandOptions,
+    options: WorkspaceCommandOptions,
     actions: ProjectCommandActions,
 ) -> int:
     require_argument_count("current", arguments, 0, 0)
-    return actions.current_project(ctx)
+    return actions.current_project(ctx, options.output_format)
 
 
 def _handle_manifest(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
-    _options: WorkspaceCommandOptions,
+    options: WorkspaceCommandOptions,
     actions: ProjectCommandActions,
 ) -> int:
     require_argument_count("manifest", arguments, 0, 1)
-    return actions.manifest_project(ctx, arguments[0] if arguments else None)
+    return actions.manifest_project(ctx, arguments[0] if arguments else None, options.output_format)
 
 
 def _handle_resolve(
@@ -197,7 +197,7 @@ def _handle_resolve(
     actions: ProjectCommandActions,
 ) -> int:
     require_argument_count("resolve", arguments, 1, 1)
-    return actions.resolve_project(ctx, arguments[0], options.workspace)
+    return actions.resolve_project(ctx, arguments[0], options.workspace, options.output_format)
 
 
 def _handle_test_command(
@@ -207,7 +207,7 @@ def _handle_test_command(
     actions: ProjectCommandActions,
 ) -> int:
     project = optional_project_argument("test-command", arguments)
-    return actions.test_command_project(ctx, project, options.workspace)
+    return actions.test_command_project(ctx, project, options.workspace, options.output_format)
 
 
 def _handle_demo_script(
@@ -217,7 +217,7 @@ def _handle_demo_script(
     actions: ProjectCommandActions,
 ) -> int:
     project = optional_project_argument("demo-script", arguments)
-    return actions.demo_script_project(ctx, project, options.workspace)
+    return actions.demo_script_project(ctx, project, options.workspace, options.output_format)
 
 
 def _handle_activation_sources(
@@ -227,7 +227,7 @@ def _handle_activation_sources(
     actions: ProjectCommandActions,
 ) -> int:
     require_argument_count("activation-sources", arguments, 1, 1)
-    return actions.activation_sources_project(ctx, arguments[0], options.workspace)
+    return actions.activation_sources_project(ctx, arguments[0], options.workspace, options.output_format)
 
 
 def _handle_run_command(
@@ -237,7 +237,7 @@ def _handle_run_command(
     actions: ProjectCommandActions,
 ) -> int:
     require_argument_count("run-command", arguments, 2, 2)
-    return actions.run_command_project(ctx, arguments[0], arguments[1], options.workspace)
+    return actions.run_command_project(ctx, arguments[0], arguments[1], options.workspace, options.output_format)
 
 
 def _handle_run_commands(
@@ -247,7 +247,7 @@ def _handle_run_commands(
     actions: ProjectCommandActions,
 ) -> int:
     project = optional_project_argument("run-commands", arguments)
-    return actions.list_run_commands(ctx, project, options.workspace)
+    return actions.list_run_commands(ctx, project, options.workspace, options.output_format)
 
 
 def _handle_build_targets(
@@ -256,7 +256,7 @@ def _handle_build_targets(
     options: WorkspaceCommandOptions,
     actions: ProjectCommandActions,
 ) -> int:
-    return actions.build_targets(ctx, arguments, options.workspace)
+    return actions.build_targets(ctx, arguments, options.workspace, options.output_format)
 
 
 def _handle_build_target_list(
@@ -265,7 +265,7 @@ def _handle_build_target_list(
     options: WorkspaceCommandOptions,
     actions: ProjectCommandActions,
 ) -> int:
-    return actions.build_target_list(ctx, arguments, options.workspace)
+    return actions.build_target_list(ctx, arguments, options.workspace, options.output_format)
 
 
 SUPPORTED_PROJECT_COMMANDS = (

--- a/cli/python/base_projects/tests/test_build_targets.py
+++ b/cli/python/base_projects/tests/test_build_targets.py
@@ -8,6 +8,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.command_protocol import loads_records
 from base_projects import engine
 
 
@@ -161,6 +162,26 @@ def uv_route_fields(project_root: Path, *, trust_required: bool = True) -> str:
 
 
 class BuildTargetTests(unittest.TestCase):
+    def test_build_target_command_protocol_uses_explicit_typed_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo with spaces"
+            write_build_manifest_with_runner(project_root, "demo")
+
+            status, stdout, stderr = run_engine(
+                ["build-targets", "demo", "--format", "command-protocol"], base_home
+            )
+
+        self.assertEqual((status, stderr), (0, ""))
+        _, records = loads_records(stdout, "build-target")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["target_name"], "package")
+        self.assertEqual(records[0]["working_dir"], str((project_root / "services" / "api").resolve()))
+        self.assertEqual(records[0]["runner"], "uv")
+        self.assertTrue(records[0]["manifest_command_trust_required"])
+
     def test_projects_build_targets_requires_project_argument(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -11,6 +11,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.command_protocol import loads_records
 from base_projects import engine, project_discovery
 
 
@@ -234,6 +235,110 @@ def run_engine_with_home(args: list[str], base_home: Path, home: Path) -> tuple[
 
 
 class ProjectDiscoveryTests(unittest.TestCase):
+    # pylint: disable=too-many-statements
+    def test_command_protocol_covers_project_command_bridge_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "space λ demo"
+            nested = project_root / "docs"
+            demo_script = project_root / "demo" / "demo λ.sh"
+            activation_script = project_root / "scripts" / "activate λ.sh"
+            demo_script.parent.mkdir(parents=True)
+            activation_script.parent.mkdir(parents=True)
+            nested.mkdir()
+            demo_script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            demo_script.chmod(0o755)
+            activation_script.write_text("export DEMO=1\n", encoding="utf-8")
+            manifest_path = project_root / "base_manifest.yaml"
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "test:",
+                        '  command: "pytest tests/\\tunit"',
+                        "commands:",
+                        "  dev:",
+                        '    command: "printf λ done"',
+                        "    runner: uv",
+                        "demo:",
+                        '  script: "demo/demo λ.sh"',
+                        "activate:",
+                        "  source:",
+                        '    - "scripts/activate λ.sh"',
+                        "artifacts: []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_engine(["resolve", "demo", "--format", "command-protocol"], base_home)
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "project-route")
+            self.assertEqual(records[0]["project_root"], str(project_root.resolve()))
+            self.assertTrue(records[0]["manifest_command_trust_required"])
+
+            status, stdout, stderr = run_engine(
+                ["test-command", "demo", "--format", "command-protocol"], base_home
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "project-command")
+            self.assertEqual(records[0]["command"], "pytest tests/\tunit")
+            self.assertIsNone(records[0]["runner"])
+
+            status, stdout, stderr = run_engine(
+                ["run-command", "demo", "dev", "--format", "command-protocol"], base_home
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "project-command")
+            self.assertEqual(records[0]["command"], "printf λ done")
+            self.assertEqual(records[0]["runner"], "uv")
+
+            status, stdout, stderr = run_engine(
+                ["run-commands", "demo", "--format", "command-protocol"], base_home
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "named-command")
+            self.assertEqual([record["command_name"] for record in records], ["test", "dev"])
+
+            status, stdout, stderr = run_engine(
+                ["demo-script", "demo", "--format", "command-protocol"], base_home
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "demo")
+            self.assertEqual(records[0]["demo_script"], str(demo_script.resolve()))
+
+            status, stdout, stderr = run_engine(
+                ["activation-sources", "demo", "--format", "command-protocol"], base_home
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "activation-source")
+            self.assertEqual(records[0]["source_path"], str(activation_script.resolve()))
+
+            status, stdout, stderr = run_engine(["list", "--format", "command-protocol"], base_home)
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "project-list-entry")
+            self.assertEqual(records[0]["project_name"], "demo")
+
+            status, stdout, stderr = run_engine(
+                ["manifest", str(manifest_path), "--format", "command-protocol"], base_home
+            )
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "project-reference")
+            self.assertEqual(records[0]["manifest_path"], str(manifest_path.resolve()))
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(nested)
+                status, stdout, stderr = run_engine(["current", "--format", "command-protocol"], base_home)
+            finally:
+                os.chdir(old_cwd)
+            self.assertEqual((status, stderr), (0, ""))
+            _, records = loads_records(stdout, "project-reference")
+            self.assertEqual(records[0]["project_name"], "demo")
+
     def test_project_discovery_implementation_is_split_from_engine(self) -> None:
         engine_path = Path(engine.__file__)
         discovery_path = engine_path.with_name("project_discovery.py")

--- a/cli/python/base_setup/project_routing.py
+++ b/cli/python/base_setup/project_routing.py
@@ -4,6 +4,8 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+from base_cli.command_protocol import dumps_record
+
 from .manifest import BaseManifest
 from .project_environment import project_venv_dir_override
 from .uv import manifest_uses_uv_project_manager
@@ -41,6 +43,16 @@ class ProjectRoute:
                 uses_uv,
             ]
         )
+
+    def to_command_record(self) -> dict[str, str | bool]:
+        return {
+            "project_name": self.project,
+            "project_root": str(self.project_root),
+            "manifest_path": str(self.manifest_path),
+            "project_venv_dir": str(self.project_venv_dir),
+            "uses_uv_manager": self.uses_uv_manager,
+            "manifest_command_trust_required": False,
+        }
 
 
 def route_for_manifest(manifest: BaseManifest) -> ProjectRoute:
@@ -82,4 +94,6 @@ def route_to_text(route: ProjectRoute, output_format: str) -> str:
         return json.dumps(route.to_json(), indent=2)
     if output_format == "text":
         return route.to_tsv()
-    raise ValueError(f"Unsupported route output format '{output_format}'. Expected text or json.")
+    if output_format == "command-protocol":
+        return dumps_record("project-route", route.to_command_record())
+    raise ValueError(f"Unsupported route output format '{output_format}'. Expected text, json, or command-protocol.")

--- a/cli/python/base_setup/tests/test_project_routing.py
+++ b/cli/python/base_setup/tests/test_project_routing.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from base_cli.command_protocol import loads_records
 from base_setup.tests.helpers import run_engine
 
 
@@ -16,6 +17,34 @@ def write_manifest(root: Path, content: str) -> Path:
 
 
 class ProjectRoutingTests(unittest.TestCase):
+    def test_route_command_protocol_reports_explicit_route_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "demo λ"
+            manifest_path = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+
+            status, stdout, stderr = run_engine(
+                ["--manifest", str(manifest_path), "--action", "route", "--format", "command-protocol", "demo"]
+            )
+
+        self.assertEqual((status, stderr), (0, ""))
+        _, records = loads_records(stdout, "project-route")
+        self.assertEqual(records[0]["project_name"], "demo")
+        self.assertEqual(records[0]["project_root"], str(root.resolve()))
+        self.assertEqual(records[0]["project_venv_dir"], str(root.resolve() / ".venv"))
+        self.assertTrue(records[0]["uses_uv_manager"])
+        self.assertFalse(records[0]["manifest_command_trust_required"])
+
     def test_route_ignores_different_active_project_venv_override(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir) / "demo"

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -252,6 +252,30 @@ callers do not need to duplicate that check.
 The standalone install path, Base resolution order, and post-migration boundary
 are documented in [Base Bash Libraries](base-bash-libs.md).
 
+## Python-To-Bash Command Metadata
+
+Base's Python project commands keep their default `text` output for people and
+existing direct callers. Bash orchestration does not parse that display format.
+It explicitly requests the internal `--format command-protocol` transport when
+it needs project, route, command, build, demo, activation, or project-list
+metadata.
+
+The transport starts with `BASE_COMMAND_PROTOCOL_V1`, declares one record type
+and record count, and carries records with explicit field names and wire types.
+UTF-8 strings use lowercase hexadecimal framing, booleans use `true` or
+`false`, and nullable strings distinguish `null` from an empty string. Decoders
+validate the exact schema, framing, types, UTF-8, and canonical decimal record
+count before a caller uses any value. Version 1 caps the count at 1,000,000.
+NUL is rejected because Bash variables cannot represent it.
+
+This is an internal Base boundary, not a public automation format. Production
+Bash callers must not fall back to tab-position parsing, and the decoder does
+not require `jq` or another Python process. The standalone Bash and Zsh
+completion scripts use narrow readers for the same versioned
+`project-list-entry` records because completion can load before the full Base
+runtime; the Bash reader remains compatible with macOS system Bash 3. Normal
+Base command paths use `lib/bash/runtime/command_protocol.sh`.
+
 ## Runtime Shell
 
 Running `basectl activate <project>` starts an interactive Bash shell with the

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -91,8 +91,18 @@ _base_runtime_activate_project_venv() {
     source "$activate_script"
 }
 
+_base_runtime_source_activation_record() {
+    local script="${BASE_COMMAND_PROTOCOL_FIELDS[source_path]}"
+
+    _base_runtime_info "Sourcing project activation script '$script'."
+    # shellcheck source=/dev/null
+    source "$script" || {
+        _base_runtime_error "Project activation script '$script' failed."
+        return 1
+    }
+}
+
 _base_runtime_source_project_activation_scripts() {
-    local script
     local scripts_output
     local wrapper="$BASE_HOME/bin/base-wrapper"
 
@@ -105,20 +115,12 @@ _base_runtime_source_project_activation_scripts() {
         return 1
     }
 
-    scripts_output="$("$wrapper" base_projects activation-sources "$BASE_PROJECT")" || {
+    scripts_output="$("$wrapper" base_projects activation-sources "$BASE_PROJECT" --format command-protocol)" || {
         _base_runtime_error "Unable to resolve project activation scripts for '$BASE_PROJECT'."
         return 1
     }
 
-    while IFS= read -r script; do
-        [[ -n "$script" ]] || continue
-        _base_runtime_info "Sourcing project activation script '$script'."
-        # shellcheck source=/dev/null
-        source "$script" || {
-            _base_runtime_error "Project activation script '$script' failed."
-            return 1
-        }
-    done <<< "$scripts_output"
+    base_command_protocol_each activation-source "$scripts_output" _base_runtime_source_activation_record
 }
 
 _base_runtime_configure_path() {

--- a/lib/bash/runtime/command_protocol.sh
+++ b/lib/bash/runtime/command_protocol.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+
+[[ -n "${_base_command_protocol_sourced:-}" ]] && return 0
+_base_command_protocol_sourced=1
+readonly _base_command_protocol_sourced
+
+readonly BASE_COMMAND_PROTOCOL_HEADER="BASE_COMMAND_PROTOCOL_V1"
+readonly BASE_COMMAND_PROTOCOL_MAX_RECORD_COUNT=1000000
+declare -gA BASE_COMMAND_PROTOCOL_FIELDS=()
+declare -gA BASE_COMMAND_PROTOCOL_NULL_FIELDS=()
+declare -g BASE_COMMAND_PROTOCOL_RECORD_COUNT=0
+
+base_command_protocol_error() {
+    printf 'ERROR: Invalid Base command protocol: %s\n' "$*" >&2
+    return 1
+}
+
+base_command_protocol_record_fields() {
+    case "$1" in
+        project-list-entry)
+            printf '%s\n' project_name project_root
+            ;;
+        project-reference)
+            printf '%s\n' project_name project_root manifest_path
+            ;;
+        project-route)
+            printf '%s\n' \
+                project_name project_root manifest_path project_venv_dir \
+                uses_uv_manager manifest_command_trust_required
+            ;;
+        project-command)
+            printf '%s\n' \
+                project_name project_root manifest_path project_venv_dir \
+                uses_uv_manager manifest_command_trust_required command runner
+            ;;
+        named-command)
+            printf '%s\n' project_name project_root manifest_path command_name command runner
+            ;;
+        build-target)
+            printf '%s\n' \
+                project_name project_root manifest_path project_venv_dir \
+                uses_uv_manager manifest_command_trust_required target_name \
+                working_dir command description runner
+            ;;
+        demo)
+            printf '%s\n' \
+                project_name project_root manifest_path project_venv_dir \
+                uses_uv_manager manifest_command_trust_required demo_script runner
+            ;;
+        activation-source)
+            printf '%s\n' source_path
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+base_command_protocol_field_spec() {
+    local record_type="$1"
+    local field_name="$2"
+
+    case "$record_type:$field_name" in
+        project-list-entry:project_name|project-list-entry:project_root|\
+        project-reference:project_name|project-reference:project_root|project-reference:manifest_path|\
+        project-route:project_name|project-route:project_root|project-route:manifest_path|\
+        project-route:project_venv_dir|\
+        project-command:project_name|project-command:project_root|project-command:manifest_path|\
+        project-command:project_venv_dir|project-command:command|\
+        named-command:project_name|named-command:project_root|named-command:manifest_path|\
+        named-command:command_name|named-command:command|\
+        build-target:project_name|build-target:project_root|build-target:manifest_path|\
+        build-target:project_venv_dir|build-target:target_name|build-target:working_dir|\
+        build-target:command|\
+        demo:project_name|demo:project_root|demo:manifest_path|demo:project_venv_dir|\
+        demo:demo_script|activation-source:source_path)
+            printf 'string\n'
+            ;;
+        project-route:uses_uv_manager|project-route:manifest_command_trust_required|\
+        project-command:uses_uv_manager|project-command:manifest_command_trust_required|\
+        build-target:uses_uv_manager|build-target:manifest_command_trust_required|\
+        demo:uses_uv_manager|demo:manifest_command_trust_required)
+            printf 'boolean\n'
+            ;;
+        project-command:runner|named-command:runner|build-target:description|\
+        build-target:runner|demo:runner)
+            printf 'nullable-string\n'
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+base_command_protocol_decode_hex() {
+    local encoded="$1"
+    local decoded=""
+    local byte pair
+    local index
+
+    if (( ${#encoded} % 2 != 0 )) || [[ "$encoded" == *[!0-9a-f]* ]]; then
+        base_command_protocol_error "string field has invalid lowercase hexadecimal data"
+        return 1
+    fi
+    base_command_protocol_validate_utf8_hex "$encoded" || return 1
+
+    for ((index = 0; index < ${#encoded}; index += 2)); do
+        pair="${encoded:index:2}"
+        [[ "$pair" != 00 ]] || {
+            base_command_protocol_error "string field cannot contain NUL"
+            return 1
+        }
+        printf -v byte '%b' "\\x$pair"
+        decoded+="$byte"
+    done
+    BASE_COMMAND_PROTOCOL_DECODED_VALUE="$decoded"
+}
+
+base_command_protocol_validate_utf8_hex() {
+    local encoded="$1"
+    local byte continuation first index=0 length=${#1}
+    local continuation_count continuation_min continuation_max
+
+    while ((index < length)); do
+        byte=$((16#${encoded:index:2}))
+        ((index += 2))
+        if ((byte <= 0x7f)); then
+            continue
+        elif ((byte >= 0xc2 && byte <= 0xdf)); then
+            continuation_count=1
+            continuation_min=0x80
+            continuation_max=0xbf
+        elif ((byte >= 0xe0 && byte <= 0xef)); then
+            continuation_count=2
+            if ((byte == 0xe0)); then
+                continuation_min=0xa0
+                continuation_max=0xbf
+            elif ((byte == 0xed)); then
+                continuation_min=0x80
+                continuation_max=0x9f
+            else
+                continuation_min=0x80
+                continuation_max=0xbf
+            fi
+        elif ((byte >= 0xf0 && byte <= 0xf4)); then
+            continuation_count=3
+            if ((byte == 0xf0)); then
+                continuation_min=0x90
+                continuation_max=0xbf
+            elif ((byte == 0xf4)); then
+                continuation_min=0x80
+                continuation_max=0x8f
+            else
+                continuation_min=0x80
+                continuation_max=0xbf
+            fi
+        else
+            base_command_protocol_error "string field has invalid UTF-8 data"
+            return 1
+        fi
+
+        ((index + continuation_count * 2 <= length)) || {
+            base_command_protocol_error "string field has invalid UTF-8 data"
+            return 1
+        }
+        first=$((16#${encoded:index:2}))
+        ((first >= continuation_min && first <= continuation_max)) || {
+            base_command_protocol_error "string field has invalid UTF-8 data"
+            return 1
+        }
+        ((index += 2))
+        for ((continuation = 1; continuation < continuation_count; continuation += 1)); do
+            byte=$((16#${encoded:index:2}))
+            ((byte >= 0x80 && byte <= 0xbf)) || {
+                base_command_protocol_error "string field has invalid UTF-8 data"
+                return 1
+            }
+            ((index += 2))
+        done
+    done
+}
+
+base_command_protocol_validate_record() {
+    local record_type="$1"
+    local field_name
+
+    while IFS= read -r field_name; do
+        [[ -n "$field_name" ]] || continue
+        [[ -n "${BASE_COMMAND_PROTOCOL_FIELDS[$field_name]+present}" ]] || {
+            base_command_protocol_error "record is missing field '$field_name' for '$record_type'"
+            return 1
+        }
+    done < <(base_command_protocol_record_fields "$record_type")
+}
+
+base_command_protocol_parse_field() {
+    local record_type="$1"
+    local line="$2"
+    local descriptor encoded field_name field_spec key value wire_type
+
+    [[ "$line" == *=* ]] || {
+        base_command_protocol_error "expected field.<name>:<type>=<payload>"
+        return 1
+    }
+    key="${line%%=*}"
+    encoded="${line#*=}"
+    [[ "$key" == field.*:* ]] || {
+        base_command_protocol_error "expected field.<name>:<type>=<payload>"
+        return 1
+    }
+    descriptor="${key#field.}"
+    field_name="${descriptor%%:*}"
+    wire_type="${descriptor#*:}"
+    [[ -n "$field_name" && -n "$wire_type" ]] || {
+        base_command_protocol_error "expected field.<name>:<type>=<payload>"
+        return 1
+    }
+    field_spec="$(base_command_protocol_field_spec "$record_type" "$field_name")" || {
+        base_command_protocol_error "record has unknown field '$field_name' for '$record_type'"
+        return 1
+    }
+    [[ -z "${BASE_COMMAND_PROTOCOL_FIELDS[$field_name]+present}" ]] || {
+        base_command_protocol_error "record duplicates field '$field_name'"
+        return 1
+    }
+
+    case "$field_spec:$wire_type" in
+        string:string|nullable-string:string)
+            base_command_protocol_decode_hex "$encoded" || return 1
+            value="$BASE_COMMAND_PROTOCOL_DECODED_VALUE"
+            ;;
+        nullable-string:null)
+            [[ -z "$encoded" ]] || {
+                base_command_protocol_error "null field '$field_name' must have an empty payload"
+                return 1
+            }
+            value=""
+            BASE_COMMAND_PROTOCOL_NULL_FIELDS["$field_name"]=1
+            ;;
+        boolean:boolean)
+            [[ "$encoded" == true || "$encoded" == false ]] || {
+                base_command_protocol_error "boolean field '$field_name' must be true or false"
+                return 1
+            }
+            value="$encoded"
+            ;;
+        *)
+            base_command_protocol_error "field '$field_name' has wire type '$wire_type', expected '$field_spec'"
+            return 1
+            ;;
+    esac
+    BASE_COMMAND_PROTOCOL_FIELDS["$field_name"]="$value"
+}
+
+_base_command_protocol_parse_pass() {
+    local expected_record_type="$1"
+    local payload="$2"
+    local callback="${3:-}"
+    local count_text="" ended=0 in_record=0 line record_index=-1 record_type=""
+    local line_number=0 next_record=0
+
+    BASE_COMMAND_PROTOCOL_RECORD_COUNT=0
+    BASE_COMMAND_PROTOCOL_FIELDS=()
+    BASE_COMMAND_PROTOCOL_NULL_FIELDS=()
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        ((line_number += 1))
+        case "$line_number" in
+            1)
+                [[ "$line" == "$BASE_COMMAND_PROTOCOL_HEADER" ]] || {
+                    base_command_protocol_error "unsupported protocol header"
+                    return 1
+                }
+                continue
+                ;;
+            2)
+                [[ "$line" == record_type=* ]] || {
+                    base_command_protocol_error "missing record_type metadata"
+                    return 1
+                }
+                record_type="${line#record_type=}"
+                [[ "$record_type" == "$expected_record_type" ]] || {
+                    base_command_protocol_error "expected record_type '$expected_record_type', got '$record_type'"
+                    return 1
+                }
+                base_command_protocol_record_fields "$record_type" >/dev/null || {
+                    base_command_protocol_error "unsupported record_type '$record_type'"
+                    return 1
+                }
+                continue
+                ;;
+            3)
+                [[ "$line" == record_count=* ]] || {
+                    base_command_protocol_error "missing record_count metadata"
+                    return 1
+                }
+                count_text="${line#record_count=}"
+                [[ "$count_text" =~ ^(0|[1-9][0-9]*)$ ]] || {
+                    base_command_protocol_error "record_count must be a canonical non-negative integer"
+                    return 1
+                }
+                ((${#count_text} <= ${#BASE_COMMAND_PROTOCOL_MAX_RECORD_COUNT})) || {
+                    base_command_protocol_error \
+                        "record_count exceeds protocol maximum of $BASE_COMMAND_PROTOCOL_MAX_RECORD_COUNT"
+                    return 1
+                }
+                BASE_COMMAND_PROTOCOL_RECORD_COUNT="$((10#$count_text))"
+                ((BASE_COMMAND_PROTOCOL_RECORD_COUNT <= BASE_COMMAND_PROTOCOL_MAX_RECORD_COUNT)) || {
+                    base_command_protocol_error \
+                        "record_count exceeds protocol maximum of $BASE_COMMAND_PROTOCOL_MAX_RECORD_COUNT"
+                    return 1
+                }
+                continue
+                ;;
+        esac
+
+        ((ended == 0)) || {
+            base_command_protocol_error "unexpected data after end_protocol marker"
+            return 1
+        }
+        if ((in_record == 0)); then
+            if [[ "$line" == "record=$next_record" && next_record -lt BASE_COMMAND_PROTOCOL_RECORD_COUNT ]]; then
+                record_index="$next_record"
+                BASE_COMMAND_PROTOCOL_FIELDS=()
+                # shellcheck disable=SC2034 # Nullable state is an output contract read by callbacks.
+                BASE_COMMAND_PROTOCOL_NULL_FIELDS=()
+                in_record=1
+                continue
+            fi
+            if [[ "$line" == "end_protocol=" && next_record -eq BASE_COMMAND_PROTOCOL_RECORD_COUNT ]]; then
+                ended=1
+                continue
+            fi
+            base_command_protocol_error "expected record=$next_record or end_protocol marker"
+            return 1
+        fi
+
+        if [[ "$line" == field.* ]]; then
+            base_command_protocol_parse_field "$record_type" "$line" || return 1
+            continue
+        fi
+        if [[ "$line" == "end_record=$record_index" ]]; then
+            base_command_protocol_validate_record "$record_type" || return 1
+            if [[ -n "$callback" ]]; then
+                "$callback" || return $?
+            fi
+            ((next_record += 1))
+            in_record=0
+            continue
+        fi
+        base_command_protocol_error "expected a field or end_record=$record_index"
+        return 1
+    done <<<"$payload"
+
+    ((line_number >= 3)) || {
+        base_command_protocol_error "incomplete protocol metadata"
+        return 1
+    }
+    ((in_record == 0 && ended == 1)) || {
+        base_command_protocol_error "protocol ended before all records were complete"
+        return 1
+    }
+}
+
+base_command_protocol_parse() {
+    _base_command_protocol_parse_pass "$1" "$2"
+}
+
+base_command_protocol_decode_one() {
+    local expected_record_type="$1"
+    local payload="$2"
+
+    base_command_protocol_parse "$expected_record_type" "$payload" || return 1
+    ((BASE_COMMAND_PROTOCOL_RECORD_COUNT == 1)) || {
+        base_command_protocol_error "expected exactly one '$expected_record_type' record"
+        return 1
+    }
+}
+
+base_command_protocol_each() {
+    local expected_record_type="$1"
+    local payload="$2"
+    local callback="$3"
+
+    [[ -n "$callback" ]] || {
+        base_command_protocol_error "record callback is required"
+        return 1
+    }
+    # Validate the entire envelope before exposing the first record. The second
+    # pass invokes callbacks only after framing, count, schema, and types for all
+    # records are known to be valid.
+    base_command_protocol_parse "$expected_record_type" "$payload" || return 1
+    _base_command_protocol_parse_pass "$expected_record_type" "$payload" "$callback"
+}

--- a/lib/python/base_cli/command_protocol.py
+++ b/lib/python/base_cli/command_protocol.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+PROTOCOL_HEADER = "BASE_COMMAND_PROTOCOL_V1"
+MAX_RECORD_COUNT = 1_000_000
+
+
+class CommandProtocolError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    value_type: str
+    nullable: bool = False
+
+
+STRING = FieldSpec("string")
+NULLABLE_STRING = FieldSpec("string", nullable=True)
+BOOLEAN = FieldSpec("boolean")
+
+PROJECT_REFERENCE_FIELDS = {
+    "project_name": STRING,
+    "project_root": STRING,
+    "manifest_path": STRING,
+}
+PROJECT_ROUTE_FIELDS = {
+    **PROJECT_REFERENCE_FIELDS,
+    "project_venv_dir": STRING,
+    "uses_uv_manager": BOOLEAN,
+    "manifest_command_trust_required": BOOLEAN,
+}
+
+RECORD_SCHEMAS: dict[str, dict[str, FieldSpec]] = {
+    "project-list-entry": {
+        "project_name": STRING,
+        "project_root": STRING,
+    },
+    "project-reference": PROJECT_REFERENCE_FIELDS,
+    "project-route": PROJECT_ROUTE_FIELDS,
+    "project-command": {
+        **PROJECT_ROUTE_FIELDS,
+        "command": STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "named-command": {
+        **PROJECT_REFERENCE_FIELDS,
+        "command_name": STRING,
+        "command": STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "build-target": {
+        **PROJECT_ROUTE_FIELDS,
+        "target_name": STRING,
+        "working_dir": STRING,
+        "command": STRING,
+        "description": NULLABLE_STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "demo": {
+        **PROJECT_ROUTE_FIELDS,
+        "demo_script": STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "activation-source": {
+        "source_path": STRING,
+    },
+}
+
+RecordValue = str | bool | None
+Record = Mapping[str, RecordValue]
+
+
+def dumps_record(record_type: str, record: Record) -> str:
+    return dumps_records(record_type, (record,))
+
+
+def dumps_records(record_type: str, records: tuple[Record, ...] | list[Record]) -> str:
+    schema = _schema(record_type)
+    if len(records) > MAX_RECORD_COUNT:
+        raise CommandProtocolError(f"record_count exceeds protocol maximum of {MAX_RECORD_COUNT}")
+    lines = [
+        PROTOCOL_HEADER,
+        f"record_type={record_type}",
+        f"record_count={len(records)}",
+    ]
+    for index, record in enumerate(records):
+        _validate_record(schema, record_type, record)
+        lines.append(f"record={index}")
+        for field_name, spec in schema.items():
+            wire_type, payload = _encode_value(field_name, spec, record[field_name])
+            lines.append(f"field.{field_name}:{wire_type}={payload}")
+        lines.append(f"end_record={index}")
+    lines.append("end_protocol=")
+    return "\n".join(lines)
+
+
+def loads_records(
+    payload: str,
+    expected_record_type: str | None = None,
+) -> tuple[str, tuple[dict[str, RecordValue], ...]]:
+    # The wire framing is LF-delimited. `str.splitlines()` also accepts CR,
+    # vertical tab, form feed, and Unicode separators, which would make the
+    # Python decoder more permissive than the Bash and Zsh readers.
+    # A CLI `print()` adds one terminal LF; accept that conventional text-file
+    # terminator without accepting an extra blank line or other separators.
+    framed_payload = payload.removesuffix("\n")
+    lines = framed_payload.split("\n")
+    cursor = 0
+
+    def take(label: str) -> str:
+        nonlocal cursor
+        if cursor >= len(lines):
+            raise CommandProtocolError(f"missing {label}")
+        line = lines[cursor]
+        cursor += 1
+        return line
+
+    if take("protocol header") != PROTOCOL_HEADER:
+        raise CommandProtocolError(f"unsupported protocol header; expected {PROTOCOL_HEADER}")
+
+    record_type = _metadata_value(take("record_type"), "record_type")
+    schema = _schema(record_type)
+    if expected_record_type is not None and record_type != expected_record_type:
+        raise CommandProtocolError(f"expected record_type '{expected_record_type}', got '{record_type}'")
+
+    record_count_text = _metadata_value(take("record_count"), "record_count")
+    record_count = _parse_record_count(record_count_text)
+
+    records: list[dict[str, RecordValue]] = []
+    for index in range(record_count):
+        if take(f"record {index}") != f"record={index}":
+            raise CommandProtocolError(f"expected record={index}")
+
+        record: dict[str, RecordValue] = {}
+        for _field_index in range(len(schema)):
+            field_name, wire_type, encoded_value = _parse_field_line(take(f"field in record {index}"))
+            if field_name in record:
+                raise CommandProtocolError(f"record {index} duplicates field '{field_name}'")
+            try:
+                spec = schema[field_name]
+            except KeyError as exc:
+                raise CommandProtocolError(
+                    f"record {index} has unknown field '{field_name}' for '{record_type}'"
+                ) from exc
+            record[field_name] = _decode_value(field_name, spec, wire_type, encoded_value)
+
+        missing = sorted(set(schema) - set(record))
+        if missing:
+            raise CommandProtocolError(f"record {index} is missing fields: {', '.join(missing)}")
+        if take(f"end_record {index}") != f"end_record={index}":
+            raise CommandProtocolError(f"expected end_record={index}")
+        records.append(record)
+
+    if take("end_protocol") != "end_protocol=":
+        raise CommandProtocolError("expected end_protocol marker")
+    if cursor != len(lines):
+        raise CommandProtocolError("unexpected data after end_protocol marker")
+    return record_type, tuple(records)
+
+
+def _schema(record_type: str) -> dict[str, FieldSpec]:
+    try:
+        return RECORD_SCHEMAS[record_type]
+    except KeyError as exc:
+        supported = ", ".join(sorted(RECORD_SCHEMAS))
+        raise CommandProtocolError(f"unsupported record_type '{record_type}'; expected one of: {supported}") from exc
+
+
+def _validate_record(schema: Mapping[str, FieldSpec], record_type: str, record: Record) -> None:
+    missing = sorted(set(schema) - set(record))
+    unknown = sorted(set(record) - set(schema))
+    if missing:
+        raise CommandProtocolError(f"record for '{record_type}' is missing fields: {', '.join(missing)}")
+    if unknown:
+        raise CommandProtocolError(f"record for '{record_type}' has unknown fields: {', '.join(unknown)}")
+
+
+def _encode_value(field_name: str, spec: FieldSpec, value: RecordValue) -> tuple[str, str]:
+    if value is None:
+        if not spec.nullable:
+            raise CommandProtocolError(f"field '{field_name}' cannot be null")
+        return "null", ""
+    if spec.value_type == "boolean":
+        if not isinstance(value, bool):
+            raise CommandProtocolError(f"field '{field_name}' must be a boolean")
+        return "boolean", "true" if value else "false"
+    if not isinstance(value, str):
+        raise CommandProtocolError(f"field '{field_name}' must be a string")
+    if "\0" in value:
+        raise CommandProtocolError(f"field '{field_name}' cannot contain NUL")
+    return "string", value.encode("utf-8").hex()
+
+
+def _decode_value(field_name: str, spec: FieldSpec, wire_type: str, payload: str) -> RecordValue:
+    if wire_type == "null":
+        if not spec.nullable:
+            raise CommandProtocolError(f"field '{field_name}' cannot be null")
+        if payload:
+            raise CommandProtocolError(f"null field '{field_name}' must have an empty payload")
+        return None
+    if spec.value_type == "boolean":
+        if wire_type != "boolean" or payload not in ("true", "false"):
+            raise CommandProtocolError(f"field '{field_name}' must use boolean:true or boolean:false")
+        return payload == "true"
+    if wire_type != "string":
+        expected = "string or null" if spec.nullable else "string"
+        raise CommandProtocolError(f"field '{field_name}' must use {expected} encoding")
+    if len(payload) % 2 != 0 or re.fullmatch(r"[0-9a-f]*", payload) is None:
+        raise CommandProtocolError(f"field '{field_name}' has invalid lowercase hexadecimal data")
+    try:
+        value = bytes.fromhex(payload).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CommandProtocolError(f"field '{field_name}' has invalid UTF-8 data") from exc
+    if "\0" in value:
+        raise CommandProtocolError(f"field '{field_name}' cannot contain NUL")
+    return value
+
+
+def _metadata_value(line: str, name: str) -> str:
+    prefix = f"{name}="
+    if not line.startswith(prefix):
+        raise CommandProtocolError(f"expected {name} metadata")
+    return line[len(prefix) :]
+
+
+def _parse_record_count(record_count_text: str) -> int:
+    if re.fullmatch(r"0|[1-9][0-9]*", record_count_text) is None:
+        raise CommandProtocolError("record_count must be a canonical non-negative integer")
+    if len(record_count_text) > len(str(MAX_RECORD_COUNT)):
+        raise CommandProtocolError(f"record_count exceeds protocol maximum of {MAX_RECORD_COUNT}")
+    record_count = int(record_count_text)
+    if record_count > MAX_RECORD_COUNT:
+        raise CommandProtocolError(f"record_count exceeds protocol maximum of {MAX_RECORD_COUNT}")
+    return record_count
+
+
+def _parse_field_line(line: str) -> tuple[str, str, str]:
+    key, separator, payload = line.partition("=")
+    if not separator or not key.startswith("field."):
+        raise CommandProtocolError("expected field.<name>:<type>=<payload>")
+    descriptor = key.removeprefix("field.")
+    field_name, separator, wire_type = descriptor.partition(":")
+    if not separator or not field_name or not wire_type:
+        raise CommandProtocolError("expected field.<name>:<type>=<payload>")
+    return field_name, wire_type, payload

--- a/lib/python/base_cli/tests/test_command_protocol.py
+++ b/lib/python/base_cli/tests/test_command_protocol.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from base_cli.command_protocol import CommandProtocolError
+from base_cli.command_protocol import dumps_record
+from base_cli.command_protocol import dumps_records
+from base_cli.command_protocol import loads_records
+
+
+def project_command_record(**overrides: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "project_name": "demo",
+        "project_root": "/tmp/work space/demo",
+        "manifest_path": "/tmp/work space/demo/base_manifest.yaml",
+        "project_venv_dir": "/tmp/work space/demo/.venv",
+        "uses_uv_manager": False,
+        "manifest_command_trust_required": True,
+        "command": "printf 'tab=\t unicode=λ newline=\n control=\x01'",
+        "runner": None,
+    }
+    record.update(overrides)
+    return record
+
+
+class CommandProtocolTests(unittest.TestCase):
+    def test_round_trip_preserves_manifest_strings_and_empty_optional_fields(self) -> None:
+        records = (
+            project_command_record(),
+            project_command_record(command="line one\nline two\t雪", runner=""),
+        )
+
+        payload = dumps_records("project-command", records)
+        record_type, decoded = loads_records(payload, expected_record_type="project-command")
+
+        self.assertEqual(record_type, "project-command")
+        self.assertEqual(decoded, records)
+        self.assertIsNone(decoded[0]["runner"])
+        self.assertEqual(decoded[1]["runner"], "")
+
+    def test_protocol_has_stable_version_type_and_explicit_field_names(self) -> None:
+        payload = dumps_record("project-command", project_command_record())
+
+        self.assertTrue(payload.startswith("BASE_COMMAND_PROTOCOL_V1\n"))
+        self.assertIn("record_type=project-command\n", payload)
+        self.assertIn("record_count=1\n", payload)
+        self.assertIn("field.project_name:string=", payload)
+        self.assertIn("field.runner:null=\n", payload)
+
+        _, decoded = loads_records(f"{payload}\n", expected_record_type="project-command")
+        self.assertEqual(decoded, (project_command_record(),))
+
+    def test_rejects_missing_and_unknown_fields_before_serializing(self) -> None:
+        missing = project_command_record()
+        del missing["command"]
+        unknown = project_command_record(extra="value")
+
+        with self.assertRaisesRegex(CommandProtocolError, "missing fields: command"):
+            dumps_record("project-command", missing)
+        with self.assertRaisesRegex(CommandProtocolError, "unknown fields: extra"):
+            dumps_record("project-command", unknown)
+
+    def test_rejects_oversized_record_sets_before_serializing(self) -> None:
+        with patch("base_cli.command_protocol.MAX_RECORD_COUNT", 0):
+            with self.assertRaisesRegex(CommandProtocolError, "protocol maximum"):
+                dumps_record("project-command", project_command_record())
+
+    def test_rejects_wrong_field_types_and_nul(self) -> None:
+        with self.assertRaisesRegex(CommandProtocolError, "uses_uv_manager.*boolean"):
+            dumps_record("project-command", project_command_record(uses_uv_manager="false"))
+        with self.assertRaisesRegex(CommandProtocolError, "runner.*string"):
+            dumps_record("project-command", project_command_record(runner=7))
+        with self.assertRaisesRegex(CommandProtocolError, "command.*NUL"):
+            dumps_record("project-command", project_command_record(command="bad\0command"))
+
+    def test_rejects_wrong_protocol_version_and_record_type(self) -> None:
+        payload = dumps_record("project-command", project_command_record())
+
+        with self.assertRaisesRegex(CommandProtocolError, "unsupported protocol header"):
+            loads_records(payload.replace("_V1", "_V2", 1))
+        with self.assertRaisesRegex(CommandProtocolError, "expected record_type 'demo'"):
+            loads_records(payload, expected_record_type="demo")
+
+    def test_rejects_malformed_record_metadata_and_trailing_data(self) -> None:
+        payload = dumps_record("project-command", project_command_record())
+
+        with self.assertRaisesRegex(CommandProtocolError, "record_count"):
+            loads_records(payload.replace("record_count=1", "record_count=one", 1))
+        with self.assertRaisesRegex(CommandProtocolError, "canonical"):
+            loads_records(payload.replace("record_count=1", "record_count=01", 1))
+        with self.assertRaisesRegex(CommandProtocolError, "protocol maximum"):
+            loads_records(payload.replace("record_count=1", "record_count=1000001", 1))
+        with self.assertRaisesRegex(CommandProtocolError, "protocol maximum"):
+            loads_records(payload.replace("record_count=1", f"record_count={'9' * 5000}", 1))
+        with self.assertRaisesRegex(CommandProtocolError, "expected record=0"):
+            loads_records(payload.replace("record=0", "record=1", 1))
+        with self.assertRaisesRegex(CommandProtocolError, "unexpected data"):
+            loads_records(f"{payload}\nextra=true")
+        with self.assertRaisesRegex(CommandProtocolError, "unexpected data"):
+            loads_records(f"{payload}\n\n")
+        with self.assertRaisesRegex(CommandProtocolError, "protocol header"):
+            loads_records(payload.replace("\n", "\r\n"))
+        with self.assertRaisesRegex(CommandProtocolError, "protocol header"):
+            loads_records(payload.replace("\n", "\v"))
+
+    def test_rejects_duplicate_unknown_missing_and_invalidly_encoded_fields(self) -> None:
+        payload = dumps_record("project-command", project_command_record())
+        duplicate = payload.replace(
+            "field.project_root:string=",
+            "field.project_name:string=",
+            1,
+        )
+        unknown = payload.replace(
+            "field.project_root:string=",
+            "field.unknown:string=",
+            1,
+        )
+        wrong_type = payload.replace(
+            "field.uses_uv_manager:boolean=false",
+            "field.uses_uv_manager:string=false",
+            1,
+        )
+        malformed_hex = payload.replace(
+            "field.project_name:string=64656d6f",
+            "field.project_name:string=xyz",
+            1,
+        )
+
+        with self.assertRaisesRegex(CommandProtocolError, "duplicates field 'project_name'"):
+            loads_records(duplicate)
+        with self.assertRaisesRegex(CommandProtocolError, "unknown field 'unknown'"):
+            loads_records(unknown)
+        with self.assertRaisesRegex(CommandProtocolError, "uses_uv_manager.*boolean"):
+            loads_records(wrong_type)
+        with self.assertRaisesRegex(CommandProtocolError, "invalid lowercase hexadecimal"):
+            loads_records(malformed_hex)
+
+    def test_python_project_list_framing_is_consumed_by_standalone_completion_reader(self) -> None:
+        payload = dumps_records(
+            "project-list-entry",
+            [
+                {"project_name": "base", "project_root": "/tmp/base"},
+                {"project_name": "demo", "project_root": "/tmp/work space/λ demo"},
+            ],
+        )
+        repo_root = Path(__file__).resolve().parents[4]
+        completion_script = repo_root / "lib" / "shell" / "completions" / "basectl_completion.sh"
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                "-c",
+                'source "$COMPLETION_SCRIPT"; '
+                '_base_basectl_completion_project_names_from_protocol "$PAYLOAD" || exit; '
+                'printf "%s\\n" "$_BASE_BASECTL_COMPLETION_PROJECT_NAMES_DECODED"',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "COMPLETION_SCRIPT": str(completion_script), "PAYLOAD": payload},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "base\ndemo\n")
+
+    def test_python_command_framing_is_consumed_by_runtime_bash_decoder(self) -> None:
+        command = "printf 'tab=\t unicode=λ newline=\n control=\x01'"
+        payload = dumps_record(
+            "project-command",
+            project_command_record(command=command),
+        )
+        repo_root = Path(__file__).resolve().parents[4]
+        decoder_script = repo_root / "lib" / "bash" / "runtime" / "command_protocol.sh"
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$DECODER_SCRIPT"; '
+                'base_command_protocol_decode_one project-command "$PAYLOAD" || exit; '
+                '[[ "${BASE_COMMAND_PROTOCOL_FIELDS[command]}" == "$EXPECTED_COMMAND" ]] || exit 2; '
+                '[[ "${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}" == "/tmp/work space/demo" ]] || exit 3; '
+                '[[ "${BASE_COMMAND_PROTOCOL_NULL_FIELDS[runner]:-}" == 1 ]] || exit 4; '
+                'printf "decoded\\n"',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "DECODER_SCRIPT": str(decoder_script),
+                "EXPECTED_COMMAND": command,
+                "PAYLOAD": payload,
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "decoded\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -19,21 +19,156 @@ _base_basectl_completion_now() {
     printf '%s\n' "${SECONDS:-0}"
 }
 
-_base_basectl_completion_project_names_from_list() {
-    local line name names=""
+_base_basectl_completion_validate_utf8_hex() {
+    local encoded="$1"
+    local byte continuation first index=0 length
+    local continuation_count continuation_min continuation_max
 
-    while IFS= read -r line; do
-        [[ -n "$line" ]] || continue
-        IFS=$'\t' read -r name _ <<<"$line"
-        [[ -n "$name" ]] || continue
-        names+="${names:+$'\n'}$name"
+    length=${#encoded}
+    while ((index < length)); do
+        byte=$((16#${encoded:index:2}))
+        ((index += 2))
+        if ((byte <= 0x7f)); then
+            continue
+        elif ((byte >= 0xc2 && byte <= 0xdf)); then
+            continuation_count=1
+            continuation_min=0x80
+            continuation_max=0xbf
+        elif ((byte >= 0xe0 && byte <= 0xef)); then
+            continuation_count=2
+            if ((byte == 0xe0)); then
+                continuation_min=0xa0
+                continuation_max=0xbf
+            elif ((byte == 0xed)); then
+                continuation_min=0x80
+                continuation_max=0x9f
+            else
+                continuation_min=0x80
+                continuation_max=0xbf
+            fi
+        elif ((byte >= 0xf0 && byte <= 0xf4)); then
+            continuation_count=3
+            if ((byte == 0xf0)); then
+                continuation_min=0x90
+                continuation_max=0xbf
+            elif ((byte == 0xf4)); then
+                continuation_min=0x80
+                continuation_max=0x8f
+            else
+                continuation_min=0x80
+                continuation_max=0xbf
+            fi
+        else
+            return 1
+        fi
+
+        ((index + continuation_count * 2 <= length)) || return 1
+        first=$((16#${encoded:index:2}))
+        ((first >= continuation_min && first <= continuation_max)) || return 1
+        ((index += 2))
+        for ((continuation = 1; continuation < continuation_count; continuation += 1)); do
+            byte=$((16#${encoded:index:2}))
+            ((byte >= 0x80 && byte <= 0xbf)) || return 1
+            ((index += 2))
+        done
     done
+}
 
-    printf '%s\n' "$names"
+_base_basectl_completion_decode_hex() {
+    local encoded="$1"
+    local byte decoded="" index pair
+
+    if (( ${#encoded} % 2 != 0 )) || [[ "$encoded" == *[!0-9a-f]* ]]; then
+        return 1
+    fi
+    _base_basectl_completion_validate_utf8_hex "$encoded" || return 1
+
+    for ((index = 0; index < ${#encoded}; index += 2)); do
+        pair="${encoded:index:2}"
+        [[ "$pair" != 00 ]] || return 1
+        printf -v byte '%b' "\\x$pair"
+        decoded+="$byte"
+    done
+    _BASE_BASECTL_COMPLETION_DECODED_VALUE="$decoded"
+}
+
+_base_basectl_completion_project_names_from_protocol() {
+    # Completion can load under macOS system Bash 3 before basectl establishes
+    # its Bash 4.2+ runtime. Keep this strict reader narrow instead of sourcing
+    # the associative-array runtime protocol decoder.
+    local payload="$1"
+    local count_text="" encoded ended=0 in_record=0 line line_number=0 names=""
+    local max_record_count=1000000 next_record=0 phase=0 project_name record_count=0
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        ((line_number += 1))
+        case "$line_number" in
+            1)
+                [[ "$line" == BASE_COMMAND_PROTOCOL_V1 ]] || return 1
+                continue
+                ;;
+            2)
+                [[ "$line" == record_type=project-list-entry ]] || return 1
+                continue
+                ;;
+            3)
+                [[ "$line" == record_count=* ]] || return 1
+                count_text="${line#record_count=}"
+                [[ "$count_text" =~ ^(0|[1-9][0-9]*)$ ]] || return 1
+                ((${#count_text} <= ${#max_record_count})) || return 1
+                record_count=$((10#$count_text))
+                ((record_count <= max_record_count)) || return 1
+                continue
+                ;;
+        esac
+
+        ((ended == 0)) || return 1
+        if ((in_record == 0)); then
+            if [[ "$line" == "record=$next_record" && next_record -lt record_count ]]; then
+                in_record=1
+                phase=1
+                continue
+            fi
+            if [[ "$line" == end_protocol= && next_record -eq record_count ]]; then
+                ended=1
+                continue
+            fi
+            return 1
+        fi
+
+        case "$phase" in
+            1)
+                [[ "$line" == field.project_name:string=* ]] || return 1
+                encoded="${line#field.project_name:string=}"
+                _base_basectl_completion_decode_hex "$encoded" || return 1
+                project_name="$_BASE_BASECTL_COMPLETION_DECODED_VALUE"
+                phase=2
+                ;;
+            2)
+                [[ "$line" == field.project_root:string=* ]] || return 1
+                encoded="${line#field.project_root:string=}"
+                _base_basectl_completion_decode_hex "$encoded" || return 1
+                phase=3
+                ;;
+            3)
+                [[ "$line" == "end_record=$next_record" ]] || return 1
+                names+="${names:+$'\n'}$project_name"
+                ((next_record += 1))
+                in_record=0
+                phase=0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    done <<<"$payload"
+
+    ((line_number >= 3 && in_record == 0 && ended == 1)) || return 1
+    _BASE_BASECTL_COMPLETION_PROJECT_NAMES_DECODED="$names"
 }
 
 _base_basectl_completion_refresh_project_cache() {
-    local names now ttl project_list
+    local names="" now ttl project_list
     local wrapper="${BASE_HOME:-}/bin/base-wrapper"
 
     [[ -x "$wrapper" ]] || {
@@ -51,8 +186,10 @@ _base_basectl_completion_refresh_project_cache() {
         return 0
     fi
 
-    project_list="$("$wrapper" --project base base_projects list 2>/dev/null || true)"
-    names="$(_base_basectl_completion_project_names_from_list <<<"$project_list")"
+    project_list="$("$wrapper" --project base base_projects list --format command-protocol 2>/dev/null || true)"
+    if _base_basectl_completion_project_names_from_protocol "$project_list"; then
+        names="$_BASE_BASECTL_COMPLETION_PROJECT_NAMES_DECODED"
+    fi
     _BASE_BASECTL_COMPLETION_PROJECT_NAMES="$names"
     _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=1
     if ((ttl > 0)); then

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -5,6 +5,7 @@
 typeset -g _BASE_BASECTL_COMPLETION_PROJECT_NAMES=''
 typeset -gi _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=0
 typeset -gi _BASE_BASECTL_COMPLETION_PROJECT_NAMES_EXPIRES_AT=0
+typeset -g _BASE_BASECTL_COMPLETION_DECODED_VALUE=''
 
 _base_basectl_completion_project_cache_ttl() {
     local ttl="${BASE_COMPLETION_PROJECT_CACHE_TTL:-5}"
@@ -19,16 +20,158 @@ _base_basectl_completion_now() {
     printf '%s\n' "${SECONDS:-0}"
 }
 
-_base_basectl_completion_project_names_from_list() {
-    local line name names=''
+_base_basectl_completion_validate_utf8_hex() {
+    local encoded="$1"
+    local pair
+    integer byte continuation continuation_count continuation_max continuation_min first
+    integer index=0 length=${#encoded}
 
-    while IFS= read -r line; do
-        [[ -n "$line" ]] || continue
-        name="${line%%$'\t'*}"
-        [[ -n "$name" ]] || continue
-        names+="${names:+$'\n'}$name"
+    while ((index < length)); do
+        pair="${encoded:$index:2}"
+        byte=$((16#$pair))
+        ((index += 2))
+        if ((byte <= 0x7f)); then
+            continue
+        elif ((byte >= 0xc2 && byte <= 0xdf)); then
+            continuation_count=1
+            continuation_min=0x80
+            continuation_max=0xbf
+        elif ((byte >= 0xe0 && byte <= 0xef)); then
+            continuation_count=2
+            if ((byte == 0xe0)); then
+                continuation_min=0xa0
+                continuation_max=0xbf
+            elif ((byte == 0xed)); then
+                continuation_min=0x80
+                continuation_max=0x9f
+            else
+                continuation_min=0x80
+                continuation_max=0xbf
+            fi
+        elif ((byte >= 0xf0 && byte <= 0xf4)); then
+            continuation_count=3
+            if ((byte == 0xf0)); then
+                continuation_min=0x90
+                continuation_max=0xbf
+            elif ((byte == 0xf4)); then
+                continuation_min=0x80
+                continuation_max=0x8f
+            else
+                continuation_min=0x80
+                continuation_max=0xbf
+            fi
+        else
+            return 1
+        fi
+
+        ((index + continuation_count * 2 <= length)) || return 1
+        pair="${encoded:$index:2}"
+        first=$((16#$pair))
+        ((first >= continuation_min && first <= continuation_max)) || return 1
+        ((index += 2))
+        for ((continuation = 1; continuation < continuation_count; continuation += 1)); do
+            pair="${encoded:$index:2}"
+            byte=$((16#$pair))
+            ((byte >= 0x80 && byte <= 0xbf)) || return 1
+            ((index += 2))
+        done
     done
+}
 
+_base_basectl_completion_decode_hex() {
+    local encoded="$1"
+    local byte decoded='' pair
+    integer index
+
+    if (( ${#encoded} % 2 != 0 )) || [[ "$encoded" == *[^0-9a-f]* ]]; then
+        return 1
+    fi
+    _base_basectl_completion_validate_utf8_hex "$encoded" || return 1
+
+    for ((index = 0; index < ${#encoded}; index += 2)); do
+        pair="${encoded:$index:2}"
+        [[ "$pair" != 00 ]] || return 1
+        printf -v byte '%b' "\\x$pair"
+        decoded+="$byte"
+    done
+    _BASE_BASECTL_COMPLETION_DECODED_VALUE="$decoded"
+}
+
+_base_basectl_completion_project_names_from_protocol() {
+    # Completion loads independently of the Bash runtime, so keep a narrow,
+    # strict reader for the versioned project-list-entry schema here.
+    local payload="$1"
+    local count_text='' encoded line names='' project_name
+    integer ended=0 in_record=0 line_number=0 max_record_count=1000000
+    integer next_record=0 phase=0 record_count=0
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        ((line_number += 1))
+        case "$line_number" in
+            1)
+                [[ "$line" == BASE_COMMAND_PROTOCOL_V1 ]] || return 1
+                continue
+                ;;
+            2)
+                [[ "$line" == record_type=project-list-entry ]] || return 1
+                continue
+                ;;
+            3)
+                [[ "$line" == record_count=* ]] || return 1
+                count_text="${line#record_count=}"
+                case "$count_text" in
+                    ''|*[!0-9]*|0?*) return 1 ;;
+                esac
+                ((${#count_text} <= ${#max_record_count})) || return 1
+                record_count=$((10#$count_text))
+                ((record_count <= max_record_count)) || return 1
+                continue
+                ;;
+        esac
+
+        ((ended == 0)) || return 1
+        if ((in_record == 0)); then
+            if [[ "$line" == "record=$next_record" && next_record -lt record_count ]]; then
+                in_record=1
+                phase=1
+                continue
+            fi
+            if [[ "$line" == end_protocol= && next_record -eq record_count ]]; then
+                ended=1
+                continue
+            fi
+            return 1
+        fi
+
+        case "$phase" in
+            1)
+                [[ "$line" == field.project_name:string=* ]] || return 1
+                encoded="${line#field.project_name:string=}"
+                _base_basectl_completion_decode_hex "$encoded" || return 1
+                project_name="$_BASE_BASECTL_COMPLETION_DECODED_VALUE"
+                phase=2
+                ;;
+            2)
+                [[ "$line" == field.project_root:string=* ]] || return 1
+                encoded="${line#field.project_root:string=}"
+                _base_basectl_completion_decode_hex "$encoded" || return 1
+                phase=3
+                ;;
+            3)
+                [[ "$line" == "end_record=$next_record" ]] || return 1
+                [[ -z "$names" ]] || names+=$'\n'
+                names+="$project_name"
+                ((next_record += 1))
+                in_record=0
+                phase=0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    done <<<"$payload"
+
+    ((line_number >= 3 && in_record == 0 && ended == 1)) || return 1
     print -r -- "$names"
 }
 
@@ -51,8 +194,10 @@ _base_basectl_completion_refresh_project_cache() {
         return 0
     fi
 
-    project_list="$("$wrapper" --project base base_projects list 2>/dev/null || true)"
-    names="$(_base_basectl_completion_project_names_from_list <<<"$project_list")"
+    project_list="$("$wrapper" --project base base_projects list --format command-protocol 2>/dev/null || true)"
+    if ! names="$(_base_basectl_completion_project_names_from_protocol "$project_list")"; then
+        names=''
+    fi
     _BASE_BASECTL_COMPLETION_PROJECT_NAMES="$names"
     _BASE_BASECTL_COMPLETION_PROJECT_NAMES_SET=1
     if ((ttl > 0)); then

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -273,20 +273,25 @@ assert_bash_completion_options_match_help() {
     mkdir -p "$(dirname "$wrapper")"
     cat > "$wrapper" <<'EOF'
 #!/usr/bin/env bash
+source "${BASE_COMPLETION_TEST_PROTOCOL_FIXTURE:?}"
+[[ " $* " == *" --format command-protocol "* ]] || exit 9
 count=0
 if [[ -f "${BASE_COMPLETION_TEST_COUNT_FILE:?}" ]]; then
     read -r count < "$BASE_COMPLETION_TEST_COUNT_FILE" || count=0
 fi
 count=$((count + 1))
 printf '%s\n' "$count" > "$BASE_COMPLETION_TEST_COUNT_FILE"
-printf 'base\t/Users/test/base\n'
-printf 'demo\t/Users/test/demo\n'
+base_test_protocol_begin project-list-entry 2
+base_test_protocol_project_list_record 0 base /Users/test/base
+base_test_protocol_project_list_record 1 demo /Users/test/demo
+base_test_protocol_end
 EOF
     chmod +x "$wrapper"
 
     run env BASE_HOME="$base_home" \
         BASE_COMPLETION_PROJECT_CACHE_TTL=60 \
         BASE_COMPLETION_TEST_COUNT_FILE="$count_file" \
+        BASE_COMPLETION_TEST_PROTOCOL_FIXTURE="$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash" \
         bash -c '\
             source "$1"; \
             COMP_WORDS=(basectl test ""); \
@@ -313,23 +318,28 @@ EOF
     mkdir -p "$(dirname "$wrapper")"
     cat > "$wrapper" <<'EOF'
 #!/usr/bin/env bash
+source "${BASE_COMPLETION_TEST_PROTOCOL_FIXTURE:?}"
+[[ " $* " == *" --format command-protocol "* ]] || exit 9
 count=0
 if [[ -f "${BASE_COMPLETION_TEST_COUNT_FILE:?}" ]]; then
     read -r count < "$BASE_COMPLETION_TEST_COUNT_FILE" || count=0
 fi
 count=$((count + 1))
 printf '%s\n' "$count" > "$BASE_COMPLETION_TEST_COUNT_FILE"
+base_test_protocol_begin project-list-entry 1
 if [[ "$count" -eq 1 ]]; then
-    printf 'base\t/Users/test/base\n'
+    base_test_protocol_project_list_record 0 base /Users/test/base
 else
-    printf 'base-fresh\t/Users/test/base-fresh\n'
+    base_test_protocol_project_list_record 0 base-fresh /Users/test/base-fresh
 fi
+base_test_protocol_end
 EOF
     chmod +x "$wrapper"
 
     run env BASE_HOME="$base_home" \
         BASE_COMPLETION_PROJECT_CACHE_TTL=1 \
         BASE_COMPLETION_TEST_COUNT_FILE="$count_file" \
+        BASE_COMPLETION_TEST_PROTOCOL_FIXTURE="$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash" \
         bash -c '\
             source "$1"; \
             _base_basectl_completion_now() { printf "%s\n" "$BASE_COMPLETION_TEST_NOW"; }; \
@@ -363,14 +373,19 @@ EOF
     mkdir -p "$(dirname "$wrapper")"
     cat > "$wrapper" <<'EOF'
 #!/usr/bin/env bash
-printf 'base\t/Users/test/base\n'
-printf 'demo app\t/Users/test/demo app\n'
-printf 'data tools\t/Users/test/data tools\n'
+source "${BASE_COMPLETION_TEST_PROTOCOL_FIXTURE:?}"
+[[ " $* " == *" --format command-protocol "* ]] || exit 9
+base_test_protocol_begin project-list-entry 3
+base_test_protocol_project_list_record 0 base /Users/test/base
+base_test_protocol_project_list_record 1 "demo app" "/Users/test/demo app"
+base_test_protocol_project_list_record 2 "data tools" "/Users/test/data tools"
+base_test_protocol_end
 EOF
     chmod +x "$wrapper"
 
     run env BASE_HOME="$base_home" \
         BASE_COMPLETION_PROJECT_CACHE_TTL=60 \
+        BASE_COMPLETION_TEST_PROTOCOL_FIXTURE="$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash" \
         bash -c '\
             source "$1"; \
             COMP_WORDS=(basectl test d); \
@@ -386,6 +401,66 @@ EOF
     [[ "$output" != *"<app>"* ]]
     [[ "$output" != *"<data>"* ]]
     [[ "$output" != *"<tools>"* ]]
+}
+
+@test "Zsh project-name completions consume structured names with spaces and Unicode" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
+    local args_file="$TEST_TMPDIR/project-list-args"
+    local base_home="$TEST_TMPDIR/base"
+    local wrapper="$base_home/bin/base-wrapper"
+
+    mkdir -p "$(dirname "$wrapper")"
+    cat > "$wrapper" <<'EOF'
+#!/usr/bin/env bash
+source "${BASE_COMPLETION_TEST_PROTOCOL_FIXTURE:?}"
+printf '%s\n' "$*" > "${BASE_COMPLETION_TEST_ARGS_FILE:?}"
+base_test_protocol_begin project-list-entry 2
+base_test_protocol_project_list_record 0 base /Users/test/base
+base_test_protocol_project_list_record 1 "demo app λ" "/Users/test/demo app λ"
+base_test_protocol_end
+EOF
+    chmod +x "$wrapper"
+
+    run env BASE_HOME="$base_home" \
+        BASE_COMPLETION_PROJECT_CACHE_TTL=60 \
+        BASE_COMPLETION_TEST_ARGS_FILE="$args_file" \
+        BASE_COMPLETION_TEST_PROTOCOL_FIXTURE="$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash" \
+        zsh -fc '\
+            source "$1"; \
+            _base_basectl_completion_refresh_project_cache || exit; \
+            print -r -- "$_BASE_BASECTL_COMPLETION_PROJECT_NAMES"' \
+            zsh "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = $'base\ndemo app λ' ]
+    [[ "$(cat "$args_file")" == *"base_projects list --format command-protocol"* ]]
+}
+
+@test "Zsh project-name protocol reader rejects overflowing record counts" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
+    local payload=$'BASE_COMMAND_PROTOCOL_V1\nrecord_type=project-list-entry\nrecord_count=18446744073709551616\nend_protocol='
+
+    run env PAYLOAD="$payload" zsh -fc '\
+        source "$1"; \
+        ! _base_basectl_completion_project_names_from_protocol "$PAYLOAD"' \
+        zsh "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "Bash project-name protocol reader rejects overflowing record counts" {
+    local payload=$'BASE_COMMAND_PROTOCOL_V1\nrecord_type=project-list-entry\nrecord_count=18446744073709551616\nend_protocol='
+
+    run env PAYLOAD="$payload" /bin/bash -c '\
+        source "$1"; \
+        ! _base_basectl_completion_project_names_from_protocol "$PAYLOAD"' \
+        bash "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.sh"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
 }
 
 @test "Bash completion now helper does not require external date" {

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -18,10 +18,11 @@ create_minimal_base_home() {
     mkdir -p \
         "$base_home/bin" \
         "$base_home/cli/bash/commands" \
-        "$base_home/lib/bash" \
+        "$base_home/lib/bash/runtime" \
         "$base_home/lib/shell"
 
     cp "$BASE_REPO_ROOT/base_init.sh" "$base_home/base_init.sh"
+    cp "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh" "$base_home/lib/bash/runtime/command_protocol.sh"
 }
 
 create_external_bash_libs() {


### PR DESCRIPTION
## Summary

- Add a versioned, named, typed protocol shared by Python producers and Bash/Zsh consumers.
- Encode UTF-8 safely across tabs, newlines, and control characters, with explicit nulls, canonical bounded record counts, and strict malformed-input rejection.
- Migrate every production Python-to-shell command-metadata consumer, including Bash and Zsh completion, without retaining a positional TSV fallback.
- Validate complete envelopes before invoking callbacks so a malformed later record cannot cause partial execution.
- Preserve public text output, trust and path-containment behavior, command exit status, and the no-`jq` runtime contract.

## Issue

Closes #1609

## Validation

- Full pre-rebase suite — 902 pytest tests passed, 1 skipped; 700/700 Bats tests passed.
- Focused post-rebase protocol, engine, build, and setup checks — 96 pytest tests passed with 4 subtests; completion and command checks — 39/39 Bats tests passed.
- Pylint, error-level ShellCheck, Bash 5/Bash 3/Zsh syntax checks, and `git diff --check` passed.
- Independent protocol review verdict: GO.

## Demo Impact

None.

## Notes

- This is an internal producer/consumer protocol, not a new public automation format.
- NUL bytes are rejected because Bash variables cannot represent them losslessly.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change. (No public behavior change.)
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable. (No architecture boundary change.)
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
