### PR TITLE
Pin CI to base-bash-libs v1.3.0

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 189ed0be4a71602de2be0f75107288e39eddf7a7
+          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
           path: .base/base-bash-libs
 
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 189ed0be4a71602de2be0f75107288e39eddf7a7
+          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
           path: .dependencies/base-bash-libs
 
       - name: Remove flaky hosted-runner apt sources
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 189ed0be4a71602de2be0f75107288e39eddf7a7
+          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 189ed0be4a71602de2be0f75107288e39eddf7a7
+          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
@@ -226,7 +226,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 189ed0be4a71602de2be0f75107288e39eddf7a7
+          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
           path: .dependencies/base-bash-libs
 
       - name: Expose reusable Bash library checkout as sibling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Updated Base CI to consume the published `base-bash-libs` v1.3.0 release
+  commit.
+
 - Migrated generic Git branch, worktree, upstream, merge, remote, and default
   branch consumers to canonical `git_*` helpers and synchronized CI with the
   merged `base-bash-libs` implementation.

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -628,7 +628,7 @@ def test_reusable_base_check_workflow_contract() -> None:
     assert "args=(check --ci \"$BASE_CHECK_PROJECT\" --format \"$BASE_CHECK_OUTPUT_FORMAT\")" in run_commands
     assert "BASE_BASH_LIBS_DIR" in run_commands
     assert "basefoundry/base-bash-libs" in str(steps)
-    assert "189ed0be4a71602de2be0f75107288e39eddf7a7" in str(steps)
+    assert "5e52e79a8d6f61f82e5e95a07c75da256642f92e" in str(steps)
     assert "${{ inputs.base-ref || github.workflow_sha }}" in str(steps)
     assert "uses: basefoundry/base/.github/workflows/base-check.yml@<base-ref-or-sha>" in ci_docs
     assert "| `setup-mode` | `source-checkout` |" in ci_docs


### PR DESCRIPTION
## Summary

- pin all Base CI checkouts of `basefoundry/base-bash-libs` to the published v1.3.0 commit
- update the workflow contract assertion
- document the release-relevant dependency handoff

Release commit:

`5e52e79a8d6f61f82e5e95a07c75da256642f92e`

## Validation

- `tests/test_github_workflows.py`: 42 passed
- `./bin/base-test`: 962 Python tests passed, 1 skipped; 733 BATS tests passed
- `git diff --check`

Closes #1650
