### PR TITLE
Close basectl help and completion parity gaps

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -1,8 +1,8 @@
 # Base Command Context
 
 `basectl` is the public Base control-plane command. Run `basectl --help` for
-top-level command families and `basectl <family> --help` for the canonical
-family subcommands.
+the journey-oriented command map. Run `basectl help <nested path>` or append
+`--help` to that path for the same leaf-specific usage.
 
 Long options with values use space-separated syntax, such as `--format json`.
 Base rejects `--option=value` before command delegation. Arguments after `--`

--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -30,8 +30,10 @@ options.
 - `basectl run <project> <command>` - run a declared project command.
 - `basectl export-context [project]` - export `.ai-context/` as a Markdown or
   Zip bundle for manual upload or copy/paste into AI tools.
-- `basectl trust <status|allow|revoke> <project>` - inspect, allow, or
-  remove local approval for manifest-declared project commands.
+- `basectl trust status [project]` - inspect one project's manifest command
+  trust or all discovered command-bearing projects.
+- `basectl trust <allow|revoke> <project>` - add or remove local approval for
+  manifest-declared project commands.
 - `basectl prompt <list|name>` - list and render repo-owned Markdown prompts
   for AI-assisted Base workflows. `product-self-review` prints the periodic
   product assessment prompt with current Base metadata, and `--output <path>`
@@ -82,7 +84,7 @@ options.
   language metadata; selecting `python` adds the explicit
   `python.manager: uv` profile while other initial language values are metadata
   only.
-- `basectl <setup|check|doctor> --ci <project>` - run Base setup/check/doctor
+- `basectl <setup|check|doctor> --ci [project]` - run Base setup/check/doctor
   with CI-safe defaults. It does not run project tests or create CI runners/VMs.
   `setup --ci --format json` uses `output` for the compact final status and
   adds `output_lines` on failures for intermediate context. `basectl ci`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Aligned `basectl` leaf help, exact-command argument errors, and Bash/Zsh
+  completions, including scoped release options and GitHub Project flags, while
+  grouping root help around the first-run and daily project journeys.
 - Made `basectl onboard --yes` reach unattended setup consent and added a
   read-only, workspace-wide manifest trust review step that never grants trust
   automatically or prompts for metadata-only manifests.

--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ Current implemented commands include:
 - `basectl update`
 - `basectl projects list`
 - `basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure>`
-- `basectl trust <status|allow|revoke> <project>`
+- `basectl trust status [project]`
+- `basectl trust <allow|revoke> <project>`
 - `basectl repo init <name>`
 - `basectl repo clone <name-or-owner/name>`
 - `basectl repo check [path]`
@@ -366,6 +367,7 @@ Current implemented commands include:
 - `basectl activate <project>`
 - `basectl test [project]`
 - `basectl build <project> [target...]`
+- `basectl demo [project]`
 - `basectl run <project> <command>`
 - `basectl export-context [project]`
 - `basectl devcontainer [project]`

--- a/README.md
+++ b/README.md
@@ -375,6 +375,10 @@ Current implemented commands include:
 - `basectl history [--report]`
 - `basectl version`
 
+Use `basectl --help` for the journey-oriented command map. For a group or leaf,
+`basectl help <nested path>` and `basectl <nested path> --help` show the same
+public usage without exposing private Python runtime options.
+
 `--ci` runs setup, check, and doctor with CI-safe defaults such as
 non-interactive behavior and JSON-capable output. The legacy `basectl ci`
 wrapper remains as a compatibility alias. Neither surface runs project tests,

--- a/bin/basectl
+++ b/bin/basectl
@@ -71,6 +71,25 @@ basectl_print_version() {
     printf 'basectl %s\n' "$(base_read_version "$base_home")"
 }
 
