### PR TITLE
Restore basectl ci compatibility alias parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Made `basectl onboard --yes` reach unattended setup consent and added a
   read-only, workspace-wide manifest trust review step that never grants trust
   automatically or prompts for metadata-only manifests.
+- Made the legacy `basectl ci setup|check|doctor` compatibility syntax pass
+  arguments directly to the canonical lifecycle parsers, restoring option,
+  help, validation, and exit-code parity.
 - Required explicit relative or absolute paths for Base runtime scripts so a
   same-named file in the current directory cannot shadow a `basectl` control
   command.

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Current implemented commands include:
 - `basectl setup [project]`
 - `basectl check`
 - `basectl doctor`
-- `basectl <setup|check|doctor> --ci <project>`
+- `basectl <setup|check|doctor> --ci [project]`
 - `basectl clean --older-than <age>`
 - `basectl clean --keep-last <count>`
 - `basectl config path`

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -74,9 +74,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
   project argument validates `project.name`.
 - `basectl check [project]` verifies the same local requirements without making
   changes and can include project manifest artifacts.
-- `basectl setup/check/doctor --ci <project>` runs Base setup, readiness
+- `basectl setup/check/doctor --ci [project]` runs Base setup, readiness
   checks, and diagnostics with CI-safe defaults and text or JSON output.
-  `basectl ci setup/check/doctor <project>` remains a compatibility alias.
+  `basectl ci setup/check/doctor [project]` remains a compatibility alias.
   Neither surface runs project tests or launches CI runners/VMs.
 - `basectl setup/check/doctor --profile <list>` manage opt-in prerequisite
   profiles. `sre` is the first additional built-in profile, and profiles compose

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -58,8 +58,8 @@ Commands:
     Run a project's declared command.
   repo <init|clone|check|configure|agent-guidance|installer-template> [options]
     Create, clone, check, and configure repository baselines and guidance.
-  ci <setup|check|doctor> <project> [options]
-    Run Base setup, checks, and diagnostics in non-interactive CI.
+  ci <setup|check|doctor> [project] [options]
+    Compatibility alias for setup, check, and doctor --ci.
   release <check|plan|notes|publish> --version <version> [options]
     Inspect release readiness, plan, notes, and guarded GitHub publishing.
   prompt <list|name> [options]

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -35,7 +35,7 @@ Purpose:
 
 See also:
   basectl doctor [project] [options]
-  basectl ci check <project> [options]  Compatibility alias for check --ci.
+  basectl ci check [project] [options]  Compatibility alias for check --ci.
 
 Check does:
   1. Verify platform-specific runtime prerequisites.

--- a/cli/bash/commands/basectl/subcommands/ci.sh
+++ b/cli/bash/commands/basectl/subcommands/ci.sh
@@ -5,35 +5,23 @@ _base_ci_subcommand_sourced=1
 readonly _base_ci_subcommand_sourced
 
 _base_ci_subcommand_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-_base_ci_setup_common_path="$_base_ci_subcommand_dir/setup_common.sh"
