### PR TITLE
Populate project metadata in history entries

### DIFF
--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -745,6 +745,7 @@ def manifest_project_command(ctx: base_cli.Context, manifest: str | None, output
     except ProjectDiscoveryError as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
+    bind_project_context(ctx, project)
 
     if output_format == "command-protocol":
         print(
@@ -768,10 +769,17 @@ def manifest_project_command(ctx: base_cli.Context, manifest: str | None, output
 def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: str | None) -> Project:
     project = find_named_project(ctx, project_name, workspace)
     if project is not None:
-        return project
+        return bind_project_context(ctx, project)
 
     workspace_root = resolve_workspace_root(ctx, workspace)
     raise ProjectDiscoveryError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
+
+
+def bind_project_context(ctx: base_cli.Context, project: Project) -> Project:
+    """Associate a resolved project with the invocation history context."""
+    ctx.project_root = project.root
+    ctx.manifest_path = project.manifest_path
+    return project
 
 
 def find_named_project(ctx: base_cli.Context, project_name: str, workspace: str | None) -> Project | None:
@@ -801,6 +809,6 @@ def select_invocation_project(
     if arguments:
         legacy_project = find_named_project(ctx, arguments[0], workspace)
         if legacy_project is not None:
-            return legacy_project, arguments[1:]
+            return bind_project_context(ctx, legacy_project), arguments[1:]
 
-    return current_project(), arguments
+    return bind_project_context(ctx, current_project()), arguments

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 from base_cli.command_protocol import loads_records
+from base_cli.history import build_finished_record
 from base_projects import engine, project_discovery
 
 
@@ -776,6 +777,34 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"demo\t{project_root.resolve()}\t{(project_root / 'base_manifest.yaml').resolve()}"
             f"{base_route_fields(base_home, 'demo', trust_required=False)}\n",
         )
+
+    def test_projects_resolve_populates_history_project_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            write_manifest(project_root, "demo")
+            outside = workspace / "outside"
+            outside.mkdir()
+            captured: list[tuple[object, ...]] = []
+
+            with (
+                mock.patch("base_cli.app.current_working_dir", return_value=outside),
+                mock.patch(
+                    "base_cli.app.write_finished_record",
+                    side_effect=lambda *args: captured.append(args),
+                ),
+            ):
+                status, _stdout, stderr = run_engine(["resolve", "demo"], base_home)
+
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertEqual(len(captured), 1)
+            record = build_finished_record(*captured[0])
+
+        self.assertEqual(record["project"], "demo")
+        self.assertEqual(record["project_root"], str(project_root.resolve()))
+        self.assertEqual(record["manifest"], str((project_root / "base_manifest.yaml").resolve()))
 
     def test_projects_resolve_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -83,6 +83,9 @@ def run(
     remote_network: bool,
 ) -> int:
     manifest_path = Path(manifest).resolve() if manifest else discover_manifest(Path(start_dir))
+    if manifest_path is not None:
+        ctx.manifest_path = manifest_path
+        ctx.project_root = manifest_path.parent
     if manifest_path is None:
         if project:
             ctx.log.error("No base_manifest.yaml found for project '%s'.", project)

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -13,6 +13,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.history import build_finished_record
 from base_setup import artifacts, process, python_artifacts
 from base_setup.artifacts import merge_artifacts
 from base_setup.errors import ArtifactError
@@ -895,6 +896,38 @@ class ArtifactReconcileTests(unittest.TestCase):
 
 
 class EngineArtifactTests(unittest.TestCase):
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_explicit_manifest_populates_history_project_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = root / "base_manifest.yaml"
+            manifest_path.write_text(
+                "project:\n  name: demo\n\nartifacts: []\n",
+                encoding="utf-8",
+            )
+            outside = root / "outside"
+            outside.mkdir()
+            captured: list[tuple[object, ...]] = []
+
+            with (
+                mock.patch("base_cli.app.current_working_dir", return_value=outside),
+                mock.patch(
+                    "base_cli.app.write_finished_record",
+                    side_effect=lambda *args: captured.append(args),
+                ),
+            ):
+                status, _stdout, stderr = run_engine(
+                    ["--manifest", str(manifest_path), "--action", "route", "demo"]
+                )
+
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertEqual(len(captured), 1)
+            record = build_finished_record(*captured[0])
+
+        self.assertEqual(record["project"], "demo")
+        self.assertEqual(record["project_root"], str(root.resolve()))
+        self.assertEqual(record["manifest"], str(manifest_path.resolve()))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_discovers_manifest_from_start_dir(self) -> None:


### PR DESCRIPTION
Fixes #1667

## Summary

- bind the manifest selected by `base_setup --manifest` or `--start-dir` to the invocation context before the command runs
- bind resolved project metadata for `base_projects` commands, including explicit and legacy project selection
- add history regressions covering project name, project root, and manifest path

## Root cause

The top-level CLI context only discovered manifests from the current working directory. `base_setup` resolved an explicit manifest later, and `base_projects` resolved named projects inside command handlers, so history was written before either selection was reflected in the context.

## Validation

- `pytest cli/python/base_setup/tests/test_artifacts.py -q`
- `pytest cli/python/base_projects/tests/test_engine.py -q`
- `./bin/base-test`
- `pylint` on touched Python files
- `git diff --check`
