### PR TITLE
Fix trust-aware onboarding and unattended setup handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made `basectl onboard --yes` reach unattended setup consent and added a
+  read-only, workspace-wide manifest trust review step that never grants trust
+  automatically or prompts for metadata-only manifests.
 - Required explicit relative or absolute paths for Base runtime scripts so a
   same-named file in the current directory cannot shadow a `basectl` control
   command.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ git clone https://github.com/basefoundry/base.git ~/work/base
 ~/work/base/bin/basectl setup --dry-run
 ~/work/base/bin/basectl setup
 ~/work/base/bin/basectl projects list --workspace ~/work
+~/work/base/bin/basectl trust status base
+```
+
+Review the manifest identity, digest, and read-only inspection commands, then
+run the exact `basectl trust allow base --manifest-sha256 ...` command printed
+by `trust status`. The digest-bound approval is never inferred from setup or an
+unattended flag. After approving the reviewed manifest, finish the proof:
+
+```bash
 ~/work/base/bin/basectl demo base -- --non-interactive
 ```
 
@@ -84,6 +93,14 @@ Base and run its walkthrough:
 ```bash
 git clone https://github.com/basefoundry/base-demo.git ~/work/base-demo
 ~/work/base/bin/basectl setup base-demo
+~/work/base/bin/basectl trust status base-demo
+```
+
+Review the reported command surfaces, then run the exact command it prints:
+`basectl trust allow base-demo --manifest-sha256 ...`. Only then launch the
+demo:
+
+```bash
 ~/work/base/bin/basectl demo base-demo
 ```
 
@@ -440,14 +457,15 @@ execution trust, lifecycle guidance, onboarding, and handoff evidence. Project
 environments and command execution remain owned by their declared substrates.
 
 Manifest-declared commands are trusted project code. Base executes
-`test.command`, `build.targets.*.command`, and `commands.*` as shell command
-strings from the project root, so shell metacharacters are honored. Review
-manifests from unfamiliar repositories before running `basectl test`,
-`basectl build`, or `basectl run`; use `--dry-run` and `--list` first when you
-only want to inspect the resolved command contract. `basectl check <project>`
-and `basectl doctor <project>` include advisory command-lint warnings for
-obvious missing executables or project scripts; those warnings do not make an
-untrusted manifest safe to run. See
+`test.command`, `build.targets.*.command`, `commands.*`, `demo.script`, and
+`activate.source` entries from the project root. Review manifests from
+unfamiliar repositories before running `basectl test`, `basectl build`,
+`basectl run`, `basectl demo`, or manifest-backed `basectl activate`; use
+`--dry-run` and `--list` first for command surfaces that support read-only
+inspection, and inspect `activate.source` entries directly before activation.
+`basectl check <project>` and `basectl doctor <project>` include advisory
+command-lint warnings for obvious missing executables or project scripts;
+those warnings do not make an untrusted manifest safe to run. See
 [Manifest Command Trust](docs/manifest-command-trust.md) for the local allow
 flow before first execution of unfamiliar manifest commands.
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ git clone https://github.com/basefoundry/base.git ~/work/base
 
 Review the manifest identity, digest, and read-only inspection commands, then
 run the exact `basectl trust allow base --manifest-sha256 ...` command printed
-by `trust status`. The digest-bound approval is never inferred from setup or an
-unattended flag. After approving the reviewed manifest, finish the proof:
+by `trust status`. Until shell-profile setup puts `basectl` on `PATH`, replace
+its leading `basectl` with `~/work/base/bin/basectl`; keep the project and
+printed digest unchanged. The digest-bound approval is never inferred from
+setup or an unattended flag. After approving the reviewed manifest, finish the
+proof:
 
 ```bash
 ~/work/base/bin/basectl demo base -- --non-interactive

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -16,7 +16,7 @@ Usage:
 Options:
   --profile <list>  Include named prerequisite profiles. Known profiles: dev, sre, ai, linux-lab.
   --dry-run     Explain planned onboarding steps without making changes.
-  --yes         Accept default answers for setup and shell profile prompts.
+  --yes         Approve setup changes and the shell-profile prompt; never grant manifest trust.
   --no-profile  Skip shell profile updates.
   -v            Enable DEBUG logging for underlying commands.
   -h, --help    Show this help text.
