### PR TITLE
Keep shell-only projects healthy without a project venv

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -55,6 +55,13 @@ an explicit Bash script, or an interactive Base runtime shell.
 with the selected project virtual environment and a `PYTHONPATH` that includes
 Base's `lib/python` and `cli/python`.
 
+Project Python ownership is explicit. A top-level `python:` mapping (including
+`python: {}`) or a `python-package` artifact requires a project runtime.
+Shell-only manifests use Base's own venv for setup/check/doctor control-plane
+work, do not inherit Base bootstrap packages into a project venv, and report
+workspace venv state as `not_applicable`. `project.languages` remains taxonomy.
+The broader runtime separation remains tracked in #1611.
+
 When Bash needs metadata from `base_projects` or the `base_setup` route action,
 it requests the internal versioned `command-protocol` format. Records have
 explicit schemas, field names, string/boolean/null types, and hex-framed UTF-8

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -24,6 +24,9 @@ The current command surface covers:
 - explicit `repo init --language` profiles with normalized
   `project.languages` metadata and Python uv opt-in
 - project Python runtime requirements through `python.requires_python`
+- shell-only setup/check/doctor routing through the Base-owned runtime without
+  a control-plane-only project venv; explicit `python:` and `python-package`
+  manifests keep project Python ownership
 - cleanup, logs, local command history, and privacy-conscious history reports
 - local config inspection
 - guided project onboarding and read-only workspace onboarding summaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Aligned `basectl` leaf help, exact-command argument errors, and Bash/Zsh
   completions, including scoped release options and GitHub Project flags, while
   grouping root help around the first-run and daily project journeys.
+- Stopped shell-only project setup, check, doctor, workspace status, and
+  onboarding from requiring a project virtual environment solely to host
+  Base's own Python control-plane dependencies. Manifests that explicitly
+  declare `python:` or a `python-package` artifact keep the existing project
+  Python environment behavior.
 - Made `basectl onboard --yes` reach unattended setup consent and added a
   read-only, workspace-wide manifest trust review step that never grants trust
   automatically or prompts for metadata-only manifests.

--- a/README.md
+++ b/README.md
@@ -607,6 +607,12 @@ For uv-managed projects, Base delegates setup to `uv sync`, uses the
 project-local `.venv` for activation and project commands, and skips
 Base-managed `python-package` reconciliation. See
 [Python Manifest Section](docs/python-manifest.md).
+Projects without a top-level `python:` section or any `python-package`
+artifacts are treated as shell-only for setup and diagnostics. Base parses and
+reconciles those manifests from its own runtime, does not create a project
+`.venv` for its control plane, and reports workspace venv state as
+`not_applicable`. An explicit `python: {}` keeps the existing Base-managed
+project venv contract; `project.languages: [python]` remains taxonomy only.
 Use `basectl check <project> --format json` for detailed runtime diagnostics
 and `basectl workspace status --format json` to compare actual project Python
 versions across a workspace.
@@ -1262,10 +1268,12 @@ exec "$BASE_HOME/bin/base-wrapper" --project "${BASE_PROJECT:-example}" example_
 reproducible across machines. The current default is `python@3.13`. Override it
 with `BASE_SETUP_PYTHON_FORMULA` when a workspace needs a different formula.
 After this Bash bootstrap layer creates Base's own Python environment, setup
-installs Base bootstrap Python packages into that environment. For project
-artifact setup, Base first seeds the target project venv with `bootstrap: true`
-default artifacts and then invokes the Python project setup layer through
-`base-wrapper --project <project>`.
+installs Base bootstrap Python packages into that environment. Shell-only
+project reconciliation runs from that Base runtime and does not copy those
+packages into a project venv. Projects that explicitly declare `python:` or a
+`python-package` artifact keep the project-runtime path: Base first seeds the
+target project venv with `bootstrap: true` default artifacts and then invokes
+the Python project setup layer through `base-wrapper --project <project>`.
 Prerequisite profiles are opt-in. Use `--profile dev` to install Base
 contributor tools from `lib/base/dev_manifest.yaml`. On macOS that includes
 Homebrew-managed BATS, GitHub CLI, and ShellCheck. On Ubuntu/Debian it installs

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -1034,7 +1034,7 @@ setup_run_project_artifact_layer() {
         log_error "Unable to resolve Base project environment for '$project'."
         return 1
     }
