### PR TITLE
Add history ordering and time filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,9 @@ basectl history --format json
 basectl history --report
 basectl history --report --format json
 basectl history --include-internal
+basectl history --oldest-first
+basectl history --last 2h --oldest-first
+basectl history --since 2026-07-17 --until 2026-07-18
 basectl history --local-time
 ```
 
@@ -1124,7 +1127,9 @@ as internal records and can be shown with `--include-internal`. History records
 point to raw logs instead of replacing them, and malformed history lines are
 ignored while listing recent runs. `--report` prints a privacy-conscious local activity
 summary with recent commands, failure counts, common failing command families,
-and log file locations. Text and Markdown timestamps use UTC by default;
+and log file locations. Use `--oldest-first` for chronological display,
+`--last 2h` for a relative window, or `--since`/`--until` for explicit bounds.
+Text and Markdown timestamps use UTC by default;
 `--local-time` renders those views in the host's local timezone. JSON retains
 canonical UTC timestamps. Reports do not include raw log contents, compact home
 paths to `~`, and redact secret-looking arguments and URL credentials. The

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -91,7 +91,8 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl logs last` prints the latest failed command metadata and a bounded
   redacted log tail, with optional JSON output for local automation.
 - `basectl history` lists recent structured Base command runs from the local
-  history index and supports table, JSON, and privacy-conscious report output.
+  history index and supports table, JSON, privacy-conscious reports, chronological
+  ordering, and bounded time-window filters.
 - `basectl config path/show/doctor` inspects Base's machine-local user config at `~/.base.d/config.yaml`.
 - `basectl trust status [project]` inspects one project's manifest command
   trust or all discovered command-bearing projects. `basectl trust

--- a/cli/bash/commands/basectl/subcommands/history.sh
+++ b/cli/bash/commands/basectl/subcommands/history.sh
@@ -18,6 +18,10 @@ Options:
                         Output format. Defaults to text, or Markdown with --report.
   --report              Print a privacy-conscious Markdown or JSON activity report.
   --include-internal    Include delegated internal steps in the output.
+  --oldest-first        Show the selected history window from oldest to newest.
+  --last <duration>     Show records from the most recent duration, such as 2h or 7d.
+  --since <time>        Include records at or after an ISO-8601 or short timestamp.
+  --until <time>        Exclude records at or after an ISO-8601 or short timestamp.
   --local-time          Render text and Markdown timestamps in the local timezone. Defaults to UTC.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
@@ -52,7 +56,11 @@ base_history_subcommand_main() {
                 args+=("$1")
                 shift
                 ;;
-            --project|--command|--status|--limit|--format)
+            --oldest-first)
+                args+=("$1")
+                shift
+                ;;
+            --project|--command|--status|--limit|--format|--last|--since|--until)
                 [[ -n "${2:-}" ]] || {
                     base_history_subcommand_usage >&2
                     print_error "Option '$1' requires an argument."
@@ -61,7 +69,7 @@ base_history_subcommand_main() {
                 args+=("$1" "$2")
                 shift 2
                 ;;
-            --project=*|--command=*|--status=*|--limit=*|--format=*)
+            --project=*|--command=*|--status=*|--limit=*|--format=*|--last=*|--since=*|--until=*)
                 args+=("$1")
                 shift
                 ;;

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -331,7 +331,7 @@ EOF
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"logs_last_options=--command --lines --format"* ]]
     [[ "$output" == *"logs_commands=last"* ]]
-    [[ "$output" == *"history_options=--project --command --status --limit --format --report --include-internal --local-time"* ]]
+    [[ "$output" == *"history_options=--project --command --status --limit --format --report --include-internal --oldest-first --last --since --until --local-time"* ]]
     [[ "$output" == *"trust_commands=status allow revoke"* ]]
     [[ "$output" == *"trust_projects=base demo"* ]]
     [[ "$output" == *"trust_status_options=--workspace --format"* ]]

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -19,11 +19,11 @@ exit 1
 EOF
     chmod +x "$python_bin"
 
-    run_basectl history --project demo --command check --status error --limit 3 --format json --include-internal --local-time
+    run_basectl history --project demo --command check --status error --limit 3 --format json --include-internal --oldest-first --last 2h --since 2026-06-10 --until 2026-06-11 --local-time
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_PROJECT=base"* ]]
-    [[ "$output" == *"ARGS=--project demo --command check --status error --limit 3 --format json --include-internal --local-time"* ]]
+    [[ "$output" == *"ARGS=--project demo --command check --status error --limit 3 --format json --include-internal --oldest-first --last 2h --since 2026-06-10 --until 2026-06-11 --local-time"* ]]
 }
 
 @test "basectl history forwards report mode to the Python history layer" {
@@ -77,6 +77,10 @@ EOF
     [[ "$output" == *"--project <name>"* ]]
     [[ "$output" == *"--report"* ]]
     [[ "$output" == *"--include-internal"* ]]
+    [[ "$output" == *"--oldest-first"* ]]
+    [[ "$output" == *"--last <duration>"* ]]
+    [[ "$output" == *"--since <time>"* ]]
+    [[ "$output" == *"--until <time>"* ]]
     [[ "$output" == *"--local-time"* ]]
     [[ "$output" == *"--format <text|markdown|json>"* ]]
 }
@@ -92,6 +96,12 @@ EOF
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"ERROR: Option '--limit' requires an argument."* ]]
+    [[ "$output" != *"FATAL"* ]]
+
+    run_basectl history --since
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Option '--since' requires an argument."* ]]
     [[ "$output" != *"FATAL"* ]]
 }
 

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections import Counter
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,7 @@ from base_cli.history import parse_finished_history_record_line
 from base_cli.history import parse_positive_int
 from base_cli.history import redact_history_argv
 from base_cli.history import redact_history_text
+from base_cli.history import utc_now
 from base_cli.paths import base_cache_root
 
 
@@ -59,6 +61,9 @@ class HistoryOptions:
     report: bool
     include_internal: bool
     local_time: bool
+    oldest_first: bool
+    since: datetime | None
+    until: datetime | None
 
 
 @dataclass(frozen=True)
@@ -90,6 +95,18 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--format", "output_format", default="text", help="Output format: text, markdown, or json.")
 @base_cli.option("--report", is_flag=True, help="Print a privacy-conscious local activity report.")
 @base_cli.option("--include-internal", is_flag=True, help="Include delegated internal steps in the output.")
+@base_cli.option("--oldest-first", is_flag=True, help="Show the selected history window from oldest to newest.")
+@base_cli.option("--last", "last_window", help="Show records from the most recent duration, such as 2h or 7d.")
+@base_cli.option(
+    "--since",
+    "since_value",
+    help="Include records at or after a timestamp; accepts ISO-8601 or YYYY-MM-DD[ HH:MM[:SS]].",
+)
+@base_cli.option(
+    "--until",
+    "until_value",
+    help="Exclude records at or after a timestamp; accepts ISO-8601 or YYYY-MM-DD[ HH:MM[:SS]].",
+)
 @base_cli.option(
     "--local-time",
     is_flag=True,
@@ -106,8 +123,13 @@ def run(
     report: bool,
     include_internal: bool,
     local_time: bool,
+    oldest_first: bool,
+    last_window: str | None,
+    since_value: str | None,
+    until_value: str | None,
 ) -> int:
     try:
+        since, until = resolve_time_window(last_window, since_value, until_value)
         options = HistoryOptions(
             project=project_filter,
             command=command_filter,
@@ -117,6 +139,9 @@ def run(
             report=report,
             include_internal=include_internal,
             local_time=local_time,
+            oldest_first=oldest_first,
+            since=since,
+            until=until,
         )
     except ValueError as exc:
         ctx.log.error(str(exc))
@@ -164,6 +189,54 @@ def normalize_report_format(value: str) -> str:
     return normalized
 
 
+def resolve_time_window(
+    last_window: str | None,
+    since_value: str | None,
+    until_value: str | None,
+) -> tuple[datetime | None, datetime | None]:
+    if last_window and (since_value or until_value):
+        raise ValueError("Options '--last' and '--since/--until' cannot be combined.")
+
+    if last_window:
+        now = utc_now()
+        return now - parse_duration("--last", last_window), now
+
+    since = parse_history_bound("--since", since_value) if since_value else None
+    until = parse_history_bound("--until", until_value) if until_value else None
+    if since is not None and until is not None and since >= until:
+        raise ValueError("Option '--since' must be earlier than '--until'.")
+    return since, until
+
+
+def parse_duration(option: str, value: str) -> timedelta:
+    units = {"d": 24 * 60 * 60, "h": 60 * 60, "m": 60, "s": 1}
+    normalized = value.strip()
+    if not re.fullmatch(r"[0-9]+[dhmsDHMS]", normalized) or int(normalized[:-1]) <= 0:
+        raise ValueError(f"Option '{option}' must be a positive duration such as 30m, 2h, or 7d.")
+    return timedelta(seconds=int(normalized[:-1]) * units[normalized[-1].lower()])
+
+
+def parse_history_bound(option: str, value: str) -> datetime:
+    normalized = value.strip()
+    parsed: datetime | None = None
+    for date_format in ("%Y-%m-%d", "%Y-%m-%d %H:%M", "%Y-%m-%d %H:%M:%S"):
+        try:
+            parsed = datetime.strptime(normalized, date_format)
+            break
+        except ValueError:
+            continue
+    if parsed is None:
+        try:
+            parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(
+                f"Option '{option}' must be ISO-8601 or YYYY-MM-DD[ HH:MM[:SS]] with an optional timezone."
+            ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.now().astimezone().tzinfo or timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def recent_history(
     cache_root: Path,
     options: HistoryOptions | None = None,
@@ -175,7 +248,8 @@ def recent_history(
     sorted_records = sorted(records, key=lambda record: (record.sort_time, record.run_id), reverse=True)
     if options is None:
         return sorted_records
-    return sorted_records[: options.limit]
+    selected = sorted_records[: options.limit]
+    return list(reversed(selected)) if options.oldest_first else selected
 
 
 def read_history_records(cache_root: Path, logger: Any | None = None) -> list[HistoryRecord]:
@@ -240,6 +314,10 @@ def filter_history(records: list[HistoryRecord], options: HistoryOptions) -> lis
         filtered = [record for record in filtered if record.command == options.command]
     if options.status:
         filtered = [record for record in filtered if record.status == options.status]
+    if options.since is not None:
+        filtered = [record for record in filtered if record.sort_time >= options.since]
+    if options.until is not None:
+        filtered = [record for record in filtered if record.sort_time < options.until]
     return filtered
 
 

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -134,6 +134,89 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertEqual((json_status, json_stderr), (0, ""))
         self.assertEqual(json.loads(json_stdout)[0]["ended_at"], "2026-06-10T10:15:00Z")
 
+    def test_oldest_first_reverses_only_the_selected_recent_window(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(cache_root, history_record("old", "check", ended_at="2026-06-10T10:00:00Z"))
+            write_history_line(cache_root, history_record("middle", "check", ended_at="2026-06-10T10:10:00Z"))
+            write_history_line(cache_root, history_record("new", "check", ended_at="2026-06-10T10:20:00Z"))
+
+            status, stdout, stderr = invoke(["--oldest-first", "--limit", "2", "--format", "json"], cache_root)
+            payload = json.loads(stdout)
+
+        self.assertEqual((status, stderr), (0, ""))
+        self.assertEqual([record["run_id"] for record in payload], ["middle", "new"])
+
+    def test_time_filters_support_explicit_bounds_and_exclusive_until(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(cache_root, history_record("before", "check", ended_at="2026-06-10T09:59:59Z"))
+            write_history_line(cache_root, history_record("start", "check", ended_at="2026-06-10T10:00:00Z"))
+            write_history_line(cache_root, history_record("inside", "check", ended_at="2026-06-10T10:30:00Z"))
+            write_history_line(cache_root, history_record("end", "check", ended_at="2026-06-10T11:00:00Z"))
+
+            status, stdout, stderr = invoke(
+                [
+                    "--since",
+                    "2026-06-10T10:00:00Z",
+                    "--until",
+                    "2026-06-10T11:00:00Z",
+                    "--oldest-first",
+                    "--format",
+                    "json",
+                ],
+                cache_root,
+            )
+            payload = json.loads(stdout)
+
+        self.assertEqual((status, stderr), (0, ""))
+        self.assertEqual([record["run_id"] for record in payload], ["start", "inside"])
+
+    def test_last_duration_uses_current_time_as_an_exclusive_upper_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(cache_root, history_record("included", "check", ended_at="2026-06-10T10:00:00Z"))
+            write_history_line(cache_root, history_record("excluded", "check", ended_at="2026-06-10T10:15:00Z"))
+            current_time = engine.datetime(2026, 6, 10, 10, 15, tzinfo=engine.timezone.utc)
+
+            with mock.patch("base_history.engine.utc_now", return_value=current_time):
+                status, stdout, stderr = invoke(["--last", "15m", "--format", "json"], cache_root)
+            payload = json.loads(stdout)
+
+        self.assertEqual((status, stderr), (0, ""))
+        self.assertEqual([record["run_id"] for record in payload], ["included"])
+
+    def test_short_time_forms_are_parsed_in_the_host_timezone(self) -> None:
+        parsed = engine.parse_history_bound("--since", "2026-06-10 10:15")
+
+        self.assertEqual(parsed.tzinfo, engine.timezone.utc)
+        self.assertEqual(parsed.minute, 15)
+
+    def test_invalid_time_filters_report_usage_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            last_status, _last_stdout, last_stderr = invoke(
+                ["--last", "2h", "--since", "2026-06-10T10:00:00Z"], Path(tmpdir)
+            )
+            malformed_status, _malformed_stdout, malformed_stderr = invoke(
+                ["--since", "tomorrow"], Path(tmpdir)
+            )
+            reversed_status, _reversed_stdout, reversed_stderr = invoke(
+                [
+                    "--since",
+                    "2026-06-10T11:00:00Z",
+                    "--until",
+                    "2026-06-10T10:00:00Z",
+                ],
+                Path(tmpdir),
+            )
+
+        self.assertEqual(last_status, 2)
+        self.assertIn("cannot be combined", last_stderr)
+        self.assertEqual(malformed_status, 2)
+        self.assertIn("must be ISO-8601", malformed_stderr)
+        self.assertEqual(reversed_status, 2)
+        self.assertIn("must be earlier", reversed_stderr)
+
     def test_json_output_filters_history_records(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -109,8 +109,8 @@ manifest trust.
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
 | `basectl logs last` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name>`, `--lines <count>`, `--format <text\|json>` |
 | `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |
-| `basectl history` | List recent user-facing Base command history records. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--format <text\|json>`, `--include-internal`, `--local-time` |
-| `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>`, `--local-time` |
+| `basectl history` | List recent user-facing Base command history records. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--limit <count>`, `--format <text\|json>`, `--include-internal`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
+| `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
 | `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name>` |
 | `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name>`, `--lines <count>` |
 | `basectl clean` | Remove old Base runtime logs, temp files, and cache entries. | `--older-than <age>`, `--keep-last <count>`, `--dry-run` |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -180,9 +180,19 @@ Expected options:
 - `--report --format json` prints the same report as deterministic JSON.
 - `--include-internal` includes delegated resolver, routing, bootstrap, and
   trust-gate records linked to each primary command.