+basectl_version_usage() {
+    cat <<'EOF'
+Usage:
+  basectl version
+
+Purpose:
+  Show the installed Base version.
+
+Options:
+  -h, --help  Show this help text.
+EOF
+}
+
+basectl_version_usage_error() {
+    printf 'ERROR: %s\n' "$*" >&2
+    printf "Run 'basectl version --help' for usage.\n" >&2
+    return 2
+}
+
 basectl_proc_translated() {
     local translated
 
@@ -316,9 +335,35 @@ main() {
     basectl_ensure_supported_bash "$@"
     base_home="$(basectl_base_home)" || basectl_die "Unable to resolve Base home."
 
-    if [[ "${1:-}" == "--version" || "${1:-}" == "version" ]]; then
+    if [[ "${1:-}" == "--version" ]]; then
+        if (($# != 1)); then
+            printf "ERROR: Option '--version' does not accept arguments.\n" >&2
+            return 2
+        fi
         basectl_print_version "$base_home"
         return 0
+    fi
+
+    if [[ "${1:-}" == "version" ]]; then
+        shift
+        case "${1:-}" in
+            -h|--help|help)
+                (($# == 1)) || {
+                    basectl_version_usage_error "version does not accept arguments."
+                    return $?
+                }
+                basectl_version_usage
+                return 0
+                ;;
+            "")
+                basectl_print_version "$base_home"
+                return 0
+                ;;
+            *)
+                basectl_version_usage_error "version does not accept arguments."
+                return $?
+                ;;
+        esac
     fi
 
     if [[ $# -eq 0 && -t 0 && -t 1 ]]; then

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -42,16 +42,19 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `docs`
 - `devcontainer`
 - `devenv-report`
+- `demo`
 - `export-context`
 - `gh`
 - `history`
 - `logs`
 - `onboard`
 - `prompt`
+- `release check/plan/notes/publish`
 - `repo init/clone/check/configure/agent-guidance/installer-template`
 - `trust status/allow/revoke`
 - `test`
 - `build`
+- `run`
 - `update-profile`
 - `update`
 - `projects list`
@@ -90,8 +93,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl history` lists recent structured Base command runs from the local
   history index and supports table, JSON, and privacy-conscious report output.
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
-- `basectl trust status/allow/revoke <project>` manages local approval for
-  manifest-declared project commands under `~/.base.d/trust/manifest-commands/`.
+- `basectl trust status [project]` inspects one project's manifest command
+  trust or all discovered command-bearing projects. `basectl trust
+  allow/revoke <project>` manages local approval under
+  `~/.base.d/trust/manifest-commands/`.
 - `basectl doctor [project]` diagnoses the local Base environment and, when
   provided, project manifest artifacts with suggested fixes.
 - `basectl doctor explain <finding-id>` prints local, deterministic guidance

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -60,8 +60,8 @@ Daily project loop:
     Run a project's declared interactive demo.
   run <project> <command> [options]
     Run a project's declared command.
-  trust <status|allow|revoke> <project> [options]
-    Manage local approval for manifest-declared project commands.
+  trust <status|allow|revoke> [project] [options]
+    Inspect trust across projects, or manage one project's local approval.
 
 Workspace and repositories:
   workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]
@@ -101,7 +101,7 @@ Diagnostics and maintenance:
 
 Compatibility:
   ci <setup|check|doctor> [project] [options]
-    Compatibility alias for setup, check, and doctor --ci mode.
+    Compatibility alias for setup, check, and doctor --ci.
 
 Other:
   version

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -36,60 +36,74 @@ basectl_show_help() {
 Usage: basectl [options] <command> [args...]
 
 Commands:
-  activate <project> [options]
-    Start an interactive Base runtime subshell for a project.
+
+Getting started:
+  onboard [project] [options]
+    Guide a user through the first Base setup checklist.
   setup [options] [project]
-    Install and bootstrap the local Base CLI environment on macOS.
+    Install and bootstrap the local Base CLI environment on macOS or Ubuntu/Debian.
   check [project] [options]
     Verify the local Base CLI environment and optional project artifacts without making changes.
+  doctor [project] [options]
+    Diagnose the local Base CLI environment and optional project artifacts.
+
+Daily project loop:
+  projects list [options]
+    List Base-managed projects discovered in the workspace.
+  activate <project> [options]
+    Start an interactive Base runtime subshell for a project.
   test [project] [options]
     Run a project's declared test command.
-  export-context [project] [options]
-    Export a project's .ai-context directory as Markdown or Zip.
-  devcontainer [project] [options]
-    Preview or write .devcontainer/devcontainer.json from a Base manifest.
-  devenv-report [project] [options]
-    Report Nix/devenv compatibility for a Base manifest.
   build <project> [target...] [options]
     Run a project's declared build targets.
   demo [project] [options]
     Run a project's declared interactive demo.
   run <project> <command> [options]
     Run a project's declared command.
+  trust <status|allow|revoke> <project> [options]
+    Manage local approval for manifest-declared project commands.
+
+Workspace and repositories:
+  workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]
+    Show workspace status, onboarding, agent readiness, checks, or explicit workspace mutations.
   repo <init|clone|check|configure|agent-guidance|installer-template> [options]
     Create, clone, check, and configure repository baselines and guidance.
-  ci <setup|check|doctor> [project] [options]
-    Compatibility alias for setup, check, and doctor --ci.
+  gh <area> <command> [options]
+    Manage GitHub issues, PRs, branches, and repository hygiene.
+
+Release and sharing:
   release <check|plan|notes|publish> --version <version> [options]
     Inspect release readiness, plan, notes, and guarded GitHub publishing.
+  export-context [project] [options]
+    Export a project's .ai-context directory as Markdown or Zip.
+  devcontainer [project] [options]
+    Preview or write .devcontainer/devcontainer.json from a Base manifest.
+  devenv-report [project] [options]
+    Report Nix/devenv compatibility for a Base manifest.
   prompt <list|name> [options]
     Print repo-owned Markdown prompts for AI-assisted Base workflows.
   docs [options]
     Open the Base documentation home page on GitHub.
-  clean [--older-than <age>] [--keep-last <count>] [options]
-    Remove old Base CLI runtime logs, temp files, and cache entries.
+
+Diagnostics and maintenance:
+  config <path|show|doctor>
+    Inspect Base's machine-local user config.
   logs [options]
     List and open recent Base CLI runtime logs.
   history [options]
     List recent Base command history records.
-  config <path|show|doctor>
-    Inspect Base's machine-local user config.
-  trust <status|allow|revoke> <project> [options]
-    Manage local approval for manifest-declared project commands.
-  doctor [project] [options]
-    Diagnose the local Base CLI environment and optional project artifacts.
-  gh <area> <command> [options]
-    Manage GitHub issues, PRs, branches, and repository hygiene.
-  onboard [project] [options]
-    Guide a user through the first Base setup checklist.
+  clean [--older-than <age>] [--keep-last <count>] [options]
+    Remove old Base CLI runtime logs, temp files, and cache entries.
   update-profile [options]
     Create or update Base-managed sections in Bash and Zsh startup files.
   update [project] [options]
     Update Base from Git and run setup.
-  projects list [options]
-    List Base-managed projects discovered in the workspace.
-  workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]
-    Show workspace status, onboarding, agent readiness, checks, or explicit workspace mutations.
+
+Compatibility:
+  ci <setup|check|doctor> [project] [options]
+    Compatibility alias for setup, check, and doctor --ci mode.
+
+Other:
   version
     Show the installed Base version.
   help
@@ -103,6 +117,7 @@ Options:
            Show the installed Base version.
 
 Wrapper options:
+  Advanced startup diagnostics; normal command flags are documented by leaf help.
   --debug-wrapper    Enable DEBUG logging before the Base runtime is loaded.
   --verbose-wrapper  Enable verbose runtime argument handling before dispatch.
   --utc-wrapper      Print wrapper/runtime log timestamps in UTC.
@@ -426,6 +441,34 @@ basectl_source_version_library() {
 }
 
 basectl_do_version() {
+    case "${1:-}" in
+        "")
+            ;;
+        -h|--help|help)
+            (($# == 1)) || {
+                basectl_error "version does not accept arguments."
+                printf "Run 'basectl version --help' for usage.\n" >&2
+                return 2
+            }
+            cat <<'EOF'
+Usage:
+  basectl version
+
+Purpose:
+  Show the installed Base version.
+
+Options:
+  -h, --help  Show this help text.
+EOF
+            return 0
+            ;;
+        *)
+            basectl_error "version does not accept arguments."
+            printf "Run 'basectl version --help' for usage.\n" >&2
+            return 2
+            ;;
+    esac
+
     basectl_source_version_library || return 1
     printf 'basectl %s\n' "$(base_read_version "$BASE_HOME")"
 }
@@ -472,6 +515,10 @@ basectl_main() {
     fi
 
     if [[ "${1:-}" == "--version" ]]; then
+        if (($# != 1)); then
+            basectl_usage_error "Option '--version' does not accept arguments."
+            return $?
+        fi
         basectl_get_base_home || return 1
         basectl_do_version
         return 0
@@ -558,7 +605,7 @@ basectl_main() {
         workspace)        basectl_do_workspace "$@" ;;
         update)           basectl_do_update "$@" ;;
         update-profile)   basectl_do_update_profile "$@" ;;
-        version)          basectl_do_version ;;
+        version)          basectl_do_version "$@" ;;
         "")
             if basectl_should_start_shell; then
                 BASE_ACTIVATE_PRESERVE_CWD=1 basectl_do_activate "$(basectl_default_activate_project)"

--- a/cli/bash/commands/basectl/subcommands/config.sh
+++ b/cli/bash/commands/basectl/subcommands/config.sh
@@ -22,6 +22,63 @@ Notes:
 EOF
 }
 
+base_config_leaf_usage() {
+    local config_command="$1"
+
+    case "$config_command" in
+        path)
+            cat <<'EOF'
+Usage:
+  basectl config path
+
+Purpose:
+  Print Base's machine-local user config path.
+
+Options:
+  -h, --help  Show this help text.
+EOF
+            ;;
+        show)
+            cat <<'EOF'
+Usage:
+  basectl config show
+
+Purpose:
+  Show Base's machine-local user config as redacted JSON.
+
+Options:
+  -h, --help  Show this help text.
+EOF
+            ;;
+        doctor)
+            cat <<'EOF'
+Usage:
+  basectl config doctor
+
+Purpose:
+  Diagnose Base's machine-local user config.
+
+Options:
+  -h, --help  Show this help text.
+EOF
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+base_config_args_request_help() {
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 base_config_path() {
     [[ -n "${HOME:-}" ]] || fatal_error "Environment variable 'HOME' is not set."
     printf '%s\n' "$HOME/.base.d/config.yaml"
@@ -44,6 +101,10 @@ base_config_subcommand_main() {
             ;;
         path)
             shift
+            if base_config_args_request_help "$@"; then
+                base_config_leaf_usage path
+                return $?
+            fi
             if (($#)); then
                 base_config_usage_error "config path does not accept arguments."
                 return $?
@@ -52,6 +113,10 @@ base_config_subcommand_main() {
             ;;
         show|doctor)
             shift
+            if base_config_args_request_help "$@"; then
+                base_config_leaf_usage "$config_command"
+                return $?
+            fi
             [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
             BASE_CLI_DISPLAY_COMMAND="basectl config" "$wrapper" --project base base_config "$config_command" "$@"
             ;;

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -108,6 +108,24 @@ Categories: bug, enhancement, documentation, ci, security.
 EOF
 }
 
+base_gh_issue_start_usage() {
+    cat <<'EOF'
+Usage:
+  basectl gh issue start <number> [options]
+
+Purpose:
+  Print the canonical issue-backed branch and worktree commands after verifying
+  the issue's standard category label.
+
+Options:
+  --repo, -R <owner/name>  Repository containing the issue. Selection order is
+                           the explicit option, GH_REPO, then the origin remote.
+  --category <category>    Must match the issue's single category label.
+  --title <title>          Override the issue title used to generate the slug.
+  -h, --help               Show this help text.
+EOF
+}
+
 base_gh_pr_usage() {
     cat <<'EOF'
 Usage:
@@ -873,6 +891,10 @@ base_gh_do_issue() {
             base_gh_issue_readiness "$@"
             ;;
         start)
+            if base_gh_args_request_help "$@"; then
+                base_gh_issue_start_usage
+                return 0
+            fi
             base_gh_issue_start "$@"
             ;;
         -h|--help|help|"")

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -126,6 +126,62 @@ Options:
 EOF
 }
 
+base_gh_issue_list_usage() {
+    cat <<'EOF'
+Usage:
+  basectl gh issue list [gh options...]
+
+Purpose:
+  List GitHub issues through the GitHub CLI.
+
+Options:
+  -h, --help  Show this help text.
+
+Additional options are passed through to `gh issue list`.
+EOF
+}
+
+base_gh_issue_create_usage() {
+    cat <<'EOF'
+Usage:
+  basectl gh issue create --title <title> [options]
+
+Purpose:
+  Create an issue with Base category, assignment, and Project conventions.
+
+Options:
+  --category <category>    Issue category. Defaults to enhancement.
+  --title <title>          Required issue title.
+  --body <body>            Issue body.
+  --repo <owner/name>      Target repository. Defaults to origin.
+  --assignee <login>       Assign the issue to a GitHub login.
+  --no-assignee            Ignore any repository assignee default.
+  --project <title>        GitHub Project title.
+  --project-owner <login>  GitHub Project owner.
+  --size <T|S|M|L>         GitHub Project Size value.
+  --no-project             Skip GitHub Project metadata updates.
+  -h, --help               Show this help text.
+
+Categories: bug, enhancement, documentation, ci, security.
+EOF
+}
+
+base_gh_issue_readiness_usage() {
+    cat <<'EOF'
+Usage:
+  basectl gh issue readiness <number> [options]
+
+Purpose:
+  Check required issue sections and optional Base Project metadata before work.
+
+Options:
+  --repo <owner/name>        Repository containing the issue.
+  --project-owner <login>    Project owner for field validation.
+  --project-number <number>  Project number for field validation.
+  -h, --help                 Show this help text.
+EOF
+}
+
 base_gh_pr_usage() {
     cat <<'EOF'
 Usage:
@@ -147,6 +203,38 @@ Notes:
 EOF
 }
 
+base_gh_pr_leaf_usage() {
+    local pr_command="$1"
+    local purpose
+
+    case "$pr_command" in
+        create) purpose="Create an issue-linked pull request from the current Base branch." ;;
+        status) purpose="Show pull-request status through the GitHub CLI." ;;
+        checks) purpose="Show pull-request checks through the GitHub CLI." ;;
+        ready) purpose="Mark a pull request ready for review through the GitHub CLI." ;;
+        merge) purpose="Merge a pull request through the GitHub CLI." ;;
+        *) return 1 ;;
+    esac
+
+    cat <<EOF
+Usage:
+  basectl gh pr $pr_command [gh options...]
+
+Purpose:
+  $purpose
+
+Options:
+EOF
+    if [[ "$pr_command" == create ]]; then
+        printf '%s\n' '  --no-fixes  Do not add the issue-closing line derived from the branch.'
+    fi
+    cat <<EOF
+  -h, --help  Show this help text.
+
+Additional options are passed through to \`gh pr $pr_command\`.
+EOF
+}
+
 base_gh_project_usage() {
     cat <<'EOF'
 Usage:
@@ -163,6 +251,52 @@ Notes:
   - Use --replace-project to replace a nonstandard repo Project from base-project-template.
     Already-standard Projects are left intact.
 EOF
+}
+
+base_gh_project_leaf_usage() {
+    local project_command="$1"
+
+    case "$project_command" in
+        doctor)
+            cat <<'EOF'
+Usage:
+  basectl gh project doctor --project <title> [options]
+
+Purpose:
+  Inspect GitHub Project metadata against the Base Project schema.
+
+Options:
+  --project <title>  Project title to inspect.
+  --owner <login>    Project owner.
+  --schema base-project  Project schema. This is the only supported value.
+  -h, --help         Show this help text.
+EOF
+            ;;
+        configure)
+            cat <<'EOF'
+Usage:
+  basectl gh project configure --project <title> [options]
+
+Purpose:
+  Create or repair Base-managed GitHub Project metadata.
+
+Options:
+  --project <title>           Project title to configure.
+  --owner <login>             Project owner.
+  --repo <owner/name>         Repository to link and backfill.
+  --schema base-project       Project schema. This is the only supported value.
+  --config <path>             Project intake config.
+  --copy-fields-from <title>  Copy missing field values from another Project.
+  --replace-project           Replace a nonstandard repository Project.
+  --initiative-option <name>  Initiative option to seed.
+  --dry-run                   Print planned changes.
+  -h, --help                  Show this help text.
+EOF
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 base_gh_project_issue_set_fields_usage() {
@@ -184,6 +318,7 @@ Options:
   --initiative <name>   Initiative option.
   --size <T|S|M|L>      Size option.
   --dry-run             Print the planned Project updates without applying them.
+  -h, --help            Show this help text.
 EOF
 }
 
@@ -205,6 +340,44 @@ Options:
   --yes          Delete merged branches after preview.
   --remote       Also prune merged GitHub remote branches and stale origin/* refs.
 EOF
+}
+
+base_gh_branch_leaf_usage() {
+    local branch_command="$1"
+
+    case "$branch_command" in
+        stale)
+            cat <<'EOF'
+Usage:
+  basectl gh branch stale [--days <days>]
+
+Purpose:
+  Report local and origin branches older than the selected threshold.
+
+Options:
+  --days <days>  Minimum age in days. Defaults to 30.
+  -h, --help     Show this help text.
+EOF
+            ;;
+        prune)
+            cat <<'EOF'
+Usage:
+  basectl gh branch prune [options]
+
+Purpose:
+  Preview or remove safely merged local and GitHub branches.
+
+Options:
+  --dry-run   Preview branches that would be deleted (default).
+  --yes       Delete safely merged branches after preview.
+  --remote    Also clean merged GitHub branches and stale origin refs.
+  -h, --help  Show this help text.
+EOF
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 base_gh_worktree_usage() {
@@ -485,7 +658,7 @@ base_gh_issue_readiness() {
         return $?
     }
     if [[ "$issue" == "help" || "$issue" == "-h" || "$issue" == "--help" ]]; then
-        base_gh_issue_usage
+        base_gh_issue_readiness_usage
         return 0
     fi
     [[ "$issue" =~ ^[0-9]+$ ]] || {
@@ -527,7 +700,7 @@ base_gh_issue_readiness() {
                 shift
                 ;;
             -h|--help)
-                base_gh_issue_usage
+                base_gh_issue_readiness_usage
                 return 0
                 ;;
             *)
@@ -879,12 +1052,16 @@ base_gh_do_issue() {
     case "$command" in
         list)
             if base_gh_args_request_help "$@"; then
-                base_gh_issue_usage
+                base_gh_issue_list_usage
                 return 0
             fi
             base_gh_run issue list "$@"
             ;;
         create)
+            if base_gh_args_request_help "$@"; then
+                base_gh_issue_create_usage
+                return 0
+            fi
             base_gh_issue_create "$@"
             ;;
         readiness)
@@ -966,7 +1143,7 @@ base_gh_issue_create() {
                 configure_project=0
                 ;;
             -h|--help)
-                base_gh_issue_usage
+                base_gh_issue_create_usage
                 return 0
                 ;;
             *)
@@ -1163,7 +1340,7 @@ base_gh_issue_start() {
                 repo_args+=("$1")
                 ;;
             -h|--help)
-                base_gh_issue_usage
+                base_gh_issue_start_usage
                 return 0
                 ;;
             *)
@@ -1232,35 +1409,35 @@ base_gh_do_pr() {
     case "$command" in
         create)
             if base_gh_args_request_help "$@"; then
-                base_gh_pr_usage
+                base_gh_pr_leaf_usage create
                 return 0
             fi
             base_gh_pr_create "$@"
             ;;
         status)
             if base_gh_args_request_help "$@"; then
-                base_gh_pr_usage
+                base_gh_pr_leaf_usage status
                 return 0
             fi
             base_gh_run pr status "$@"
             ;;
         checks)
             if base_gh_args_request_help "$@"; then
-                base_gh_pr_usage
+                base_gh_pr_leaf_usage checks
                 return 0
             fi
             base_gh_run pr checks "$@"
             ;;
         ready)
             if base_gh_args_request_help "$@"; then
-                base_gh_pr_usage
+                base_gh_pr_leaf_usage ready
                 return 0
             fi
             base_gh_run pr ready "$@"
             ;;
         merge)
             if base_gh_args_request_help "$@"; then
-                base_gh_pr_usage
+                base_gh_pr_leaf_usage merge
                 return 0
             fi
             base_gh_run pr merge "$@"
@@ -1281,6 +1458,10 @@ base_gh_do_project() {
     if [[ "${1:-}" == "issue" && "${2:-}" == "set-fields" ]] && base_gh_args_request_help "$@"; then
         base_gh_project_issue_set_fields_usage
         return 0
+    fi
+    if [[ "${1:-}" == doctor || "${1:-}" == configure ]] && base_gh_args_request_help "$@"; then
+        base_gh_project_leaf_usage "$1"
+        return $?
     fi
     if base_gh_args_request_help "$@"; then
         base_gh_project_usage

--- a/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
@@ -14,7 +14,7 @@ base_gh_branch_stale() {
                 shift
                 ;;
             -h|--help)
-                base_gh_branch_usage
+                base_gh_branch_leaf_usage stale
                 return 0
                 ;;
             *)
@@ -314,7 +314,7 @@ base_gh_branch_prune() {
                 remote=1
                 ;;
             -h|--help)
-                base_gh_branch_usage
+                base_gh_branch_leaf_usage prune
                 return 0
                 ;;
             *)

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -25,14 +25,97 @@ Surface recent Base CLI runtime logs from the Base cache root.
 EOF
 }
 
+base_logs_recent_usage() {
+    cat <<'EOF'
+Usage:
+  basectl logs [options]
+  basectl logs last [options]
+
+Purpose:
+  List recent Base CLI runtime logs, or inspect the newest matching log.
+
+Commands:
+  last  Print the latest failed command metadata and a bounded redacted log tail.
+
+Options:
+  --command <name>  Filter by basectl command or Python CLI name.
+  --limit <count>   Number of recent log entries to list. Defaults to 10.
+  --path            Print the most recent matching log path only.
+  --tail            Tail and follow the most recent matching log.
+  --open            Open the most recent matching log in PAGER or EDITOR.
+  --lines <count>   Line count to show before following with --tail. Defaults to 40.
+  -v                Enable DEBUG logging for this subcommand.
+  -h, --help        Show this help text.
+EOF
+}
+
+base_logs_last_usage() {
+    cat <<'EOF'
+Usage:
+  basectl logs last [options]
+
+Purpose:
+  Print the latest failed command metadata and a bounded redacted log tail.
+
+Options:
+  --command <name>   Filter by basectl command or Python CLI name.
+  --lines <count>    Maximum log-tail lines to print. Defaults to 40.
+  --format <format>  Output format: text or json. Defaults to text.
+  -v                 Enable DEBUG logging for this subcommand.
+  -h, --help         Show this help text.
+EOF
+}
+
+base_logs_help_target() {
+    local expect_value=0
+    local argument
+
+    for argument in "$@"; do
+        if ((expect_value)); then
+            expect_value=0
+            continue
+        fi
+        case "$argument" in
+            --command|--limit|--lines|--format)
+                expect_value=1
+                ;;
+            last)
+                printf 'last\n'
+                return 0
+                ;;
+        esac
+    done
+    printf 'recent\n'
+}
+
+base_logs_args_request_help() {
+    local argument
+
+    for argument in "$@"; do
+        case "$argument" in
+            -h|--help) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 base_logs_subcommand_main() {
     local wrapper="$BASE_HOME/bin/base-wrapper"
     local args=()
 
+    if base_logs_args_request_help "$@"; then
+        if [[ "$(base_logs_help_target "$@")" == last ]]; then
+            base_logs_last_usage
+        else
+            base_logs_recent_usage
+        fi
+        return 0
+    fi
+
     while (($# > 0)); do
         case "$1" in
             -h|--help)
-                base_logs_subcommand_usage
+                base_logs_recent_usage
                 return 0
                 ;;
             -v)

--- a/cli/bash/commands/basectl/subcommands/prompt.sh
+++ b/cli/bash/commands/basectl/subcommands/prompt.sh
@@ -23,6 +23,38 @@ the prompt; an AI tool performs the review.
 EOF
 }
 
+base_prompt_leaf_usage() {
+    local prompt_name="$1"
+
+    if [[ "$prompt_name" == list ]]; then
+        cat <<'EOF'
+Usage:
+  basectl prompt list
+
+Purpose:
+  List the repo-owned Markdown prompts that Base can render.
+
+Options:
+  -v          Enable DEBUG logging for this subcommand.
+  -h, --help  Show this help text.
+EOF
+        return 0
+    fi
+
+    cat <<EOF
+Usage:
+  basectl prompt $prompt_name [--output <path>]
+
+Purpose:
+  Render the repo-owned '$prompt_name' Markdown prompt.
+
+Options:
+  --output <path>  Write the rendered prompt Markdown to this path.
+  -v               Enable DEBUG logging for this subcommand.
+  -h, --help       Show this help text.
+EOF
+}
+
 base_prompt_usage_error() {
     base_prompt_subcommand_usage >&2
     print_error "$*"
@@ -40,8 +72,12 @@ base_prompt_subcommand_main() {
     while (($#)); do
         case "$1" in
             -h|--help|help)
-                base_prompt_subcommand_usage
-                return 0
+                if ((${#prompt_args[@]})); then
+                    base_prompt_leaf_usage "${prompt_args[0]}"
+                else
+                    base_prompt_subcommand_usage
+                fi
+                return $?
                 ;;
             -v)
                 debug=1

--- a/cli/bash/commands/basectl/subcommands/release.sh
+++ b/cli/bash/commands/basectl/subcommands/release.sh
@@ -30,6 +30,71 @@ Homebrew tap updates remain a manual handoff.
 EOF
 }
 
+base_release_leaf_usage() {
+    local release_command="$1"
+    local purpose=""
+
+    case "$release_command" in
+        check)
+            purpose="Verify release readiness for the version, changelog, Git, and GitHub."
+            ;;
+        plan)
+            purpose="Show the release plan without creating tags or releases."
+            ;;
+        notes)
+            purpose="Print changelog notes for the target version."
+            ;;
+        publish)
+            purpose="Tag the release and create the GitHub Release after readiness passes."
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    if [[ "$release_command" == "publish" ]]; then
+        cat <<EOF
+Usage:
+  basectl release publish --version <version> [--manifest <path>] [--dry-run] [--yes]
+
+Purpose:
+  $purpose
+
+Options:
+  --version <version>  Release version to publish.
+  --manifest <path>    Use a specific base_manifest.yaml path.
+  --dry-run            Print publish actions without creating tags or releases.
+  --yes                Publish without an interactive confirmation prompt.
+  -h, --help           Show this help text.
+EOF
+        return 0
+    fi
+
+    cat <<EOF
+Usage:
+  basectl release $release_command --version <version> [--manifest <path>]
+
+Purpose:
+  $purpose
+
+Options:
+  --version <version>  Release version to inspect.
+  --manifest <path>    Use a specific base_manifest.yaml path.
+  -h, --help           Show this help text.
+EOF
+}
+
+base_release_args_request_help() {
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 base_release_usage_error() {
     base_release_subcommand_usage >&2
     print_error "$*"
@@ -52,6 +117,11 @@ base_release_subcommand_main() {
             return $?
             ;;
     esac
+
+    if base_release_args_request_help "${@:2}"; then
+        base_release_leaf_usage "$release_command"
+        return $?
+    fi
 
     [[ -x "$wrapper" ]] || fatal_error "Base Python wrapper '$wrapper' is missing or is not executable."
     BASE_CLI_DISPLAY_COMMAND="basectl release" "$wrapper" --project base base_release "$@"

--- a/cli/bash/commands/basectl/subcommands/trust.sh
+++ b/cli/bash/commands/basectl/subcommands/trust.sh
@@ -22,6 +22,62 @@ approval for manifest-declared project commands.
 EOF
 }
 
+base_trust_leaf_usage() {
+    local trust_command="$1"
+
+    case "$trust_command" in
+        status)
+            cat <<'EOF'
+Usage:
+  basectl trust status [project] [options]
+
+Purpose:
+  Show manifest command trust for one project, or for all discovered
+  command-bearing projects when no project is supplied.
+
+Options:
+  --workspace <path>    Workspace directory to scan.
+  --format <text|json>  Output format. Defaults to text.
+  -v                    Enable DEBUG logging for this subcommand.
+  -h, --help            Show this help text.
+EOF
+            ;;
+        allow)
+            cat <<'EOF'
+Usage:
+  basectl trust allow <project> [options]
+
+Purpose:
+  Approve the current manifest command contract for one project on this
+  machine.
+
+Options:
+  --workspace <path>          Workspace directory to scan.
+  --manifest-sha256 <sha256>  Require the current manifest to match this digest.
+  -v                          Enable DEBUG logging for this subcommand.
+  -h, --help                  Show this help text.
+EOF
+            ;;
+        revoke)
+            cat <<'EOF'
+Usage:
+  basectl trust revoke <project> [options]
+
+Purpose:
+  Remove local manifest command approval for one project.
+
+Options:
+  --workspace <path>  Workspace directory to scan.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+EOF
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 base_trust_usage_error() {
     base_trust_subcommand_usage >&2
     print_error "$*"
@@ -51,8 +107,8 @@ base_trust_subcommand_main() {
     while (($# > 0)); do
         case "$1" in
             -h|--help)
-                base_trust_subcommand_usage
-                return 0
+                base_trust_leaf_usage "$trust_command"
+                return $?
                 ;;
             -v)
                 args+=(--debug)

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -197,6 +197,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "logs_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl logs last --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "logs_last_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl logs l); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -324,7 +328,8 @@ EOF
     [[ "$output" == *"prompt_options=--output --help"* ]]
     [[ "$output" == *"docs_options=--show-url"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
-    [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines --format"* ]]
+    [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
+    [[ "$output" == *"logs_last_options=--command --lines --format"* ]]
     [[ "$output" == *"logs_commands=last"* ]]
     [[ "$output" == *"history_options=--project --command --status --limit --format --report"* ]]
     [[ "$output" == *"trust_commands=status allow revoke"* ]]

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -335,7 +335,7 @@ EOF
     [[ "$output" == *"repo_commands=init clone check configure agent-guidance installer-template"* ]]
     [[ "$output" == *"repo_init_options=--path --repo --issue --category --pr --agent-ready --release --language --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --copy-project-fields-from --no-project --dry-run"* ]]
     [[ "$output" == *"repo_clone_options=--owner --path --dry-run"* ]]
-    [[ "$output" == *"repo_check_options=--agent-guidance --agent-ready"* ]]
+    [[ "$output" == *"repo_check_options=--agent-guidance --agent-ready --release"* ]]
     [[ "$output" == *"repo_configure_options=--repo --no-protect-default-branch --project --project-owner --project-schema --initiative-option --copy-project-fields-from --replace-project --no-project --release --dry-run"* ]]
     [[ "$output" == *"repo_agent_guidance_options=--repo --issue --category --repo-name --default-branch --validation-command --pr --dry-run"* ]]
     [[ "$output" == *"repo_installer_template_options=--print --stdout --repo --issue --category --pr --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/config.bats
+++ b/cli/bash/commands/basectl/tests/config.bats
@@ -9,6 +9,25 @@ line_at() {
     printf '%s\n' "$text" | sed -n "${line_number}p"
 }
 
+@test "basectl config leaves print focused help without Python runtime options" {
+    local command
+
+    for command in path show doctor; do
+        run_basectl config "$command" --help
+
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Usage:"* ]]
+        [[ "$output" == *"basectl config $command"* ]]
+        [[ "$output" != *"[show|doctor]"* ]]
+        [[ "$output" != *"--quiet"* ]]
+        [[ "$output" != *"--debug"* ]]
+        [[ "$output" != *"--environment"* ]]
+        [[ "$output" != *"--config"* ]]
+        [[ "$output" != *"--keep-temp"* ]]
+        [[ "$output" != *"--log-file"* ]]
+    done
+}
+
 @test "basectl config path rejects extra arguments with focused usage hint" {
     run_basectl config path extra
 

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -330,6 +330,25 @@ run_gh_subcommand() {
     [[ "$output" != *"ERROR:"* ]]
 }
 
+@test "basectl gh issue leaves print command-scoped help" {
+    run_basectl gh issue list --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh issue list [gh options...]"* ]]
+    [[ "$output" != *"--category"* ]]
+
+    run_basectl gh issue create --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh issue create --title <title> [options]"* ]]
+    [[ "$output" == *"--no-project"* ]]
+    [[ "$output" != *"--project-number"* ]]
+
+    run_basectl gh issue readiness --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh issue readiness <number> [options]"* ]]
+    [[ "$output" == *"--project-number <number>"* ]]
+    [[ "$output" != *"--category"* ]]
+}
+
 @test "basectl gh issue readiness reports ready when body and Project metadata are complete" {
     write_issue_readiness_gh_mock
     write_complete_issue_readiness_body
@@ -410,6 +429,20 @@ run_gh_subcommand() {
     [[ "$output" != *"basectl gh branch prune"* ]]
 }
 
+@test "basectl gh pr leaves print command-scoped help" {
+    run_basectl gh pr create --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh pr create [gh options...]"* ]]
+    [[ "$output" == *"--no-fixes"* ]]
+    [[ "$output" != *"basectl gh pr merge"* ]]
+
+    run_basectl gh pr status --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh pr status [gh options...]"* ]]
+    [[ "$output" != *"--no-fixes"* ]]
+    [[ "$output" != *"basectl gh pr create"* ]]
+}
+
 @test "basectl gh project prints area help" {
     run_basectl gh project --help
 
@@ -423,12 +456,34 @@ run_gh_subcommand() {
 }
 
 @test "basectl gh project configure help lists delegated Python options" {
-    run_basectl gh project --help
+    run_basectl gh project configure --help
 
     [ "$status" -eq 0 ]
     for flag in "--schema base-project" "--config <path>" "--copy-fields-from <title>" "--replace-project" "--initiative-option <name>" "--dry-run"; do
         [[ "$output" == *"$flag"* ]]
     done
+}
+
+@test "basectl gh project and branch leaves print command-scoped help" {
+    run_basectl gh project doctor --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh project doctor --project <title> [options]"* ]]
+    [[ "$output" == *"--schema base-project"* ]]
+    [[ "$output" != *"--dry-run"* ]]
+    [[ "$output" != *"basectl gh project configure"* ]]
+
+    run_basectl gh branch stale --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh branch stale [--days <days>]"* ]]
+    [[ "$output" != *"--dry-run"* ]]
+    [[ "$output" != *"--remote"* ]]
+
+    run_basectl gh branch prune --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl gh branch prune [options]"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"--remote"* ]]
+    [[ "$output" != *"--days"* ]]
 }
 
 @test "basectl gh project issue set-fields prints concrete help" {

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -317,6 +317,19 @@ run_gh_subcommand() {
     [[ "$output" != *"basectl gh worktree prune"* ]]
 }
 
+@test "basectl gh issue start prints leaf help without an issue number" {
+    run_basectl gh issue start --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl gh issue start <number>"* ]]
+    [[ "$output" == *"--repo, -R <owner/name>"* ]]
+    [[ "$output" == *"--category <category>"* ]]
+    [[ "$output" == *"--title <title>"* ]]
+    [[ "$output" != *"basectl gh issue create"* ]]
+    [[ "$output" != *"ERROR:"* ]]
+}
+
 @test "basectl gh issue readiness reports ready when body and Project metadata are complete" {
     write_issue_readiness_gh_mock
     write_complete_issue_readiness_body

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -43,6 +43,21 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--color"* ]]
 }
 
+@test "basectl groups default help by user journey and describes supported setup platforms" {
+    run_basectl --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Getting started:"* ]]
+    [[ "$output" == *"Daily project loop:"* ]]
+    [[ "$output" == *"Workspace and repositories:"* ]]
+    [[ "$output" == *"Release and sharing:"* ]]
+    [[ "$output" == *"Diagnostics and maintenance:"* ]]
+    [[ "$output" == *"Compatibility:"* ]]
+    [[ "$output" == *"Install and bootstrap the local Base CLI environment on macOS or Ubuntu/Debian."* ]]
+    [[ "$output" == *"Compatibility alias for setup, check, and doctor --ci mode."* ]]
+    [[ "$output" != *"environment on macOS."* ]]
+}
+
 @test "basectl help omits legacy leftover commands" {
     run_basectl --help
 
@@ -98,6 +113,66 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl release check --version <version>"* ]]
     [[ "$output" != *"Usage: basectl [options] <command> [args...]"* ]]
+}
+
+@test "basectl nested help matches the corresponding leaf help" {
+    local direct_output
+    local path
+
+    for path in \
+        "release check" \
+        "release publish" \
+        "config path" \
+        "config show" \
+        "gh issue start"; do
+        run_basectl $path --help
+        [ "$status" -eq 0 ]
+        direct_output="$output"
+
+        run_basectl help $path
+        [ "$status" -eq 0 ]
+        [ "$output" = "$direct_output" ]
+    done
+}
+
+@test "every documented public leaf returns usage from --help" {
+    local args=()
+    local path
+    local paths=(
+        "activate" "setup" "check" "doctor" "doctor explain"
+        "test" "build" "run" "demo" "export-context" "devcontainer"
+        "devenv-report" "projects list" "trust status" "trust allow"
+        "trust revoke" "workspace status" "workspace check" "workspace doctor"
+        "workspace onboarding" "workspace agent-brief" "workspace clone"
+        "workspace pull" "workspace init" "workspace configure" "repo init"
+        "repo clone" "repo check" "repo configure" "repo agent-guidance"
+        "repo installer-template" "ci setup" "ci check" "ci doctor"
+        "release check" "release plan" "release notes" "release publish"
+        "prompt list" "prompt product-self-review" "docs" "clean" "logs"
+        "history" "config path" "config show" "config doctor" "gh issue list"
+        "gh issue create" "gh issue readiness" "gh issue start" "gh pr create"
+        "gh pr status" "gh pr checks" "gh pr ready" "gh pr merge"
+        "gh project doctor" "gh project configure" "gh project issue set-fields"
+        "gh branch stale" "gh branch prune" "gh worktree prune" "onboard"
+        "update-profile" "update" "version"
+    )
+
+    for path in "${paths[@]}"; do
+        read -r -a args <<<"$path"
+        run_basectl "${args[@]}" --help
+
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Usage:"* ]]
+    done
+}
+
+@test "command reference documents nested help and repo check release parity" {
+    local command_reference="$BASE_REPO_ROOT/docs/command-reference.md"
+    local repo_check_row
+
+    grep -Fq 'Run `basectl help <nested path>` or append `--help` to that path' "$command_reference"
+    repo_check_row="$(grep -F '| `basectl repo check [path]` |' "$command_reference")"
+    [[ "$repo_check_row" == *'`--release`'* ]]
 }
 
 @test "basectl rejects equals-form long option values before command delegation" {

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -26,7 +26,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"logs [options]"* ]]
     [[ "$output" == *"history [options]"* ]]
     [[ "$output" == *"config <path|show|doctor>"* ]]
-    [[ "$output" == *"trust <status|allow|revoke> <project> [options]"* ]]
+    [[ "$output" == *"trust <status|allow|revoke> [project] [options]"* ]]
     [[ "$output" == *"doctor [project] [options]"* ]]
     [[ "$output" == *"gh <area> <command> [options]"* ]]
     [[ "$output" == *"onboard [project] [options]"* ]]
@@ -54,7 +54,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Diagnostics and maintenance:"* ]]
     [[ "$output" == *"Compatibility:"* ]]
     [[ "$output" == *"Install and bootstrap the local Base CLI environment on macOS or Ubuntu/Debian."* ]]
-    [[ "$output" == *"Compatibility alias for setup, check, and doctor --ci mode."* ]]
+    [[ "$output" == *"Compatibility alias for setup, check, and doctor --ci."* ]]
     [[ "$output" != *"environment on macOS."* ]]
 }
 
@@ -86,7 +86,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  history [options]' <<<"$output"
     grep -Fqx '  workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]' <<<"$output"
-    grep -Fqx '  trust <status|allow|revoke> <project> [options]' <<<"$output"
+    grep -Fqx '  trust <status|allow|revoke> [project] [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
     [[ "$output" != *"-V"* ]]
@@ -137,6 +137,7 @@ load ./basectl_helpers.bash
 
 @test "every documented public leaf returns usage from --help" {
     local args=()
+    local direct_output
     local path
     local paths=(
         "activate" "setup" "check" "doctor" "doctor explain"
@@ -149,7 +150,7 @@ load ./basectl_helpers.bash
         "repo installer-template" "ci setup" "ci check" "ci doctor"
         "release check" "release plan" "release notes" "release publish"
         "prompt list" "prompt product-self-review" "docs" "clean" "logs"
-        "history" "config path" "config show" "config doctor" "gh issue list"
+        "logs last" "history" "config path" "config show" "config doctor" "gh issue list"
         "gh issue create" "gh issue readiness" "gh issue start" "gh pr create"
         "gh pr status" "gh pr checks" "gh pr ready" "gh pr merge"
         "gh project doctor" "gh project configure" "gh project issue set-fields"
@@ -163,6 +164,11 @@ load ./basectl_helpers.bash
 
         [ "$status" -eq 0 ]
         [[ "$output" == *"Usage:"* ]]
+        direct_output="$output"
+
+        run_basectl help "${args[@]}"
+        [ "$status" -eq 0 ]
+        [ "$output" = "$direct_output" ]
     done
 }
 
@@ -236,7 +242,18 @@ load ./basectl_helpers.bash
     grep -Fqx -- "- \`basectl repo <init|clone|check|configure|agent-guidance|installer-template>\` -" "$commands_file"
     grep -Fqx -- "- \`basectl update [project]\` - update Base or a named project using the" "$commands_file"
     grep -Fqx -- "- \`basectl docs\` - open the Base documentation home page on GitHub." "$commands_file"
-    grep -Fqx -- "- \`basectl trust <status|allow|revoke> <project>\` - inspect, allow, or" "$commands_file"
+    grep -Fqx -- "- \`basectl trust status [project]\` - inspect one project's manifest command" "$commands_file"
+    grep -Fqx -- "- \`basectl trust <allow|revoke> <project>\` - add or remove local approval for" "$commands_file"
+}
+
+@test "public command inventories include demo, run, and release" {
+    local cli_readme="$BASE_REPO_ROOT/cli/bash/commands/basectl/README.md"
+    local root_readme="$BASE_REPO_ROOT/README.md"
+
+    grep -Fqx -- '- `basectl demo [project]`' "$root_readme"
+    grep -Fqx -- '- `demo`' "$cli_readme"
+    grep -Fqx -- '- `run`' "$cli_readme"
+    grep -Fqx -- '- `release check/plan/notes/publish`' "$cli_readme"
 }
 
 @test "command reference documents workspace init help surface" {

--- a/cli/bash/commands/basectl/tests/logs.bats
+++ b/cli/bash/commands/basectl/tests/logs.bats
@@ -79,7 +79,20 @@ EOF
     [[ "$output" == *"basectl logs last"* ]]
     [[ "$output" == *"--command <name>"* ]]
     [[ "$output" == *"--path"* ]]
+    [[ "$output" != *"--format <format>"* ]]
+}
+
+@test "basectl logs last prints focused help" {
+    run_basectl logs last --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl logs last [options]"* ]]
     [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--lines <count>"* ]]
+    [[ "$output" != *"--limit"* ]]
+    [[ "$output" != *"--path"* ]]
+    [[ "$output" != *"--tail"* ]]
+    [[ "$output" != *"--open"* ]]
 }
 
 @test "basectl logs reports missing option arguments as usage errors" {

--- a/cli/bash/commands/basectl/tests/prompt.bats
+++ b/cli/bash/commands/basectl/tests/prompt.bats
@@ -14,6 +14,22 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--output <path>"* ]]
 }
 
+@test "basectl prompt leaves scope output help to rendered prompts" {
+    run_basectl prompt list --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl prompt list"* ]]
+    [[ "$output" != *"--output"* ]]
+    [[ "$output" != *"basectl prompt <name>"* ]]
+
+    run_basectl prompt product-self-review --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl prompt product-self-review [--output <path>]"* ]]
+    [[ "$output" == *"--output <path>"* ]]
+    [[ "$output" != *"basectl prompt list"* ]]
+}
+
 @test "basectl prompt forwards prompt names to the Python prompt renderer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local state_file="$TEST_TMPDIR/prompt-state"

--- a/cli/bash/commands/basectl/tests/release.bats
+++ b/cli/bash/commands/basectl/tests/release.bats
@@ -30,6 +30,40 @@ load ./basectl_helpers.bash
     [[ "$output" != *"Encountered a fatal error"* ]]
 }
 
+@test "basectl release leaves print scoped public help without Python runtime options" {
+    local command
+
+    for command in check plan notes; do
+        run_basectl release "$command" --help
+
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"basectl release $command --version <version> [--manifest <path>]"* ]]
+        [[ "$output" == *"--version <version>"* ]]
+        [[ "$output" == *"--manifest <path>"* ]]
+        [[ "$output" != *"--dry-run"* ]]
+        [[ "$output" != *"--yes"* ]]
+        [[ "$output" != *"--quiet"* ]]
+        [[ "$output" != *"--debug"* ]]
+        [[ "$output" != *"--environment"* ]]
+        [[ "$output" != *"--config"* ]]
+        [[ "$output" != *"--keep-temp"* ]]
+        [[ "$output" != *"--log-file"* ]]
+    done
+
+    run_basectl release publish --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl release publish --version <version> [--manifest <path>] [--dry-run] [--yes]"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"--yes"* ]]
+    [[ "$output" != *"--quiet"* ]]
+    [[ "$output" != *"--debug"* ]]
+    [[ "$output" != *"--environment"* ]]
+    [[ "$output" != *"--config"* ]]
+    [[ "$output" != *"--keep-temp"* ]]
+    [[ "$output" != *"--log-file"* ]]
+}
+
 @test "basectl release delegates to the Python release layer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local manifest="$TEST_TMPDIR/base_manifest.yaml"
@@ -61,7 +95,7 @@ EOF
     [ "$(cat "$TEST_TMPDIR/release-state")" = "BASE_PROJECT=base" ]
 }
 
-@test "Bash completion includes release publish commands and options" {
+@test "Bash completion scopes release options to the selected leaf" {
     run env \
         BASE_HOME="$BASE_REPO_ROOT" \
         bash -c '\
@@ -70,6 +104,10 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "release_commands=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl release check --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "release_check_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl release publish --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
@@ -77,5 +115,6 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"release_commands=check plan notes publish"* ]]
+    [[ "$output" == *"release_check_options=--version --manifest"* ]]
     [[ "$output" == *"release_publish_options=--version --manifest --dry-run --yes"* ]]
 }

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -83,6 +83,27 @@ EOF
     [ "$output" = "basectl $expected_version" ]
 }
 
+@test "basectl version has leaf help and rejects trailing arguments" {
+    run_basectl version --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"basectl version"* ]]
+    [[ "$output" == *"Show the installed Base version."* ]]
+
+    run_basectl help version
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl version"* ]]
+
+    run_basectl version nonsense
+
+    [ "$status" -eq 2 ]
+    [ "${lines[0]}" = "ERROR: version does not accept arguments." ]
+    [ "${lines[1]}" = "Run 'basectl version --help' for usage." ]
+    [[ "$output" != *"basectl $(head -n 1 "$BASE_REPO_ROOT/VERSION")"* ]]
+}
+
 @test "README version badge matches VERSION" {
     local expected_version expected_badge
 

--- a/cli/bash/commands/basectl/tests/trust.bats
+++ b/cli/bash/commands/basectl/tests/trust.bats
@@ -14,6 +14,32 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--manifest-sha256 <sha256>"* ]]
 }
 
+@test "basectl trust leaves print command-scoped help" {
+    run_basectl trust status --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl trust status [project] [options]"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" != *"--manifest-sha256"* ]]
+    [[ "$output" != *"basectl trust revoke"* ]]
+
+    run_basectl trust allow --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl trust allow <project> [options]"* ]]
+    [[ "$output" == *"--manifest-sha256 <sha256>"* ]]
+    [[ "$output" != *"--format"* ]]
+    [[ "$output" != *"basectl trust status"* ]]
+
+    run_basectl trust revoke --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl trust revoke <project> [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" != *"--format"* ]]
+    [[ "$output" != *"--manifest-sha256"* ]]
+}
+
 @test "basectl trust status forwards without a project for workspace inspection" {
     local base_home="$TEST_TMPDIR/base-home"
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,7 +1,8 @@
 # basectl Quick Reference
 
 This page is a compact lookup table for the current `basectl` command surface.
-Run `basectl --help` or `basectl <command> --help` for full usage.
+Run `basectl help <nested path>` or append `--help` to that path for the same
+leaf-specific usage. Run `basectl --help` for the journey-oriented command map.
 
 Use space-separated values for long options, for example `--format json`.
 Base rejects `--option=value` syntax before command delegation. Arguments after
@@ -115,7 +116,7 @@ daily project loop commands from the local checkout.
 |---|---|---|
 | `basectl repo init <name>` | Create a Base-managed repository baseline, including `.github/base-project.yml`, and optionally create/configure the GitHub repo. Use `--path .` for the current checkout; plain init does not commit or push local files, while `--pr --issue <number>` commits baseline changes on a canonical issue-backed branch, pushes it to `origin`, and opens a PR. Real PR runs derive the issue category; offline `--pr --dry-run` also requires `--category <name>`. Use `--agent-ready` to seed `AGENTS.md` and `skills.md` with the baseline. Use repeatable `--language <csv>` values to seed normalized `project.languages` metadata; selecting `python` also writes `python.manager: uv`. | `--path <path>`, `--repo <owner/name>`, `--issue <number>`, `--category <name>`, `--language <csv>`, `--description <text>`, `--copyright-holder <name>`, `--public`, `--private`, `--pr`, `--agent-ready`, `--project <title>`, `--project-owner <login>`, `--project-schema <schema>`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--no-configure`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo clone <name-or-owner/name>` | Clone one GitHub repository into the configured Base workspace, treating matching existing checkouts as already satisfied. | `--owner <owner>`, `--path <path>`, `--dry-run` |
-| `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance`, `--agent-ready` |
+| `basectl repo check [path]` | Verify the local repository baseline. | `--agent-guidance`, `--agent-ready`, `--release` |
 | `basectl repo configure [path]` | Apply Base-managed GitHub repository settings, labels, default branch protection, non-default branch naming enforcement, the trusted issue/category branch policy workflow, and repo Project metadata. After a default-branch dispatch produces a recent trusted success, its GitHub-Actions-bound PR-head status becomes required. Reads `.github/base-project.yml` to seed options and fill missing issue defaults when present. | `--repo <owner/name>`, `--project <title>`, `--project-owner <login>`, `--project-schema <schema>`, `--copy-project-fields-from <title>`, `--initiative-option <name>`, `--replace-project`, `--no-project`, `--no-protect-default-branch`, `--dry-run` |
 | `basectl repo agent-guidance [path]` | Seed optional repo-local agent guidance files, optionally through a draft PR. Real PR runs derive the issue category; offline `--pr --dry-run` also requires `--category <name>`. | `--repo <owner/name>`, `--repo-name <name>`, `--default-branch <name>`, `--validation-command <cmd>`, `--issue <number>`, `--category <name>`, `--pr`, `--dry-run` |
 | `basectl repo installer-template [path]` | Write the maintained project installer starter script to a path, defaulting to `./install.sh`, optionally through a draft PR. Real PR runs derive the issue category; offline `--pr --dry-run` also requires `--category <name>`. | `--print`, `--repo <owner/name>`, `--issue <number>`, `--category <name>`, `--pr`, `--dry-run` |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -235,11 +235,44 @@ _base_basectl_completion_profiles() {
 _base_basectl_completion_project_or_options() {
     local options="$1"
     local current="$2"
+    local value_options="${3:-}"
+    local argument_start="${4:-2}"
+    local expect_value=0 index word
 
-    if ((COMP_CWORD == 2)) && [[ "$current" != -* ]]; then
-        _base_basectl_completion_project_candidates "$current"
-    else
+    if [[ "$current" == -* ]]; then
         _base_basectl_completion_compgen "$options" "$current"
+        return 0
+    fi
+
+    for ((index = argument_start; index < COMP_CWORD; index += 1)); do
+        word="${COMP_WORDS[index]:-}"
+        if ((expect_value)); then
+            expect_value=0
+            continue
+        fi
+        if [[ " $value_options " == *" $word "* ]]; then
+            expect_value=1
+            continue
+        fi
+        case "$word" in
+            --)
+                _base_basectl_completion_compgen "$options" "$current"
+                return 0
+                ;;
+            -*)
+                continue
+                ;;
+            *)
+                _base_basectl_completion_compgen "$options" "$current"
+                return 0
+                ;;
+        esac
+    done
+
+    if [[ " $value_options " == *" ${COMP_WORDS[COMP_CWORD - 1]:-} "* ]]; then
+        _base_basectl_completion_compgen "$options" "$current"
+    else
+        _base_basectl_completion_project_candidates "$current"
     fi
 }
 
@@ -247,14 +280,14 @@ _base_basectl_completion_project_profiles_or_options() {
     local current="$1"
     local options="$2"
     local project_position="${3:-2}"
+    local value_options="${4:-}"
     local previous="${COMP_WORDS[COMP_CWORD - 1]:-}"
 
     if [[ "$previous" == "--profile" ]]; then
         _base_basectl_completion_compgen "$(_base_basectl_completion_profiles)" "$current"
-    elif ((COMP_CWORD == project_position)) && [[ "$current" != -* ]]; then
-        _base_basectl_completion_project_candidates "$current"
     else
-        _base_basectl_completion_compgen "$options" "$current"
+        _base_basectl_completion_project_or_options \
+            "$options" "$current" "$value_options --profile" "$project_position"
     fi
 }
 
@@ -290,11 +323,8 @@ _base_basectl_completion() {
     command="${COMP_WORDS[1]:-}"
     case "$command" in
         activate)
-            if ((COMP_CWORD == 2)); then
-                _base_basectl_completion_project_candidates "$cur"
-            else
-                _base_basectl_completion_compgen "--workspace --no-cd -v -h --help" "$cur"
-            fi
+            _base_basectl_completion_project_or_options \
+                "--workspace --no-cd -v -h --help" "$cur" "--workspace"
             ;;
         projects)
             if ((COMP_CWORD == 2)); then
@@ -306,18 +336,20 @@ _base_basectl_completion() {
         trust)
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "status allow revoke" "$cur"
-            elif ((COMP_CWORD == 3)) && [[ "$cur" != -* ]]; then
-                _base_basectl_completion_project_candidates "$cur"
             else
                 case "${COMP_WORDS[2]:-}" in
                     status)
-                        _base_basectl_completion_compgen "--workspace --format -v -h --help" "$cur"
+                        _base_basectl_completion_project_or_options \
+                            "--workspace --format -v -h --help" "$cur" "--workspace --format" 3
                         ;;
                     allow)
-                        _base_basectl_completion_compgen "--workspace --manifest-sha256 -v -h --help" "$cur"
+                        _base_basectl_completion_project_or_options \
+                            "--workspace --manifest-sha256 -v -h --help" "$cur" \
+                            "--workspace --manifest-sha256" 3
                         ;;
                     revoke)
-                        _base_basectl_completion_compgen "--workspace -v -h --help" "$cur"
+                        _base_basectl_completion_project_or_options \
+                            "--workspace -v -h --help" "$cur" "--workspace" 3
                         ;;
                 esac
             fi
@@ -349,37 +381,48 @@ _base_basectl_completion() {
             fi
             ;;
         setup)
-            _base_basectl_completion_project_profiles_or_options "$cur" "$setup_options"
+            _base_basectl_completion_project_profiles_or_options \
+                "$cur" "$setup_options" 2 "--format --manifest"
             ;;
         check)
-            _base_basectl_completion_project_profiles_or_options "$cur" "$check_options"
+            _base_basectl_completion_project_profiles_or_options \
+                "$cur" "$check_options" 2 "--format --manifest"
             ;;
         test)
-            _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options \
+                "--workspace --dry-run -v -h --help" "$cur" "--workspace"
             ;;
         export-context)
-            _base_basectl_completion_project_or_options "--workspace --format --output --print --list-files -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options \
+                "--workspace --format --output --print --list-files -v -h --help" "$cur" \
+                "--workspace --format --output"
             ;;
         devcontainer)
-            _base_basectl_completion_project_or_options "--workspace --format --write -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options \
+                "--workspace --format --write -v -h --help" "$cur" "--workspace --format"
             ;;
         devenv-report)
-            _base_basectl_completion_project_or_options "--workspace --format -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options \
+                "--workspace --format -v -h --help" "$cur" "--workspace --format"
             ;;
         build)
-            _base_basectl_completion_project_or_options "--workspace --dry-run --list -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options \
+                "--workspace --dry-run --list -v -h --help" "$cur" "--workspace"
             ;;
         demo)
-            _base_basectl_completion_project_or_options "--workspace --dry-run -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options \
+                "--workspace --dry-run -v -h --help" "$cur" "--workspace"
             ;;
         run)
-            _base_basectl_completion_project_or_options "--workspace --dry-run --list -v -h --help" "$cur"
+            _base_basectl_completion_project_or_options \
+                "--workspace --dry-run --list -v -h --help" "$cur" "--workspace"
             ;;
         repo)
-            case "${COMP_WORDS[2]:-}" in
-                "")
-                    _base_basectl_completion_compgen "init clone check configure agent-guidance installer-template" "$cur"
-                    ;;
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen \
+                    "init clone check configure agent-guidance installer-template" "$cur"
+            else
+                case "${COMP_WORDS[2]:-}" in
                 init)
                     _base_basectl_completion_compgen "--path --repo --issue --category --pr --agent-ready --release --language --description --copyright-holder --private --public --no-configure --no-protect-default-branch --project --project-owner --project-schema --initiative-option --copy-project-fields-from --no-project --dry-run -v -h --help" "$cur"
                     ;;
@@ -398,23 +441,28 @@ _base_basectl_completion() {
                 installer-template)
                     _base_basectl_completion_compgen "--print --stdout --repo --issue --category --pr --dry-run -v -h --help" "$cur"
                     ;;
-            esac
+                esac
+            fi
             ;;
         ci)
-            case "${COMP_WORDS[2]:-}" in
-                "")
-                    _base_basectl_completion_compgen "setup check doctor" "$cur"
-                    ;;
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "setup check doctor" "$cur"
+            else
+                case "${COMP_WORDS[2]:-}" in
                 setup)
-                    _base_basectl_completion_project_profiles_or_options "$cur" "$setup_options" 3
+                    _base_basectl_completion_project_profiles_or_options \
+                        "$cur" "$setup_options" 3 "--format --manifest"
                     ;;
                 check)
-                    _base_basectl_completion_project_profiles_or_options "$cur" "$check_options" 3
+                    _base_basectl_completion_project_profiles_or_options \
+                        "$cur" "$check_options" 3 "--format --manifest"
                     ;;
                 doctor)
-                    _base_basectl_completion_project_profiles_or_options "$cur" "$doctor_options" 3
+                    _base_basectl_completion_project_profiles_or_options \
+                        "$cur" "$doctor_options" 3 "--format --manifest"
                     ;;
-            esac
+                esac
+            fi
             ;;
         release)
             if ((COMP_CWORD == 2)); then
@@ -434,7 +482,14 @@ _base_basectl_completion() {
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "list product-self-review" "$cur"
             else
-                _base_basectl_completion_compgen "--output -v -h --help" "$cur"
+                case "${COMP_WORDS[2]:-}" in
+                    list)
+                        _base_basectl_completion_compgen "-v -h --help" "$cur"
+                        ;;
+                    *)
+                        _base_basectl_completion_compgen "--output -v -h --help" "$cur"
+                        ;;
+                esac
             fi
             ;;
         docs)
@@ -446,8 +501,10 @@ _base_basectl_completion() {
         logs)
             if ((COMP_CWORD == 2)) && [[ "$cur" != -* ]]; then
                 _base_basectl_completion_compgen "last" "$cur"
+            elif [[ "${COMP_WORDS[2]:-}" == last ]]; then
+                _base_basectl_completion_compgen "--command --lines --format -v -h --help" "$cur"
             else
-                _base_basectl_completion_compgen "--command --limit --path --tail --open --lines --format -v -h --help" "$cur"
+                _base_basectl_completion_compgen "--command --limit --path --tail --open --lines -v -h --help" "$cur"
             fi
             ;;
         history)
@@ -469,35 +526,51 @@ _base_basectl_completion() {
                     COMPREPLY+=("explain")
                 fi
             else
-                _base_basectl_completion_project_profiles_or_options "$cur" "$doctor_options"
+                _base_basectl_completion_project_profiles_or_options \
+                    "$cur" "$doctor_options" 2 "--format --manifest"
             fi
             ;;
         gh)
-            case "${COMP_WORDS[2]:-}" in
-                "")
-                    _base_basectl_completion_compgen "issue pr branch worktree project" "$cur"
-                    ;;
+            if ((COMP_CWORD == 2)); then
+                _base_basectl_completion_compgen "issue pr branch worktree project" "$cur"
+            else
+                case "${COMP_WORDS[2]:-}" in
                 issue)
                     if ((COMP_CWORD == 3)); then
                         _base_basectl_completion_compgen "list create start readiness" "$cur"
-                    elif [[ "${COMP_WORDS[3]:-}" == "readiness" ]]; then
-                        _base_basectl_completion_compgen "--repo --project-owner --project-number -h --help" "$cur"
-                    elif [[ "${COMP_WORDS[3]:-}" == "start" ]]; then
-                        _base_basectl_completion_compgen "--category --title --repo -R -h --help" "$cur"
                     else
-                        _base_basectl_completion_compgen "--category --title --body --repo --assignee --no-assignee --project --project-owner --size --no-project -h --help" "$cur"
+                        case "${COMP_WORDS[3]:-}" in
+                            list)
+                                _base_basectl_completion_compgen "-h --help" "$cur"
+                                ;;
+                            create)
+                                _base_basectl_completion_compgen "--category --title --body --repo --assignee --no-assignee --project --project-owner --size --no-project -h --help" "$cur"
+                                ;;
+                            readiness)
+                                _base_basectl_completion_compgen "--repo --project-owner --project-number -h --help" "$cur"
+                                ;;
+                            start)
+                                _base_basectl_completion_compgen "--category --title --repo -R -h --help" "$cur"
+                                ;;
+                        esac
                     fi
                     ;;
                 pr)
                     if ((COMP_CWORD == 3)); then
                         _base_basectl_completion_compgen "create status checks ready merge" "$cur"
+                    elif [[ "${COMP_WORDS[3]:-}" == create ]]; then
+                        _base_basectl_completion_compgen "--no-fixes -h --help" "$cur"
+                    else
+                        _base_basectl_completion_compgen "-h --help" "$cur"
                     fi
                     ;;
                 branch)
                     if ((COMP_CWORD == 3)); then
                         _base_basectl_completion_compgen "stale prune" "$cur"
-                    else
-                        _base_basectl_completion_compgen "--days --dry-run --yes --remote -h --help" "$cur"
+                    elif [[ "${COMP_WORDS[3]:-}" == stale ]]; then
+                        _base_basectl_completion_compgen "--days -h --help" "$cur"
+                    elif [[ "${COMP_WORDS[3]:-}" == prune ]]; then
+                        _base_basectl_completion_compgen "--dry-run --yes --remote -h --help" "$cur"
                     fi
                     ;;
                 worktree)
@@ -508,10 +581,10 @@ _base_basectl_completion() {
                     fi
                     ;;
                 project)
-                    case "${COMP_WORDS[3]:-}" in
-                        "")
-                            _base_basectl_completion_compgen "doctor configure issue" "$cur"
-                            ;;
+                    if ((COMP_CWORD == 3)); then
+                        _base_basectl_completion_compgen "doctor configure issue" "$cur"
+                    else
+                        case "${COMP_WORDS[3]:-}" in
                         doctor)
                             _base_basectl_completion_compgen "--project --owner --schema -h --help" "$cur"
                             ;;
@@ -525,14 +598,17 @@ _base_basectl_completion() {
                                 _base_basectl_completion_compgen "--repo --project --owner --config --status --priority --area --initiative --size --dry-run -h --help" "$cur"
                             fi
                             ;;
-                    esac
+                        esac
+                    fi
                     ;;
-            esac
+                esac
+            fi
             ;;
         onboard)
             _base_basectl_completion_project_profiles_or_options \
                 "$cur" \
-                "--profile --dry-run --yes --no-profile -v -h --help"
+                "--profile --dry-run --yes --no-profile -v -h --help" \
+                2 ""
             ;;
         update-profile)
             _base_basectl_completion_compgen "--defaults --no-defaults --remove --dry-run -v -h --help" "$cur"

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -258,6 +258,20 @@ _base_basectl_completion_project_profiles_or_options() {
     fi
 }
 
+_base_basectl_completion_help() {
+    local saved_cword="$COMP_CWORD"
+    local -a saved_words=("${COMP_WORDS[@]}")
+    local status
+
+    COMP_WORDS=(basectl "${saved_words[@]:2}")
+    COMP_CWORD=$((saved_cword - 1))
+    _base_basectl_completion
+    status=$?
+    COMP_WORDS=("${saved_words[@]}")
+    COMP_CWORD="$saved_cword"
+    return "$status"
+}
+
 _base_basectl_completion() {
     local command cur
     local commands="activate setup check test export-context devcontainer devenv-report build demo run repo ci release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
@@ -373,7 +387,7 @@ _base_basectl_completion() {
                     _base_basectl_completion_compgen "--owner --path --dry-run -v -h --help" "$cur"
                     ;;
                 check)
-                    _base_basectl_completion_compgen "--agent-guidance --agent-ready -v -h --help" "$cur"
+                    _base_basectl_completion_compgen "--agent-guidance --agent-ready --release -v -h --help" "$cur"
                     ;;
                 configure)
                     _base_basectl_completion_compgen "--repo --no-protect-default-branch --project --project-owner --project-schema --initiative-option --copy-project-fields-from --replace-project --no-project --release --dry-run -v -h --help" "$cur"
@@ -406,7 +420,14 @@ _base_basectl_completion() {
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "check plan notes publish" "$cur"
             else
-                _base_basectl_completion_compgen "--version --manifest --dry-run --yes -h --help" "$cur"
+                case "${COMP_WORDS[2]:-}" in
+                    check|plan|notes)
+                        _base_basectl_completion_compgen "--version --manifest -h --help" "$cur"
+                        ;;
+                    publish)
+                        _base_basectl_completion_compgen "--version --manifest --dry-run --yes -h --help" "$cur"
+                        ;;
+                esac
             fi
             ;;
         prompt)
@@ -435,6 +456,8 @@ _base_basectl_completion() {
         config)
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "path show doctor" "$cur"
+            else
+                _base_basectl_completion_compgen "-h --help" "$cur"
             fi
             ;;
         doctor)
@@ -516,6 +539,12 @@ _base_basectl_completion() {
             ;;
         update)
             _base_basectl_completion_project_or_options "--dry-run -v -h --help" "$cur"
+            ;;
+        version)
+            _base_basectl_completion_compgen "-h --help" "$cur"
+            ;;
+        help)
+            _base_basectl_completion_help
             ;;
     esac
 }

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -263,17 +263,17 @@ _base_basectl_completion() {
 
     case "${words[2]:-}" in
         activate)
-            if ((CURRENT == 3)); then
+            _arguments '--workspace[Workspace directory to scan]:path:_files' \
+                '--no-cd[Preserve the caller current directory]' \
+                '-v[Enable DEBUG logging]' \
+                '(-h --help)'{-h,--help}'[Show help text]' \
+                '2:Base project:->projects'
+            if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
-            else
-                _arguments '--workspace[Workspace directory to scan]:path:_files' \
-                    '--no-cd[Preserve the caller current directory]' \
-                    '-v[Enable DEBUG logging]' \
-                    '(-h --help)'{-h,--help}'[Show help text]'
             fi
             ;;
         projects)
-            _arguments '1:projects command:(list)' \
+            _arguments '2:projects command:(list)' \
                 '--workspace[Workspace directory to scan]:path:_files' \
                 '--format[Output format]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
@@ -281,27 +281,27 @@ _base_basectl_completion() {
         trust)
             case "${words[3]:-}" in
                 status)
-                    _arguments '1:trust command:(status allow revoke)' \
-                        '2::Base project:->projects' \
+                    _arguments '2:trust command:(status allow revoke)' \
+                        '3::Base project:->projects' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--format[Output format]:format:(text json)' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 allow)
-                    _arguments '1:trust command:(status allow revoke)' \
-                        '2:Base project:->projects' \
+                    _arguments '2:trust command:(status allow revoke)' \
+                        '3:Base project:->projects' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest-sha256[Expected manifest SHA-256]:sha256:' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 revoke)
-                    _arguments '1:trust command:(status allow revoke)' \
-                        '2:Base project:->projects' \
+                    _arguments '2:trust command:(status allow revoke)' \
+                        '3:Base project:->projects' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)
-                    _arguments '1:trust command:(status allow revoke)'
+                    _arguments '2:trust command:(status allow revoke)'
                     ;;
             esac
             if [[ "$state" == projects ]]; then
@@ -311,14 +311,14 @@ _base_basectl_completion() {
         workspace)
             case "${words[3]:-}" in
                 status|check|doctor|onboarding|agent-brief)
-                    _arguments '1:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--format[Output format]:format:(text json)' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 clone)
-                    _arguments '1:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--include-optional[Include optional manifest repositories when cloning]' \
@@ -326,15 +326,15 @@ _base_basectl_completion() {
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 pull)
-                    _arguments '1:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
                         '--source[Canonical workspace manifest source]:url-or-path:' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--dry-run[Show planned workspace pull work without writing]' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 init)
-                    _arguments '1:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
-                        '2:workspace source:' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                        '3:workspace source:' \
                         '--owner[GitHub owner for short workspace repository names]:owner:' \
                         '--path[Workspace configuration repository checkout path]:path:_files' \
                         '--workspace[Workspace directory for member repositories]:path:_files' \
@@ -344,14 +344,14 @@ _base_basectl_completion() {
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 configure)
-                    _arguments '1:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
                         '--workspace[Workspace directory to configure]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--dry-run[Show planned workspace configuration without applying repo changes]' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)
-                    _arguments '1:workspace command:(status check doctor onboarding agent-brief clone pull init configure)'
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)'
                     ;;
             esac
             ;;
@@ -387,7 +387,7 @@ _base_basectl_completion() {
             _arguments '--workspace[Workspace directory to scan]:path:_files' \
                 '--dry-run[Print the resolved test command without running it]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -399,7 +399,7 @@ _base_basectl_completion() {
                 '--print[Print the Markdown export to stdout]' \
                 '--list-files[List files in export order]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -409,7 +409,7 @@ _base_basectl_completion() {
                 '--format[Output format]:format:(text json)' \
                 '--write[Write .devcontainer/devcontainer.json]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -418,7 +418,7 @@ _base_basectl_completion() {
             _arguments '--workspace[Workspace directory to scan]:path:_files' \
                 '--format[Output format]:format:(text json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -428,7 +428,7 @@ _base_basectl_completion() {
                 '--dry-run[Print resolved build commands without running them]' \
                 '--list[List build targets]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects' '*:Build target:'
+                '2:Base project:->projects' '*:Build target:'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -437,7 +437,7 @@ _base_basectl_completion() {
             _arguments '--workspace[Workspace directory to scan]:path:_files' \
                 '--dry-run[Print the resolved demo script without running it]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -447,16 +447,25 @@ _base_basectl_completion() {
                 '--dry-run[Print the resolved command without running it]' \
                 '--list[List runnable project commands]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects' '2:Project command:'
+                '2:Base project:->projects' '3:Project command:'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
             ;;
         prompt)
-            _arguments '1:prompt:(list product-self-review)' \
-                '--output[Write rendered prompt Markdown to this path]:path:_files' \
-                '-v[Enable DEBUG logging]' \
-                '(-h --help)'{-h,--help}'[Show help text]'
+            case "${words[3]:-}" in
+                list)
+                    _arguments '2:prompt:(list product-self-review)' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                *)
+                    _arguments '2:prompt:(list product-self-review)' \
+                        '--output[Write rendered prompt Markdown to this path]:path:_files' \
+                        '-v[Enable DEBUG logging]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+            esac
             ;;
         docs)
             _arguments '--show-url[Print the documentation URL without opening a browser]' \
@@ -465,8 +474,8 @@ _base_basectl_completion() {
         repo)
             case "${words[3]:-}" in
                 init)
-                    _arguments '1:repo command:(init clone check configure agent-guidance installer-template)' \
-                        '2:repository name:' \
+                    _arguments '2:repo command:(init clone check configure agent-guidance installer-template)' \
+                        '3:repository name:' \
                         '--path[Target path]:path:_files' \
                         '--repo[GitHub repository]:repo:' \
                         '--issue[Issue number for pull request]:number:' \
@@ -492,8 +501,8 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 clone)
-                    _arguments '1:repo command:(init clone check configure agent-guidance installer-template)' \
-                        '2:repository name or owner/name:' \
+                    _arguments '2:repo command:(init clone check configure agent-guidance installer-template)' \
+                        '3:repository name or owner/name:' \
                         '--owner[GitHub owner for short repository names]:owner:' \
                         '--path[Clone destination]:path:_files' \
                         '--dry-run[Print planned clone without modifying the filesystem]' \
@@ -501,8 +510,8 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 check)
-                    _arguments '1:repo command:(init clone check configure agent-guidance installer-template)' \
-                        '2:path:_files' \
+                    _arguments '2:repo command:(init clone check configure agent-guidance installer-template)' \
+                        '3:path:_files' \
                         '--agent-guidance[Include optional agent guidance files]' \
                         '--agent-ready[Include the agent-ready repo guidance contract]' \
                         '--release[Include the release contract and process document]' \
@@ -510,8 +519,8 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 configure)
-                    _arguments '1:repo command:(init clone check configure agent-guidance installer-template)' \
-                        '2:path:_files' \
+                    _arguments '2:repo command:(init clone check configure agent-guidance installer-template)' \
+                        '3:path:_files' \
                         '--repo[GitHub repository]:repo:' \
                         '--no-protect-default-branch[Skip Base-managed default branch protection]' \
                         '--project[GitHub Project title]:title:' \
@@ -527,8 +536,8 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 agent-guidance)
-                    _arguments '1:repo command:(init clone check configure agent-guidance installer-template)' \
-                        '2:path:_files' \
+                    _arguments '2:repo command:(init clone check configure agent-guidance installer-template)' \
+                        '3:path:_files' \
                         '--repo[GitHub repository for pull request]:repo:' \
                         '--issue[Issue number for pull request]:number:' \
                         '--category[Issue category for pull request dry-run]:category:(bug enhancement documentation ci security)' \
@@ -541,8 +550,8 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 installer-template)
-                    _arguments '1:repo command:(init clone check configure agent-guidance installer-template)' \
-                        '2:path:_files' \
+                    _arguments '2:repo command:(init clone check configure agent-guidance installer-template)' \
+                        '3:path:_files' \
                         '--print[Print the maintained template to stdout instead of writing a file]' \
                         '--stdout[Alias for --print]' \
                         '--repo[GitHub repository for pull request]:repo:' \
@@ -554,7 +563,7 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)
-                    _arguments '1:repo command:(init clone check configure agent-guidance installer-template)'
+                    _arguments '2:repo command:(init clone check configure agent-guidance installer-template)'
                     ;;
             esac
             ;;
@@ -609,13 +618,13 @@ _base_basectl_completion() {
         release)
             case "${words[3]:-}" in
                 check|plan|notes)
-                    _arguments '1:release command:(check plan notes publish)' \
+                    _arguments '2:release command:(check plan notes publish)' \
                         '--version[Release version]:version:' \
                         '--manifest[Use a specific manifest]:path:_files' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 publish)
-                    _arguments '1:release command:(check plan notes publish)' \
+                    _arguments '2:release command:(check plan notes publish)' \
                         '--version[Release version]:version:' \
                         '--manifest[Use a specific manifest]:path:_files' \
                         '--dry-run[Print publish actions without creating tags or releases]' \
@@ -623,7 +632,7 @@ _base_basectl_completion() {
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)
-                    _arguments '1:release command:(check plan notes publish)'
+                    _arguments '2:release command:(check plan notes publish)'
                     ;;
             esac
             ;;
@@ -634,15 +643,22 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         logs)
-            _arguments '1:logs command:(last)' \
-                '--command[Filter by command]:command:' \
-                '--limit[Number of entries]:count:' \
-                '--path[Print most recent log path]' \
-                '--tail[Tail and follow most recent log]' \
-                '--open[Open most recent log]' \
-                '--lines[Lines to show before following]:count:' \
-                '--format[Output format for logs last]:format:(text json)' \
-                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            if [[ "${words[3]:-}" == last ]]; then
+                _arguments '2:logs command:(last)' \
+                    '--command[Filter by command]:command:' \
+                    '--lines[Maximum log-tail lines]:count:' \
+                    '--format[Output format]:format:(text json)' \
+                    '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            else
+                _arguments '2:logs command:(last)' \
+                    '--command[Filter by command]:command:' \
+                    '--limit[Number of entries]:count:' \
+                    '--path[Print most recent log path]' \
+                    '--tail[Tail and follow most recent log]' \
+                    '--open[Open most recent log]' \
+                    '--lines[Lines to show before following]:count:' \
+                    '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            fi
             ;;
         history)
             _arguments '--project[Filter by Base project]:project:' \
@@ -654,7 +670,7 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         config)
-            _arguments '1:config command:(path show doctor)' \
+            _arguments '2:config command:(path show doctor)' \
                 '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         doctor)
@@ -662,7 +678,7 @@ _base_basectl_completion() {
                 explain)
                     _arguments '--format[Output format]:format:(text json)' \
                         '(-h --help)'{-h,--help}'[Show help text]' \
-                        '2:finding id:'
+                        '3:finding id:'
                     ;;
                 *)
                     _arguments '--ci[Run diagnostics with CI-safe defaults]' \
@@ -686,9 +702,14 @@ _base_basectl_completion() {
             case "${words[3]:-}" in
                 issue)
                     case "${words[4]:-}" in
+                        list)
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:issue command:(list create start readiness)' \
+                                '(-h --help)'{-h,--help}'[Show help text]'
+                            ;;
                         create)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:issue command:(list create start readiness)' \
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:issue command:(list create start readiness)' \
                                 '--category[Issue category]:category:(bug enhancement documentation ci security)' \
                                 '--title[Issue title]:title:' \
                                 '--body[Issue body]:body:' \
@@ -702,46 +723,63 @@ _base_basectl_completion() {
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         start)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:issue command:(list create start readiness)' \
-                                '3:issue number:' \
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:issue command:(list create start readiness)' \
+                                '4:issue number:' \
                                 '--category[Issue category]:category:(bug enhancement documentation ci security)' \
                                 '--title[Issue title]:title:' \
                                 '(-R --repo)'{-R,--repo}'[Repository containing the issue]:repo:' \
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         readiness)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:issue command:(list create start readiness)' \
-                                '3:issue number:' \
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:issue command:(list create start readiness)' \
+                                '4:issue number:' \
                                 '--repo[GitHub repository]:repo:' \
                                 '--project-owner[GitHub Project owner]:owner:' \
                                 '--project-number[GitHub Project number]:number:' \
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         *)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:issue command:(list create start readiness)' \
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:issue command:(list create start readiness)' \
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                     esac
                     ;;
                 pr)
-                    _arguments '1:gh area:(issue pr branch worktree project)' \
-                        '2:pr command:(create status checks ready merge)'
+                    if [[ "${words[4]:-}" == create ]]; then
+                        _arguments '2:gh area:(issue pr branch worktree project)' \
+                            '3:pr command:(create status checks ready merge)' \
+                            '--no-fixes[Do not add an issue-closing line derived from the branch]' \
+                            '(-h --help)'{-h,--help}'[Show help text]'
+                    else
+                        _arguments '2:gh area:(issue pr branch worktree project)' \
+                            '3:pr command:(create status checks ready merge)' \
+                            '(-h --help)'{-h,--help}'[Show help text]'
+                    fi
                     ;;
                 branch)
-                    _arguments '1:gh area:(issue pr branch worktree project)' \
-                        '2:branch command:(stale prune)' \
-                        '--days[Stale threshold in days]:days:' \
-                        '--dry-run[Show planned deletions]' \
-                        '--yes[Apply branch pruning]' \
-                        '--remote[Prune stale remote tracking refs]' \
-                        '(-h --help)'{-h,--help}'[Show help text]'
+                    if [[ "${words[4]:-}" == stale ]]; then
+                        _arguments '2:gh area:(issue pr branch worktree project)' \
+                            '3:branch command:(stale prune)' \
+                            '--days[Stale threshold in days]:days:' \
+                            '(-h --help)'{-h,--help}'[Show help text]'
+                    elif [[ "${words[4]:-}" == prune ]]; then
+                        _arguments '2:gh area:(issue pr branch worktree project)' \
+                            '3:branch command:(stale prune)' \
+                            '--dry-run[Show planned deletions]' \
+                            '--yes[Apply branch pruning]' \
+                            '--remote[Prune stale remote tracking refs]' \
+                            '(-h --help)'{-h,--help}'[Show help text]'
+                    else
+                        _arguments '2:gh area:(issue pr branch worktree project)' \
+                            '3:branch command:(stale prune)'
+                    fi
                     ;;
                 worktree)
-                    _arguments '1:gh area:(issue pr branch worktree project)' \
-                        '2:worktree command:(prune)' \
+                    _arguments '2:gh area:(issue pr branch worktree project)' \
+                        '3:worktree command:(prune)' \
                         '--dry-run[Show planned removals]' \
                         '--yes[Apply worktree pruning]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
@@ -749,16 +787,16 @@ _base_basectl_completion() {
                 project)
                     case "${words[4]:-}" in
                         doctor)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:project command:(doctor configure issue)' \
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:project command:(doctor configure issue)' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
                                 '--schema[Project metadata schema]:schema:(base-project)' \
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         configure)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:project command:(doctor configure issue)' \
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:project command:(doctor configure issue)' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
                                 '--schema[Project metadata schema]:schema:(base-project)' \
@@ -771,10 +809,10 @@ _base_basectl_completion() {
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         issue)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:project command:(doctor configure issue)' \
-                                '3:issue command:(set-fields)' \
-                                '4:issue number:' \
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:project command:(doctor configure issue)' \
+                                '4:issue command:(set-fields)' \
+                                '5:issue number:' \
                                 '--repo[GitHub repository]:repo:' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
@@ -788,13 +826,13 @@ _base_basectl_completion() {
                                 '(-h --help)'{-h,--help}'[Show help text]'
                             ;;
                         *)
-                            _arguments '1:gh area:(issue pr branch worktree project)' \
-                                '2:project command:(doctor configure issue)'
+                            _arguments '2:gh area:(issue pr branch worktree project)' \
+                                '3:project command:(doctor configure issue)'
                             ;;
                     esac
                     ;;
                 *)
-                    _arguments '1:gh area:(issue pr branch worktree project)'
+                    _arguments '2:gh area:(issue pr branch worktree project)'
                     ;;
             esac
             ;;
@@ -805,7 +843,7 @@ _base_basectl_completion() {
                 '--no-profile[Skip shell profile updates]' \
                 '-v[Enable DEBUG logging]' \
                 '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
@@ -819,7 +857,7 @@ _base_basectl_completion() {
         update)
             _arguments '--dry-run[Log without pulling or running setup]' '-v[Enable DEBUG logging]' \
                 '(-h --help)'{-h,--help}'[Show help text]' \
-                '1:Base project:->projects'
+                '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -505,6 +505,7 @@ _base_basectl_completion() {
                         '2:path:_files' \
                         '--agent-guidance[Include optional agent guidance files]' \
                         '--agent-ready[Include the agent-ready repo guidance contract]' \
+                        '--release[Include the release contract and process document]' \
                         '-v[Enable DEBUG logging]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
@@ -606,12 +607,25 @@ _base_basectl_completion() {
             fi
             ;;
         release)
-            _arguments '1:release command:(check plan notes publish)' \
-                '--version[Release version]:version:' \
-                '--manifest[Use a specific manifest]:path:_files' \
-                '--dry-run[Print publish actions without creating tags or releases]' \
-                '--yes[Publish without an interactive confirmation prompt]' \
-                '(-h --help)'{-h,--help}'[Show help text]'
+            case "${words[3]:-}" in
+                check|plan|notes)
+                    _arguments '1:release command:(check plan notes publish)' \
+                        '--version[Release version]:version:' \
+                        '--manifest[Use a specific manifest]:path:_files' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                publish)
+                    _arguments '1:release command:(check plan notes publish)' \
+                        '--version[Release version]:version:' \
+                        '--manifest[Use a specific manifest]:path:_files' \
+                        '--dry-run[Print publish actions without creating tags or releases]' \
+                        '--yes[Publish without an interactive confirmation prompt]' \
+                        '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                *)
+                    _arguments '1:release command:(check plan notes publish)'
+                    ;;
+            esac
             ;;
         clean)
             _arguments '--older-than[Artifact age]:age:' \
@@ -636,10 +650,12 @@ _base_basectl_completion() {
                 '--status[Filter by status]:status:(ok warn error)' \
                 '--limit[Number of records]:count:' \
                 '--format[Output format]:format:(text json)' \
+                '--report[Print a privacy-conscious Markdown or JSON activity report]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         config)
-            _arguments '1:config command:(path show doctor)'
+            _arguments '1:config command:(path show doctor)' \
+                '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         doctor)
             case "${words[3]:-}" in
@@ -746,6 +762,8 @@ _base_basectl_completion() {
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
                                 '--schema[Project metadata schema]:schema:(base-project)' \
+                                '--config[Project intake config]:path:_files' \
+                                '--copy-fields-from[Copy missing field values from another Project]:title:' \
                                 '--initiative-option[Initiative option to seed]:name:' \
                                 '--repo[GitHub repository]:repo:' \
                                 '--replace-project[Replace a nonstandard existing Project from base-project-template]' \
@@ -760,6 +778,7 @@ _base_basectl_completion() {
                                 '--repo[GitHub repository]:repo:' \
                                 '--project[GitHub Project title]:title:' \
                                 '--owner[GitHub Project owner]:owner:' \
+                                '--config[Project intake config]:path:_files' \
                                 '--status[Status option]:status:' \
                                 '--priority[Priority option]:priority:' \
                                 '--area[Area option]:area:' \
@@ -804,6 +823,20 @@ _base_basectl_completion() {
             if [[ "$state" == projects ]]; then
                 _base_basectl_completion_describe_projects
             fi
+            ;;
+        version)
+            _arguments '(-h --help)'{-h,--help}'[Show help text]'
+            ;;
+        help)
+            local -a help_words
+            local help_current="$CURRENT"
+
+            help_words=("${words[@]}")
+            words=("$help_words[1]" "${help_words[@]:2}")
+            CURRENT=$((help_current - 1))
+            _base_basectl_completion
+            words=("${help_words[@]}")
+            CURRENT="$help_current"
             ;;
     esac
 }

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -290,8 +290,29 @@ run_zsh_positional_completion() {
     assert_bash_completion_options_match_help devcontainer devcontainer
     assert_bash_completion_options_match_help devenv-report devenv-report
     assert_bash_completion_options_match_help repo-init repo init
+    assert_bash_completion_options_match_help repo-check repo check
     assert_bash_completion_options_match_help repo-configure repo configure
     assert_bash_completion_options_match_help repo-installer-template repo installer-template
+    assert_bash_completion_options_match_help release-check release check
+    assert_bash_completion_options_match_help release-plan release plan
+    assert_bash_completion_options_match_help release-notes release notes
+    assert_bash_completion_options_match_help release-publish release publish
+}
+
+@test "Bash help completion mirrors command and nested leaf candidates" {
+    local direct nested
+
+    direct="$(bash_completion_candidates basectl "" | sort)"
+    nested="$(bash_completion_candidates basectl help "" | sort)"
+    [ "$nested" = "$direct" ]
+
+    direct="$(bash_completion_candidates basectl release "" | sort)"
+    nested="$(bash_completion_candidates basectl help release "" | sort)"
+    [ "$nested" = "$direct" ]
+
+    direct="$(bash_completion_candidates basectl gh project "" | sort)"
+    nested="$(bash_completion_candidates basectl help gh project "" | sort)"
+    [ "$nested" = "$direct" ]
 }
 
 @test "Bash ci alias option completions match canonical command help" {
@@ -386,6 +407,56 @@ run_zsh_positional_completion() {
     block="$(zsh_completion_deep_nested_block gh project configure)"
 
     [[ "$block" == *"--replace-project"* ]]
+    [[ "$block" == *"--config"* ]]
+    [[ "$block" == *"--copy-fields-from"* ]]
+}
+
+@test "Zsh gh project issue completion includes config option" {
+    local block
+
+    block="$(zsh_completion_deep_nested_block gh project issue)"
+
+    [[ "$block" == *"--config"* ]]
+}
+
+@test "Zsh history completion includes report option" {
+    local block
+
+    block="$(
+        awk '
+            /^[[:space:]]*history\)/ { in_block = 1 }
+            in_block && /^[[:space:]]*;;/ { exit }
+            in_block { print }
+        ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
+    )"
+
+    [[ "$block" == *"--report"* ]]
+}
+
+@test "Zsh release completion scopes publish-only options" {
+    local block
+
+    block="$(sed -n '/^[[:space:]]*release)$/,/^[[:space:]]*clean)$/p' \
+        "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh")"
+
+    [[ "$block" == *"check|plan|notes)"* ]]
+    [[ "$block" == *"publish)"* ]]
+    [[ "$block" == *"--dry-run"* ]]
+    [[ "$block" == *"--yes"* ]]
+}
+
+@test "Zsh help completion delegates to normal command completion" {
+    local block
+
+    block="$(
+        awk '
+            /^[[:space:]]*help\)/ { in_block = 1 }
+            in_block && /^[[:space:]]*;;/ { exit }
+            in_block { print }
+        ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
+    )"
+
+    [[ "$block" == *"_base_basectl_completion"* ]]
 }
 
 @test "Zsh prompt completion includes output option" {

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -77,8 +77,9 @@ bash_completion_nested_commands() {
 zsh_completion_nested_commands() {
     local area="$1"
 
-    awk -v area="$area" '
-        $0 ~ "1:" area " command:\\(" {
+    zsh_completion_specs basectl "$area" "" |
+        awk -v area="$area" '
+        $0 ~ "^spec=2:" area " command:\\(" {
             line = $0
             sub(/.*command:\(/, "", line)
             sub(/\).*/, "", line)
@@ -90,7 +91,36 @@ zsh_completion_nested_commands() {
             }
             exit
         }
-    ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh" |
+    ' |
+        sort -u
+}
+
+zsh_completion_specs() {
+    env BASE_HOME="$BASE_REPO_ROOT" zsh -fc '
+        compdef() { :; }
+        source "$BASE_HOME/lib/shell/completions/basectl_completion.zsh"
+        _arguments() {
+            printf "spec=%s\n" "$@"
+        }
+        _describe() { :; }
+        _alternative() { :; }
+        words=("$@")
+        CURRENT=${#words}
+        _base_basectl_completion
+    ' zsh "$@"
+}
+
+zsh_completion_long_options() {
+    zsh_completion_specs "$@" |
+        awk '
+            {
+                line = $0
+                while (match(line, /--[-A-Za-z0-9_]+/)) {
+                    print substr(line, RSTART, RLENGTH)
+                    line = substr(line, RSTART + RLENGTH)
+                }
+            }
+        ' |
         sort -u
 }
 
@@ -167,6 +197,20 @@ assert_bash_completion_options_match_help() {
 
     long_options_from_help "$@" > "$expected"
     bash_completion_long_options basectl "$@" -- > "$actual"
+
+    bats_run diff -u "$expected" "$actual"
+
+    [ "$status" -eq 0 ]
+}
+
+assert_zsh_completion_options_match_help() {
+    local label="$1"
+    shift
+    local expected="$TEST_TMPDIR/zsh-$label-help-options"
+    local actual="$TEST_TMPDIR/zsh-$label-completion-options"
+
+    long_options_from_help "$@" > "$expected"
+    zsh_completion_long_options basectl "$@" -- > "$actual"
 
     bats_run diff -u "$expected" "$actual"
 
@@ -285,6 +329,7 @@ run_zsh_positional_completion() {
 
 @test "Bash option completions match command help" {
     assert_bash_completion_options_match_help setup setup
+    assert_bash_completion_options_match_help activate activate
     assert_bash_completion_options_match_help check check
     assert_bash_completion_options_match_help doctor doctor
     assert_bash_completion_options_match_help devcontainer devcontainer
@@ -297,6 +342,36 @@ run_zsh_positional_completion() {
     assert_bash_completion_options_match_help release-plan release plan
     assert_bash_completion_options_match_help release-notes release notes
     assert_bash_completion_options_match_help release-publish release publish
+    assert_bash_completion_options_match_help trust-status trust status
+    assert_bash_completion_options_match_help trust-allow trust allow
+    assert_bash_completion_options_match_help trust-revoke trust revoke
+    assert_bash_completion_options_match_help prompt-list prompt list
+    assert_bash_completion_options_match_help prompt-render prompt product-self-review
+    assert_bash_completion_options_match_help logs logs
+    assert_bash_completion_options_match_help logs-last logs last
+    assert_bash_completion_options_match_help gh-branch-stale gh branch stale
+    assert_bash_completion_options_match_help gh-branch-prune gh branch prune
+    assert_bash_completion_options_match_help gh-project-doctor gh project doctor
+    assert_bash_completion_options_match_help gh-project-configure gh project configure
+}
+
+@test "Zsh option completions match focused leaf help" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
+    assert_zsh_completion_options_match_help activate activate
+    assert_zsh_completion_options_match_help trust-status trust status
+    assert_zsh_completion_options_match_help trust-allow trust allow
+    assert_zsh_completion_options_match_help trust-revoke trust revoke
+    assert_zsh_completion_options_match_help release-check release check
+    assert_zsh_completion_options_match_help release-publish release publish
+    assert_zsh_completion_options_match_help prompt-list prompt list
+    assert_zsh_completion_options_match_help prompt-render prompt product-self-review
+    assert_zsh_completion_options_match_help logs logs
+    assert_zsh_completion_options_match_help logs-last logs last
+    assert_zsh_completion_options_match_help gh-branch-stale gh branch stale
+    assert_zsh_completion_options_match_help gh-branch-prune gh branch prune
+    assert_zsh_completion_options_match_help gh-project-doctor gh project doctor
+    assert_zsh_completion_options_match_help gh-project-configure gh project configure
 }
 
 @test "Bash help completion mirrors command and nested leaf candidates" {
@@ -365,6 +440,83 @@ run_zsh_positional_completion() {
     [[ "$output" == *"projects=base demo"* ]]
 }
 
+@test "Zsh public nested and positional completions use executable argument positions" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
+    run_zsh_positional_completion basectl projects ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:projects command:(list)"* ]]
+
+    run_zsh_positional_completion basectl trust allow ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:Base project:->projects"* ]]
+    [[ "$output" == *"projects=base demo"* ]]
+
+    run_zsh_positional_completion basectl workspace init ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:workspace source:"* ]]
+
+    run_zsh_positional_completion basectl test ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:Base project:->projects"* ]]
+
+    run_zsh_positional_completion basectl run demo ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:Project command:"* ]]
+
+    run_zsh_positional_completion basectl prompt ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:prompt:(list product-self-review)"* ]]
+
+    run_zsh_positional_completion basectl repo ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:repo command:(init clone check configure agent-guidance installer-template)"* ]]
+
+    run_zsh_positional_completion basectl repo check ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:path:_files"* ]]
+
+    run_zsh_positional_completion basectl release ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:release command:(check plan notes publish)"* ]]
+
+    run_zsh_positional_completion basectl logs ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:logs command:(last)"* ]]
+
+    run_zsh_positional_completion basectl config ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:config command:(path show doctor)"* ]]
+
+    run_zsh_positional_completion basectl doctor explain ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:finding id:"* ]]
+
+    run_zsh_positional_completion basectl gh ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:gh area:(issue pr branch worktree project)"* ]]
+
+    run_zsh_positional_completion basectl gh issue ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=3:issue command:(list create start readiness)"* ]]
+
+    run_zsh_positional_completion basectl gh issue readiness ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=4:issue number:"* ]]
+
+    run_zsh_positional_completion basectl gh project issue set-fields ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=5:issue number:"* ]]
+
+    run_zsh_positional_completion basectl onboard ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:Base project:->projects"* ]]
+
+    run_zsh_positional_completion basectl update ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"positional=2:Base project:->projects"* ]]
+}
+
 @test "Zsh repo installer-template completion includes print options" {
     local block
 
@@ -375,18 +527,19 @@ run_zsh_positional_completion() {
 }
 
 @test "Zsh gh issue completion includes issue create project options" {
-    local block
+    local options specs
 
-    block="$(zsh_completion_nested_block gh issue)"
+    specs="$(zsh_completion_specs basectl gh issue "")"
+    options="$(zsh_completion_long_options basectl gh issue create --)"
 
-    [[ "$block" == *"2:issue command:(list create start readiness)"* ]]
-    [[ "$block" == *"--repo"* ]]
-    [[ "$block" == *"--assignee"* ]]
-    [[ "$block" == *"--no-assignee"* ]]
-    [[ "$block" == *"--project"* ]]
-    [[ "$block" == *"--project-owner"* ]]
-    [[ "$block" == *"--size"* ]]
-    [[ "$block" == *"--no-project"* ]]
+    [[ "$specs" == *"3:issue command:(list create start readiness)"* ]]
+    [[ "$options" == *"--repo"* ]]
+    [[ "$options" == *"--assignee"* ]]
+    [[ "$options" == *"--no-assignee"* ]]
+    [[ "$options" == *"--project"* ]]
+    [[ "$options" == *"--project-owner"* ]]
+    [[ "$options" == *"--size"* ]]
+    [[ "$options" == *"--no-project"* ]]
 }
 
 @test "Zsh gh issue start completion includes repository selectors" {
@@ -460,17 +613,13 @@ run_zsh_positional_completion() {
 }
 
 @test "Zsh prompt completion includes output option" {
-    local block
+    local list_options render_options
 
-    block="$(
-        awk '
-            /^[[:space:]]*prompt\)/ { in_block = 1 }
-            in_block && /^[[:space:]]*;;/ { exit }
-            in_block { print }
-        ' "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.zsh"
-    )"
+    list_options="$(zsh_completion_long_options basectl prompt list --)"
+    render_options="$(zsh_completion_long_options basectl prompt product-self-review --)"
 
-    [[ "$block" == *"--output"* ]]
+    [[ "$list_options" != *"--output"* ]]
+    [[ "$render_options" == *"--output"* ]]
 }
 
 @test "Bash project-name completions reuse shell-session project cache" {
@@ -525,7 +674,15 @@ EOF
             COMP_WORDS=(basectl ci doctor ""); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
-            printf "ci-doctor=%s\n" "${COMPREPLY[*]}"' \
+            printf "ci-doctor=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl setup --profile dev ""); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "setup-after-options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl test --workspace /tmp ""); \
+            COMP_CWORD=4; \
+            _base_basectl_completion; \
+            printf "test-after-options=%s\n" "${COMPREPLY[*]}"' \
             bash "$BASE_REPO_ROOT/lib/shell/completions/basectl_completion.sh"
 
     [ "$status" -eq 0 ]
@@ -535,6 +692,8 @@ EOF
     [[ "$output" == *"ci-setup=base demo"* ]]
     [[ "$output" == *"ci-check=base demo"* ]]
     [[ "$output" == *"ci-doctor=base demo"* ]]
+    [[ "$output" == *"setup-after-options=base demo"* ]]
+    [[ "$output" == *"test-after-options=base demo"* ]]
     [ "$(cat "$count_file")" = "1" ]
 }
 

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -323,6 +323,8 @@ run_zsh_positional_completion() {
 }
 
 @test "Zsh nested command completions match command help" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
     assert_nested_completion_matches_help workspace zsh
     assert_nested_completion_matches_help repo zsh
 }
@@ -529,6 +531,8 @@ run_zsh_positional_completion() {
 @test "Zsh gh issue completion includes issue create project options" {
     local options specs
 
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
+
     specs="$(zsh_completion_specs basectl gh issue "")"
     options="$(zsh_completion_long_options basectl gh issue create --)"
 
@@ -614,6 +618,8 @@ run_zsh_positional_completion() {
 
 @test "Zsh prompt completion includes output option" {
     local list_options render_options
+
+    command -v zsh >/dev/null 2>&1 || skip "zsh is not available"
 
     list_options="$(zsh_completion_long_options basectl prompt list --)"
     render_options="$(zsh_completion_long_options basectl prompt product-self-review --)"


### PR DESCRIPTION
## Summary

- give documented public leaves focused help and make nested `basectl help` equivalent
- reject trailing arguments for exact commands and keep private Python runtime flags out of public help
- align Bash and Zsh command, positional, and option completion with the selected leaf
- regroup root help around onboarding and the daily project loop, with updated command inventories and docs
- add a 69-leaf help matrix plus focused Bash/Zsh parity regressions

## Validation

- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test`
  - 969 Python tests passed, 1 skipped
  - 768 BATS tests passed
- focused help/completion matrix: 122 BATS tests passed
- `bash -n`, `zsh -n`, ShellCheck warning+, and `git diff --check`

Fixes #1645