-    base_command_protocol_decode_one project-route "$route_output" || {
+    base_command_protocol_decode_one project-setup-route "$route_output" || {
         log_error "Python project routing returned invalid metadata for '$project'."
         return 1
     }

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -1003,7 +1003,7 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path platform precheck_json project project_uses_uv_manager project_venv_dir python_bin remote_network resolved_root route_output venv_dir
+    local exit_code manifest_path platform precheck_json project project_requires_python project_uses_uv_manager project_venv_dir python_bin remote_network resolved_root route_output venv_dir
     local args=()
     local project_env_args=()
 
@@ -1043,12 +1043,17 @@ setup_run_project_artifact_layer() {
     manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
     project_venv_dir="${BASE_COMMAND_PROTOCOL_FIELDS[project_venv_dir]}"
     project_uses_uv_manager="${BASE_COMMAND_PROTOCOL_FIELDS[uses_uv_manager]}"
+    project_requires_python="${BASE_COMMAND_PROTOCOL_FIELDS[requires_project_python]}"
     if [[ -z "$project" || -z "$resolved_root" || -z "$manifest_path" || -z "$project_venv_dir" ]]; then
         log_error "Python project routing returned incomplete metadata for '$project'."
         return 1
     fi
     if [[ "$project_uses_uv_manager" != true && "$project_uses_uv_manager" != false ]]; then
         log_error "Python project routing returned invalid uv-manager metadata for '$project'."
+        return 1
+    fi
+    if [[ "$project_requires_python" != true && "$project_requires_python" != false ]]; then
+        log_error "Python project routing returned invalid project-Python metadata for '$project'."
         return 1
     fi
     if [[ "$project" == base ]]; then
@@ -1084,7 +1089,7 @@ setup_run_project_artifact_layer() {
         fi
     fi
 
-    if [[ "$action" == setup && "$project_uses_uv_manager" != true ]]; then
+    if [[ "$action" == setup && "$project_requires_python" == true && "$project_uses_uv_manager" != true ]]; then
         setup_run_project_bootstrap_layer "$manifest_path" "$project" "$output_format" "$resolved_root" "$project_venv_dir"
         exit_code=$?
         if ((exit_code)); then
@@ -1094,7 +1099,7 @@ setup_run_project_artifact_layer() {
         fi
     fi
 
-    if [[ "$project_uses_uv_manager" != true ]] && ! setup_virtualenv_healthy_path "$project_venv_dir"; then
+    if [[ "$project_requires_python" == true && "$project_uses_uv_manager" != true ]] && ! setup_virtualenv_healthy_path "$project_venv_dir"; then
         if setup_is_dry_run && [[ "$action" == setup ]]; then
             log_info "[DRY-RUN] Would run Python project setup layer through base-wrapper for project '$project'."
             return 0
@@ -1137,7 +1142,7 @@ setup_run_project_artifact_layer() {
         return 1
     fi
 
-    if [[ "$project_uses_uv_manager" == true ]]; then
+    if [[ "$project_uses_uv_manager" == true || "$project_requires_python" != true ]]; then
         env "${project_env_args[@]}" \
             BASE_HOME="$BASE_HOME" \
             BASE_PLATFORM="$platform" \

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -364,7 +364,7 @@ EOF
     touch "$TEST_STATE_DIR/python-installed"
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
-    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$base_venv_dir"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$demo_venv_dir"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$inherited_venv"
@@ -425,7 +425,7 @@ EOF
     touch "$TEST_STATE_DIR/python-installed"
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
-    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
     resolved_demo_root="$(cd "$workspace/demo" && pwd -P)"
 
@@ -465,6 +465,30 @@ EOF
     [[ "$output" != *"$workspace/demo/.venv"* ]]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$manifest_path" --action check --format json demo)" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
+}
+
+@test "basectl check shell-only project runs from Base runtime without project venv" {
+    local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local project_root="$TEST_TMPDIR/shell-only"
+    local manifest_path="$project_root/base_manifest.yaml"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$project_root"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_project_setup_venv_stub "$base_venv_dir"
+    cp "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml" "$manifest_path"
+
+    run_base_command check shell-only --manifest "$manifest_path"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$project_root/.venv" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-python")" = "$base_venv_dir/bin/python" ]
+    [[ "$output" != *"Project virtual environment"* ]]
+    [[ "$output" != *"BASE-P050"* ]]
 }
 
 @test "basectl check project passes opt-in remote network diagnostics flag" {
@@ -783,7 +807,7 @@ EOF
     touch "$TEST_STATE_DIR/bats-installed"
     touch "$TEST_STATE_DIR/pyyaml-installed"
     touch "$TEST_STATE_DIR/click-installed"
-    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$workspace/demo/.venv"
     printf 'home = %s\n' "$missing_home" > "$workspace/demo/.venv/pyvenv.cfg"

--- a/cli/bash/commands/basectl/tests/ci.bats
+++ b/cli/bash/commands/basectl/tests/ci.bats
@@ -14,6 +14,8 @@ schema_version: 1
 
 project:
   name: $project
+
+python: {}
 EOF
 }
 

--- a/cli/bash/commands/basectl/tests/command-protocol.bats
+++ b/cli/bash/commands/basectl/tests/command-protocol.bats
@@ -23,6 +23,22 @@ load ./basectl_helpers.bash
     [ "$output" = decoded ]
 }
 
+@test "project Python requirement metadata is scoped to setup routes" {
+    run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
+        source "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash"
+        source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
+        route_payload="$(base_test_protocol_project_route demo /tmp/demo /tmp/demo/base_manifest.yaml /tmp/demo/.venv false false)"
+        base_command_protocol_decode_one project-route "$route_payload" || exit
+        [[ -z "${BASE_COMMAND_PROTOCOL_FIELDS[requires_project_python]+present}" ]]
+
+        setup_payload="$(base_test_protocol_project_setup_route demo /tmp/demo /tmp/demo/base_manifest.yaml /tmp/demo/.venv false false false)"
+        base_command_protocol_decode_one project-setup-route "$setup_payload" || exit
+        [[ "${BASE_COMMAND_PROTOCOL_FIELDS[requires_project_python]}" == false ]]
+    '
+
+    [ "$status" -eq 0 ]
+}
+
 @test "command protocol distinguishes an empty string from null" {
     run env BASE_REPO_ROOT="$BASE_REPO_ROOT" "$BASH" -c '
         source "$BASE_REPO_ROOT/lib/bash/runtime/command_protocol.sh"
@@ -35,7 +51,6 @@ field.project_root:string=2f746d702f64656d6f
 field.manifest_path:string=2f746d702f64656d6f2f626173655f6d616e69666573742e79616d6c
 field.project_venv_dir:string=2f746d702f64656d6f2f2e76656e76
 field.uses_uv_manager:boolean=false
-field.requires_project_python:boolean=true
 field.manifest_command_trust_required:boolean=true
 field.command:string=7072696e7466206f6b
 field.runner:string=

--- a/cli/bash/commands/basectl/tests/command-protocol.bats
+++ b/cli/bash/commands/basectl/tests/command-protocol.bats
@@ -35,6 +35,7 @@ field.project_root:string=2f746d702f64656d6f
 field.manifest_path:string=2f746d702f64656d6f2f626173655f6d616e69666573742e79616d6c
 field.project_venv_dir:string=2f746d702f64656d6f2f2e76656e76
 field.uses_uv_manager:boolean=false
+field.requires_project_python:boolean=true
 field.manifest_command_trust_required:boolean=true
 field.command:string=7072696e7466206f6b
 field.runner:string=

--- a/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
+++ b/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
@@ -47,23 +47,29 @@ base_test_protocol_project_reference_record() {
 }
 
 base_test_protocol_project_route_record() {
+    local requires_project_python="${8:-true}"
+
     printf 'record=%s\n' "$1"
     base_test_protocol_string project_name "$2"
     base_test_protocol_string project_root "$3"
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
     printf 'end_record=%s\n' "$1"
 }
 
 base_test_protocol_project_command_record() {
+    local requires_project_python="${10:-true}"
+
     printf 'record=%s\n' "$1"
     base_test_protocol_string project_name "$2"
     base_test_protocol_string project_root "$3"
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
     base_test_protocol_string command "$8"
     base_test_protocol_nullable_string runner "${9:-}"
@@ -86,6 +92,7 @@ base_test_protocol_build_target_record() {
     local command="${10}"
     local description="${11:-}"
     local runner="${12:-}"
+    local requires_project_python="${13:-true}"
 
     printf 'record=%s\n' "$record_index"
     base_test_protocol_string project_name "$2"
@@ -93,6 +100,7 @@ base_test_protocol_build_target_record() {
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
     base_test_protocol_string target_name "$8"
     base_test_protocol_string working_dir "$9"
@@ -103,12 +111,15 @@ base_test_protocol_build_target_record() {
 }
 
 base_test_protocol_demo_record() {
+    local requires_project_python="${10:-true}"
+
     printf 'record=%s\n' "$1"
     base_test_protocol_string project_name "$2"
     base_test_protocol_string project_root "$3"
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
     base_test_protocol_string demo_script "$8"
     base_test_protocol_nullable_string runner "${9:-}"

--- a/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
+++ b/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
@@ -47,6 +47,17 @@ base_test_protocol_project_reference_record() {
 }
 
 base_test_protocol_project_route_record() {
+    printf 'record=%s\n' "$1"
+    base_test_protocol_string project_name "$2"
+    base_test_protocol_string project_root "$3"
+    base_test_protocol_string manifest_path "$4"
+    base_test_protocol_string project_venv_dir "$5"
+    base_test_protocol_boolean uses_uv_manager "$6"
+    base_test_protocol_boolean manifest_command_trust_required "$7"
+    printf 'end_record=%s\n' "$1"
+}
+
+base_test_protocol_project_setup_route_record() {
     local requires_project_python="${8:-true}"
 
     printf 'record=%s\n' "$1"
@@ -55,21 +66,18 @@ base_test_protocol_project_route_record() {
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
-    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
+    base_test_protocol_boolean requires_project_python "$requires_project_python"
     printf 'end_record=%s\n' "$1"
 }
 
 base_test_protocol_project_command_record() {
-    local requires_project_python="${10:-true}"
-
     printf 'record=%s\n' "$1"
     base_test_protocol_string project_name "$2"
     base_test_protocol_string project_root "$3"
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
-    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
     base_test_protocol_string command "$8"
     base_test_protocol_nullable_string runner "${9:-}"
@@ -92,15 +100,12 @@ base_test_protocol_build_target_record() {
     local command="${10}"
     local description="${11:-}"
     local runner="${12:-}"
-    local requires_project_python="${13:-true}"
-
     printf 'record=%s\n' "$record_index"
     base_test_protocol_string project_name "$2"
     base_test_protocol_string project_root "$3"
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
-    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
     base_test_protocol_string target_name "$8"
     base_test_protocol_string working_dir "$9"
@@ -111,15 +116,12 @@ base_test_protocol_build_target_record() {
 }
 
 base_test_protocol_demo_record() {
-    local requires_project_python="${10:-true}"
-
     printf 'record=%s\n' "$1"
     base_test_protocol_string project_name "$2"
     base_test_protocol_string project_root "$3"
     base_test_protocol_string manifest_path "$4"
     base_test_protocol_string project_venv_dir "$5"
     base_test_protocol_boolean uses_uv_manager "$6"
-    base_test_protocol_boolean requires_project_python "$requires_project_python"
     base_test_protocol_boolean manifest_command_trust_required "$7"
     base_test_protocol_string demo_script "$8"
     base_test_protocol_nullable_string runner "${9:-}"
@@ -148,6 +150,12 @@ base_test_protocol_project_reference() {
 base_test_protocol_project_route() {
     base_test_protocol_begin project-route 1
     base_test_protocol_project_route_record 0 "$@"
+    base_test_protocol_end
+}
+
+base_test_protocol_project_setup_route() {
+    base_test_protocol_begin project-setup-route 1
+    base_test_protocol_project_setup_route_record 0 "$@"
     base_test_protocol_end
 }
 

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -934,8 +934,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
-            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
+        base_test_protocol_project_setup_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false true
         exit 0
     fi
     printf 'ok     demo-artifact               Project artifact check passed.\n'
@@ -993,12 +993,12 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" ]]; then
     base_test_protocol_project_route shell-only "${BASE_TEST_PROJECT_ROOT:?}" \
-        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false false
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route shell-only "${BASE_TEST_PROJECT_ROOT:?}" \
+        base_test_protocol_project_setup_route shell-only "${BASE_TEST_PROJECT_ROOT:?}" \
             "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false false
         exit 0
     fi
@@ -1084,8 +1084,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
-            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
+        base_test_protocol_project_setup_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false true
         exit 0
     fi
     printf '%s\n' "$@" > "${BASE_TEST_PROJECT_ARGS:?}"
@@ -1172,8 +1172,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
-            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
+        base_test_protocol_project_setup_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false true
         exit 0
     fi
     printf '[{"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"}]\n'
@@ -1258,8 +1258,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
-            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
+        base_test_protocol_project_setup_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false true
         exit 0
     fi
     printf '%s\n' "$@" > "${BASE_TEST_PROJECT_ARGS:?}"

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -968,6 +968,66 @@ EOF
     [[ "$output" == *"Base doctor found no blocking issues for project 'demo'."* ]]
 }
 
+@test "basectl doctor shell-only project runs from Base runtime without project venv" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local project_root="$TEST_TMPDIR/shell-only"
+    local manifest_path="$project_root/base_manifest.yaml"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$project_root"
+    create_doctor_success_stubs "$fake_bin" "$venv_python"
+    cp "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml" "$manifest_path"
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-c" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
+    case "${4:-}" in
+        PyYAML|click) exit 0 ;;
+    esac
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" ]]; then
+    base_test_protocol_project_route shell-only "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false false
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
+    if [[ "$*" == *"--action route"* ]]; then
+        base_test_protocol_project_route shell-only "${BASE_TEST_PROJECT_ROOT:?}" \
+            "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false false
+        exit 0
+    fi
+    printf '%s\n' "$0" > "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-python"
+    printf 'ok     demo-artifact               Project artifact check passed.\n'
+    exit 0
+fi
+printf 'unexpected doctor shell-only Python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$venv_python"
+
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$project_root" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor shell-only --manifest "$manifest_path"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$project_root/.venv" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-python")" = "$venv_python" ]
+    [[ "$output" != *"Project virtualenv"* ]]
+    [[ "$output" != *"BASE-P050"* ]]
+}
+
 @test "basectl doctor project passes opt-in remote network diagnostics flag" {
     local fake_bin="$TEST_TMPDIR/bin"
     local project_python="$TEST_TMPDIR/workspace/demo/.venv/bin/python"

--- a/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml
+++ b/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+
+project:
+  name: shell-only
+
+artifacts: []

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -304,8 +304,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -406,8 +406,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -890,7 +890,7 @@ EOF
     create_project_setup_venv_stub "$base_venv_dir"
     cp "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml" "$manifest_path"
 
-    run_base_command setup --dry-run --manifest "$manifest_path"
+    run_base_command setup --manifest "$manifest_path"
 
     [ "$status" -eq 0 ]
     [ ! -e "$project_root/.venv" ]

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -471,7 +471,7 @@ EOF
     create_project_setup_venv_stub "$base_venv_dir"
     create_project_setup_venv_stub "$demo_venv_dir"
     create_project_setup_venv_stub "$inherited_venv"
-    printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest_path"
+    printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$manifest_path"
 
     run_base_command \
         BASE_PROJECT=base \
@@ -812,7 +812,7 @@ EOF
     create_project_setup_venv_stub "$base_venv_dir"
     create_project_setup_venv_stub "$demo_venv_dir"
     printf 'base marker\n' > "$base_venv_dir/old.txt"
-    printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest_path"
+    printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$manifest_path"
 
     run_base_command setup --dry-run --manifest "$manifest_path" --recreate-venv demo
 
@@ -873,6 +873,31 @@ EOF
     [ ! -e "$TEST_HOME/.base.d/demo/.venv" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
+}
+
+@test "basectl setup shell-only project runs from Base runtime without project venv" {
+    local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local project_root="$TEST_TMPDIR/shell-only"
+    local manifest_path="$project_root/base_manifest.yaml"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$project_root"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_project_setup_venv_stub "$base_venv_dir"
+    cp "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml" "$manifest_path"
+
+    run_base_command setup --dry-run --manifest "$manifest_path"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$project_root/.venv" ]
+    [ -f "$TEST_STATE_DIR/project-setup-python" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-python")" = "$base_venv_dir/bin/python" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "shell-only" ]
+    [ ! -e "$TEST_STATE_DIR/project-bootstrap-recreate-venv" ]
 }
 
 @test "basectl setup --yes linux-debian forwards consent to uv-managed project setup" {

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -837,6 +837,16 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
         fi
         if awk '
             /^[[:space:]]*#/ { next }
+            /^python:[[:space:]]*/ { found = 1 }
+            /^[[:space:]]*-[[:space:]]+type:[[:space:]]*['\''"]?python-package['\''"]?[[:space:]]*(#.*)?$/ { found = 1 }
+            END { exit found ? 0 : 1 }
+        ' "$manifest_path"; then
+            requires_project_python=true
+        else
+            requires_project_python=false
+        fi
+        if awk '
+            /^[[:space:]]*#/ { next }
             /^[^[:space:]][^:]*:/ { in_python = 0 }
             /^[[:space:]]*python:[[:space:]]*$/ { in_python = 1; next }
             in_python && /^[[:space:]]+venv_location:[[:space:]]*['\''"]?external['\''"]?[[:space:]]*(#.*)?$/ { found = 1 }
@@ -854,13 +864,14 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
             route_venv_dir="$HOME/.base.d/$project_arg/.venv"
         fi
         if [[ "$output_format" == "json" ]]; then
-            printf '{"schema_version":1,"project":"%s","project_root":"%s","manifest_path":"%s","project_venv_dir":"%s","uses_uv_manager":%s}\n' \
-                "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager"
+            printf '{"schema_version":1,"project":"%s","project_root":"%s","manifest_path":"%s","project_venv_dir":"%s","uses_uv_manager":%s,"requires_project_python":%s}\n' \
+                "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager" "$requires_project_python"
         elif [[ "$output_format" == "command-protocol" ]]; then
             base_test_protocol_project_route \
-                "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager" false
+                "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager" false "$requires_project_python"
         else
-            printf '%s\t%s\t%s\t%s\t%s\n' "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager"
+            printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+                "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager" "$requires_project_python"
         fi
         exit 0
     fi

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -179,8 +179,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -382,8 +382,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -434,8 +434,8 @@ VENVEOF
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -549,8 +549,8 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -601,8 +601,8 @@ VENVEOF
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -739,8 +739,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" ==
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
-        base_test_protocol_project_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
-            "$HOME/.base.d/base/.venv" false false
+        base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
+            "$HOME/.base.d/base/.venv" false false true
         exit 0
     fi
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/project-setup-ran"
@@ -867,7 +867,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
             printf '{"schema_version":1,"project":"%s","project_root":"%s","manifest_path":"%s","project_venv_dir":"%s","uses_uv_manager":%s,"requires_project_python":%s}\n' \
                 "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager" "$requires_project_python"
         elif [[ "$output_format" == "command-protocol" ]]; then
-            base_test_protocol_project_route \
+            base_test_protocol_project_setup_route \
                 "$project_arg" "$project_root" "$manifest_path" "$route_venv_dir" "$uses_uv_manager" false "$requires_project_python"
         else
             printf '%s\t%s\t%s\t%s\t%s\t%s\n' \

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -34,6 +34,39 @@ EOF
     [ "$(cat "$TEST_TMPDIR/workspace-status-state")" = "BASE_PROJECT=base" ]
 }
 
+@test "basectl workspace status exposes shell-only fixture venv as not applicable" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local project_root="$TEST_TMPDIR/workspace/shell-only"
+
+    mkdir -p "$(dirname "$python_bin")" "$project_root"
+    cp "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml" \
+        "$project_root/base_manifest.yaml"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "status" ]]; then
+    [[ ! -e "${BASE_TEST_SHELL_PROJECT_ROOT:?}/.venv" ]] || exit 10
+    ! grep -Eq '^[[:space:]]*python:' "${BASE_TEST_SHELL_PROJECT_ROOT:?}/base_manifest.yaml" || exit 11
+    printf '{"schema_version":1,"status":"ok","projects":[{"name":"shell-only","status":"ok","venv":"not_applicable","manifest":"valid","issues":[]}]}\n'
+    exit 0
+fi
+printf 'unexpected shell-only workspace status Python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_SHELL_PROJECT_ROOT="$project_root" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace status \
+        --workspace "$TEST_TMPDIR/workspace" --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"name":"shell-only"'* ]]
+    [[ "$output" == *'"venv":"not_applicable"'* ]]
+    [ ! -e "$project_root/.venv" ]
+}
+
 @test "basectl workspace check delegates to the Python projects layer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/python/base_projects/project_commands.py
+++ b/cli/python/base_projects/project_commands.py
@@ -48,10 +48,12 @@ def project_command(manifest: BaseManifest, command_name: str) -> CommandConfig:
 def route_metadata_fields(manifest: BaseManifest, *, manifest_command_trust_required: bool = False) -> list[str]:
     route = route_for_manifest(manifest)
     uses_uv = "true" if route.uses_uv_manager else "false"
+    requires_python = "true" if route.requires_project_python else "false"
     trust_required = "true" if manifest_command_trust_required else "false"
     return [
         f"__base_project_venv_dir={route.project_venv_dir}",
         f"__base_uses_uv_manager={uses_uv}",
+        f"__base_requires_project_python={requires_python}",
         f"__base_manifest_command_trust_required={trust_required}",
     ]
 
@@ -65,6 +67,7 @@ def route_metadata_record(
     return {
         "project_venv_dir": str(route.project_venv_dir),
         "uses_uv_manager": route.uses_uv_manager,
+        "requires_project_python": route.requires_project_python,
         "manifest_command_trust_required": manifest_command_trust_required,
     }
 

--- a/cli/python/base_projects/project_commands.py
+++ b/cli/python/base_projects/project_commands.py
@@ -48,12 +48,10 @@ def project_command(manifest: BaseManifest, command_name: str) -> CommandConfig:
 def route_metadata_fields(manifest: BaseManifest, *, manifest_command_trust_required: bool = False) -> list[str]:
     route = route_for_manifest(manifest)
     uses_uv = "true" if route.uses_uv_manager else "false"
-    requires_python = "true" if route.requires_project_python else "false"
     trust_required = "true" if manifest_command_trust_required else "false"
     return [
         f"__base_project_venv_dir={route.project_venv_dir}",
         f"__base_uses_uv_manager={uses_uv}",
-        f"__base_requires_project_python={requires_python}",
         f"__base_manifest_command_trust_required={trust_required}",
     ]
 
@@ -67,7 +65,6 @@ def route_metadata_record(
     return {
         "project_venv_dir": str(route.project_venv_dir),
         "uses_uv_manager": route.uses_uv_manager,
-        "requires_project_python": route.requires_project_python,
         "manifest_command_trust_required": manifest_command_trust_required,
     }
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -72,7 +72,6 @@ def base_route_fields(
     *,
     trust_required: bool = True,
     project_root: Path | None = None,
-    requires_project_python: bool = False,
 ) -> str:
     if not _engine_homes:
         raise AssertionError("run_engine must be called before base_route_fields")
@@ -82,12 +81,10 @@ def base_route_fields(
     else:
         resolved_root = project_root if project_root is not None else base_home.parent / project
         venv_dir = (resolved_root / ".venv").resolve()
-    requires_python_value = "true" if requires_project_python else "false"
     trust_value = "true" if trust_required else "false"
     return (
         f"\t__base_project_venv_dir={venv_dir}"
         "\t__base_uses_uv_manager=false"
-        f"\t__base_requires_project_python={requires_python_value}"
         f"\t__base_manifest_command_trust_required={trust_value}"
     )
 
@@ -97,7 +94,6 @@ def uv_route_fields(project_root: Path, *, trust_required: bool = True) -> str:
     return (
         f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
         "\t__base_uses_uv_manager=true"
-        "\t__base_requires_project_python=true"
         f"\t__base_manifest_command_trust_required={trust_value}"
     )
 
@@ -734,7 +730,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'demo', trust_required=False, requires_project_python=True)}\n",
+            f"{base_route_fields(base_home, 'demo', trust_required=False)}\n",
         )
 
     def test_projects_resolve_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
@@ -782,7 +778,6 @@ class ProjectDiscoveryTests(unittest.TestCase):
             "demo",
             trust_required=False,
             project_root=project_root,
-            requires_project_python=True,
         )
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -817,7 +812,6 @@ class ProjectDiscoveryTests(unittest.TestCase):
             "demo",
             trust_required=False,
             project_root=explicit_root,
-            requires_project_python=True,
         )
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -867,7 +861,6 @@ class ProjectDiscoveryTests(unittest.TestCase):
             "demo",
             trust_required=False,
             project_root=project_root,
-            requires_project_python=True,
         )
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -892,7 +885,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'base', trust_required=False, requires_project_python=True)}\n",
+            f"{base_route_fields(base_home, 'base', trust_required=False)}\n",
         )
 
     def test_projects_resolve_base_uses_base_home_with_configured_workspace(self) -> None:
@@ -915,7 +908,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'base', trust_required=False, requires_project_python=True)}\n",
+            f"{base_route_fields(base_home, 'base', trust_required=False)}\n",
         )
 
     def test_projects_test_command_prints_project_details_and_command(self) -> None:
@@ -980,7 +973,6 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tpytest tests/\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
             "\t__base_uses_uv_manager=true"
-            "\t__base_requires_project_python=true"
             "\t__base_manifest_command_trust_required=true\n",
         )
 
@@ -1232,7 +1224,6 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tuvicorn app:app --reload\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
             "\t__base_uses_uv_manager=true"
-            "\t__base_requires_project_python=true"
             "\t__base_manifest_command_trust_required=true\n",
         )
 
@@ -1358,7 +1349,6 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\t{script.resolve()}\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
             "\t__base_uses_uv_manager=true"
-            "\t__base_requires_project_python=true"
             "\t__base_manifest_command_trust_required=true\n",
         )
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -18,6 +18,14 @@ from base_projects import engine, project_discovery
 def write_manifest(project_root: Path, name: str) -> None:
     project_root.mkdir(parents=True)
     (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\npython: {{}}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
+def write_shell_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
         f"project:\n  name: {name}\nartifacts: []\n",
         encoding="utf-8",
     )
@@ -64,18 +72,22 @@ def base_route_fields(
     *,
     trust_required: bool = True,
     project_root: Path | None = None,
+    requires_project_python: bool = False,
 ) -> str:
     if not _engine_homes:
         raise AssertionError("run_engine must be called before base_route_fields")
     if project == "base":