-# shellcheck source=/dev/null
-source "$_base_ci_setup_common_path"
 
 base_ci_subcommand_usage() {
     cat <<'EOF'
 Usage:
-  basectl ci setup <project> [options]
-  basectl ci check <project> [options]
-  basectl ci doctor <project> [options]
+  basectl ci setup [project] [options]
+  basectl ci check [project] [options]
+  basectl ci doctor [project] [options]
 
 Options:
-  --format <text|json>  Select output format. Defaults to text.
-  --manifest <path>     Use a specific base_manifest.yaml path.
-  --profile <list>      Include named prerequisite profiles. Known profiles: dev, sre, ai, linux-lab.
-  --recreate-venv       Back up and recreate the project virtual environment during setup.
-  -v                    Enable DEBUG logging for this subcommand.
-  -h, --help            Show this help text.
-
-Profiles:
-  Profile lists are comma-separated, for example: --profile dev,sre.
-  dev       - Base development tooling for this repository.
-  sre       - production/SRE prerequisite tooling.
-  ai        - AI coding assistant tooling.
-  linux-lab - Multipass tooling for local Ubuntu lab VMs on macOS hosts.
+  Target command options are passed through unchanged after --ci is added.
+  Run `basectl setup --help`, `basectl check --help`, or
+  `basectl doctor --help` for the canonical option list.
+  -h, --help  Show this help text.
 
 Purpose:
   Compatibility alias for setup/check/doctor --ci.
-  Prefer: basectl <setup|check|doctor> --ci <project> [options]
+  Prefer: basectl <setup|check|doctor> --ci [project] [options]
   Sets BASE_CI=true so setup and diagnostic paths can choose CI-safe behavior.
   Does not run project tests, launch GitHub Actions, or create Ubuntu/Multipass VMs.
 EOF
@@ -43,10 +31,6 @@ base_ci_usage_error() {
     print_error "$*"
     base_ci_subcommand_usage >&2
     return 2
-}
-
-base_ci_apply_environment() {
-    setup_enable_ci_mode
 }
 
 base_ci_source_subcommand_module() {
@@ -62,142 +46,26 @@ base_ci_source_subcommand_module() {
     source "$subcommand_script"
 }
 
-base_ci_parse_args() {
+base_ci_delegate() {
     local command="$1"
     shift
 
-    BASE_CI_FORMAT="text"
-    BASE_CI_MANIFEST=""
-    BASE_CI_PROFILE=""
-    BASE_CI_PROJECT=""
-    BASE_CI_RECREATE_VENV=0
-    BASE_CI_VERBOSE=0
-    BASE_CI_HELP_REQUESTED=0
-
-    while (($#)); do
-        case "$1" in
-            -h|--help|help)
-                base_ci_subcommand_usage
-                BASE_CI_HELP_REQUESTED=1
-                return 0
-                ;;
-            --format)
-                shift
-                [[ -n "${1:-}" ]] || {
-                    base_ci_usage_error "Option '--format' requires an argument."
-                    return $?
-                }
-                case "$1" in
-                    text|json)
-                        BASE_CI_FORMAT="$1"
-                        ;;
-                    *)
-                        base_ci_usage_error "Unsupported ci output format '$1'."
-                        return $?
-                        ;;
-                esac
-                ;;
-            --manifest)
-                shift
-                [[ -n "${1:-}" ]] || {
-                    base_ci_usage_error "Option '--manifest' requires an argument."
-                    return $?
-                }
-                BASE_CI_MANIFEST="$1"
-                ;;
-            --profile)
-                shift
-                [[ -n "${1:-}" ]] || {
-                    base_ci_usage_error "Option '--profile' requires an argument."
-                    return $?
-                }
-                BASE_CI_PROFILE="$1"
-                ;;
-            --recreate-venv)
-                [[ "$command" == setup ]] || {
-                    base_ci_usage_error "Option '--recreate-venv' is only supported for setup --ci."
-                    return $?
-                }
-                BASE_CI_RECREATE_VENV=1
-                ;;
-            -v)
-                BASE_CI_VERBOSE=1
-                ;;
-            -*)
-                base_ci_usage_error "Unknown ci $command option '$1'."
-                return $?
-                ;;
-            *)
-                if [[ -n "$BASE_CI_PROJECT" ]]; then
-                    base_ci_usage_error "The 'ci $command' command accepts exactly one project name."
-                    return $?
-                fi
-                BASE_CI_PROJECT="$1"
-                ;;
-        esac
-        shift
-    done
-
-    [[ -n "$BASE_CI_PROJECT" ]] || {
-        base_ci_usage_error "The 'ci $command' command requires a project name."
-        return $?
-    }
-}
-
-base_ci_common_delegate_args() {
-    printf '%s\n' --ci
-    if [[ -n "$BASE_CI_PROFILE" ]]; then
-        printf '%s\n' --profile "$BASE_CI_PROFILE"
-    fi
-    if [[ -n "$BASE_CI_MANIFEST" ]]; then
-        printf '%s\n' --manifest "$BASE_CI_MANIFEST"
-    fi
-    if ((BASE_CI_VERBOSE)); then
-        printf '%s\n' -v
-    fi
-}
-
-base_ci_setup_delegate_args() {
-    base_ci_common_delegate_args
-    printf '%s\n' --format "$BASE_CI_FORMAT"
-    if ((BASE_CI_RECREATE_VENV)); then
-        printf '%s\n' --recreate-venv
-    fi
-    printf '%s\n' "$BASE_CI_PROJECT"
-}
-
-base_ci_check_or_doctor_delegate_args() {
-    base_ci_common_delegate_args
-    printf '%s\n' "$BASE_CI_PROJECT" --format "$BASE_CI_FORMAT"
-}
-
-base_ci_run_setup() {
-    local args=()
-
-    mapfile -t args < <(base_ci_setup_delegate_args)
-    base_ci_source_subcommand_module setup || return 1
-    base_setup_subcommand_main "${args[@]}"
-}
-
-base_ci_run_check() {
-    local args=()
-
-    mapfile -t args < <(base_ci_check_or_doctor_delegate_args)
-    base_ci_source_subcommand_module check || return 1
-    base_check_subcommand_main "${args[@]}"
-}
-
-base_ci_run_doctor() {
-    local args=()
-
-    mapfile -t args < <(base_ci_check_or_doctor_delegate_args)
-    base_ci_source_subcommand_module doctor || return 1
-    base_doctor_subcommand_main "${args[@]}"
+    base_ci_source_subcommand_module "$command" || return 1
+    case "$command" in
+        setup)
+            base_setup_subcommand_main --ci "$@"
+            ;;
+        check)
+            base_check_subcommand_main --ci "$@"
+            ;;
+        doctor)
+            base_doctor_subcommand_main --ci "$@"
+            ;;
+    esac
 }
 
 base_ci_subcommand_main() {
     local command="${1:-}"
-    local parse_status
 
     case "$command" in
         -h|--help|help)
