### PR TITLE
Align workspace status text columns for shell-only projects

### DIFF
--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -491,8 +491,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertIn(f"Workspace: {workspace.resolve()} (2 projects)", stdout)
-        self.assertIn("base                 ok     ready    valid    2026-06-17", stdout)
-        self.assertIn("demo                 warn   missing  valid    -", stdout)
+        self.assertIn("base                 ok     ready          valid    2026-06-17", stdout)
+        self.assertIn("demo                 warn   missing        valid    -", stdout)
         self.assertIn("1 project(s) need attention", stdout)
 
     def test_workspace_status_reports_uv_project_venv_ready_without_base_project_venv(self) -> None:
@@ -509,7 +509,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertIn("bankbuddy            ok     ready    valid    -", stdout)
+        self.assertIn("bankbuddy            ok     ready          valid    -", stdout)
         self.assertIn("All discovered projects look ok.", stdout)
 
     def test_workspace_status_reports_shell_only_project_venv_not_applicable(self) -> None:
@@ -536,6 +536,33 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(payload["projects"][0]["status"], "ok")
         self.assertEqual(payload["projects"][0]["venv"], "not_applicable")
         self.assertEqual(payload["projects"][0]["issues"], [])
+
+    def test_workspace_status_text_aligns_shell_only_project_columns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            project_root = workspace / "shell-only"
+            write_shell_manifest(project_root, "shell-only")
+
+            status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
+
+        lines = stdout.splitlines()
+        header = next(line for line in lines if line.startswith("PROJECT"))
+        project_line = next(line for line in lines if line.startswith("shell-only"))
+        manifest_column = header.index("MANIFEST")
+        last_check_column = header.index("LAST CHECK")
+        path_column = header.index("PATH")
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(project_line[header.index("VENV") : manifest_column].rstrip(), "not_applicable")
+        self.assertEqual(project_line[manifest_column : manifest_column + len("valid")], "valid")
+        self.assertEqual(project_line[last_check_column], "-")
+        self.assertEqual(project_line[path_column:], str(project_root.resolve()))
 
     def test_workspace_status_supports_json_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -645,8 +672,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
-        self.assertIn("broken               error  unknown  invalid", stdout)
-        self.assertIn("demo                 warn   missing  valid", stdout)
+        self.assertIn("broken               error  unknown        invalid", stdout)
+        self.assertIn("demo                 warn   missing        valid", stdout)
         self.assertIn("2 project(s) need attention", stdout)
 
     def test_projects_list_reuses_project_cache_when_manifests_are_unchanged(self) -> None:

--- a/cli/python/base_projects/workspace_report_text.py
+++ b/cli/python/base_projects/workspace_report_text.py
@@ -35,12 +35,12 @@ def print_workspace_status(
         print("No Base-managed projects discovered.")
         return
 
-    print(f"{'PROJECT':<20} {'STATUS':<6} {'VENV':<8} {'MANIFEST':<8} {'LAST CHECK':<10} PATH")
+    print(f"{'PROJECT':<20} {'STATUS':<6} {'VENV':<14} {'MANIFEST':<8} {'LAST CHECK':<10} PATH")
     for status in statuses:
         print(
             f"{status.name:<20} "
             f"{status.status:<6} "
-            f"{status.venv:<8} "
+            f"{status.venv:<14} "
             f"{status.manifest:<8} "
             f"{last_check_display(status.last_check):<10} "
             f"{status.root}"


### PR DESCRIPTION
## Summary

- widen the non-manifest workspace `VENV` column to fit every valid state, including `not_applicable`
- add text-mode regression coverage that pins the `MANIFEST`, `LAST CHECK`, and `PATH` column positions
- preserve the manifest-backed table and JSON output contracts

## Issue

Fixes #1663

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py -q -p no:cacheprovider` (`73 passed, 4 subtests passed`)
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint cli/python/base_projects/workspace_report_text.py cli/python/base_projects/tests/test_engine.py`
- real source smoke: `basectl workspace status --workspace /Users/rameshhp/work`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1663-full-test ./bin/base-test` (`996 passed, 1 skipped`; `796 BATS tests, 0 failures`)
- `git diff --check`

## Demo Impact

None.

## Notes

The root cause was a fixed eight-character `VENV` width after shell-only projects introduced the 14-character `not_applicable` value. Documentation and `.ai-context/` do not need updates because this only repairs display alignment; it does not change the command or output-data contracts.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current worktree.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fix includes regression proof and a real reproduction smoke test.
- [x] Documentation impact was evaluated; no update is needed for an alignment-only repair.
- [x] AI context impact was evaluated; no update is needed.
- [x] PR includes `Fixes #1663`.
- [x] Demo Impact is explicitly `None.`