+        resolved_root = base_home
         venv_dir = _engine_homes[-1] / ".base.d" / project / ".venv"
     else:
         resolved_root = project_root if project_root is not None else base_home.parent / project
         venv_dir = (resolved_root / ".venv").resolve()
+    requires_python_value = "true" if requires_project_python else "false"
     trust_value = "true" if trust_required else "false"
     return (
         f"\t__base_project_venv_dir={venv_dir}"
         "\t__base_uses_uv_manager=false"
+        f"\t__base_requires_project_python={requires_python_value}"
         f"\t__base_manifest_command_trust_required={trust_value}"
     )
 
@@ -85,6 +97,7 @@ def uv_route_fields(project_root: Path, *, trust_required: bool = True) -> str:
     return (
         f"\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
         "\t__base_uses_uv_manager=true"
+        "\t__base_requires_project_python=true"
         f"\t__base_manifest_command_trust_required={trust_value}"
     )
 
@@ -503,6 +516,31 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertIn("bankbuddy            ok     ready    valid    -", stdout)
         self.assertIn("All discovered projects look ok.", stdout)
 
+    def test_workspace_status_reports_shell_only_project_venv_not_applicable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            project_root = workspace / "shell-only"
+            write_shell_manifest(project_root, "shell-only")
+
+            status, stdout, stderr = invoke_engine(
+                ["status", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+            self.assertFalse((project_root / ".venv").exists())
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["projects"][0]["status"], "ok")
+        self.assertEqual(payload["projects"][0]["venv"], "not_applicable")
+        self.assertEqual(payload["projects"][0]["issues"], [])
+
     def test_workspace_status_supports_json_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -696,7 +734,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'demo', trust_required=False)}\n",
+            f"{base_route_fields(base_home, 'demo', trust_required=False, requires_project_python=True)}\n",
         )
 
     def test_projects_resolve_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
@@ -739,12 +777,19 @@ class ProjectDiscoveryTests(unittest.TestCase):
                     },
                 )
 
+        route_fields = base_route_fields(
+            base_home,
+            "demo",
+            trust_required=False,
+            project_root=project_root,
+            requires_project_python=True,
+        )
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{manifest_path.resolve()}"
-            f"{base_route_fields(base_home, 'demo', trust_required=False, project_root=project_root)}\n",
+            f"{route_fields}\n",
         )
 
     def test_projects_resolve_explicit_workspace_wins_over_active_project(self) -> None:
@@ -767,12 +812,19 @@ class ProjectDiscoveryTests(unittest.TestCase):
                 },
             )
 
+        route_fields = base_route_fields(
+            base_home,
+            "demo",
+            trust_required=False,
+            project_root=explicit_root,
+            requires_project_python=True,
+        )
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
             f"demo\t{explicit_root.resolve()}\t{(explicit_root / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'demo', trust_required=False, project_root=explicit_root)}\n",
+            f"{route_fields}\n",
         )
 
     def test_projects_resolve_rejects_active_project_manifest_mismatch(self) -> None:
@@ -810,12 +862,19 @@ class ProjectDiscoveryTests(unittest.TestCase):
                 user_config=f"workspace:\n  root: {workspace}\n",
             )
 
+        route_fields = base_route_fields(
+            base_home,
+            "demo",
+            trust_required=False,
+            project_root=project_root,
+            requires_project_python=True,
+        )
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(
             stdout,
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'demo', trust_required=False, project_root=project_root)}\n",
+            f"{route_fields}\n",
         )
 
     def test_projects_resolve_base_uses_base_home_without_workspace_scan(self) -> None:
@@ -833,7 +892,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'base', trust_required=False)}\n",
+            f"{base_route_fields(base_home, 'base', trust_required=False, requires_project_python=True)}\n",
         )
 
     def test_projects_resolve_base_uses_base_home_with_configured_workspace(self) -> None:
