### PR TITLE
Bind project context across all project-targeting handlers

### DIFF
--- a/cli/python/base_export_context/engine.py
+++ b/cli/python/base_export_context/engine.py
@@ -72,6 +72,12 @@ def run(
         print_bundle=print_bundle,
         list_files=list_files,
     )
+    manifest_path = options.project_root / "base_manifest.yaml"
+    ctx.bind_project(
+        options.project_name,
+        options.project_root,
+        manifest_path if manifest_path.is_file() else None,
+    )
     validation_error = validate_options(options, raw_output_format=output_format)
     if validation_error is not None:
         ctx.log.error(validation_error)

--- a/cli/python/base_export_context/tests/test_engine.py
+++ b/cli/python/base_export_context/tests/test_engine.py
@@ -9,6 +9,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.history import build_finished_record
 from base_export_context import engine
 
 
@@ -32,6 +33,46 @@ def invoke_engine(args: list[str], project_root: Path) -> tuple[int, str, str]:
 
 
 class ExportContextTests(unittest.TestCase):
+    def test_explicit_project_root_populates_history_project_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            project_root = root / "demo"
+            project_root.mkdir()
+            (project_root / "base_manifest.yaml").write_text(
+                "project:\n  name: demo\nartifacts: []\n",
+                encoding="utf-8",
+            )
+            write_context_file(project_root, "PROJECT.md", "Project\n")
+            outside = root / "outside"
+            outside.mkdir()
+            captured: list[tuple[object, ...]] = []
+
+            with (
+                mock.patch("base_cli.app.current_working_dir", return_value=outside),
+                mock.patch(
+                    "base_cli.app.write_finished_record",
+                    side_effect=lambda *args: captured.append(args),
+                ),
+            ):
+                status, _stdout, stderr = invoke_engine(
+                    [
+                        "--project-name",
+                        "demo",
+                        "--project-root",
+                        str(project_root),
+                        "--list-files",
+                    ],
+                    project_root,
+                )
+
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertEqual(len(captured), 1)
+            record = build_finished_record(*captured[0])
+
+        self.assertEqual(record["project"], "demo")
+        self.assertEqual(record["project_root"], str(project_root.resolve()))
+        self.assertEqual(record["manifest"], str((project_root / "base_manifest.yaml").resolve()))
+
     def test_main_reports_unknown_option_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "demo"