+- `--oldest-first` reverses the selected window from newest-to-oldest to
+  oldest-to-newest; the default remains newest-first.
+- `--last <duration>` selects a relative window such as `30m`, `2h`, or `7d`.
+- `--since <time>` and `--until <time>` select a bounded window. Values accept
+  ISO-8601 or `YYYY-MM-DD[ HH:MM[:SS]]`; short values use the host timezone,
+  while explicit offsets or `Z` take precedence. `--until` is exclusive.
 - Text and Markdown timestamps are labeled `TIME (UTC)`/`Time (UTC)` by default.
   `--local-time` renders those views in the host's local timezone; JSON keeps
   canonical UTC timestamps for stable automation.
+
+Time filters are applied before ordering and `--limit`. `--last` cannot be
+combined with `--since` or `--until`, and invalid or reversed ranges are usage
+errors.
 
 `basectl logs` should remain the command for opening or tailing raw log files.
 `basectl history` should point to logs, not replace them.

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -178,7 +178,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | `basectl check [project] [--profile]` | Quick pass/fail readiness check |
 | `basectl doctor [project] [--profile]` | Human-readable findings + fix commands |
 | `basectl logs [--tail\|--command\|--path\|--open]` | Inspect runtime logs |
-| `basectl history [--format json]` | Inspect structured local command history |
+| `basectl history [--format json]` | Inspect structured local command history with ordering and time-window filters |
 | `basectl history --report [--format json]` | Summarize local command history and log metadata without raw log dumps |
 | `basectl config path\|show\|doctor` | Machine-local config |
 | `basectl clean [--older-than\|--keep-last]` | Prune cache/logs |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -766,7 +766,7 @@ _base_basectl_completion() {
             fi
             ;;
         history)