@@ -856,7 +915,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(
             stdout,
             f"base\t{base_home.resolve()}\t{(base_home / 'base_manifest.yaml').resolve()}"
-            f"{base_route_fields(base_home, 'base', trust_required=False)}\n",
+            f"{base_route_fields(base_home, 'base', trust_required=False, requires_project_python=True)}\n",
         )
 
     def test_projects_test_command_prints_project_details_and_command(self) -> None:
@@ -921,6 +980,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tpytest tests/\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
             "\t__base_uses_uv_manager=true"
+            "\t__base_requires_project_python=true"
             "\t__base_manifest_command_trust_required=true\n",
         )
 
@@ -1172,6 +1232,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\tuvicorn app:app --reload\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
             "\t__base_uses_uv_manager=true"
+            "\t__base_requires_project_python=true"
             "\t__base_manifest_command_trust_required=true\n",
         )
 
@@ -1297,6 +1358,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"\t{script.resolve()}\t__base_project_venv_dir={(project_root / '.venv').resolve()}"
             "\t__base_uses_uv_manager=true"
+            "\t__base_requires_project_python=true"
             "\t__base_manifest_command_trust_required=true\n",
         )
 

--- a/cli/python/base_projects/tests/test_workspace_agent_brief.py
+++ b/cli/python/base_projects/tests/test_workspace_agent_brief.py
@@ -46,7 +46,7 @@ def write_project_manifest(project_root: Path, name: str, test_command: str | No
     lines = ["project:", f"  name: {name}"]
     if test_command is not None:
         lines.extend(["test:", f"  command: {test_command}"])
-    lines.extend(["artifacts: []", ""])
+    lines.extend(["python: {}", "artifacts: []", ""])
     (project_root / "base_manifest.yaml").write_text("\n".join(lines), encoding="utf-8")
 
 

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -15,6 +15,14 @@ from base_projects import engine
 def write_manifest(project_root: Path, name: str) -> None:
     project_root.mkdir(parents=True)
     (project_root / "base_manifest.yaml").write_text(
+        f"project:\n  name: {name}\npython: {{}}\nartifacts: []\n",
+        encoding="utf-8",
+    )
+
+
+def write_shell_manifest(project_root: Path, name: str) -> None:
+    project_root.mkdir(parents=True)
+    (project_root / "base_manifest.yaml").write_text(
         f"project:\n  name: {name}\nartifacts: []\n",
         encoding="utf-8",
     )
@@ -279,6 +287,31 @@ class WorkspaceCheckTests(unittest.TestCase):
         self.assertIn("BASE-P154", stdout)
         self.assertNotIn("BASE-P050", stdout)
         self.assertIn("All discovered projects passed.", stdout)
+
+    def test_workspace_check_and_doctor_skip_project_venv_for_shell_only_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_shell_manifest(workspace / "shell-only", "shell-only")
+
+            for command in ("check", "doctor"):
+                with self.subTest(command=command):
+                    status, stdout, stderr = invoke_engine(
+                        [command, "--workspace", str(workspace)],
+                        base_home,
+                        home,
+                    )
+                    self.assertEqual(status, 0, stderr)
+                    self.assertIn("Project: shell-only [ok]", stdout)
+                    self.assertNotIn("BASE-P050", stdout + stderr)
+                    self.assertIn("All discovered projects passed.", stdout)
+
+            self.assertFalse((workspace / "shell-only" / ".venv").exists())
 
     def test_workspace_check_supports_json_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/tests/test_workspace_onboarding.py
+++ b/cli/python/base_projects/tests/test_workspace_onboarding.py
@@ -25,7 +25,7 @@ def write_project_manifest(project_root: Path, name: str, test_command: str | No
                 f"  command: {test_command}",
             ]
         )
-    lines.extend(["artifacts: []", ""])
+    lines.extend(["python: {}", "artifacts: []", ""])
     (project_root / "base_manifest.yaml").write_text("\n".join(lines), encoding="utf-8")
 
 
@@ -76,6 +76,46 @@ def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, st
 
 
 class WorkspaceOnboardingTests(unittest.TestCase):
+    def test_shell_only_repository_is_ready_without_project_venv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            manifest_path.write_text(
+                "schema_version: 1\nworkspace:\n  name: demo-suite\nrepos:\n  - name: shell-only\n",
+                encoding="utf-8",
+            )
+            project_root = workspace / "shell-only"
+            project_root.mkdir(parents=True)
+            (project_root / "base_manifest.yaml").write_text(
+                "project:\n  name: shell-only\nartifacts: []\n",
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "onboarding",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(manifest_path),
+                    "--format",
+                    "json",
+                ],
+                base_home,
+                home,
+            )
+
+        repository = json.loads(stdout)["repositories"][0]
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(repository["status"], "ready")
+        self.assertEqual(repository["venv"], "not_applicable")
+        self.assertEqual(repository["next_action"], "Run validation command.")
+
     def test_workspace_onboarding_json_reports_complete_manifest_repositories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_workspace_status_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_status_manifest.py
@@ -15,7 +15,7 @@ from base_projects import engine
 def write_manifest(project_root: Path, name: str) -> None:
     project_root.mkdir(parents=True)
     (project_root / "base_manifest.yaml").write_text(
-        f"project:\n  name: {name}\nartifacts: []\n",
+        f"project:\n  name: {name}\npython: {{}}\nartifacts: []\n",
         encoding="utf-8",
     )
 

--- a/cli/python/base_projects/workspace_agent_brief.py
+++ b/cli/python/base_projects/workspace_agent_brief.py
@@ -326,7 +326,7 @@ def repository_handoff_status(
         handoff_status = "needs_manifest_repair"
     elif baseline.status != "complete" or status.manifest != "valid":
         handoff_status = "needs_baseline"
-    elif status.venv not in ("ready", "present_unverified"):
+    elif status.venv not in ("ready", "present_unverified", "not_applicable"):
         handoff_status = "needs_setup"
     elif agent_guidance.status != "complete":
         handoff_status = "needs_agent_guidance"
@@ -365,7 +365,7 @@ def repository_next_actions(
     elif baseline.status != "complete" or status.manifest != "valid":
         actions.append(repo_init_command(status))
 
-    if status.manifest == "valid" and status.venv not in ("ready", "present_unverified"):
+    if status.manifest == "valid" and status.venv not in ("ready", "present_unverified", "not_applicable"):
         actions.append(command_in_directory(status.root, "basectl setup"))
 
     if baseline.status == "complete" and agent_guidance.status != "complete":

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -23,6 +23,7 @@ from base_setup.engine import read_default_manifest
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 from base_setup.manifest_model import BaseManifest
+from base_setup.project_routing import manifest_requires_project_python
 from base_setup.uv import manifest_uses_uv_project_manager
 
 
@@ -182,7 +183,7 @@ def workspace_project_check_result(
             checks=checks,
         )
 
-    if manifest_uses_uv_project_manager(manifest):
+    if not manifest_requires_project_python(manifest) or manifest_uses_uv_project_manager(manifest):
         checks = manifest_checks(default_manifest, manifest)
     else:
         venv_check = project_venv_check(manifest)

--- a/cli/python/base_projects/workspace_onboarding.py
+++ b/cli/python/base_projects/workspace_onboarding.py
@@ -89,7 +89,7 @@ def onboarding_status(status: WorkspaceProjectStatus) -> str:
         return "present_without_manifest"
     if status.manifest == "invalid":
         return "invalid_manifest"
-    if status.venv == "ready":
+    if status.venv in ("ready", "not_applicable"):
         return "ready"
     return "needs_setup"
 

--- a/cli/python/base_projects/workspace_statuses.py
+++ b/cli/python/base_projects/workspace_statuses.py
@@ -19,6 +19,7 @@ from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 from base_setup.python_runtime import ProjectPythonRuntime
 from base_setup.python_runtime import project_python_runtime
+from base_setup.project_routing import manifest_requires_project_python
 
 
 @dataclass(frozen=True)
@@ -164,6 +165,18 @@ def workspace_project_status(entry: ManifestEntry, *, probe_venv: bool = True) -
         )
 
     last_check = project_last_check(manifest.project_name)
+    if not manifest_requires_project_python(manifest):
+        return WorkspaceProjectStatus(
+            name=manifest.project_name,
+            root=root,
+            manifest_path=entry.path.resolve(),
+            status="ok",
+            venv="not_applicable",
+            manifest="valid",
+            issues=(),
+            last_check=last_check,
+        )
+
     venv_dir = project_venv_dir(manifest)
     if probe_venv:
         venv_ready = project_venv_ready(venv_dir)

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -74,6 +74,7 @@ def read_manifest(path: Path) -> BaseManifest:
         commands=commands,
         activate=activate,
         python=python,
+        python_declared="python" in data,
         github=github,
         demo=demo,
         build=build,

--- a/cli/python/base_setup/manifest_model.py
+++ b/cli/python/base_setup/manifest_model.py
@@ -127,3 +127,4 @@ class BaseManifest:
     demo: DemoConfig | None = None
     build: BuildConfig | None = None
     release: ReleaseConfig | None = None
+    python_declared: bool = False

--- a/cli/python/base_setup/project_routing.py
+++ b/cli/python/base_setup/project_routing.py
@@ -109,5 +109,5 @@ def route_to_text(route: ProjectRoute, output_format: str) -> str:
     if output_format == "text":
         return route.to_tsv()
     if output_format == "command-protocol":
-        return dumps_record("project-route", route.to_command_record())
+        return dumps_record("project-setup-route", route.to_command_record())
     raise ValueError(f"Unsupported route output format '{output_format}'. Expected text, json, or command-protocol.")

--- a/cli/python/base_setup/project_routing.py
+++ b/cli/python/base_setup/project_routing.py
@@ -21,6 +21,7 @@ class ProjectRoute:
     manifest_path: Path
     project_venv_dir: Path
     uses_uv_manager: bool
+    requires_project_python: bool
 
     def to_json(self) -> dict[str, object]:
         return {
@@ -30,10 +31,12 @@ class ProjectRoute:
             "manifest_path": str(self.manifest_path),
             "project_venv_dir": str(self.project_venv_dir),
             "uses_uv_manager": self.uses_uv_manager,
+            "requires_project_python": self.requires_project_python,
         }
 
     def to_tsv(self) -> str:
         uses_uv = "true" if self.uses_uv_manager else "false"
+        requires_python = "true" if self.requires_project_python else "false"
         return "\t".join(
             [
                 self.project,
@@ -41,6 +44,7 @@ class ProjectRoute:
                 str(self.manifest_path),
                 str(self.project_venv_dir),
                 uses_uv,
+                requires_python,
             ]
         )
 
@@ -51,6 +55,7 @@ class ProjectRoute:
             "manifest_path": str(self.manifest_path),
             "project_venv_dir": str(self.project_venv_dir),
             "uses_uv_manager": self.uses_uv_manager,
+            "requires_project_python": self.requires_project_python,
             "manifest_command_trust_required": False,
         }
 