@@ -210,31 +78,12 @@ base_ci_subcommand_main() {
             ;;
         setup|check|doctor)
             shift
-            base_ci_parse_args "$command" "$@"
-            parse_status=$?
-            if ((parse_status != 0)); then
-                return "$parse_status"
-            fi
-            if ((BASE_CI_HELP_REQUESTED)); then
-                    return 0
-            fi
+            base_ci_delegate "$command" "$@"
+            return $?
             ;;
         *)
             base_ci_usage_error "Unknown ci command '$command'."
             return $?
-            ;;
-    esac
-
-    base_ci_apply_environment
-    case "$command" in
-        setup)
-            base_ci_run_setup
-            ;;
-        check)
-            base_ci_run_check
-            ;;
-        doctor)
-            base_ci_run_doctor
             ;;
     esac
 }

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -38,7 +38,7 @@ Purpose:
 
 See also:
   basectl check [project] [options]
-  basectl ci doctor <project> [options]  Compatibility alias for doctor --ci.
+  basectl ci doctor [project] [options]  Compatibility alias for doctor --ci.
 EOF
 }
 

--- a/cli/bash/commands/basectl/tests/ci.bats
+++ b/cli/bash/commands/basectl/tests/ci.bats
@@ -31,38 +31,7 @@ prepare_ci_runtime() {
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$workspace/demo/.venv"
 }
 
