### PR TITLE
Show valid --format choices in workspace command help

### DIFF
--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -12,7 +12,8 @@ Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
-  --format <format>   Output format for the workspace command: text or json.
+  --format <text|json>
+                      Output format for the workspace command. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
@@ -66,7 +67,8 @@ Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
-  --format <format>   Output format for the onboarding summary: text or json.
+  --format <text|json>
+                      Output format for the onboarding summary. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
@@ -83,7 +85,8 @@ Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
-  --format <format>   Output format for the agent brief: text or json.
+  --format <text|json>
+                      Output format for the agent brief. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -292,7 +292,7 @@ load ./basectl_helpers.bash
         [[ "$output" == *"$flag"* ]]
         [[ "$agent_brief_row" == *"$flag"* ]]
     done
-    [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
     [[ "$agent_brief_row" == *'--format <text\|json>'* ]]
 }
 

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -296,7 +296,8 @@ EOF
     [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
-    [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"Output format for the workspace command. Defaults to text."* ]]
 
     run_basectl workspace agent-brief --help
 
@@ -304,20 +305,21 @@ EOF
     [[ "$output" == *"basectl workspace agent-brief [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
-    [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"Output format for the agent brief. Defaults to text."* ]]
     [[ "$output" == *"without cloning, setup, or network calls"* ]]
 
     run_basectl workspace check --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
-    [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
 
     run_basectl workspace doctor --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
-    [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
 
     run_basectl workspace onboarding --help
 
@@ -325,7 +327,8 @@ EOF
     [[ "$output" == *"basectl workspace onboarding [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
-    [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"Output format for the onboarding summary. Defaults to text."* ]]
 
     run_basectl workspace clone --help
 
@@ -335,7 +338,7 @@ EOF
     [[ "$output" == *"--manifest <path>"* ]]
     [[ "$output" == *"--include-optional"* ]]
     [[ "$output" == *"--dry-run"* ]]
-    [[ "$output" != *"--format <format>"* ]]
+    [[ "$output" != *"--format"* ]]
 
     run_basectl workspace pull --help
 
@@ -344,7 +347,7 @@ EOF
     [[ "$output" == *"--source <url-or-path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
     [[ "$output" == *"--dry-run"* ]]
-    [[ "$output" != *"--format <format>"* ]]
+    [[ "$output" != *"--format"* ]]
 
     run_basectl workspace configure --help
 
@@ -353,7 +356,7 @@ EOF
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
     [[ "$output" == *"--dry-run"* ]]
-    [[ "$output" != *"--format <format>"* ]]
+    [[ "$output" != *"--format"* ]]
 
     run_basectl workspace init --help
 
@@ -365,7 +368,7 @@ EOF
     [[ "$output" == *"--manifest <path>"* ]]
     [[ "$output" == *"--include-optional"* ]]
     [[ "$output" == *"--dry-run"* ]]
-    [[ "$output" != *"--format <format>"* ]]
+    [[ "$output" != *"--format"* ]]
 
     run_basectl workspace help
 


### PR DESCRIPTION
## Summary

- show `--format <text|json>` directly in help for workspace `status`, `check`, `doctor`, `onboarding`, and `agent-brief`
- state that text is the default while keeping the longer option signature readable with the existing wrapped-help style
- strengthen help regression coverage, including non-format workspace commands and command-reference parity

## Issue

Fixes #1664

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/completions.bats` (`38 tests, 0 failures`)
- direct source help smoke for `workspace status`, `workspace onboarding`, and `workspace agent-brief`
- `shellcheck cli/bash/commands/basectl/subcommands/workspace.sh`
- `bash -n cli/bash/commands/basectl/subcommands/workspace.sh`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1664-full-test ./bin/base-test` (`996 passed, 1 skipped`; `796 BATS tests, 0 failures`)
- `git diff --check`

## Demo Impact

None.

## Notes

This is the narrow help-correctness fix tracked by #1664. It is related to, but independent of, the broader canonical command-metadata work in #1606. The command reference and Bash/Zsh completions already expose `text` and `json`, so no docs, completion, parser, changelog, or `.ai-context/` update is needed.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current worktree.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fix includes regression proof and direct source help smoke tests.
- [x] Documentation impact was evaluated; the command reference is already correct.
- [x] AI context impact was evaluated; no update is needed.
- [x] PR includes `Fixes #1664`.
- [x] Demo Impact is explicitly `None.`