@@ -70,7 +75,16 @@ def route_for_manifest(manifest: BaseManifest) -> ProjectRoute:
             venv_location=manifest.python.venv_location,
         ),
         uses_uv_manager=uses_uv_manager,
+        requires_project_python=manifest_requires_project_python(manifest),
     )
+
+
+def manifest_requires_project_python(manifest: BaseManifest) -> bool:
+    """Return whether the manifest explicitly owns a project Python runtime."""
+
+    if manifest.python_declared:
+        return True
+    return any(artifact.artifact_type == "python-package" for artifact in manifest.artifacts)
 
 
 def project_venv_dir(

--- a/cli/python/base_setup/setup_reconcile.py
+++ b/cli/python/base_setup/setup_reconcile.py
@@ -18,6 +18,7 @@ from .ide_extensions import reconcile_ide_extensions
 from .ide_installs import reconcile_ide_installs
 from .ide_settings import reconcile_ide_settings
 from .manifest import BaseManifest
+from .project_routing import manifest_requires_project_python
 from .project_routing import route_for_manifest
 from .uv import manifest_uses_uv_project_manager
 from .uv import reconcile_uv_project
@@ -71,6 +72,13 @@ def reconcile_bootstrap_artifacts(
     manifest: BaseManifest,
     dry_run: bool,
 ) -> None:
+    if not manifest_requires_project_python(manifest):
+        ctx.log.info(
+            "Project '%s' does not declare a Python runtime; skipping project bootstrap.",
+            manifest.project_name,
+        )
+        return
+
     ctx.log.info("Bootstrapping project '%s' Python runtime.", manifest.project_name)
 
     artifacts = tuple(artifact for artifact in default_manifest.artifacts if artifact.bootstrap)
@@ -101,7 +109,12 @@ def effective_manifest_with_user_config(manifest: BaseManifest, user_config: Use
 
 
 def setup_artifacts(default_manifest: BaseManifest, manifest: BaseManifest) -> tuple:
-    artifacts = merge_artifacts(default_manifest.artifacts, manifest.artifacts)
+    default_artifacts = default_manifest.artifacts
+    if not manifest_requires_project_python(manifest):
+        default_artifacts = tuple(
+            artifact for artifact in default_artifacts if artifact.artifact_type != "python-package"
+        )
+    artifacts = merge_artifacts(default_artifacts, manifest.artifacts)
     if not manifest_uses_uv_project_manager(manifest):
         return artifacts
     return tuple(artifact for artifact in artifacts if artifact.artifact_type != "python-package")

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -955,6 +955,8 @@ class EngineArtifactTests(unittest.TestCase):
                         "project:",
                         "  name: demo",
                         "",
+                        "python: {}",
+                        "",
                         "artifacts: []",
                     ]
                 ),

--- a/cli/python/base_setup/tests/test_bootstrap.py
+++ b/cli/python/base_setup/tests/test_bootstrap.py
@@ -9,6 +9,7 @@ from base_setup import engine
 from base_setup.artifacts import merge_artifacts
 from base_setup.artifacts import ProjectRuntimeConfig
 from base_setup.manifest import ArtifactRequest, BaseManifest, ManifestError, read_manifest
+from base_setup.setup_reconcile import setup_artifacts
 from base_setup.tests.helpers import fake_context
 
 class BootstrapManifestTests(unittest.TestCase):
@@ -29,6 +30,7 @@ class BootstrapManifestTests(unittest.TestCase):
             project_name="demo",
             brewfile=None,
             artifacts=(),
+            python_declared=True,
         )
 
         with mock.patch("base_setup.setup_reconcile.reconcile_artifacts") as reconcile_artifacts:
@@ -40,6 +42,30 @@ class BootstrapManifestTests(unittest.TestCase):
         self.assertIsInstance(runtime_config, ProjectRuntimeConfig)
         self.assertEqual(runtime_config.name, "demo")
         self.assertEqual(runtime_config.venv_dir, (Path.cwd() / ".venv").resolve())
+
+    def test_shell_only_manifest_does_not_inherit_base_python_artifacts(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(
+                ArtifactRequest("python-package", "click", "8.4.1", bootstrap=True),
+                ArtifactRequest("tool", "shellcheck", "latest"),
+            ),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="shell-only",
+            brewfile=None,
+            artifacts=(ArtifactRequest("tool", "jq", "latest"),),
+        )
+
+        artifacts = setup_artifacts(default_manifest, manifest)
+
+        self.assertEqual(
+            tuple((artifact.artifact_type, artifact.name) for artifact in artifacts),
+            (("tool", "shellcheck"), ("tool", "jq")),
+        )
 
 
 

--- a/cli/python/base_setup/tests/test_project_routing.py
+++ b/cli/python/base_setup/tests/test_project_routing.py
@@ -59,7 +59,7 @@ class ProjectRoutingTests(unittest.TestCase):
             )
 
         self.assertEqual((status, stderr), (0, ""))
-        _, records = loads_records(stdout, "project-route")
+        _, records = loads_records(stdout, "project-setup-route")
         self.assertEqual(records[0]["project_name"], "demo")
         self.assertEqual(records[0]["project_root"], str(root.resolve()))
         self.assertEqual(records[0]["project_venv_dir"], str(root.resolve() / ".venv"))

--- a/cli/python/base_setup/tests/test_project_routing.py
+++ b/cli/python/base_setup/tests/test_project_routing.py
@@ -6,6 +6,8 @@ import unittest
 from pathlib import Path
 
 from base_cli.command_protocol import loads_records
+from base_setup.manifest import read_manifest
+from base_setup.project_routing import manifest_requires_project_python
 from base_setup.tests.helpers import run_engine
 
 
@@ -17,6 +19,25 @@ def write_manifest(root: Path, content: str) -> Path:
 
 
 class ProjectRoutingTests(unittest.TestCase):
