### PR TITLE
Clarify Bash library import conventions

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -502,6 +502,10 @@ lib/bash/
 Base Bash command code should use `import_base_lib` for reusable libraries such
 as `arg/lib_arg.sh`, `file/lib_file.sh`, `git/lib_git.sh`, or
 `str/lib_str.sh`; `base_init.sh` resolves those imports from `base-bash-libs`.
+Do not use the stdlib `import` helper as a general replacement for Bash
+`source`: keep `source` for runtime bootstrap, Base-owned command modules,
+shell startup files, virtual environment activation scripts, OS metadata files,
+and project activation scripts.
 
 ### 6.3 Python Packages
 

--- a/docs/base-bash-libs.md
+++ b/docs/base-bash-libs.md
@@ -151,6 +151,13 @@ import_base_lib str/lib_str.sh
 runtime and version helpers remain in `basefoundry/base` under `lib/bash`, but
 the reusable libraries come from `base-bash-libs`.
 
+The stdlib `import` helper is for standalone scripts that have already sourced
+`lib_std.sh`. Inside Base, do not treat `import` as a blanket replacement for
+Bash `source`: `base_init.sh` still sources the stdlib, and Base-owned command
+modules, shell startup files, virtual environment activation scripts, OS
+metadata files, and project activation scripts should continue to use
+purpose-specific `source` calls.
+
 ## Post-Migration Contract
 
 The Base contract is external-required:


### PR DESCRIPTION
## Summary
- Clarify when Base should keep using Bash `source`.
- Document that stdlib `import` is for standalone stdlib consumers, while Base command code uses `import_base_lib` for reusable `base-bash-libs` modules.

## Issue
Closes #1640

## Validation
- `git diff --check`

## Demo Impact
None. Documentation-only change.