-@test "basectl ci prints help" {
-    run_base_command ci --help
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl ci setup <project>"* ]]
-    [[ "$output" == *"basectl ci check <project>"* ]]
-    [[ "$output" == *"basectl ci doctor <project>"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
-    [[ "$output" == *"--profile <list>"* ]]
-    [[ "$output" == *"Profile lists are comma-separated, for example: --profile dev,sre."* ]]
-    [[ "$output" == *"dev       - Base development tooling for this repository."* ]]
-    [[ "$output" == *"sre       - production/SRE prerequisite tooling."* ]]
-    [[ "$output" == *"ai        - AI coding assistant tooling."* ]]
-    [[ "$output" == *"linux-lab - Multipass tooling for local Ubuntu lab VMs on macOS hosts."* ]]
-    [[ "$output" == *"Compatibility alias for setup/check/doctor --ci."* ]]
-    [[ "$output" == *"Prefer: basectl <setup|check|doctor> --ci <project> [options]"* ]]
-    [[ "$output" == *"BASE_CI=true"* ]]
-    [[ "$output" == *"Does not run project tests, launch GitHub Actions, or create Ubuntu/Multipass VMs."* ]]
-}
-
-@test "basectl ci requires a command and project" {
-    run_base_command ci
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"CI command is required."* ]]
-
-    run_base_command ci check --format json
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"The 'ci check' command requires a project name."* ]]
-}
-
-@test "basectl ci parser tracks help without magic status codes" {
+run_ci_delegate_capture() {
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
@@ -70,13 +39,159 @@ prepare_ci_runtime() {
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/ci.sh"
-            base_ci_parse_args setup --help
-            printf "status=%s help=%s\n" "$?" "${BASE_CI_HELP_REQUESTED:-}"
-        '
+
+            base_ci_source_subcommand_module() {
+                return 0
+            }
+            base_setup_subcommand_main() {
+                printf "command=setup\n"
+                printf "arg=<%s>\n" "$@"
+            }
+            base_check_subcommand_main() {
+                printf "command=check\n"
+                printf "arg=<%s>\n" "$@"
+            }
+            base_doctor_subcommand_main() {
+                printf "command=doctor\n"
+                printf "arg=<%s>\n" "$@"
+            }
+
+            base_ci_subcommand_main "$@"
+        ' bash "$@"
+}
+
+@test "basectl ci prints help" {
+    run_base_command ci --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"status=0 help=1"* ]]
+    [[ "$output" == *"basectl ci setup [project] [options]"* ]]
+    [[ "$output" == *"basectl ci check [project] [options]"* ]]
+    [[ "$output" == *"basectl ci doctor [project] [options]"* ]]
+    [[ "$output" == *"Target command options are passed through unchanged after --ci is added."* ]]
+    [[ "$output" == *'Run `basectl setup --help`, `basectl check --help`, or'* ]]
+    [[ "$output" == *'`basectl doctor --help` for the canonical option list.'* ]]
+    [[ "$output" == *"Compatibility alias for setup/check/doctor --ci."* ]]
+    [[ "$output" == *"Prefer: basectl <setup|check|doctor> --ci [project] [options]"* ]]
+    [[ "$output" == *"BASE_CI=true"* ]]
+    [[ "$output" == *"Does not run project tests, launch GitHub Actions, or create Ubuntu/Multipass VMs."* ]]
+}
+
+@test "basectl ci requires a supported lifecycle command" {
+    run_base_command ci
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"CI command is required."* ]]
+
+    run_base_command ci deploy demo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown ci command 'deploy'."* ]]
+}
+
+@test "basectl ci passes lifecycle arguments through unchanged after adding --ci" {
+    run_ci_delegate_capture setup demo --dry-run --yes --notify --no-notify --recreate-venv
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(printf '%s\n' \
+        'command=setup' \
+        'arg=<--ci>' \
+        'arg=<demo>' \
+        'arg=<--dry-run>' \
+        'arg=<--yes>' \
+        'arg=<--notify>' \
+        'arg=<--no-notify>' \
+        'arg=<--recreate-venv>')" ]
+
+    run_ci_delegate_capture check demo --remote-network
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(printf '%s\n' \
+        'command=check' \
+        'arg=<--ci>' \
+        'arg=<demo>' \
+        'arg=<--remote-network>')" ]
+
+    run_ci_delegate_capture doctor demo --remote-network --no-color
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(printf '%s\n' \
+        'command=doctor' \
+        'arg=<--ci>' \
+        'arg=<demo>' \
+        'arg=<--remote-network>' \
+        'arg=<--no-color>')" ]
+}
+
+@test "basectl ci lifecycle help and parser errors match canonical commands" {
+    local command
+    local alias_output alias_status canonical_output canonical_status
+
+    for command in setup check doctor; do
+        run_base_command ci "$command" --help
+        alias_status="$status"
+        alias_output="$output"
+        run_base_command "$command" --ci --help
+        canonical_status="$status"
+        canonical_output="$output"
+
+        [ "$alias_status" -eq "$canonical_status" ]
+        [ "$alias_output" = "$canonical_output" ]
+
+        run_base_command ci "$command" demo --not-a-real-option
+        alias_status="$status"
+        alias_output="$output"
+        run_base_command "$command" --ci demo --not-a-real-option
+        canonical_status="$status"
+        canonical_output="$output"
+
+        [ "$alias_status" -eq "$canonical_status" ]
+        [ "$alias_output" = "$canonical_output" ]
+    done
+}
+
+@test "basectl ci forwards canonical setup mutation controls" {
+    local workspace="$TEST_TMPDIR/workspace"
+
+    prepare_ci_runtime "$workspace"
+
+    run_base_command \
+        BASE_SETUP_TEST_WORKSPACE="$workspace" \
+        ci setup demo --dry-run --yes --no-notify --recreate-venv
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' \
+        --dry-run \
+        --manifest "$workspace/demo/base_manifest.yaml" \
+        --action setup \
+        demo)" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-yes")" = "true" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-notify")" = "false" ]
+    [ "$(cat "$TEST_STATE_DIR/project-bootstrap-recreate-venv")" = "true" ]
+}
+
+@test "basectl ci forwards canonical check and doctor diagnostic controls" {
+    local workspace="$TEST_TMPDIR/workspace"
+
+    prepare_ci_runtime "$workspace"
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" ci check demo --remote-network
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' \
+        --manifest "$workspace/demo/base_manifest.yaml" \
+        --action check \
+        --format text \
+        --remote-network \
+        demo)" ]
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" ci doctor demo --remote-network --no-color
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' \
+        --manifest "$workspace/demo/base_manifest.yaml" \
+        --action doctor \
+        --format text \
+        --remote-network \
+        demo)" ]
 }
 
 @test "basectl ci check delegates with CI defaults and JSON output" {

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -237,10 +237,30 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "ci_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci setup ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci_setup_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci setup --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci_setup_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci check ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci_check_projects=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl ci check --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "ci_check_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci doctor ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci_doctor_projects=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci doctor --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci_doctor_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl gh ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -320,7 +340,12 @@ EOF
     [[ "$output" == *"repo_agent_guidance_options=--repo --issue --category --repo-name --default-branch --validation-command --pr --dry-run"* ]]
     [[ "$output" == *"repo_installer_template_options=--print --stdout --repo --issue --category --pr --dry-run"* ]]
     [[ "$output" == *"ci_commands=setup check doctor"* ]]
-    [[ "$output" == *"ci_check_options=--format --manifest --profile"* ]]
+    [[ "$output" == *"ci_setup_projects=base demo"* ]]
+    [[ "$output" == *"ci_setup_options=--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --yes"* ]]
+    [[ "$output" == *"ci_check_projects=base demo"* ]]
+    [[ "$output" == *"ci_check_options=--ci --profile --format --manifest --remote-network"* ]]
+    [[ "$output" == *"ci_doctor_projects=base demo"* ]]
+    [[ "$output" == *"ci_doctor_options=--ci --profile --format --manifest --remote-network --no-color"* ]]
     [[ "$output" == *"gh_areas=issue pr branch worktree project"* ]]
     [[ "$output" == *"gh_project_commands=doctor configure issue"* ]]
     [[ "$output" == *"gh_project_configure_options=--project --owner --schema --config --copy-fields-from --initiative-option --repo --replace-project --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -17,7 +17,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"devenv-report [project] [options]"* ]]
     [[ "$output" == *"run <project> <command> [options]"* ]]
     [[ "$output" == *"repo <init|clone|check|configure|agent-guidance|installer-template> [options]"* ]]
-    [[ "$output" == *"ci <setup|check|doctor> <project> [options]"* ]]
+    [[ "$output" == *"ci <setup|check|doctor> [project] [options]"* ]]
+    [[ "$output" == *"Compatibility alias for setup, check, and doctor --ci."* ]]
     [[ "$output" == *"release <check|plan|notes|publish> --version <version> [options]"* ]]
     [[ "$output" == *"prompt <list|name> [options]"* ]]
     [[ "$output" == *"docs [options]"* ]]
@@ -63,7 +64,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  devcontainer [project] [options]' <<<"$output"
     grep -Fqx '  devenv-report [project] [options]' <<<"$output"
     grep -Fqx '  repo <init|clone|check|configure|agent-guidance|installer-template> [options]' <<<"$output"
-    grep -Fqx '  ci <setup|check|doctor> <project> [options]' <<<"$output"
+    grep -Fqx '  ci <setup|check|doctor> [project] [options]' <<<"$output"
     grep -Fqx '  release <check|plan|notes|publish> --version <version> [options]' <<<"$output"
     grep -Fqx '  prompt <list|name> [options]' <<<"$output"
     grep -Fqx '  docs [options]' <<<"$output"

--- a/docs/basectl-ci.md
+++ b/docs/basectl-ci.md
@@ -19,9 +19,9 @@ with their own runners and test commands.
 ## Interface
 
 ```bash
-basectl setup --ci <project> [--format text|json]
-basectl check --ci <project> [--format text|json]
-basectl doctor --ci <project> [--format text|json]
+basectl setup --ci [project] [--format text|json]
+basectl check --ci [project] [--format text|json]
+basectl doctor --ci [project] [--format text|json]
 ```
 
 All commands also accept `--manifest <path>` for CI jobs that know the manifest
@@ -32,8 +32,10 @@ The default mode is non-interactive. If a required action cannot be performed
 without prompting, the command fails with a clear fix message.
 
 `basectl ci setup|check|doctor` remains a backward-compatible alias for the
-same behavior, but new docs and automation should prefer the `--ci` flag on the
-underlying command.
+same behavior. The alias prepends `--ci` and passes all remaining arguments to
+the underlying command unchanged, so that command's help, option validation,
+and exit codes are authoritative. New docs and automation should prefer the
+`--ci` flag on the underlying command.
 
 ## Behavior
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -74,11 +74,11 @@ available and inspect `activate.source` directly before activation.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl setup --ci <project>` | Run setup with CI-safe defaults. Does not run tests or create runners/VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv` |
+| `basectl setup --ci [project]` | Run setup with CI-safe defaults. Does not run tests or create runners/VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv` |
 | `basectl check [project]` | Verify Base and optional project readiness without making changes. Project checks record the latest result under `~/.base.d/<project>/checks/last.json`. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
-| `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
+| `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network`, `--no-color` |
 | `basectl doctor explain <finding-id>` | Print local, deterministic guidance for a stable finding ID. | `--format <text\|json>` |
-| `basectl ci setup\|check\|doctor <project>` | Compatibility alias for the corresponding `--ci` mode command. | Same options as the target command. |
+| `basectl ci setup\|check\|doctor [project]` | Compatibility alias for the corresponding `--ci` mode command. | Same options, help, validation, and exit codes as the target command. |
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
 | `basectl logs last` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name>`, `--lines <count>`, `--format <text\|json>` |
 | `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -243,33 +243,27 @@ _base_basectl_completion_project_or_options() {
     fi
 }
 
-_base_basectl_completion_profiles_or_options() {
-    local current="$1"
-    local options="$2"
-    local previous="${COMP_WORDS[COMP_CWORD - 1]:-}"
-
-    if [[ "$previous" == "--profile" ]]; then
-        _base_basectl_completion_compgen "$(_base_basectl_completion_profiles)" "$current"
-    else
-        _base_basectl_completion_compgen "$options" "$current"
-    fi
-}
-
 _base_basectl_completion_project_profiles_or_options() {
     local current="$1"
     local options="$2"
+    local project_position="${3:-2}"
     local previous="${COMP_WORDS[COMP_CWORD - 1]:-}"
 
     if [[ "$previous" == "--profile" ]]; then
         _base_basectl_completion_compgen "$(_base_basectl_completion_profiles)" "$current"
+    elif ((COMP_CWORD == project_position)) && [[ "$current" != -* ]]; then
+        _base_basectl_completion_project_candidates "$current"
     else
-        _base_basectl_completion_project_or_options "$options" "$current"
+        _base_basectl_completion_compgen "$options" "$current"
     fi
 }
 
 _base_basectl_completion() {
     local command cur
     local commands="activate setup check test export-context devcontainer devenv-report build demo run repo ci release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
+    local setup_options="--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --yes -v -h --help"
+    local check_options="--ci --profile --format --manifest --remote-network -v -h --help"
+    local doctor_options="--ci --profile --format --manifest --remote-network --no-color -v -h --help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -341,12 +335,10 @@ _base_basectl_completion() {
             fi
             ;;
         setup)
-            _base_basectl_completion_profiles_or_options \
-                "$cur" \
-                "--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --yes -v -h --help"
+            _base_basectl_completion_project_profiles_or_options "$cur" "$setup_options"
             ;;
         check)
-            _base_basectl_completion_project_profiles_or_options "$cur" "--ci --profile --format --manifest --remote-network -v -h --help"
+            _base_basectl_completion_project_profiles_or_options "$cur" "$check_options"
             ;;
         test)
             _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
@@ -400,10 +392,13 @@ _base_basectl_completion() {
                     _base_basectl_completion_compgen "setup check doctor" "$cur"
                     ;;
                 setup)
-                    _base_basectl_completion_project_profiles_or_options "$cur" "--format --manifest --profile --recreate-venv -v -h --help"
+                    _base_basectl_completion_project_profiles_or_options "$cur" "$setup_options" 3
                     ;;
-                check|doctor)
-                    _base_basectl_completion_project_profiles_or_options "$cur" "--format --manifest --profile -v -h --help"
+                check)
+                    _base_basectl_completion_project_profiles_or_options "$cur" "$check_options" 3
+                    ;;
+                doctor)
+                    _base_basectl_completion_project_profiles_or_options "$cur" "$doctor_options" 3
                     ;;
             esac
             ;;