+    def test_manifest_requires_project_python_only_for_explicit_python_contracts(self) -> None:
+        cases = (
+            ("project:\n  name: shell-only\nartifacts: []\n", False),
+            ("project:\n  name: taxonomy-only\n  languages: [python]\nartifacts: []\n", False),
+            ("project:\n  name: explicit-empty\npython: {}\nartifacts: []\n", True),
+            (
+                "project:\n  name: packages\nartifacts:\n"
+                "  - type: python-package\n    name: requests\n    version: latest\n",
+                True,
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for index, (content, expected) in enumerate(cases):
+                with self.subTest(content=content):
+                    manifest = read_manifest(write_manifest(root / str(index), content))
+                    self.assertEqual(manifest_requires_project_python(manifest), expected)
+
     def test_route_command_protocol_reports_explicit_route_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir) / "demo λ"
@@ -43,6 +64,7 @@ class ProjectRoutingTests(unittest.TestCase):
         self.assertEqual(records[0]["project_root"], str(root.resolve()))
         self.assertEqual(records[0]["project_venv_dir"], str(root.resolve() / ".venv"))
         self.assertTrue(records[0]["uses_uv_manager"])
+        self.assertTrue(records[0]["requires_project_python"])
         self.assertFalse(records[0]["manifest_command_trust_required"])
 
     def test_route_ignores_different_active_project_venv_override(self) -> None:
@@ -126,6 +148,7 @@ class ProjectRoutingTests(unittest.TestCase):
         self.assertEqual(route["manifest_path"], str(manifest_path.resolve()))
         self.assertEqual(route["project_venv_dir"], str(root.resolve() / ".venv"))
         self.assertTrue(route["uses_uv_manager"])
+        self.assertTrue(route["requires_project_python"])
 
     def test_route_json_reports_project_local_venv_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -149,6 +172,7 @@ class ProjectRoutingTests(unittest.TestCase):
         route = json.loads(stdout)
         self.assertEqual(route["project_venv_dir"], str(root.resolve() / ".venv"))
         self.assertFalse(route["uses_uv_manager"])
+        self.assertFalse(route["requires_project_python"])
 
     def test_route_json_preserves_external_project_venv_when_manifest_opts_in(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -203,6 +227,7 @@ class ProjectRoutingTests(unittest.TestCase):
                     str(root.resolve()),
                     str(manifest_path.resolve()),
                     str(root.resolve() / ".venv"),
+                    "true",
                     "true",
                 ]
             )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -472,8 +472,9 @@ orchestration actions. The design rule is delegation-first:
   affect the interactive runtime shell, such as local environment loading,
   aliases, or functions. Source paths must be relative to the project root and
   must resolve inside that root.
-- Let Base own the project virtual environment and Base-aware package
-  reconciliation.
+- Let Base own Base-aware package reconciliation and any project virtual
+  environment explicitly requested by `python:` or `python-package` manifest
+  contracts. Shell-only manifests use the Base runtime for control-plane work.
 - Do not run arbitrary project setup hooks until Base has a clear safety
   contract for dry-run behavior, interactivity, setup diagnostics, and broader
   side effects. See [setup-hooks.md](setup-hooks.md) for the setup no-hooks
@@ -501,6 +502,22 @@ Base-managed virtualenv creation, while check/doctor distinguish unsupported
 requests from supported-but-unavailable interpreters. See
 [python-manifest.md](python-manifest.md) for the current contract and migration
 boundary.
+
+A manifest requires project Python when it contains a top-level `python:`
+mapping, including an explicit empty `python: {}`, or declares at least one
+`python-package` artifact. `project.languages: [python]` remains taxonomy and
+does not independently create an environment. When neither project-Python
+contract is present, setup, check, and doctor run Base-owned parsing and
+reconciliation from `~/.base.d/base/.venv`, skip Base's default project Python
+bootstrap artifacts, and do not require `<project-root>/.venv`. Workspace
+status reports that venv as `not_applicable` rather than missing.
+
+This is the shell-only vertical slice of the broader runtime-boundary work in
+[#1611](https://github.com/basefoundry/base/issues/1611). Activation and
+project-owned run, test, build, and demo command environment semantics retain
+their existing routing in this slice; the remaining migration should continue
+to separate Base control-plane execution from project-owned runtime execution
+without adding another special-purpose runtime.
 
 Homebrew-managed `tool` artifacts currently support `version: latest`. If a
 project requests a pinned Homebrew version, setup fails clearly instead of
@@ -714,9 +731,11 @@ On a fresh Mac, installation and first-run setup use this sequence:
    separate one-time shell-profile step; run it again only when updating
    Base-managed shell dotfiles
 7. Scan the parent directory for peer repos with base manifests
-8. For each project setup target, seed the project venv with `bootstrap: true`
-   default artifacts, then run project artifact reconciliation through
-   `base-wrapper --project <project>`
+8. For a shell-only setup target, run manifest reconciliation from Base's own
+   venv without creating a project venv. For a target that explicitly declares
+   project Python, seed its project venv with `bootstrap: true` default
+   artifacts, then run reconciliation through `base-wrapper --project
+   <project>`.
 
 Homebrew installation follows Homebrew's official `install/HEAD/install.sh`
 bootstrap command. That means Base intentionally trusts Homebrew's mutable

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -2,6 +2,33 @@
 
 Base supports two Python project shapes.
 
+## When A Project Python Runtime Is Required
+
+Base treats project Python as explicit. A manifest requires a project Python
+runtime when either of these is present:
+
+- a top-level `python:` mapping, including `python: {}`
+- at least one `python-package` artifact
+
+The empty mapping is a compatibility opt-in to Base's default managed project
+venv. `project.languages: [python]` is classification metadata only and does
+not independently request an environment.
+
+A manifest with neither contract is shell-only for Base setup and diagnostics.
+`basectl setup`, `basectl check`, and `basectl doctor` run Base-owned manifest
+parsing and reconciliation from `~/.base.d/base/.venv`; they do not copy
+Click, PyYAML, tomli, or other Base bootstrap packages into the project and do
+not create `<project-root>/.venv` solely for Base. Workspace status and
+onboarding expose the venv state as `not_applicable` and can report the project
+healthy without a project interpreter.
+
+This is a scoped boundary, not the complete migration tracked in
+[#1611](https://github.com/basefoundry/base/issues/1611). Project-owned
+activation, run, test, build, and demo command routing keeps its existing
+environment behavior for now. Future work should move more Base-owned control
+plane execution to the Base runtime while preserving environments explicitly
+owned by projects.
+
 The Base-managed shape uses `python-package` artifact rows and installs
 packages into the project's virtual environment:
 
@@ -265,6 +292,8 @@ from unfamiliar repositories before running their declared commands.
 object for each ready, inspectable project environment. That summary reports
 the environment manager, virtualenv path, interpreter path, and actual Python
 minor version for both Base-managed and uv-managed projects.
+Shell-only projects instead report `venv: "not_applicable"` and omit
+`python_runtime`.
 
 ## Non-Goals
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -80,10 +80,12 @@ libraries are documented in [Base Bash Libraries](base-bash-libs.md).
 
 **Layer 3 — Project environment** (`basectl activate <project>`)
 
-Spawns a Bash runtime shell, sets `BASE_PROJECT`, activates the project venv at
-`<project-root>/.venv`, runs `activate.source` scripts declared in the
-manifest, and updates the prompt to `[project: branch] ~/path $`. Exit that
-shell to return to the original environment - no deactivation logic needed.
+Spawns a Bash runtime shell, sets `BASE_PROJECT`, applies the project runtime
+route, runs `activate.source` scripts declared in the manifest, and updates the
+prompt to `[project: branch] ~/path $`. Python projects activate their selected
+project venv. Shell-only setup/check/doctor work does not create one solely for
+Base's control plane. Exit that shell to return to the original environment -
+no deactivation logic needed.
 
 **Design choice — no `cd`-triggered activation:** switching directories does not
 change environment. Users explicitly activate projects with `basectl activate`.
@@ -245,7 +247,7 @@ exec "$SHELL" -l
 | Path | Purpose |
 |---|---|
 | `~/.base.d/config.yaml` | Machine-local config (workspace root, workspace manifest, canonical manifest source, log level) |
-| `<project-root>/.venv` | Default non-Base project Python virtual environment |
+| `<project-root>/.venv` | Default non-Base project Python virtual environment when the manifest declares `python:` or `python-package` artifacts; not created for shell-only control-plane work |
 | `~/.base.d/<project>/.venv` | Historical external project Python virtual environment when `python.venv_location: external` is set |
 | `~/.base.d/<project>/checks/last.json` | Latest recorded `basectl check <project>` result used by workspace status |
 | `~/Library/Caches/base/` | Runtime logs, temp files, project discovery cache |

--- a/lib/bash/runtime/command_protocol.sh
+++ b/lib/bash/runtime/command_protocol.sh
@@ -26,12 +26,17 @@ base_command_protocol_record_fields() {
         project-route)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager requires_project_python manifest_command_trust_required
+                uses_uv_manager manifest_command_trust_required
+            ;;
+        project-setup-route)
+            printf '%s\n' \
+                project_name project_root manifest_path project_venv_dir \
+                uses_uv_manager manifest_command_trust_required requires_project_python
             ;;
         project-command)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager requires_project_python manifest_command_trust_required command runner
+                uses_uv_manager manifest_command_trust_required command runner
             ;;
         named-command)
             printf '%s\n' project_name project_root manifest_path command_name command runner
@@ -39,13 +44,13 @@ base_command_protocol_record_fields() {
         build-target)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager requires_project_python manifest_command_trust_required target_name \
