### PR TITLE
Migrate Base to canonical Git helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Migrated generic branch, worktree, default-branch, upstream, merge, and
+  remote inspection consumers to the canonical `git_*` APIs from
+  `base-bash-libs`, leaving `base_gh_*` as the command-facing wrapper layer.
 - Registered every Python-owned remote shell installer in one policy and added
   paired URL/SHA-256 overrides for verified uv and mise bootstrap on
   Debian-family Linux, while explicitly disclosing unverified mutable defaults.

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -4,6 +4,7 @@
 _base_gh_subcommand_sourced=1
 readonly _base_gh_subcommand_sourced
 
+import_base_lib git/lib_git.sh
 import_base_lib gh/lib_gh.sh
 import_base_lib str/lib_str.sh
 
@@ -270,7 +271,7 @@ base_gh_default_branch() {
     local base_default_branch repo_root
 
     repo_root="$(git rev-parse --show-toplevel 2>/dev/null || printf '.')"
-    if gh_detect_default_branch "$repo_root" base_default_branch; then
+    if git_detect_default_branch "$repo_root" base_default_branch; then
         printf '%s\n' "$base_default_branch"
         return 0
     fi

--- a/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
@@ -57,20 +57,20 @@ base_gh_format_unix_date() {
 base_gh_worktree_path_for_branch() {
     local branch="$1"
 
-    gh_worktree_path_for_branch "$branch"
+    git_worktree_path_for_branch "$branch"
 }
 
 base_gh_branch_upstream() {
     local branch="$1"
 
-    gh_branch_upstream . "$branch"
+    git_branch_upstream . "$branch"
 }
 
 base_gh_branch_merged_to_ref() {
     local branch="$1"
     local ref="$2"
 
-    gh_branch_merged_to_ref . "$branch" "$ref"
+    git_branch_merged_to_ref . "$branch" "$ref"
 }
 
 base_gh_prune_github_ready() {
@@ -129,7 +129,7 @@ base_gh_branch_delete() {
 }
 
 base_gh_list_remote_branches() {
-    gh_list_remote_branches .
+    git_list_remote_branches .
 }
 
 base_gh_branch_delete_remote() {
@@ -348,7 +348,7 @@ base_gh_resolve_physical_path() {
 }
 
 base_gh_list_worktree_branches() {
-    gh_list_worktree_branches .
+    git_list_worktree_branches .
 }
 
 base_gh_worktree_dirty() {

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -4,6 +4,7 @@
 _base_repo_subcommand_sourced=1
 readonly _base_repo_subcommand_sourced
 
+import_base_lib git/lib_git.sh
 import_base_lib gh/lib_gh.sh
 import_base_lib str/lib_str.sh
 
@@ -1293,7 +1294,7 @@ base_repo_detect_default_branch() {
     local base_default_branch
     local root="$1"
 
-    if gh_detect_default_branch "$root" base_default_branch; then
+    if git_detect_default_branch "$root" base_default_branch; then
         printf '%s\n' "$base_default_branch"
         return 0
     fi

--- a/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
+++ b/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
@@ -9,19 +9,19 @@ load ./basectl_helpers.bash
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            gh_worktree_path_for_branch() {
+            git_worktree_path_for_branch() {
                 printf "%s\n" "/tmp/shared-worktree"
             }
-            gh_branch_upstream() {
+            git_branch_upstream() {
                 printf "%s\n" "origin/feature"
             }
-            gh_branch_merged_to_ref() {
+            git_branch_merged_to_ref() {
                 [[ "$2" == "feature" && "$3" == "main" ]]
             }
-            gh_list_remote_branches() {
+            git_list_remote_branches() {
                 printf "%s\n" "main" "feature"
             }
-            gh_list_worktree_branches() {
+            git_list_worktree_branches() {
                 printf "%s\t%s\n" "/tmp/shared-worktree" "feature"
             }
             remote_branches="$(base_gh_list_remote_branches)"

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -230,10 +230,10 @@ run_gh_subcommand() {
             [[ "$(type -t gh_require_cli)" == "function" ]]
             [[ "$(type -t gh_auth_status_diagnostics)" == "function" ]]
             [[ "$(type -t gh_run)" == "function" ]]
-            [[ "$(type -t gh_detect_default_branch)" == "function" ]]
+            [[ "$(type -t git_detect_default_branch)" == "function" ]]
             [[ "$(type -t gh_infer_repo_from_origin)" == "function" ]]
-            [[ "$(type -t gh_worktree_path_for_branch)" == "function" ]]
-            [[ "$(type -t gh_branch_merged_to_ref)" == "function" ]]
+            [[ "$(type -t git_worktree_path_for_branch)" == "function" ]]
+            [[ "$(type -t git_branch_merged_to_ref)" == "function" ]]
         '
 
     [ "$status" -eq 0 ]
@@ -246,7 +246,7 @@ run_gh_subcommand() {
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
-            gh_detect_default_branch() {
+            git_detect_default_branch() {
                 printf -v "$2" "%s" "develop"
             }
             gh_infer_repo_from_origin() {

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -144,7 +144,7 @@ run_repo_command_with_mocks() {
             [[ "$(type -t gh_auth_status_diagnostics)" == "function" ]]
             [[ "$(type -t gh_run)" == "function" ]]
             [[ "$(type -t gh_infer_repo_from_origin)" == "function" ]]
-            [[ "$(type -t gh_detect_default_branch)" == "function" ]]
+            [[ "$(type -t git_detect_default_branch)" == "function" ]]
             [[ "$(type -t gh_repo_default_branch)" == "function" ]]
         '
 
@@ -164,7 +164,7 @@ run_repo_command_with_mocks() {
             gh_infer_repo_from_origin() {
                 printf -v "$2" "%s" "owner/repo"
             }
-            gh_detect_default_branch() {
+            git_detect_default_branch() {
                 printf -v "$2" "%s" "develop"
             }
             gh_repo_default_branch() {


### PR DESCRIPTION
## Summary

- import `lib/bash/git/lib_git.sh` alongside the GitHub helpers in Base GH and repo consumers
- migrate generic default-branch, worktree, upstream, merge, and remote calls to canonical `git_*` APIs
- keep Base's `base_gh_*` command-facing wrappers and behavior unchanged
- update focused BATS coverage and changelog

## Related work

Fixes #1636

Coordinated with `basefoundry/base-bash-libs#168` and its canonical API PR.

## Validation

- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh-branch-worktree.bats cli/bash/commands/basectl/tests/gh.bats cli/bash/commands/basectl/tests/repo.bats`
- `./bin/base-test` (962 Python tests passed, 1 skipped; 731 BATS tests passed)
- `git diff --check`