@@ -451,7 +446,7 @@ _base_basectl_completion() {
                     COMPREPLY+=("explain")
                 fi
             else
-                _base_basectl_completion_project_profiles_or_options "$cur" "--ci --profile --format --manifest --remote-network --no-color -v -h --help"
+                _base_basectl_completion_project_profiles_or_options "$cur" "$doctor_options"
             fi
             ;;
         gh)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -366,7 +366,7 @@ _base_basectl_completion() {
                 '--recreate-venv[Recreate the Base venv]' \
                 '--yes[Apply setup changes that require explicit confirmation]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -378,7 +378,7 @@ _base_basectl_completion() {
                 '--manifest[Use a specific manifest]:path:_files' \
                 '--remote-network[Opt in to bounded project Git origin reachability checks]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -560,7 +560,7 @@ _base_basectl_completion() {
         ci)
             case "${words[3]:-}" in
                 setup)
-                    _arguments '1:ci command:(setup check doctor)' \
+                    _arguments '2:ci command:(setup check doctor)' \
                         '--ci[Run setup with CI-safe defaults]' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
@@ -572,10 +572,10 @@ _base_basectl_completion() {
                         '--yes[Apply setup changes that require explicit confirmation]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]' \
-                        '2:Base project:->projects'
+                        '3:Base project:->projects'
                     ;;
                 check)