@@ -129,7 +129,9 @@ base_onboard_subcommand_main() {
     local yes=0
     local check_status=0
     local profile_status=0
+    local projects_status=0
     local setup_status=0
+    local trust_status=0
     local check_args=()
     local doctor_args=()
     local setup_args=()
@@ -266,12 +268,23 @@ base_onboard_subcommand_main() {
         base_onboard_execute "$dry_run" "${projects_args[@]}" || return $?
     else
         base_onboard_print_next "${projects_args[@]}"
-        base_onboard_run_command "${projects_args[@]}" || printf '%s\n' "Project discovery is not available yet."
+        base_onboard_run_command "${projects_args[@]}"
+        projects_status=$?
+        if ((projects_status != 0)); then
+            printf '%s\n' "Project discovery failed after setup."
+            printf '%s\n' "Retry 'basectl projects list', then run 'basectl trust status' before manifest-backed commands."
+            return "$projects_status"
+        fi
     fi
 
     base_onboard_print_heading "Trust"
     printf '%s\n' "Base will report manifest command trust for discovered projects without approving any manifest."
-    base_onboard_execute "$dry_run" "${trust_args[@]}" || return $?
+    base_onboard_execute "$dry_run" "${trust_args[@]}"
+    trust_status=$?
+    if ((trust_status != 0)); then
+        printf '%s\n' "Manifest trust status is unavailable. Retry 'basectl trust status' before manifest-backed commands."
+        return "$trust_status"
+    fi
 
     base_onboard_print_heading "Next Steps"
     printf "%s\n" "After reviewing and allowing any blocked manifest command contracts, run 'basectl' to enter the nearest Base project shell, or 'basectl activate $project' to start with '$project'."

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -23,7 +23,7 @@ Options:
 
 Purpose:
   Guide a user through the first Base setup by orchestrating check, setup,
-  update-profile, doctor, and project discovery commands.
+  update-profile, doctor, project discovery, and manifest command trust status.
 
 Project:
   Defaults to 'base'. The selected project is passed to check, setup, and doctor.
@@ -135,6 +135,7 @@ base_onboard_subcommand_main() {
     local setup_args=()
     local profile_args=(update-profile)
     local projects_args=(projects list)
+    local trust_args=(trust status)
 
     while (($#)); do
         case "$1" in
@@ -196,6 +197,10 @@ base_onboard_subcommand_main() {
         doctor_args+=(-v)
         profile_args+=(-v)
         projects_args+=(-v)
+        trust_args+=(-v)
+    fi
+    if ((yes)); then
+        setup_args+=(--yes)
     fi
     if ((dry_run)); then
         setup_args+=(--dry-run)
@@ -264,6 +269,10 @@ base_onboard_subcommand_main() {
         base_onboard_run_command "${projects_args[@]}" || printf '%s\n' "Project discovery is not available yet."
     fi
 
+    base_onboard_print_heading "Trust"
+    printf '%s\n' "Base will report manifest command trust for discovered projects without approving any manifest."
+    base_onboard_execute "$dry_run" "${trust_args[@]}" || return $?
+
     base_onboard_print_heading "Next Steps"
-    printf "%s\n" "Run 'basectl' to enter the nearest Base project shell, or 'basectl activate $project' to start with '$project'."
+    printf "%s\n" "After reviewing and allowing any blocked manifest command contracts, run 'basectl' to enter the nearest Base project shell, or 'basectl activate $project' to start with '$project'."
 }

--- a/cli/bash/commands/basectl/subcommands/trust.sh
+++ b/cli/bash/commands/basectl/subcommands/trust.sh
@@ -6,7 +6,7 @@ readonly _base_trust_subcommand_sourced
 base_trust_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl trust status <project> [options]
+  basectl trust status [project] [options]
   basectl trust allow <project> [options]
   basectl trust revoke <project> [options]
 
@@ -17,7 +17,8 @@ Options:
   -v                            Enable DEBUG logging for this subcommand.
   -h, --help                    Show this help text.
 
-Manage local approval for manifest-declared project commands.
+Inspect trust for one project or all discovered projects, and manage local
+approval for manifest-declared project commands.
 EOF
 }
 

--- a/cli/bash/commands/basectl/subcommands/trust.sh
+++ b/cli/bash/commands/basectl/subcommands/trust.sh
@@ -66,5 +66,8 @@ base_trust_subcommand_main() {
     done
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
-    BASE_CLI_DISPLAY_COMMAND="basectl trust" "$wrapper" --project base base_trust "${args[@]}"
+    BASE_TRUST_ACTIVE_PROJECT="${BASE_PROJECT:-}" \
+        BASE_TRUST_ACTIVE_PROJECT_MANIFEST="${BASE_PROJECT_MANIFEST:-}" \
+        BASE_CLI_DISPLAY_COMMAND="basectl trust" \
+        "$wrapper" --project base base_trust "${args[@]}"
 }

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -210,7 +210,7 @@ load ./basectl_helpers.bash
 @test "command reference documents trust commands" {
     local command_reference="$BASE_REPO_ROOT/docs/command-reference.md"
 
-    grep -Fqx -- "| \`basectl trust status <project>\` | Show local manifest command trust status. | \`--workspace <path>\`, \`--format <text\\|json>\` |" "$command_reference"
+    grep -Fqx -- "| \`basectl trust status [project]\` | Show one project's manifest trust status, or all discovered command-bearing projects. | \`--workspace <path>\`, \`--format <text\\|json>\` |" "$command_reference"
     grep -Fqx -- "| \`basectl trust allow <project>\` | Approve the current manifest command contract on this machine. | \`--workspace <path>\`, \`--manifest-sha256 <sha256>\` |" "$command_reference"
     grep -Fqx -- "| \`basectl trust revoke <project>\` | Remove local manifest command approval. | \`--workspace <path>\` |" "$command_reference"
 }

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -205,6 +205,40 @@ load ./basectl_helpers.bash
     [[ "$output" != *"RUN:update-profile"* ]]
 }
 
+@test "basectl onboard --yes satisfies the Ubuntu Debian setup consent boundary" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_MODE=true \
+        BASE_ONBOARD_TEST_STATE="$TEST_STATE_DIR/onboard-linux-consent" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/setup.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_setup_run_text() {
+                setup_require_linux_debian_system_consent \
+                    "Ubuntu/Debian setup requires package-manager consent." || return $?
+                touch "$BASE_ONBOARD_TEST_STATE"
+            }
+            base_onboard_run_command() {
+                if [[ "$1" == setup ]]; then
+                    shift
+                    base_setup_subcommand_main "$@"
+                    return $?
+                fi
+                printf "RUN:%s\n" "$*"
+            }
+            base_onboard_subcommand_main --yes --no-profile
+        '
+
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_STATE_DIR/onboard-linux-consent" ]
+    [[ "$output" == *"Next: basectl setup base --yes"* ]]
+    [[ "$output" != *"rerun with '--yes'"* ]]
+    [[ "$output" != *"Proceed with Ubuntu/Debian setup changes?"* ]]
+    [[ "$output" != *"trust allow"* ]]
+}
+
 @test "basectl onboard setup failure stops profile updates and returns setup status" {
     run env \
         HOME="$TEST_HOME" \
@@ -249,4 +283,26 @@ load ./basectl_helpers.bash
     [[ "$output" != *"RUN:trust allow"* ]]
     [[ "$output" != *"Next Steps"* ]]
     [[ "$output" != *"basectl activate base"* ]]
+}
+
+@test "basectl onboard stops consistently when project discovery fails" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() {
+                printf "RUN:%s\n" "$*"
+                [[ "$1 $2" == "projects list" ]] && return 9
+                return 0
+            }
+            base_onboard_subcommand_main --yes --no-profile
+        '
+
+    [ "$status" -eq 9 ]
+    [[ "$output" == *"Project discovery failed after setup."* ]]
+    [[ "$output" == *"Retry 'basectl projects list', then run 'basectl trust status'"* ]]
+    [[ "$output" != *"RUN:trust status"* ]]
+    [[ "$output" != *"Next Steps"* ]]
 }

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -14,6 +14,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--dry-run"* ]]
     [[ "$output" == *"--no-profile"* ]]
     [[ "$output" == *"Defaults to 'base'."* ]]
+    [[ "$output" == *"manifest command trust"* ]]
 }
 
 @test "basectl onboard dry-run shows planned commands without prompting" {
@@ -33,6 +34,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"[DRY-RUN] Would run basectl update-profile --dry-run"* ]]
     [[ "$output" == *"[DRY-RUN] Would run basectl doctor base --profile dev"* ]]
     [[ "$output" == *"[DRY-RUN] Would run basectl projects list"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl trust status"* ]]
+    [[ "$output" != *"trust allow"* ]]
     [[ "$output" != *"Next: basectl check base --profile dev"* ]]
     [[ "$output" != *"Next: basectl setup base --profile dev --dry-run"* ]]
     [[ "$output" != *"Next: basectl update-profile --dry-run"* ]]
@@ -73,6 +76,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"[DRY-RUN] Would run basectl check bankbuddy --profile dev"* ]]
     [[ "$output" == *"[DRY-RUN] Would run basectl setup bankbuddy --profile dev --dry-run"* ]]
     [[ "$output" == *"[DRY-RUN] Would run basectl doctor bankbuddy --profile dev"* ]]
+    [[ "$output" == *"[DRY-RUN] Would run basectl trust status"* ]]
     [[ "$output" == *"basectl activate bankbuddy"* ]]
     [[ "$output" != *"unexpected run"* ]]
 }
@@ -175,6 +179,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"RUN:update-profile"* ]]
     [[ "$output" == *"RUN:doctor base --profile dev"* ]]
     [[ "$output" == *"RUN:projects list"* ]]
