### PR TITLE
Use str_trim for repo config parsing

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -350,8 +350,7 @@ base_repo_strip_config_value() {
     local value="$1"
 
     value="${value%%#*}"
-    value="${value#"${value%%[![:space:]]*}"}"
-    value="${value%"${value##*[![:space:]]}"}"
+    str_trim value
 
     case "$value" in
         \"*\")

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -268,6 +268,28 @@ EOF
     [ ! -e "$repo_dir" ]
 }
 
+@test "basectl repo clone trims user config values before applying them" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+    local workspace_root="$TEST_TMPDIR/workspace-root"
+    local repo_dir="$workspace_root/base-demo"
+
+    mkdir -p "$TEST_HOME/.base.d" "$nested_dir" "$workspace_root"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<EOF
+workspace:
+  root:   $workspace_root   # local workspace
+github:
+  default_owner:   codeforester   # repo owner
+  clone_protocol:   ssh
+EOF
+
+    cd "$nested_dir"
+    run_basectl repo clone base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [ "$(line_at "$output" 1)" = "[DRY-RUN] Would clone codeforester/base-demo (git@github.com:codeforester/base-demo.git) into $repo_dir." ]
+    [ "$(line_at "$output" 2)" = "[DRY-RUN] Would run: gh repo clone codeforester/base-demo $repo_dir" ]
+}
+
 @test "basectl repo clone supports explicit owner and path dry-run" {
     local repo_dir="$TEST_HOME/work/base-demo"
 


### PR DESCRIPTION
## Summary
- replace hand-rolled whitespace trimming in `base_repo_strip_config_value` with `str_trim`
- add a repo clone config regression that covers whitespace plus trailing comments

## Validation
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --filter 'trims user config values before applying them' cli/bash/commands/basectl/tests/repo.bats`\n- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/repo.bats`\n- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/repo.sh`\n- `git diff --check`\n\nFixes #1633