-                    _arguments '1:ci command:(setup check doctor)' \
+                    _arguments '2:ci command:(setup check doctor)' \
                         '--ci[Run checks with CI-safe defaults]' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
@@ -583,10 +583,10 @@ _base_basectl_completion() {
                         '--remote-network[Opt in to bounded project Git origin reachability checks]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]' \
-                        '2:Base project:->projects'
+                        '3:Base project:->projects'
                     ;;
                 doctor)
-                    _arguments '1:ci command:(setup check doctor)' \
+                    _arguments '2:ci command:(setup check doctor)' \
                         '--ci[Run diagnostics with CI-safe defaults]' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
@@ -595,10 +595,10 @@ _base_basectl_completion() {
                         '--no-color[Disable doctor status colors and symbols in text output]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]' \
-                        '2:Base project:->projects'
+                        '3:Base project:->projects'
                     ;;
                 *)
-                    _arguments '1:ci command:(setup check doctor)'
+                    _arguments '2:ci command:(setup check doctor)'
                     ;;
             esac
             if [[ "$state" == projects ]]; then
@@ -657,7 +657,7 @@ _base_basectl_completion() {
                         '--no-color[Disable doctor status colors and symbols in text output]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]' \
-                        '1:doctor command or project:->doctor_targets'
+                        '2:doctor command or project:->doctor_targets'
                     if [[ "$state" == doctor_targets ]]; then
                         _alternative \
                             'commands:doctor command:(explain)' \

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -365,7 +365,11 @@ _base_basectl_completion() {
                 '--no-notify[Disable setup completion notification]' \
                 '--recreate-venv[Recreate the Base venv]' \
                 '--yes[Apply setup changes that require explicit confirmation]' \
-                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
+                '1:Base project:->projects'
+            if [[ "$state" == projects ]]; then
+                _base_basectl_completion_describe_projects
+            fi
             ;;
         check)
             _arguments '--ci[Run checks with CI-safe defaults]' \
@@ -557,19 +561,38 @@ _base_basectl_completion() {
             case "${words[3]:-}" in
                 setup)
                     _arguments '1:ci command:(setup check doctor)' \
+                        '--ci[Run setup with CI-safe defaults]' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
                         '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
+                        '--dry-run[Log without making changes]' \
+                        '--notify[Force a setup completion notification]' \
+                        '--no-notify[Disable setup completion notification]' \
                         '--recreate-venv[Recreate the project virtual environment]' \
+                        '--yes[Apply setup changes that require explicit confirmation]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]' \
                         '2:Base project:->projects'
                     ;;
-                check|doctor)
+                check)
                     _arguments '1:ci command:(setup check doctor)' \