+    [[ "$output" == *"RUN:trust status"* ]]
+    [[ "$output" != *"RUN:trust allow"* ]]
 }
 
 @test "basectl onboard --yes accepts setup and profile prompts" {
@@ -192,8 +198,10 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Proceed with setup? [yes]"* ]]
     [[ "$output" == *"This installs or verifies Base platform prerequisites, Base Python, and Base-managed artifacts."* ]]
     [[ "$output" != *"This installs or verifies Homebrew, Xcode Command Line Tools"* ]]
-    [[ "$output" == *"RUN:setup base"* ]]
+    [[ "$output" == *"RUN:setup base --yes"* ]]
     [[ "$output" == *"Shell profile updates skipped because --no-profile was set."* ]]
+    [[ "$output" == *"RUN:trust status"* ]]
+    [[ "$output" != *"RUN:trust allow"* ]]
     [[ "$output" != *"RUN:update-profile"* ]]
 }
 
@@ -214,8 +222,31 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 7 ]
     [[ "$output" == *"RUN:check base"* ]]
-    [[ "$output" == *"RUN:setup base"* ]]
+    [[ "$output" == *"RUN:setup base --yes"* ]]
     [[ "$output" == *"Setup failed. Running doctor can show the remaining issues."* ]]
     [[ "$output" == *"RUN:doctor base"* ]]
     [[ "$output" != *"RUN:update-profile"* ]]
+    [[ "$output" != *"RUN:trust status"* ]]
+}
+
+@test "basectl onboard stops before activation guidance when trust status fails" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() {
+                printf "RUN:%s\n" "$*"
+                [[ "$1 $2" == "trust status" ]] && return 8
+                return 0
+            }
+            base_onboard_subcommand_main --yes --no-profile
+        '
+
+    [ "$status" -eq 8 ]
+    [[ "$output" == *"RUN:trust status"* ]]
+    [[ "$output" != *"RUN:trust allow"* ]]
+    [[ "$output" != *"Next Steps"* ]]
+    [[ "$output" != *"basectl activate base"* ]]
 }

--- a/cli/bash/commands/basectl/tests/trust.bats
+++ b/cli/bash/commands/basectl/tests/trust.bats
@@ -21,12 +21,16 @@ load ./basectl_helpers.bash
     cat > "$base_home/bin/base-wrapper" <<'EOF'
 #!/usr/bin/env bash
 printf 'args=%s\n' "$*"
+printf 'active_project=%s\n' "${BASE_TRUST_ACTIVE_PROJECT:-}"
+printf 'active_manifest=%s\n' "${BASE_TRUST_ACTIVE_PROJECT_MANIFEST:-}"
 EOF
     chmod +x "$base_home/bin/base-wrapper"
 
     run env \
         BASE_HOME="$base_home" \
         BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        BASE_PROJECT=demo \
+        BASE_PROJECT_MANIFEST=/tmp/work/demo/base_manifest.yaml \
         bash -c '
             source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/trust.sh"
             base_trust_subcommand_main status --workspace /tmp/work
