### PR TITLE
Prevent local files from shadowing basectl commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Required explicit relative or absolute paths for Base runtime scripts so a
+  same-named file in the current directory cannot shadow a `basectl` control
+  command.
 - Reported `basectl setup`, `check`, and `doctor` runtime chain diagnostics up
   front and rejected x86_64 Base virtual environments under Apple Silicon
   Homebrew before profile setup reaches later `brew install` steps.

--- a/bin/basectl
+++ b/bin/basectl
@@ -198,7 +198,7 @@ basectl_ensure_supported_bash() {
 
 basectl_is_script_argument() {
     local candidate="${1:-}"
-    [[ "$candidate" == */* || -f "$candidate" ]]
+    [[ "$candidate" == */* ]]
 }
 
 basectl_normalize_script_name() {

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -137,6 +137,17 @@ basectl_usage_error() {
     return 2
 }
 
+basectl_bare_script_usage_error() {
+    local candidate="$1"
+    local explicit_path
+
+    printf -v explicit_path '%q' "./$candidate"
+    printf "ERROR: Bare script name '%s' is not executed implicitly.\n" "$candidate" >&2
+    printf 'Use an explicit path instead:\n' >&2
+    printf '  basectl %s\n' "$explicit_path" >&2
+    return 2
+}
+
 basectl_equals_option_usage_error() {
     local argument="$1"
     local option="${argument%%=*}"
@@ -556,7 +567,11 @@ basectl_main() {
             fi
             ;;
         *)
-            basectl_usage_error "Unrecognized command: $command"
+            if [[ -f "$command" ]]; then
+                basectl_bare_script_usage_error "$command"
+            else
+                basectl_usage_error "Unrecognized command: $command"
+            fi
             ;;
     esac
 }

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -278,6 +278,62 @@ EOF
     [[ "$output" == *"script path wins: arg1"* ]]
 }
 
+@test "basectl command names cannot be shadowed by same-named files" {
+    local workdir="$TEST_TMPDIR/command-shadow"
+
+    mkdir -p "$workdir"
+    cat > "$workdir/test" <<'EOF'
+main() {
+    printf 'local file shadowed test\n'
+}
+EOF
+
+    cd "$workdir"
+    run_basectl test --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl test [project] [options]"* ]]
+    [[ "$output" != *"local file shadowed test"* ]]
+}
+
+@test "basectl rejects bare script names with an explicit-path hint" {
+    local workdir="$TEST_TMPDIR/bare-script"
+
+    mkdir -p "$workdir"
+    cat > "$workdir/deploy" <<'EOF'
+main() {
+    printf 'bare script executed unexpectedly\n'
+}
+EOF
+
+    cd "$workdir"
+    run_basectl deploy
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Bare script name 'deploy' is not executed implicitly."* ]]
+    [[ "$output" == *"basectl ./deploy"* ]]
+    [[ "$output" != *"bare script executed unexpectedly"* ]]
+}
+
+@test "basectl runs explicit relative script paths containing spaces" {
+    local workdir="$TEST_TMPDIR/explicit-script"
+    local script_name="deploy task.sh"
+
+    mkdir -p "$workdir"
+    cat > "$workdir/$script_name" <<'EOF'
+main() {
+    printf 'explicit script: %s\n' "$1"
+}
+EOF
+
+    cd "$workdir"
+    run_basectl "./$script_name" "release candidate"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"explicit script: release candidate"* ]]
+}
+
 @test "basectl marks command dispatch metadata readonly" {
     local script_path="$TEST_TMPDIR/inspect-command-env.sh"
     local script_dir

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -48,22 +48,22 @@ When `basectl` starts, it uses this dispatch order:
 1. If no arguments are provided and stdin/stdout are attached to a terminal,
    start a Base-enabled interactive Bash shell with Base's project virtual
    environment activated, while preserving the caller's current directory.
-2. If the first argument is path-like or names an existing file, treat it as a
-   Bash script path and run that script inside the Base runtime.
+2. If the first argument is an explicit path containing `/`, treat it as a Bash
+   script path and run that script inside the Base runtime.
 3. If the first argument matches a Base command implementation by convention,
    run that command implementation.
 4. Otherwise, run the umbrella Base command dispatcher.
 
-This ordering lets explicit script paths win over command names.
+This ordering lets explicit script paths win while ensuring a local file cannot
+shadow a Base control command with the same name. The umbrella dispatcher checks
+its named commands before reporting an unknown bare file; if that file exists,
+the error includes a hint to use an explicit path such as `./script.sh`.
 
 ## Script Arguments
 
-A first argument is treated as a script when either condition is true:
-
-- it contains `/`, such as `./script.sh`, `scripts/deploy`, or
-  `/tmp/base-task.sh`
-- it is an existing file in the current directory, such as `deploy.sh` or
-  `deploy`
+A first argument is treated as a script only when it contains `/`, such as
+`./script.sh`, `scripts/deploy`, or `/tmp/base-task.sh`. A bare file name is not
+executed implicitly; use an explicit relative or absolute path instead.
 
 Script files do not need a `.sh` extension. The script is sourced as Bash and
 must define a `main` function. After sourcing the script, `basectl` calls
@@ -77,7 +77,7 @@ Examples:
 ```bash
 basectl ./scripts/deploy.sh prod
 basectl scripts/deploy prod
-basectl deploy.sh prod      # works if deploy.sh exists in the current directory
+basectl ./deploy.sh prod
 ```
 
 A script can also opt into Base with a shebang:


### PR DESCRIPTION
## Summary

- require an explicit relative or absolute path before `basectl` enters script mode
- dispatch built-in control commands before considering same-named local files
- return a focused explicit-path hint for unknown bare script names
- document the invocation boundary and add collision/path regression coverage

## Why

The launcher treated any existing bare filename as a script before normal command dispatch. A local file named `test`, `build`, `check`, or `run` could therefore replace the intended Base control command. Explicit paths remain supported, including shebang invocation, paths with spaces, and absolute paths.

## Validation

- regression reproduced first in `runtime-dispatch.bats`
- focused runtime/help BATS: 34 passed
- Bash syntax and ShellCheck: passed
- contract suite: passed
- full `./bin/base-test`: 962 Python passed, 1 skipped; 736 BATS passed
- `git diff --check`

Fixes #1643