+                        '--ci[Run checks with CI-safe defaults]' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
                         '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
+                        '--remote-network[Opt in to bounded project Git origin reachability checks]' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]' \
+                        '2:Base project:->projects'
+                    ;;
+                doctor)
+                    _arguments '1:ci command:(setup check doctor)' \
+                        '--ci[Run diagnostics with CI-safe defaults]' \
+                        '--format[Output format]:format:(text json)' \
+                        '--manifest[Use a specific manifest]:path:_files' \
+                        '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
+                        '--remote-network[Opt in to bounded project Git origin reachability diagnostics]' \
+                        '--no-color[Disable doctor status colors and symbols in text output]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]' \
                         '2:Base project:->projects'

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -307,6 +307,8 @@ run_zsh_positional_completion() {
 }
 
 @test "Zsh lifecycle project completions use executable argument positions" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
     run_zsh_positional_completion basectl ci ""
     [ "$status" -eq 0 ]
     [[ "$output" == *"positional=2:ci command:(setup check doctor)"* ]]

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -216,6 +216,39 @@ assert_zsh_ci_completion_options_match_help() {
     [ "$status" -eq 0 ]
 }
 
+run_zsh_positional_completion() {
+    run env BASE_HOME="$BASE_REPO_ROOT" zsh -fc '
+        compdef() { :; }
+        source "$BASE_HOME/lib/shell/completions/basectl_completion.zsh"
+
+        _arguments() {
+            local positional_argument=$((CURRENT - 1)) spec
+
+            for spec in "$@"; do
+                if [[ "$spec" == "${positional_argument}:"* ]]; then
+                    print -r -- "positional=$spec"
+                    case "$spec" in
+                        *"->projects") state=projects ;;
+                        *"->doctor_targets") state=doctor_targets ;;
+                    esac
+                    return 0
+                fi
+            done
+            print -r -- "positional=<none>"
+        }
+        _base_basectl_completion_describe_projects() {
+            print -r -- "projects=base demo"
+        }
+        _alternative() {
+            print -r -- "doctor_targets=explain base demo"
+        }
+
+        words=("$@")
+        CURRENT=${#words}
+        _base_basectl_completion
+    ' zsh "$@"
+}
+
 @test "Bash completion top-level commands match basectl help" {
     local expected="$TEST_TMPDIR/help-commands"
     local actual="$TEST_TMPDIR/bash-completion-commands"
@@ -271,6 +304,42 @@ assert_zsh_ci_completion_options_match_help() {
     assert_zsh_ci_completion_options_match_help setup
     assert_zsh_ci_completion_options_match_help check
     assert_zsh_ci_completion_options_match_help doctor
+}
+
+@test "Zsh lifecycle project completions use executable argument positions" {
+    run_zsh_positional_completion basectl ci ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:ci command:(setup check doctor)"* ]]
+
+    run_zsh_positional_completion basectl setup ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:Base project:->projects"* ]]
+    [[ "$output" == *"projects=base demo"* ]]
+
+    run_zsh_positional_completion basectl check ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:Base project:->projects"* ]]
+    [[ "$output" == *"projects=base demo"* ]]
+
+    run_zsh_positional_completion basectl doctor ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:doctor command or project:->doctor_targets"* ]]
+    [[ "$output" == *"doctor_targets=explain base demo"* ]]
+
+    run_zsh_positional_completion basectl ci setup ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:Base project:->projects"* ]]
+    [[ "$output" == *"projects=base demo"* ]]
+
+    run_zsh_positional_completion basectl ci check ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:Base project:->projects"* ]]
+    [[ "$output" == *"projects=base demo"* ]]
+
+    run_zsh_positional_completion basectl ci doctor ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:Base project:->projects"* ]]
+    [[ "$output" == *"projects=base demo"* ]]
 }
 
 @test "Zsh repo installer-template completion includes print options" {

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -173,6 +173,49 @@ assert_bash_completion_options_match_help() {
     [ "$status" -eq 0 ]
 }
 
+zsh_completion_nested_long_options() {
+    local parent="$1"
+    local child="$2"
+
+    zsh_completion_nested_block "$parent" "$child" |
+        awk '
+            {
+                line = $0
+                while (match(line, /--[-A-Za-z0-9_]+/)) {
+                    print substr(line, RSTART, RLENGTH)
+                    line = substr(line, RSTART + RLENGTH)
+                }
+            }
+        ' |
+        sort -u
+}
+
+assert_bash_ci_completion_options_match_help() {
+    local command="$1"
+    local expected="$TEST_TMPDIR/bash-ci-$command-help-options"
+    local actual="$TEST_TMPDIR/bash-ci-$command-completion-options"
+
+    long_options_from_help "$command" > "$expected"
+    bash_completion_long_options basectl ci "$command" -- > "$actual"
+
+    bats_run diff -u "$expected" "$actual"
+
+    [ "$status" -eq 0 ]
+}
+
+assert_zsh_ci_completion_options_match_help() {
+    local command="$1"
+    local expected="$TEST_TMPDIR/zsh-ci-$command-help-options"
+    local actual="$TEST_TMPDIR/zsh-ci-$command-completion-options"
+
+    long_options_from_help "$command" > "$expected"
+    zsh_completion_nested_long_options ci "$command" > "$actual"
+
+    bats_run diff -u "$expected" "$actual"
+
+    [ "$status" -eq 0 ]
+}
+
 @test "Bash completion top-level commands match basectl help" {
     local expected="$TEST_TMPDIR/help-commands"
     local actual="$TEST_TMPDIR/bash-completion-commands"
@@ -216,6 +259,18 @@ assert_bash_completion_options_match_help() {
     assert_bash_completion_options_match_help repo-init repo init
     assert_bash_completion_options_match_help repo-configure repo configure
     assert_bash_completion_options_match_help repo-installer-template repo installer-template
+}
+
+@test "Bash ci alias option completions match canonical command help" {
+    assert_bash_ci_completion_options_match_help setup
+    assert_bash_ci_completion_options_match_help check
+    assert_bash_ci_completion_options_match_help doctor
+}
+
+@test "Zsh ci alias option completions match canonical command help" {
+    assert_zsh_ci_completion_options_match_help setup
+    assert_zsh_ci_completion_options_match_help check
+    assert_zsh_ci_completion_options_match_help doctor
 }
 
 @test "Zsh repo installer-template completion includes print options" {
@@ -312,12 +367,32 @@ EOF
             COMP_WORDS=(basectl build ""); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
-            printf "second=%s\n" "${COMPREPLY[*]}"' \
+            printf "second=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl setup ""); \
+            COMP_CWORD=2; \
+            _base_basectl_completion; \
+            printf "setup=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci setup ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci-setup=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci check ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci-check=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl ci doctor ""); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "ci-doctor=%s\n" "${COMPREPLY[*]}"' \
             bash "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.sh"
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"first=base demo"* ]]
     [[ "$output" == *"second=base demo"* ]]
+    [[ "$output" == *"setup=base demo"* ]]
+    [[ "$output" == *"ci-setup=base demo"* ]]
+    [[ "$output" == *"ci-check=base demo"* ]]
+    [[ "$output" == *"ci-doctor=base demo"* ]]
     [ "$(cat "$count_file")" = "1" ]
 }
 


### PR DESCRIPTION
## Summary

- replace the independent `basectl ci` parser with a thin dispatch that prepends `--ci` and forwards every remaining argument to canonical setup, check, or doctor handling
- preserve optional-project behavior, canonical help and validation, command-specific options, and delegated exit status through the compatibility syntax
- make Bash and Zsh alias completions mirror the canonical command option sets and complete projects at the nested alias position
- label `basectl ci` consistently as compatibility syntax and keep `basectl <command> --ci` primary in help and docs
- add contract coverage that fails when canonical help and alias completion options drift

## Issue

Closes #1648

## Validation

- focused CI/help/completion BATS suites (53 passed)
- focused documentation/workflow Python suites (47 passed)
- `bash -n` for touched Bash files
- `zsh -n lib/shell/completions/basectl_completion.zsh`
- ShellCheck for touched Bash files
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test` (969 Python passed, 1 skipped; 746 BATS passed)
- `git diff --check`

## Demo Impact

None. This restores compatibility syntax parity without changing the canonical lifecycle behavior or the self-demo.

## Notes

- The compatibility layer owns no lifecycle options; setup, check, and doctor remain the parser and behavior source of truth.
- `.ai-context/` is unchanged because this removes duplicate parsing without changing Base's architectural ownership boundaries.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