+                uses_uv_manager manifest_command_trust_required target_name \
                 working_dir command description runner
             ;;
         demo)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager requires_project_python manifest_command_trust_required demo_script runner
+                uses_uv_manager manifest_command_trust_required demo_script runner
             ;;
         activation-source)
             printf '%s\n' source_path
@@ -64,7 +69,9 @@ base_command_protocol_field_spec() {
         project-list-entry:project_name|project-list-entry:project_root|\
         project-reference:project_name|project-reference:project_root|project-reference:manifest_path|\
         project-route:project_name|project-route:project_root|project-route:manifest_path|\
-        project-route:project_venv_dir|\
+        project-route:project_venv_dir|project-setup-route:project_name|\
+        project-setup-route:project_root|project-setup-route:manifest_path|\
+        project-setup-route:project_venv_dir|\
         project-command:project_name|project-command:project_root|project-command:manifest_path|\
         project-command:project_venv_dir|project-command:command|\
         named-command:project_name|named-command:project_root|named-command:manifest_path|\
@@ -76,12 +83,12 @@ base_command_protocol_field_spec() {
         demo:demo_script|activation-source:source_path)
             printf 'string\n'
             ;;
-        project-route:uses_uv_manager|project-route:requires_project_python|\
-        project-route:manifest_command_trust_required|project-command:uses_uv_manager|\
-        project-command:requires_project_python|project-command:manifest_command_trust_required|\
-        build-target:uses_uv_manager|build-target:requires_project_python|\
+        project-route:uses_uv_manager|project-route:manifest_command_trust_required|\
+        project-setup-route:uses_uv_manager|project-setup-route:manifest_command_trust_required|\
+        project-setup-route:requires_project_python|project-command:uses_uv_manager|\
+        project-command:manifest_command_trust_required|build-target:uses_uv_manager|\
         build-target:manifest_command_trust_required|demo:uses_uv_manager|\
-        demo:requires_project_python|demo:manifest_command_trust_required)
+        demo:manifest_command_trust_required)
             printf 'boolean\n'
             ;;
         project-command:runner|named-command:runner|build-target:description|\

--- a/lib/bash/runtime/command_protocol.sh
+++ b/lib/bash/runtime/command_protocol.sh
@@ -26,12 +26,12 @@ base_command_protocol_record_fields() {
         project-route)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager manifest_command_trust_required
+                uses_uv_manager requires_project_python manifest_command_trust_required
             ;;
         project-command)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager manifest_command_trust_required command runner
+                uses_uv_manager requires_project_python manifest_command_trust_required command runner
             ;;
         named-command)
             printf '%s\n' project_name project_root manifest_path command_name command runner
@@ -39,13 +39,13 @@ base_command_protocol_record_fields() {
         build-target)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager manifest_command_trust_required target_name \
+                uses_uv_manager requires_project_python manifest_command_trust_required target_name \
                 working_dir command description runner
             ;;
         demo)
             printf '%s\n' \
                 project_name project_root manifest_path project_venv_dir \
-                uses_uv_manager manifest_command_trust_required demo_script runner
+                uses_uv_manager requires_project_python manifest_command_trust_required demo_script runner
             ;;
         activation-source)
             printf '%s\n' source_path
@@ -76,10 +76,12 @@ base_command_protocol_field_spec() {
         demo:demo_script|activation-source:source_path)
             printf 'string\n'
             ;;
-        project-route:uses_uv_manager|project-route:manifest_command_trust_required|\
-        project-command:uses_uv_manager|project-command:manifest_command_trust_required|\
-        build-target:uses_uv_manager|build-target:manifest_command_trust_required|\
-        demo:uses_uv_manager|demo:manifest_command_trust_required)
+        project-route:uses_uv_manager|project-route:requires_project_python|\
+        project-route:manifest_command_trust_required|project-command:uses_uv_manager|\
+        project-command:requires_project_python|project-command:manifest_command_trust_required|\
+        build-target:uses_uv_manager|build-target:requires_project_python|\
+        build-target:manifest_command_trust_required|demo:uses_uv_manager|\
+        demo:requires_project_python|demo:manifest_command_trust_required)
             printf 'boolean\n'
             ;;
         project-command:runner|named-command:runner|build-target:description|\

--- a/lib/python/base_cli/command_protocol.py
+++ b/lib/python/base_cli/command_protocol.py
@@ -32,8 +32,11 @@ PROJECT_ROUTE_FIELDS = {
     **PROJECT_REFERENCE_FIELDS,
     "project_venv_dir": STRING,
     "uses_uv_manager": BOOLEAN,
-    "requires_project_python": BOOLEAN,
     "manifest_command_trust_required": BOOLEAN,
+}
+PROJECT_SETUP_ROUTE_FIELDS = {
+    **PROJECT_ROUTE_FIELDS,
+    "requires_project_python": BOOLEAN,
 }
 
 RECORD_SCHEMAS: dict[str, dict[str, FieldSpec]] = {
@@ -43,6 +46,7 @@ RECORD_SCHEMAS: dict[str, dict[str, FieldSpec]] = {
     },
     "project-reference": PROJECT_REFERENCE_FIELDS,
     "project-route": PROJECT_ROUTE_FIELDS,
+    "project-setup-route": PROJECT_SETUP_ROUTE_FIELDS,
     "project-command": {
         **PROJECT_ROUTE_FIELDS,
         "command": STRING,

--- a/lib/python/base_cli/command_protocol.py
+++ b/lib/python/base_cli/command_protocol.py
@@ -32,6 +32,7 @@ PROJECT_ROUTE_FIELDS = {
     **PROJECT_REFERENCE_FIELDS,
     "project_venv_dir": STRING,
     "uses_uv_manager": BOOLEAN,
+    "requires_project_python": BOOLEAN,
     "manifest_command_trust_required": BOOLEAN,
 }
 

--- a/lib/python/base_cli/tests/test_command_protocol.py
+++ b/lib/python/base_cli/tests/test_command_protocol.py
@@ -10,6 +10,7 @@ from base_cli.command_protocol import CommandProtocolError
 from base_cli.command_protocol import dumps_record
 from base_cli.command_protocol import dumps_records
 from base_cli.command_protocol import loads_records
+from base_cli.command_protocol import RECORD_SCHEMAS
 
 
 def project_command_record(**overrides: object) -> dict[str, object]:
@@ -19,7 +20,6 @@ def project_command_record(**overrides: object) -> dict[str, object]:
         "manifest_path": "/tmp/work space/demo/base_manifest.yaml",
         "project_venv_dir": "/tmp/work space/demo/.venv",
         "uses_uv_manager": False,
-        "requires_project_python": True,
         "manifest_command_trust_required": True,
         "command": "printf 'tab=\t unicode=λ newline=\n control=\x01'",
         "runner": None,
@@ -29,6 +29,12 @@ def project_command_record(**overrides: object) -> dict[str, object]:
 
 
 class CommandProtocolTests(unittest.TestCase):
+    def test_project_python_requirement_is_scoped_to_project_setup_route_records(self) -> None:
+        self.assertIn("requires_project_python", RECORD_SCHEMAS["project-setup-route"])
+        for record_type in ("project-route", "project-command", "build-target", "demo"):
+            with self.subTest(record_type=record_type):
+                self.assertNotIn("requires_project_python", RECORD_SCHEMAS[record_type])
+
     def test_round_trip_preserves_manifest_strings_and_empty_optional_fields(self) -> None:
         records = (
             project_command_record(),

--- a/lib/python/base_cli/tests/test_command_protocol.py
+++ b/lib/python/base_cli/tests/test_command_protocol.py
@@ -19,6 +19,7 @@ def project_command_record(**overrides: object) -> dict[str, object]:
         "manifest_path": "/tmp/work space/demo/base_manifest.yaml",
         "project_venv_dir": "/tmp/work space/demo/.venv",
         "uses_uv_manager": False,
+        "requires_project_python": True,
         "manifest_command_trust_required": True,
         "command": "printf 'tab=\t unicode=λ newline=\n control=\x01'",
         "runner": None,


### PR DESCRIPTION
## Summary

- treat project Python as an explicit manifest contract (`python:` or `python-package`)
- run shell-only setup, check, and doctor work through Base's own Python runtime without creating a project `.venv`
- report shell-only workspace environments as `not_applicable` while preserving explicit Python and uv behavior
- keep existing run/test/build/demo routing and command-protocol records compatible

## Validation

- 985 Python tests passed, 1 skipped
- 155 focused setup/check/doctor/workspace BATS tests passed
- 14 CI alias BATS tests passed after making its project-venv fixture explicit
- full 785-test BATS suite passed
- Pylint passed for touched Python modules
- Bash syntax passed; `git diff --check` passed
- independent compatibility review found no material issues

Closes #1649