--- a/cli/python/base_pr_policy/engine.py
+++ b/cli/python/base_pr_policy/engine.py
@@ -125,6 +125,7 @@ def run(
     if manifest_path is None:
         ctx.log.error("No base_manifest.yaml found from the current directory upward.")
         return base_cli.ExitCode.USAGE_ERROR
+    ctx.bind_project(None, manifest_path.parent, manifest_path)
     try:
         body = body_from_manifest(
             manifest_path,

--- a/cli/python/base_pr_policy/tests/test_engine.py
+++ b/cli/python/base_pr_policy/tests/test_engine.py
@@ -1,10 +1,45 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest import mock
 
+from base_cli.history import build_finished_record
+from base_cli.testing import invoke
 from base_pr_policy import engine
 from base_pr_policy.engine import PrPolicyInputs, render_pr_body
 from base_setup.github_manifest import GithubPrConfig, GithubPrRequiredSectionsConfig
+
+
+def test_explicit_manifest_populates_history_project_metadata(tmp_path) -> None:
+    project_root = tmp_path / "demo"
+    project_root.mkdir()
+    manifest_path = project_root / "base_manifest.yaml"
+    manifest_path.write_text(
+        "project:\n  name: demo\ngithub:\n  pr:\n    required_sections:\n      default: [Summary]\n",
+        encoding="utf-8",
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    captured = []
+
+    with mock.patch(
+        "base_cli.app.write_finished_record",
+        side_effect=lambda *args: captured.append(args),
+    ):
+        result = invoke(
+            engine.app,
+            ["body", "--manifest", str(manifest_path)],
+            home=tmp_path / "home",
+            cwd=outside,
+            env={"BASE_HOME": str(project_root)},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert len(captured) == 1
+    record = build_finished_record(*captured[0])
+    assert record["project"] == "demo"
+    assert record["project_root"] == str(project_root.resolve())
+    assert record["manifest"] == str(manifest_path.resolve())
 
 
 def test_main_rejects_equals_form_options(capsys) -> None:

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -777,8 +777,7 @@ def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: s
 
 def bind_project_context(ctx: base_cli.Context, project: Project) -> Project:
     """Associate a resolved project with the invocation history context."""
-    ctx.project_root = project.root
-    ctx.manifest_path = project.manifest_path
+    ctx.bind_project(project.name, project.root, project.manifest_path)
     return project
 
 

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -99,11 +99,13 @@ def build_release_context(ctx: base_cli.Context, args: ReleaseArguments) -> Rele
     if manifest_path is None:
         raise ReleaseError("No base_manifest.yaml was found. Pass --manifest <path>.")
     manifest_path = manifest_path.resolve()
+    ctx.bind_project(None, manifest_path.parent, manifest_path)
     manifest = read_manifest(manifest_path)
     if manifest.release is None:
         raise ReleaseError(f"{manifest_path}: manifest does not declare release metadata.")
 
     project_root = manifest_path.parent
+    ctx.bind_project(manifest.project_name, project_root, manifest_path)
     release = manifest.release
     return ReleaseContext(
         manifest_path=manifest_path,

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -12,6 +12,7 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.history import build_finished_record
 from base_release import release_publish
 from base_release import release_readiness
 from base_release.engine import ReleaseError
@@ -192,7 +193,37 @@ class ReleaseUsageTests(unittest.TestCase):
         self.assertNotIn("base_release", stderr)
 
 
-class ReleaseEngineTests(unittest.TestCase):
+class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-methods
+
+    def test_explicit_manifest_populates_history_project_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            project_root = root / "demo"
+            project_root.mkdir()
+            manifest_path = write_release_project(project_root)
+            outside = root / "outside"
+            outside.mkdir()
+            captured: list[tuple[object, ...]] = []
+
+            with (
+                mock.patch("base_cli.app.current_working_dir", return_value=outside),
+                mock.patch(
+                    "base_cli.app.write_finished_record",
+                    side_effect=lambda *args: captured.append(args),
+                ),
+            ):
+                status, _stdout, stderr = run_engine(
+                    ["notes", "--version", "1.2.3", "--manifest", str(manifest_path)],
+                    outside,
+                )
+
+            self.assertEqual((status, stderr), (0, ""))
+            self.assertEqual(len(captured), 1)
+            record = build_finished_record(*captured[0])
+
+        self.assertEqual(record["project"], "demo")
+        self.assertEqual(record["project_root"], str(project_root.resolve()))
+        self.assertEqual(record["manifest"], str(manifest_path.resolve()))
 
     def test_check_json_reports_ready_findings_with_stable_envelope(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -84,8 +84,7 @@ def run(
 ) -> int:
     manifest_path = Path(manifest).resolve() if manifest else discover_manifest(Path(start_dir))
     if manifest_path is not None:
-        ctx.manifest_path = manifest_path
-        ctx.project_root = manifest_path.parent
+        ctx.bind_project(None, manifest_path.parent, manifest_path)
     if manifest_path is None:
         if project:
             ctx.log.error("No base_manifest.yaml found for project '%s'.", project)
@@ -95,6 +94,7 @@ def run(
 
     try:
         base_manifest = read_manifest(manifest_path)
+        ctx.bind_project(base_manifest.project_name, manifest_path.parent, manifest_path)
         validate_project_name(base_manifest, project)
         manifest_action = ManifestAction(action, dry_run, output_format, write, remote_network)
         if action == "route":

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -246,6 +246,7 @@ def resolve_trust_identity_for_require(
         return resolve_trust_identity(ctx, project_name, workspace)
 
     identity = compute_trust_identity_for_manifest(Path(manifest_path))
+    ctx.bind_project(identity.project_name, identity.project_root, identity.manifest_path)
     if identity.project_name != project_name:
         raise TrustError(
             f"Resolved manifest '{identity.manifest_path}' declares project '{identity.project_name}', "

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -11,6 +11,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_cli.history import build_finished_record
 from base_cli.testing import invoke
 
 
@@ -95,6 +96,39 @@ def init_git_repo(project_root: Path, origin: str) -> str:
 
 
 class ManifestCommandTrustTests(unittest.TestCase):
+    def test_require_explicit_manifest_populates_history_project_metadata(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project_root = root / "work" / "demo"
+            manifest_path = write_manifest(project_root)
+            outside = root / "outside"
+            outside.mkdir()
+            captured: list[tuple[object, ...]] = []
+
+            with mock.patch(
+                "base_cli.app.write_finished_record",
+                side_effect=lambda *args: captured.append(args),
+            ):
+                result = invoke(
+                    engine.app,
+                    ["require", "demo", "--manifest", str(manifest_path)],
+                    home=home,
+                    cwd=outside,
+                    env={"BASE_HOME": str(root / "base")},
+                )
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Manifest-declared commands are not allowed", result.stderr)
+            self.assertEqual(len(captured), 1)
+            record = build_finished_record(*captured[0])
+
+        self.assertEqual(record["project"], "demo")
+        self.assertEqual(record["project_root"], str(project_root.resolve()))
+        self.assertEqual(record["manifest"], str(manifest_path.resolve()))
+
     def test_engine_reexports_trust_store_helpers(self) -> None:
         from base_trust import engine, trust_store
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -125,6 +125,7 @@ registration.
 ctx.cli_name       # str
 ctx.run_id         # str
 ctx.base_home      # Path | None
+ctx.project_name   # selected project name, or None
 ctx.project_root   # Path | None
 ctx.manifest_path  # Path | None
 ctx.workspace_root # configured workspace root, or None

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -38,6 +38,7 @@ class Context:
     base_home: Path | None = None
     project_root: Path | None = None
     manifest_path: Path | None = None
+    project_name: str | None = None
     user_config: UserConfig = field(default_factory=_default_user_config)
     cleanup_hooks: list[Callable[[], None]] = field(default_factory=list)
     workspace_root: Path | None = None
@@ -45,6 +46,12 @@ class Context:
 
     def on_cleanup(self, hook: Callable[[], None]) -> None:
         self.cleanup_hooks.append(hook)
+
+    def bind_project(self, project_name: str | None, project_root: Path, manifest_path: Path | None = None) -> None:
+        """Bind the selected project to this invocation's history context."""
+        self.project_name = project_name
+        self.project_root = project_root.resolve()
+        self.manifest_path = manifest_path.resolve() if manifest_path is not None else None
 
     def cleanup(self) -> None:
         for hook in self.cleanup_hooks:

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -171,6 +171,8 @@ def base_setup_action(argv: list[str]) -> str | None:
 
 
 def project_name(context: Context) -> str | None:
+    if context.project_name:
+        return context.project_name
     if context.manifest_path is None:
         return None
     try:


### PR DESCRIPTION
Fixes #1669

## Summary

- add a shared `Context.bind_project()` API for invocation history attribution
- bind explicit targets in release, PR policy, trust, and export-context handlers
- preserve the existing setup and projects fixes while recording the selected project name
- add regressions that run from outside the selected project and assert project metadata
- document the selected project field on the public Context API

## Root cause

Several handlers resolved an explicit manifest or project root into local command state but left the top-level CLI context pointing at the caller's working directory. The history finalizer reads that context, so explicit-target invocations were recorded as the current project or as `-`.

## Validation

- focused Python tests: 239 passed, 42 subtests passed
- full Python suite: 1,002 passed, 1 skipped
- full shell/Bats suite: 796 passed
- focused pylint: clean
- `git diff --check`: clean