-            _base_basectl_completion_compgen "--project --command --status --limit --format --report --include-internal --local-time -v -h --help" "$cur"
+            _base_basectl_completion_compgen "--project --command --status --limit --format --report --include-internal --oldest-first --last --since --until --local-time -v -h --help" "$cur"
             ;;
         config)
             if ((COMP_CWORD == 2)); then

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -916,6 +916,10 @@ _base_basectl_completion() {
                 '--format[Output format]:format:(text json)' \
                 '--report[Print a privacy-conscious Markdown or JSON activity report]' \
                 '--include-internal[Include delegated internal steps in the output]' \
+                '--oldest-first[Show the selected history window from oldest to newest]' \
+                '--last[Show records from the most recent duration]:duration:' \
+                '--since[Include records at or after a timestamp]:time:' \
+                '--until[Exclude records at or after a timestamp]:time:' \
                 '--local-time[Render text and Markdown timestamps in local time; defaults to UTC]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -587,7 +587,7 @@ run_zsh_positional_completion() {
     [[ "$block" == *"--config"* ]]
 }
 
-@test "Zsh history completion includes report and local-time options" {
+@test "Zsh history completion includes report, ordering, and time options" {
     local block
 
     block="$(
@@ -600,6 +600,10 @@ run_zsh_positional_completion() {
 
     [[ "$block" == *"--report"* ]]
     [[ "$block" == *"--include-internal"* ]]
+    [[ "$block" == *"--oldest-first"* ]]
+    [[ "$block" == *"--last"* ]]
+    [[ "$block" == *"--since"* ]]
+    [[ "$block" == *"--until"* ]]
     [[ "$block" == *"--local-time"* ]]
 }
 


### PR DESCRIPTION
## Summary

- add `--oldest-first` while keeping newest-first as the default
- add `--last`, `--since`, and `--until` history filters with concise duration and timestamp forms
- define exclusive upper bounds, local-time parsing for naive short values, and UTC normalization
- update help, README, observability, command-reference, technical overview, completions, and tests

Closes #1676

## Validation

- focused history Python, Bash, and completion suites
- `./bin/base-test` (`1012 passed, 1 skipped`)
- ShellCheck and `git diff --check`