@@ -34,6 +38,8 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"args=--project base base_trust status --workspace /tmp/work"* ]]
+    [[ "$output" == *"active_project=demo"* ]]
+    [[ "$output" == *"active_manifest=/tmp/work/demo/base_manifest.yaml"* ]]
 }
 
 @test "basectl trust forwards through the Python wrapper" {

--- a/cli/bash/commands/basectl/tests/trust.bats
+++ b/cli/bash/commands/basectl/tests/trust.bats
@@ -8,10 +8,32 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl trust status <project> [options]"* ]]
+    [[ "$output" == *"basectl trust status [project] [options]"* ]]
     [[ "$output" == *"basectl trust allow <project> [options]"* ]]
     [[ "$output" == *"basectl trust revoke <project> [options]"* ]]
     [[ "$output" == *"--manifest-sha256 <sha256>"* ]]
+}
+
+@test "basectl trust status forwards without a project for workspace inspection" {
+    local base_home="$TEST_TMPDIR/base-home"
+
+    mkdir -p "$base_home/bin"
+    cat > "$base_home/bin/base-wrapper" <<'EOF'
+#!/usr/bin/env bash
+printf 'args=%s\n' "$*"
+EOF
+    chmod +x "$base_home/bin/base-wrapper"
+
+    run env \
+        BASE_HOME="$base_home" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/trust.sh"
+            base_trust_subcommand_main status --workspace /tmp/work
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"args=--project base base_trust status --workspace /tmp/work"* ]]
 }
 
 @test "basectl trust forwards through the Python wrapper" {

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -8,6 +8,8 @@ from typing import Any
 import base_cli
 from base_cli.history import base_version as read_base_version
 from base_projects import engine as project_engine
+from base_projects.project_discovery import discover_projects_cached
+from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_setup.manifest_loader import ManifestError
 from .trust_store import ALLOWED_COMMANDS  # pylint: disable=unused-import
@@ -22,6 +24,7 @@ from .trust_store import git_head  # pylint: disable=unused-import
 from .trust_store import git_origin  # pylint: disable=unused-import
 from .trust_store import git_repository_root  # pylint: disable=unused-import
 from .trust_store import identity_key_from_record  # pylint: disable=unused-import
+from .trust_store import manifest_command_surfaces
 from .trust_store import sha256_file  # pylint: disable=unused-import
 from .trust_store import write_json_atomic  # pylint: disable=unused-import
 
@@ -37,27 +40,32 @@ def main(argv: list[str] | None = None) -> int:
 
 
 @app.subcommand("status", context_settings={"help_option_names": ["-h", "--help"]})
-@base_cli.argument("project")
+@base_cli.argument("project", required=False)
 @base_cli.option(
     "--workspace",
     help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
 )
 @base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
-def status_command(ctx: base_cli.Context, project: str, workspace: str | None, output_format: str) -> int:
+def status_command(ctx: base_cli.Context, project: str | None, workspace: str | None, output_format: str) -> int:
     if output_format not in {"text", "json"}:
         ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
         return base_cli.ExitCode.USAGE_ERROR
+
+    if project is None:
+        return workspace_status_command(ctx, workspace, output_format)
+
     try:
         identity = resolve_trust_identity(ctx, project, workspace)
+        surfaces = manifest_command_surfaces(identity.manifest_path)
     except (ProjectDiscoveryError, ManifestError, TrustError) as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    trust_status = ManifestCommandTrustStore().status(identity)
+    trust_status = trust_status_for_surfaces(identity, surfaces)
     if output_format == "json":
         print(json.dumps(status_payload(trust_status), indent=2, sort_keys=True))
     else:
-        print_status_text(trust_status)
+        print_status_text(trust_status, surfaces)
     return base_cli.ExitCode.SUCCESS
 
 
@@ -79,7 +87,11 @@ def require_command(ctx: base_cli.Context, project: str, workspace: str | None, 
     if trust_status.is_allowed:
         return base_cli.ExitCode.SUCCESS
 
-    print_blocked_command_text(trust_status, stream=sys.stderr)
+    print_blocked_command_text(
+        trust_status,
+        manifest_command_surfaces(identity.manifest_path),
+        stream=sys.stderr,
+    )
     return base_cli.ExitCode.FAILURE
 
 
@@ -136,6 +148,46 @@ class TrustError(RuntimeError):
     pass
 
 
+def workspace_status_command(ctx: base_cli.Context, workspace: str | None, output_format: str) -> int:
+    try:
+        workspace_root = resolve_workspace_root(ctx, workspace)
+        projects = discover_projects_cached(ctx, workspace_root)
+        store = ManifestCommandTrustStore()
+        statuses = []
+        for project in projects:
+            surfaces = manifest_command_surfaces(project.manifest_path)
+            if not surfaces:
+                continue
+            identity = compute_trust_identity_for_manifest(project.manifest_path)
+            statuses.append((store.status(identity), surfaces))
+    except (ProjectDiscoveryError, ManifestError, TrustError) as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    if output_format == "json":
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "projects": [status_payload(trust_status) for trust_status, _surfaces in statuses],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return base_cli.ExitCode.SUCCESS
+
+    if not statuses:
+        print("No discovered projects require manifest command trust.")
+        return base_cli.ExitCode.SUCCESS
+
+    for index, (trust_status, surfaces) in enumerate(statuses):
+        if index:
+            print()
+        print_status_text(trust_status, surfaces)
+    return base_cli.ExitCode.SUCCESS
+
+
 def resolve_trust_identity(
     ctx: base_cli.Context,
     project_name: str,
@@ -172,7 +224,7 @@ def status_payload(trust_status: TrustStatus) -> dict[str, Any]:
     }
     if trust_status.is_allowed:
         payload["record"] = trust_status.record
-    else:
+    elif trust_status.status != "not_required":
         payload["allow_command"] = allow_command_text(trust_status.identity)
     if trust_status.changed_record is not None:
         changed_project = trust_status.changed_record.get("project", {})
@@ -185,8 +237,28 @@ def allow_command_text(identity: ManifestCommandTrustIdentity) -> str:
     return f"basectl trust allow {identity.project_name} --manifest-sha256 {identity.manifest_sha256}"
 
 
-def print_status_text(trust_status: TrustStatus) -> None:
+def trust_status_for_surfaces(
+    identity: ManifestCommandTrustIdentity,
+    surfaces: tuple[str, ...],
+) -> TrustStatus:
+    if not surfaces:
+        return TrustStatus(
+            status="not_required",
+            reason="no_executable_commands",
+            identity=identity,
+        )
+    return ManifestCommandTrustStore().status(identity)
+
+
+def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> None:
     identity = trust_status.identity
+    if trust_status.status == "not_required":
+        print(
+            f"Manifest command trust is not required for project '{identity.project_name}': "
+            "the manifest declares no executable command surfaces."
+        )
+        return
+
     if trust_status.is_allowed:
         print(f"Manifest command trust is allowed for project '{identity.project_name}'.")
         print_identity("Trusted identity", identity)
@@ -200,10 +272,19 @@ def print_status_text(trust_status: TrustStatus) -> None:
     else:
         print(f"Manifest command trust is blocked for project '{identity.project_name}'.")
     print_identity("Current identity", identity)
-    print(f"Allow after review: {allow_command_text(identity)}")
+    print()
+    print_review_guidance(identity, surfaces, stream=sys.stdout)
+    print()
+    print("Allow after review:")
+    print(f"  {allow_command_text(identity)}")
 
 
-def print_blocked_command_text(trust_status: TrustStatus, *, stream: Any) -> None:
+def print_blocked_command_text(
+    trust_status: TrustStatus,
+    surfaces: tuple[str, ...],
+    *,
+    stream: Any,
+) -> None:
     identity = trust_status.identity
     if trust_status.reason == "manifest_changed":
         print(
@@ -227,13 +308,33 @@ def print_blocked_command_text(trust_status: TrustStatus, *, stream: Any) -> Non
     if identity.origin is not None:
         print(f"Origin: {identity.origin}", file=stream)
     print(file=stream)
-    print("Review first:", file=stream)
-    print(f"  basectl run {identity.project_name} --list", file=stream)
-    print(f"  basectl build {identity.project_name} --list", file=stream)
-    print(f"  basectl test {identity.project_name} --dry-run", file=stream)
+    print_review_guidance(identity, surfaces, stream=stream)
     print(file=stream)
     print("Allow after review:", file=stream)
     print(f"  {allow_command_text(identity)}", file=stream)
+
+
+def print_review_guidance(
+    identity: ManifestCommandTrustIdentity,
+    surfaces: tuple[str, ...],
+    *,
+    stream: Any,
+) -> None:
+    print("Review first:", file=stream)
+    if "run" in surfaces:
+        print(f"  basectl run {identity.project_name} --list", file=stream)
+    if "build" in surfaces:
+        print(f"  basectl build {identity.project_name} --list", file=stream)
+    if "test" in surfaces:
+        print(f"  basectl test {identity.project_name} --dry-run", file=stream)
+    if "demo" in surfaces:
+        print(f"  basectl demo {identity.project_name} --dry-run", file=stream)
+    if "activate" in surfaces:
+        print(
+            f"  Inspect activate.source entries in {identity.manifest_path} before running "
+            f"'basectl activate {identity.project_name}'.",
+            file=stream,
+        )
 
 
 def print_identity(title: str, identity: ManifestCommandTrustIdentity) -> None:

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -8,7 +9,9 @@ from typing import Any
 import base_cli
 from base_cli.history import base_version as read_base_version
 from base_projects import engine as project_engine
+from base_projects.project_discovery import Project
 from base_projects.project_discovery import discover_projects_cached
+from base_projects.project_discovery import read_project
 from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_setup.manifest_loader import ManifestError
@@ -61,7 +64,7 @@ def status_command(ctx: base_cli.Context, project: str | None, workspace: str | 
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    trust_status = trust_status_for_surfaces(identity, surfaces)
+    trust_status = ManifestCommandTrustStore().status(identity)
     if output_format == "json":
         print(json.dumps(status_payload(trust_status), indent=2, sort_keys=True))
     else:
@@ -150,8 +153,7 @@ class TrustError(RuntimeError):
 
 def workspace_status_command(ctx: base_cli.Context, workspace: str | None, output_format: str) -> int:
     try:
-        workspace_root = resolve_workspace_root(ctx, workspace)
-        projects = discover_projects_cached(ctx, workspace_root)
+        projects = workspace_status_projects(ctx, workspace)
         store = ManifestCommandTrustStore()
         statuses = []
         for project in projects:
@@ -186,6 +188,43 @@ def workspace_status_command(ctx: base_cli.Context, workspace: str | None, outpu
             print()
         print_status_text(trust_status, surfaces)
     return base_cli.ExitCode.SUCCESS
+
+
+def workspace_status_projects(ctx: base_cli.Context, workspace: str | None) -> tuple[Project, ...]:
+    workspace_root = resolve_workspace_root(ctx, workspace)
+    projects_by_name = {project.name: project for project in discover_projects_cached(ctx, workspace_root)}
+
+    if workspace is None:
+        active_project = workspace_status_active_project()
+        if active_project is not None:
+            projects_by_name[active_project.name] = active_project
+
+        if ctx.base_home is not None:
+            base_manifest = ctx.base_home / "base_manifest.yaml"
+            if base_manifest.is_file():
+                base_project = read_project(base_manifest)
+                projects_by_name[base_project.name] = base_project
+
+    return tuple(sorted(projects_by_name.values()))
+
+
+def workspace_status_active_project() -> Project | None:
+    if "BASE_TRUST_ACTIVE_PROJECT" in os.environ:
+        active_name = os.environ.get("BASE_TRUST_ACTIVE_PROJECT")
+        active_manifest = os.environ.get("BASE_TRUST_ACTIVE_PROJECT_MANIFEST")
+    else:
+        active_name = os.environ.get("BASE_PROJECT")
+        active_manifest = os.environ.get("BASE_PROJECT_MANIFEST")
+
+    if not active_name or not active_manifest:
+        return None
+
+    project = read_project(Path(active_manifest).expanduser().resolve())
+    if project.name != active_name:
+        raise ProjectDiscoveryError(
+            f"Active project is '{active_name}' but its manifest declares project '{project.name}'."
+        )
+    return project
 
 
 def resolve_trust_identity(
@@ -224,7 +263,7 @@ def status_payload(trust_status: TrustStatus) -> dict[str, Any]:
     }
     if trust_status.is_allowed:
         payload["record"] = trust_status.record
-    elif trust_status.status != "not_required":
+    else:
         payload["allow_command"] = allow_command_text(trust_status.identity)
     if trust_status.changed_record is not None:
         changed_project = trust_status.changed_record.get("project", {})
@@ -237,22 +276,9 @@ def allow_command_text(identity: ManifestCommandTrustIdentity) -> str:
     return f"basectl trust allow {identity.project_name} --manifest-sha256 {identity.manifest_sha256}"
 
 
-def trust_status_for_surfaces(
-    identity: ManifestCommandTrustIdentity,
-    surfaces: tuple[str, ...],
-) -> TrustStatus:
-    if not surfaces:
-        return TrustStatus(
-            status="not_required",
-            reason="no_executable_commands",
-            identity=identity,
-        )
-    return ManifestCommandTrustStore().status(identity)
-
-
 def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> None:
     identity = trust_status.identity
-    if trust_status.status == "not_required":
+    if not surfaces:
         print(
             f"Manifest command trust is not required for project '{identity.project_name}': "
             "the manifest declares no executable command surfaces."

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -14,7 +14,21 @@ from unittest import mock
 from base_cli.testing import invoke
 
 
-def write_manifest(project_root: Path, name: str = "demo", command: str = "pytest tests/") -> Path:
+def write_manifest(project_root: Path, name: str = "demo", command: str | None = "pytest tests/") -> Path:
+    project_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = project_root / "base_manifest.yaml"
+    lines = ["project:", f"  name: {name}"]
+    if command is not None:
+        lines.extend(["test:", f"  command: {command}"])
+    lines.append("artifacts: []")
+    manifest_path.write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def write_all_command_surfaces_manifest(project_root: Path, name: str = "demo") -> Path:
     project_root.mkdir(parents=True, exist_ok=True)
     manifest_path = project_root / "base_manifest.yaml"
     manifest_path.write_text(
@@ -23,7 +37,18 @@ def write_manifest(project_root: Path, name: str = "demo", command: str = "pytes
                 "project:",
                 f"  name: {name}",
                 "test:",
-                f"  command: {command}",
+                "  command: pytest tests/",
+                "commands:",
+                "  lint: ruff check .",
+                "build:",
+                "  targets:",
+                "    api:",
+                "      command: go build ./...",
+                "demo:",
+                "  script: demo.sh",
+                "activate:",
+                "  source:",
+                "    - .base/activate.sh",
                 "artifacts: []",
             ]
         )
@@ -86,6 +111,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             "git_origin",
             "git_repository_root",
             "identity_key_from_record",
+            "manifest_command_surfaces",
             "sha256_file",
             "write_json_atomic",
         )
@@ -113,6 +139,20 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertEqual(identity.origin, "https://github.com/example/demo.git")
         self.assertEqual(identity.head, head)
         self.assertNotIn("secret", identity.identity_key)
+
+    def test_manifest_command_surfaces_classifies_only_executable_manifest_fields(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            all_surfaces = write_all_command_surfaces_manifest(root / "all")
+            no_surfaces = write_manifest(root / "none", name="none", command=None)
+
+            self.assertEqual(
+                engine.manifest_command_surfaces(all_surfaces),
+                ("test", "run", "build", "demo", "activate"),
+            )
+            self.assertEqual(engine.manifest_command_surfaces(no_surfaces), ())
 
     def test_trust_store_writes_allow_record_under_base_state_with_schema_version_one(self) -> None:
         from base_trust import engine
@@ -171,6 +211,94 @@ class ManifestCommandTrustTests(unittest.TestCase):
             f"basectl trust allow demo --manifest-sha256 {expected_digest}",
         )
 
+    def test_workspace_status_reports_only_projects_with_executable_manifest_surfaces(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            write_manifest(workspace / "fresh", name="fresh")
+            allowed_manifest = write_manifest(workspace / "allowed", name="allowed")
+            changed_manifest = write_manifest(workspace / "changed", name="changed")
+            write_manifest(workspace / "metadata-only", name="metadata-only", command=None)
+            store = engine.ManifestCommandTrustStore(home=home)
+            store.allow(
+                engine.compute_trust_identity_for_manifest(allowed_manifest),
+                base_version="9.9.9",
+            )
+            store.allow(
+                engine.compute_trust_identity_for_manifest(changed_manifest),
+                base_version="9.9.9",
+            )
+            changed_manifest.write_text(
+                changed_manifest.read_text(encoding="utf-8").replace("pytest tests/", "pytest -q"),
+                encoding="utf-8",
+            )
+
+            result = invoke(
+                engine.app,
+                ["status", "--workspace", str(workspace), "--format", "json"],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+            text_result = invoke(
+                engine.app,
+                ["status", "--workspace", str(workspace)],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual([item["project"]["name"] for item in payload["projects"]], ["allowed", "changed", "fresh"])
+        self.assertEqual(
+            {item["project"]["name"]: item["status"] for item in payload["projects"]},
+            {"allowed": "allowed", "changed": "blocked", "fresh": "blocked"},
+        )
+        self.assertEqual(
+            next(item for item in payload["projects"] if item["project"]["name"] == "changed")["reason"],
+            "manifest_changed",
+        )
+        self.assertNotIn("metadata-only", result.stdout)
+        self.assertEqual(text_result.exit_code, 0, text_result.output)
+        self.assertIn("trust is allowed for project 'allowed'", text_result.stdout)
+        self.assertIn("manifest changed", text_result.stdout)
+        self.assertIn("trust is blocked for project 'fresh'", text_result.stdout)
+        self.assertNotIn("metadata-only", text_result.stdout)
+
+    def test_status_for_project_without_commands_is_not_required_and_omits_allow_guidance(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            write_manifest(workspace / "docs", name="docs", command=None)
+
+            result = invoke(
+                engine.app,
+                ["status", "docs", "--workspace", str(workspace), "--format", "json"],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+            text_result = invoke(
+                engine.app,
+                ["status", "docs", "--workspace", str(workspace)],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "not_required")
+        self.assertEqual(payload["reason"], "no_executable_commands")
+        self.assertNotIn("allow_command", payload)
+        self.assertEqual(text_result.exit_code, 0, text_result.output)
+        self.assertIn("trust is not required", text_result.stdout)
+        self.assertNotIn("trust allow", text_result.stdout)
+
     def test_require_blocks_unapproved_manifest_with_review_guidance(self) -> None:
         from base_trust import engine
 
@@ -199,9 +327,68 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertIn("Manifest-declared commands are not allowed for project 'demo'", stderr.getvalue())
         self.assertIn(f"Manifest SHA-256: {expected_digest}", stderr.getvalue())
         self.assertIn("Review first:", stderr.getvalue())
-        self.assertIn("  basectl run demo --list", stderr.getvalue())
+        self.assertIn("  basectl test demo --dry-run", stderr.getvalue())
+        self.assertNotIn("  basectl run demo --list", stderr.getvalue())
         self.assertIn("Allow after review:", stderr.getvalue())
         self.assertIn(f"  basectl trust allow demo --manifest-sha256 {expected_digest}", stderr.getvalue())
+
+    def test_status_guidance_covers_demo_and_manifest_backed_activation(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            manifest_path = write_all_command_surfaces_manifest(workspace / "demo")
+
+            result = invoke(
+                engine.app,
+                ["status", "demo", "--workspace", str(workspace)],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Review first:", result.stdout)
+        self.assertIn("basectl run demo --list", result.stdout)
+        self.assertIn("basectl build demo --list", result.stdout)
+        self.assertIn("basectl test demo --dry-run", result.stdout)
+        self.assertIn("basectl demo demo --dry-run", result.stdout)
+        self.assertIn(f"Inspect activate.source entries in {manifest_path.resolve()}", result.stdout)
+        self.assertIn("basectl trust allow demo --manifest-sha256", result.stdout)
+
+    def test_changed_manifest_status_shows_recorded_digest_and_reapproval_guidance(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "work"
+            manifest_path = write_manifest(workspace / "demo")
+            identity = engine.compute_trust_identity_for_manifest(manifest_path)
+            engine.ManifestCommandTrustStore(home=home).allow(identity, base_version="9.9.9")
+            manifest_path.write_text(
+                manifest_path.read_text(encoding="utf-8").replace("pytest tests/", "pytest -q"),
+                encoding="utf-8",
+            )
+            current_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+            result = invoke(
+                engine.app,
+                ["status", "demo", "--workspace", str(workspace)],
+                home=home,
+                env={"BASE_HOME": str(workspace / "base")},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("manifest changed", result.stdout)
+        self.assertIn(f"Recorded Manifest SHA-256: {identity.manifest_sha256}", result.stdout)
+        self.assertIn(f"Manifest SHA-256: {current_digest}", result.stdout)
+        self.assertIn("basectl test demo --dry-run", result.stdout)
+        self.assertIn(
+            f"basectl trust allow demo --manifest-sha256 {current_digest}",
+            result.stdout,
+        )
 
     def test_require_allows_matching_trust_record_for_manifest_path(self) -> None:
         from base_trust import engine

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -268,7 +268,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertIn("trust is blocked for project 'fresh'", text_result.stdout)
         self.assertNotIn("metadata-only", text_result.stdout)
 
-    def test_status_for_project_without_commands_is_not_required_and_omits_allow_guidance(self) -> None:
+    def test_status_for_project_without_commands_keeps_json_v1_and_omits_text_guidance(self) -> None:
         from base_trust import engine
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -292,12 +292,66 @@ class ManifestCommandTrustTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.stdout)
-        self.assertEqual(payload["status"], "not_required")
-        self.assertEqual(payload["reason"], "no_executable_commands")
-        self.assertNotIn("allow_command", payload)
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["reason"], "not_allowed")
+        self.assertIn("allow_command", payload)
         self.assertEqual(text_result.exit_code, 0, text_result.output)
         self.assertIn("trust is not required", text_result.stdout)
         self.assertNotIn("trust allow", text_result.stdout)
+
+    def test_workspace_status_adds_context_projects_only_for_implicit_workspace(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "configured-workspace"
+            base_home = root / "installed-base"
+            active_root = root / "active"
+            write_manifest(workspace / "scoped", name="scoped")
+            write_manifest(base_home, name="base")
+            active_manifest = write_manifest(active_root, name="active")
+            config_path = home / ".base.d" / "config.yaml"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(f"workspace:\n  root: {workspace}\n", encoding="utf-8")
+
+            implicit_result = invoke(
+                engine.app,
+                ["status", "--format", "json"],
+                home=home,
+                env={
+                    "BASE_HOME": str(base_home),
+                    "BASE_PROJECT": "base",
+                    "BASE_PROJECT_MANIFEST": str(active_manifest),
+                    "BASE_TRUST_ACTIVE_PROJECT": "active",
+                    "BASE_TRUST_ACTIVE_PROJECT_MANIFEST": str(active_manifest),
+                },
+            )
+            explicit_result = invoke(
+                engine.app,
+                ["status", "--workspace", str(workspace), "--format", "json"],
+                home=home,
+                env={
+                    "BASE_HOME": str(base_home),
+                    "BASE_PROJECT": "base",
+                    "BASE_PROJECT_MANIFEST": str(active_manifest),
+                    "BASE_TRUST_ACTIVE_PROJECT": "active",
+                    "BASE_TRUST_ACTIVE_PROJECT_MANIFEST": str(active_manifest),
+                },
+            )
+
+        self.assertEqual(implicit_result.exit_code, 0, implicit_result.output)
+        implicit_payload = json.loads(implicit_result.stdout)
+        self.assertEqual(
+            [item["project"]["name"] for item in implicit_payload["projects"]],
+            ["active", "base", "scoped"],
+        )
+        self.assertEqual(explicit_result.exit_code, 0, explicit_result.output)
+        explicit_payload = json.loads(explicit_result.stdout)
+        self.assertEqual(
+            [item["project"]["name"] for item in explicit_payload["projects"]],
+            ["scoped"],
+        )
 
     def test_require_blocks_unapproved_manifest_with_review_guidance(self) -> None:
         from base_trust import engine

--- a/cli/python/base_trust/trust_store.py
+++ b/cli/python/base_trust/trust_store.py
@@ -147,6 +147,22 @@ class ManifestCommandTrustStore:
         return removed
 
 
+def manifest_command_surfaces(manifest_path: Path) -> tuple[str, ...]:
+    manifest = read_manifest(manifest_path.expanduser().resolve())
+    surfaces = []
+    if manifest.test is not None:
+        surfaces.append("test")
+    if manifest.commands:
+        surfaces.append("run")
+    if manifest.build is not None and manifest.build.targets:
+        surfaces.append("build")
+    if manifest.demo is not None:
+        surfaces.append("demo")
+    if manifest.activate.source:
+        surfaces.append("activate")
+    return tuple(surfaces)
+
+
 def compute_trust_identity_for_manifest(manifest_path: Path) -> ManifestCommandTrustIdentity:
     manifest = read_manifest(manifest_path.expanduser().resolve())
     canonical_manifest = manifest.path.resolve()

--- a/docs/basectl-onboard.md
+++ b/docs/basectl-onboard.md
@@ -122,7 +122,8 @@ Options:
 ```text
   --profile <list> Include named prerequisite profiles.
   --dry-run        Explain and show planned actions without making changes.
-  --yes            Accept default answers for non-destructive prompts.
+  --yes            Approve setup changes and the shell-profile prompt; never
+                   grant manifest trust.
   --no-profile     Skip shell profile updates.
   -v               Enable DEBUG logging for underlying commands.
   -h, --help       Show help text.
@@ -193,6 +194,10 @@ Failures are recoverable and specific:
   profile updates.
 - If `basectl update-profile` fails, leave setup success intact and explain how
   to rerun that step.
+- If project discovery or trust status fails after setup, stop before activation
+  guidance, preserve the failing status, and tell the user to retry
+  `basectl projects list` followed by `basectl trust status`. Earlier setup or
+  profile changes remain applied.
 - Preserve the failing command's exit status when onboarding cannot complete.
 
 ## Non-Goals

--- a/docs/basectl-onboard.md
+++ b/docs/basectl-onboard.md
@@ -19,7 +19,9 @@ commands:
    disabled
 4. runs `basectl doctor [project]`
 5. lists discovered projects with `basectl projects list`
-6. suggests the next interactive shell step
+6. reports trust status for discovered manifests with executable command
+   surfaces, without approving them
+7. suggests the next interactive shell step after any required trust review
 
 It keeps underlying command output visible and shows each Base command before it
 runs it. Use it when you want a guided first setup. Use `basectl setup` directly
@@ -36,7 +38,7 @@ Options:
 ```text
   --profile <list> Include named prerequisite profiles.
   --dry-run        Explain and show planned actions without making changes.
-  --yes            Accept default answers for setup/profile prompts.
+  --yes            Accept setup/profile prompts; never approve manifest trust.
   --no-profile     Skip shell profile updates.
   -v               Enable DEBUG logging for underlying commands.
   -h, --help       Show help text.
@@ -100,6 +102,8 @@ boundary.
   profiles
 - `basectl update-profile` for shell startup integration
 - `basectl projects list` to show discovered projects after setup
+- `basectl trust status` to show digest-bound command trust for discovered
+  projects without granting approval
 - `basectl activate <project>` as the final suggested next step
 
 It does not duplicate Homebrew, Python, venv, manifest, or shell-profile logic.
@@ -141,7 +145,11 @@ The shipped flow is simple and checklist-oriented:
    `--no-profile` was set.
 7. Run `basectl doctor` to summarize the final state.
 8. Print discovered projects with `basectl projects list` when available.
-9. Suggest `basectl` or `basectl activate base` as the next interactive step.
+9. Run the read-only `basectl trust status` workspace view, which filters out
+   manifests without executable command surfaces and prints exact review and
+   digest-bound allow guidance for those that need it.
+10. Suggest `basectl` or `basectl activate base` after any required trust
+    review.
 
 The command shows the exact Base command before it runs it. For example:
 
@@ -160,7 +168,9 @@ Prompts should be explicit but sparse:
 - Do not prompt before read-only checks.
 - Treat Enter as the conservative answer when there is risk.
 - `--yes` may accept normal setup/profile prompts, but should not bypass fatal
-  safety checks such as unsupported operating systems.
+  safety checks such as unsupported operating systems or grant manifest
+  command trust. It is forwarded to setup so package-manager consent does not
+  unexpectedly remain interactive on Ubuntu/Debian.
 - `--dry-run` should not prompt for actions it will not perform.
 
 ## Output Style

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -61,14 +61,14 @@ full compatibility contract.
 | `basectl demo [project]` | Run a project-owned demo script. | `--workspace <path>`, `--dry-run`, `-- <args>` |
 | `basectl devcontainer [project]` | Preview or write `.devcontainer/devcontainer.json` from a Base manifest. Dry-run is the default. | `--workspace <path>`, `--format <text\|json>`, `--write` |
 | `basectl devenv-report [project]` | Classify Base manifest fields for Nix/devenv planning without generating files or requiring Nix. | `--workspace <path>`, `--format <text\|json>` |
-| `basectl trust status <project>` | Show local manifest command trust status. | `--workspace <path>`, `--format <text\|json>` |
+| `basectl trust status [project]` | Show one project's manifest trust status, or all discovered command-bearing projects. | `--workspace <path>`, `--format <text\|json>` |
 | `basectl trust allow <project>` | Approve the current manifest command contract on this machine. | `--workspace <path>`, `--manifest-sha256 <sha256>` |
 | `basectl trust revoke <project>` | Remove local manifest command approval. | `--workspace <path>` |
 
-Manifest-declared `test`, `run`, and `build` commands are project-owned shell
-command strings executed from the project root. Review manifests from
-unfamiliar repositories before running them; use `--dry-run` or `--list` to
-inspect the resolved command contract first.
+Manifest-declared `test`, `run`, `build`, `demo`, and activation surfaces are
+project-owned code executed from the project root. Review manifests from
+unfamiliar repositories before running them; use `--dry-run` or `--list` where
+available and inspect `activate.source` directly before activation.
 
 ## Diagnostics And Logs
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -44,7 +44,7 @@ full compatibility contract.
 | `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--ci`, `--format <text\|json>`, `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv`, `--notify`, `--no-notify` |
 | `basectl update-profile` | Create, refresh, or remove Base-managed Bash and Zsh startup snippets, backing up existing dotfiles before changes. | `--defaults`, `--no-defaults`, `--remove`, `--dry-run` |
 | `basectl update [project]` | Update a Base-managed project checkout through Git, or update Base through Homebrew when Base is Homebrew-managed, then run setup for the selected project. | `--dry-run` |
-| `basectl onboard [project]` | Guide first-run setup by orchestrating check, setup, shell profile, doctor, and project discovery. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
+| `basectl onboard [project]` | Guide first-run setup through check, setup, shell profile, doctor, project discovery, and read-only manifest trust status. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
 | `basectl version` | Show the installed Base version. | none |
 
 ## Daily Project Loop

--- a/docs/manifest-command-trust.md
+++ b/docs/manifest-command-trust.md
@@ -123,6 +123,13 @@ reports every discovered project whose manifest declares an executable test,
 run, build, demo, or activation surface. Metadata-only manifests are omitted so
 workspace onboarding does not suggest unnecessary approval.
 
+For schema-v1 compatibility, explicit single-project JSON continues to report
+the underlying allow-record state, including `status: blocked` and an
+`allow_command` for a metadata-only manifest. Human text reports that approval
+is not required, and the project-less workspace view omits that manifest. The
+existing `status`, `reason`, and conditional `allow_command`/`record` meanings
+are unchanged.
+
 `basectl trust allow` prints the exact identity being approved and requires the
 supplied `--manifest-sha256` to match when that option is present. That flag is
 useful for scripted, non-interactive approval after a prior review step.

--- a/docs/manifest-command-trust.md
+++ b/docs/manifest-command-trust.md
@@ -113,10 +113,15 @@ repositories.
 Use the focused trust command to inspect, allow, or revoke approval:
 
 ```bash
-basectl trust status <project> [--workspace <path>] [--format text|json]
+basectl trust status [project] [--workspace <path>] [--format text|json]
 basectl trust allow <project> [--workspace <path>] [--manifest-sha256 <sha256>]
 basectl trust revoke <project> [--workspace <path>]
 ```
+
+With a project, `trust status` reports that one manifest. Without a project, it
+reports every discovered project whose manifest declares an executable test,
+run, build, demo, or activation surface. Metadata-only manifests are omitted so
+workspace onboarding does not suggest unnecessary approval.
 
 `basectl trust allow` prints the exact identity being approved and requires the
 supplied `--manifest-sha256` to match when that option is present. That flag is
@@ -136,6 +141,8 @@ Review first:
   basectl run demo --list
   basectl build demo --list
   basectl test demo --dry-run
+  basectl demo demo --dry-run
+  Inspect activate.source entries in /Users/rameshhp/work/demo/base_manifest.yaml before running 'basectl activate demo'.
 
 Allow after review:
   basectl trust allow demo --manifest-sha256 <sha256>
@@ -163,7 +170,7 @@ If a workflow cannot precompute the digest, it may run `basectl trust status
 base-demo --format json` first, review the emitted `manifest_sha256` in a prior
 step, and then call `trust allow` with that digest.
 
-`basectl trust status --format json` should return a structured payload:
+`basectl trust status <project> --format json` returns a structured payload:
 
 ```json
 {
@@ -179,6 +186,27 @@ step, and then call `trust allow` with that digest.
     "head": "<commit-sha>"
   },
   "allow_command": "basectl trust allow demo --manifest-sha256 <sha256>"
+}
+```
+
+The project-less workspace form preserves each project payload under a
+versioned collection:
+
+```json
+{
+  "schema_version": 1,
+  "projects": [
+    {
+      "schema_version": 1,
+      "status": "blocked",
+      "reason": "not_allowed",
+      "project": {
+        "name": "demo",
+        "manifest_sha256": "<sha256>"
+      },
+      "allow_command": "basectl trust allow demo --manifest-sha256 <sha256>"
+    }
+  ]
 }
 ```
 

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -282,7 +282,7 @@ _base_basectl_completion() {
             case "${words[3]:-}" in
                 status)
                     _arguments '1:trust command:(status allow revoke)' \
-                        '2:Base project:->projects' \
+                        '2::Base project:->projects' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--format[Output format]:format:(text json)' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'

--- a/tests/test_bootstrap_docs.py
+++ b/tests/test_bootstrap_docs.py
@@ -36,3 +36,17 @@ def test_bootstrap_quick_start_surfaces_verified_homebrew_installer_path() -> No
     assert "BASE_BOOTSTRAP_HOMEBREW_INSTALLER_SHA256" in quick_start
     assert "BASE_HOMEBREW_INSTALLER_URL" in quick_start
     assert "BASE_HOMEBREW_INSTALLER_SHA256" in quick_start
+
+
+def test_readme_90_second_proof_reviews_manifest_trust_before_demo() -> None:
+    text = README.read_text(encoding="utf-8")
+    proof = section(text, "### 90-Second Proof, No Dotfile Changes", "### Shell Startup Is Explicit")
+
+    base_status = proof.index("basectl trust status base")
+    base_demo = proof.index("basectl demo base")
+    demo_status = proof.index("basectl trust status base-demo")
+    demo_demo = proof.index("basectl demo base-demo")
+
+    assert base_status < base_demo
+    assert demo_status < demo_demo
+    assert "exact `basectl trust allow" in proof

--- a/tests/test_bootstrap_docs.py
+++ b/tests/test_bootstrap_docs.py
@@ -41,6 +41,7 @@ def test_bootstrap_quick_start_surfaces_verified_homebrew_installer_path() -> No
 def test_readme_90_second_proof_reviews_manifest_trust_before_demo() -> None:
     text = README.read_text(encoding="utf-8")
     proof = section(text, "### 90-Second Proof, No Dotfile Changes", "### Shell Startup Is Explicit")
+    normalized_proof = " ".join(proof.split())
 
     base_status = proof.index("basectl trust status base")
     base_demo = proof.index("basectl demo base")
@@ -50,3 +51,4 @@ def test_readme_90_second_proof_reviews_manifest_trust_before_demo() -> None:
     assert base_status < base_demo
     assert demo_status < demo_demo
     assert "exact `basectl trust allow" in proof
+    assert "replace its leading `basectl` with `~/work/base/bin/basectl`" in normalized_proof


### PR DESCRIPTION
## Summary

- forward `basectl onboard --yes` to setup so Ubuntu/Debian package consent is genuinely unattended
- add a read-only workspace trust-status step that never grants approval and filters manifests without executable command surfaces
- make fresh and changed trust states show surface-specific review commands, the current digest, and the exact digest-bound allow command, including demo and activation guidance
- keep explicit `--workspace` status deterministic while implicit onboarding status includes the installed Base and active project, even across wrapper dispatch
- stop onboarding consistently when project discovery or trust inspection fails, with retry guidance before activation
- document explicit-checkout trust commands and the `--yes` boundary accurately

## Issue

Closes #1644

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/onboard.bats cli/bash/commands/basectl/tests/trust.bats cli/bash/commands/basectl/tests/help.bats` (32 passed)
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_trust/tests/test_engine.py tests/test_bootstrap_docs.py -q` (17 passed, 15 subtests)
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_trust/engine.py cli/python/base_trust/tests/test_engine.py`
- `bash -n cli/bash/commands/basectl/subcommands/onboard.sh cli/bash/commands/basectl/subcommands/trust.sh`
- `shellcheck cli/bash/commands/basectl/subcommands/onboard.sh cli/bash/commands/basectl/subcommands/trust.sh`
- fresh-store explicit-checkout proof: trust status, digest-bound trust allow, and `demo base -- --non-interactive` completed from a temporary `HOME`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test` (969 Python passed, 1 skipped; 740 BATS passed)
- `git diff --check`

## Demo Impact

The self-demo implementation is unchanged. The README proof now requires explicit digest review and approval before either Base demo, preventing the previous unexplained fresh-store failure.

## Notes

- Existing single-project trust JSON remains compatible. The project-less form returns a versioned `projects` collection and omits metadata-only manifests.
- Explicit `--workspace` inspection stays scoped to that workspace; implicit inspection adds the installed Base and active project for onboarding.
- `--yes` still cannot call `trust allow`; explicit local approval remains the security boundary.
- `.ai-context/` is not changed because this patch does not alter Base's architectural ownership boundaries.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
