### PR TITLE
Implement owner-aware runtime bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,8 +1120,11 @@ basectl history --since 2026-07-17 --until 2026-07-18
 basectl history --local-time
 ```
 
-`basectl history` reads the local history index at
-`<base-cache-root>/history/runs.jsonl`. The default view shows one primary row
+`basectl history` reads the local Base history index at
+`<base-cache-root>/base/history/runs.jsonl`. Each invocation also has a
+run-oriented bundle under `<base-cache-root>/base/runs/<run-id>/`, while
+project-native commands use `<base-cache-root>/projects/<project>/<checkout>/`.
+The default view shows one primary row
 per public `basectl` command; delegated Python and resolver steps remain linked
 as internal records and can be shown with `--include-internal`. History records
 point to raw logs instead of replacing them, and malformed history lines are
@@ -1169,9 +1172,9 @@ unless `--yes` is supplied, creates an annotated tag, pushes the tag, and
 creates the GitHub Release from the matching changelog section. Homebrew tap
 updates remain a manual handoff printed by the command.
 
-Use `--keep-last <count>` to retain the newest log files per CLI log directory
-while pruning older logs. This retention mode applies only to `*.log` files;
-temp and cache artifacts continue to use `--older-than`.
+Use `--keep-last <count>` to retain the newest completed run bundles per owner
+namespace. `--older-than` removes completed bundles and persistent component
+caches by age; active bundles and durable `~/.base.d` state are never removed.
 
 Use `basectl doctor` when you want a human-oriented diagnosis with suggested
 fixes. Each finding includes a stable identifier that automation can use

--- a/bin/base-wrapper
+++ b/bin/base-wrapper
@@ -108,7 +108,11 @@ main() {
 
     BASE_HOME="$base_home"
     BASE_PROJECT="$project"
-    export BASE_HOME BASE_PROJECT
+    # This wrapper always launches Base's control-plane Python packages. The
+    # selected project only chooses the virtual environment; it must not move
+    # Base-owned runtime artifacts into a project's namespace.
+    BASE_CLI_RUNTIME_OWNER=base
+    export BASE_HOME BASE_PROJECT BASE_CLI_RUNTIME_OWNER
 
     python_bin="${BASE_PROJECT_VENV_DIR:-$HOME/.base.d/$project/.venv}/bin/python"
     [[ -x "$python_bin" ]] || base_wrapper_die "Project virtual environment Python was not found at '$python_bin'. Run 'basectl setup'."

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -506,6 +506,71 @@ basectl_history_recordable_command() {
     esac
 }
 
+basectl_args_request_help() {
+    local argument
+    for argument in "$@"; do
+        [[ "$argument" == "-h" || "$argument" == "--help" ]] && return 0
+    done
+    return 1
+}
+
+basectl_cache_root() {
+    if [[ -n "${BASE_CACHE_DIR:-}" ]]; then
+        printf '%s\n' "${BASE_CACHE_DIR%/}"
+        return 0
+    fi
+    if [[ "$(uname -s 2>/dev/null || true)" == Darwin ]]; then
+        printf '%s\n' "$HOME/Library/Caches/base"
+    else
+        printf '%s\n' "$HOME/.cache/base"
+    fi
+}
+
+basectl_initialize_run_bundle() {
+    local cache_root run_id run_root
+
+    if [[ -n "${BASE_CLI_RUN_ROOT:-}" ]]; then
+        export BASE_CLI_RUNTIME_OWNER=base
+        export BASE_CLI_RUN_ID="${BASE_CLI_RUN_ID:-$(basename -- "$BASE_CLI_RUN_ROOT")}"
+        export BASE_CLI_PRIMARY_LOG="${BASE_CLI_PRIMARY_LOG:-$BASE_CLI_RUN_ROOT/logs/primary.log}"
+        export BASE_CLI_HISTORY_PARENT_RUN_ID="${BASE_CLI_HISTORY_PARENT_RUN_ID:-$BASE_CLI_RUN_ID}"
+        return 0
+    fi
+
+    cache_root="$(basectl_cache_root)"
+    run_id="$(date -u +%Y%m%dT%H%M%S 2>/dev/null || true)_${BASHPID:-$$}_${RANDOM}"
+    run_root="$cache_root/base/runs/$run_id"
+    mkdir -p "$run_root/logs" "$run_root/tmp" || {
+        basectl_error "Unable to create Base run bundle '$run_root'. Check BASE_CACHE_DIR permissions."
+        return 1
+    }
+
+    export BASE_CLI_RUNTIME_OWNER=base
+    export BASE_CLI_RUN_ID="$run_id"
+    export BASE_CLI_RUN_ROOT="$run_root"
+    export BASE_CLI_PRIMARY_LOG="$run_root/logs/primary.log"
+    export BASE_CLI_HISTORY_PARENT_RUN_ID="$run_id"
+    printf '{"run_id":"%s","owner":"base","status":"running","started_at":"%s"}\n' \
+        "$run_id" "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" >"$run_root/run.json"
+    printf '%s basectl start run_id=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" "$run_id" >>"$BASE_CLI_PRIMARY_LOG"
+}
+
+basectl_finalize_run_bundle() {
+    local exit_code="$1" run_root tmp_file
+
+    run_root="${BASE_CLI_RUN_ROOT:-}"
+    [[ -n "$run_root" && -d "$run_root" ]] || return 0
+    printf '%s basectl finish status=%s exit_code=%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" \
+        "$([[ "$exit_code" == 0 ]] && printf ok || printf error)" "$exit_code" >>"${BASE_CLI_PRIMARY_LOG:-$run_root/logs/primary.log}"
+    tmp_file="$run_root/run.json.tmp"
+    printf '{"run_id":"%s","owner":"base","status":"%s","exit_code":%s,"started_at":"%s","ended_at":"%s"}\n' \
+        "${BASE_CLI_RUN_ID:-$(basename -- "$run_root")}" \
+        "$([[ "$exit_code" == 0 ]] && printf ok || printf error)" "$exit_code" \
+        "${BASE_CLI_HISTORY_STARTED_AT:-}" \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" >"$tmp_file" && mv -f "$tmp_file" "$run_root/run.json"
+}
+
 basectl_history_record() {
     local command="$1"
     local exit_code="$2"
@@ -521,6 +586,10 @@ basectl_history_record() {
     args+=(--run-id "${BASE_CLI_HISTORY_PARENT_RUN_ID:-}")
     args+=(--exit-code "$exit_code")
     args+=(--scope "$scope")
+    args+=(--owner "${BASE_CLI_RUNTIME_OWNER:-base}")
+    if [[ -n "${BASE_CLI_RUN_ROOT:-}" ]]; then
+        args+=(--bundle-path "$BASE_CLI_RUN_ROOT")
+    fi
     if [[ -n "${BASE_CLI_HISTORY_STARTED_AT:-}" ]]; then
         args+=(--started-at "$BASE_CLI_HISTORY_STARTED_AT")
     fi
@@ -539,7 +608,7 @@ basectl_history_record() {
 
 
 basectl_main() {
-    local base_debug=0 command="" command_status
+    local base_debug=0 command="" command_status run_bundle_enabled=1
     local history_args=() history_scope="${BASE_CLI_HISTORY_SCOPE:-primary}"
     local opt
 
@@ -615,10 +684,12 @@ basectl_main() {
 
     basectl_reject_equals_option_values "$@" || return $?
     basectl_reject_private_standard_options "$@" || return $?
+    basectl_args_request_help "$@" && run_bundle_enabled=0
+    basectl_history_recordable_command "$command" || run_bundle_enabled=0
 
     basectl_get_base_home || return 1
-    if [[ -z "${BASE_CLI_HISTORY_PARENT_RUN_ID:-}" ]]; then
-        export BASE_CLI_HISTORY_PARENT_RUN_ID="basectl-${BASHPID:-$$}-${RANDOM}"
+    if ((run_bundle_enabled)); then
+        basectl_initialize_run_bundle || return 1
     fi
     export BASE_CLI_HISTORY_SCOPE=internal
     BASE_CLI_HISTORY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
@@ -675,7 +746,10 @@ basectl_main() {
             ;;
     esac
 
-    basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+    if ((run_bundle_enabled)); then
+        basectl_finalize_run_bundle "$command_status"
+        basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+    fi
     return "$command_status"
 }
 

--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -85,6 +85,9 @@ base_project_activate_environment() {
     export BASE_PROJECT_ROOT="$project_root"
     export BASE_PROJECT_MANIFEST="$manifest_path"
     export BASE_PROJECT_VENV_DIR="$venv_dir"
+    export BASE_CLI_PROJECT_NAME="$project"
+    export BASE_CLI_PROJECT_ROOT="$project_root"
+    export BASE_CLI_PROJECT_MANIFEST="$manifest_path"
 
     if [[ -d "$venv_dir/bin" ]]; then
         PATH="$venv_dir/bin:$PATH"
@@ -149,7 +152,16 @@ base_project_run_shell_command() {
 
     # Bash assigns the word after `bash -c <command>` to `$0`; use a stable
     # sentinel so delegated extra args start at `$1` and populate `$@`.
-    (cd "$working_dir" && bash -c "$command_to_run" "$command_name" "$@")
+    (
+        export BASE_CLI_RUNTIME_OWNER=project
+        export BASE_CLI_PROJECT_ROOT="${BASE_PROJECT_ROOT:-$working_dir}"
+        export BASE_CLI_PROJECT_NAME="${BASE_PROJECT:-$(basename -- "$working_dir")}"
+        export BASE_CLI_PROJECT_MANIFEST="${BASE_PROJECT_MANIFEST:-}"
+        # A project command gets its own owner-scoped bundle. Keep the parent
+        # history ID, but do not let it write raw logs into Base's bundle.
+        unset BASE_CLI_RUN_ROOT BASE_CLI_RUN_ID BASE_CLI_PRIMARY_LOG
+        cd "$working_dir" && bash -c "$command_to_run" "$command_name" "$@"
+    )
 }
 
 base_validate_command_runner() {

--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -137,7 +137,14 @@ def find_log_retention_candidates(
                 run_dirs.append((path, run_metadata_mtime(path)))
             except OSError:
                 continue
-        retained = {path for path, _mtime in sorted(run_dirs, key=lambda item: (item[1], item[0].name), reverse=True)[:keep_count]}
+        retained = {
+            path
+            for path, _mtime in sorted(
+                run_dirs,
+                key=lambda item: (item[1], item[0].name),
+                reverse=True,
+            )[:keep_count]
+        }
         candidates.extend(
             CleanCandidate(path=path, category="run", age_seconds=int(time.time() - mtime))
             for path, mtime in run_dirs

--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import time
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -28,7 +29,7 @@ def main(argv: list[str] | None = None) -> int:
     "--older-than",
     help="Remove runtime artifacts older than an age such as 30d, 12h, 45m, or 60s.",
 )
-@base_cli.option("--keep-last", help="Keep the newest N log files per CLI log directory.")
+@base_cli.option("--keep-last", help="Keep the newest N run bundles per owner namespace.")
 @base_cli.option("--dry-run", is_flag=True, help="Print what would be removed without deleting anything.")
 def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dry_run: bool) -> int:
     if not older_than and not keep_last:
@@ -107,19 +108,12 @@ def parse_keep_last(value: str) -> int:
 
 
 def find_clean_candidates(cache_root: Path, cutoff: float, logger: object | None = None) -> list[CleanCandidate]:
-    cli_root = cache_root / "cli"
-    if logger is not None:
-        logger.debug("Scanning Base CLI runtime root '%s'.", cli_root)
-    if not cli_root.is_dir():
-        return []
-
     candidates: list[CleanCandidate] = []
-    for cli_dir in sorted(cli_root.iterdir(), key=lambda path: path.name):
-        if not cli_dir.is_dir():
-            continue
-        candidates.extend(find_category_candidates(cli_dir / "logs", "log", cutoff, logger))
-        candidates.extend(find_category_candidates(cli_dir / "tmp", "temp", cutoff, logger))
-        candidates.extend(find_category_candidates(cli_dir / "cache", "cache", cutoff, logger))
+    for owner_root in runtime_owner_roots(cache_root):
+        if logger is not None:
+            logger.debug("Scanning runtime owner root '%s'.", owner_root)
+        candidates.extend(find_category_candidates(owner_root / "runs", "run", cutoff, logger))
+        candidates.extend(find_category_candidates(owner_root / "cache" / "components", "cache", cutoff, logger))
     return sorted(candidates, key=lambda candidate: str(candidate.path))
 
 
@@ -128,18 +122,48 @@ def find_log_retention_candidates(
     keep_count: int,
     logger: object | None = None,
 ) -> list[CleanCandidate]:
-    cli_root = cache_root / "cli"
-    if logger is not None:
-        logger.debug("Scanning Base CLI log retention root '%s'.", cli_root)
-    if not cli_root.is_dir():
-        return []
-
     candidates: list[CleanCandidate] = []
-    for cli_dir in sorted(cli_root.iterdir(), key=lambda path: path.name):
-        if not cli_dir.is_dir():
+    for owner_root in runtime_owner_roots(cache_root):
+        runs_root = owner_root / "runs"
+        if logger is not None:
+            logger.debug("Scanning run retention artifacts in '%s'.", runs_root)
+        if not runs_root.is_dir():
             continue
-        candidates.extend(find_log_retention_candidates_for_dir(cli_dir / "logs", keep_count, logger))
+        run_dirs = []
+        for path in sorted(runs_root.iterdir(), key=lambda item: item.name):
+            if not path.is_dir() or run_is_running(path):
+                continue
+            try:
+                run_dirs.append((path, run_metadata_mtime(path)))
+            except OSError:
+                continue
+        retained = {path for path, _mtime in sorted(run_dirs, key=lambda item: (item[1], item[0].name), reverse=True)[:keep_count]}
+        candidates.extend(
+            CleanCandidate(path=path, category="run", age_seconds=int(time.time() - mtime))
+            for path, mtime in run_dirs
+            if path not in retained
+        )
     return sorted(candidates, key=lambda candidate: str(candidate.path))
+
+
+def runtime_owner_roots(cache_root: Path) -> list[Path]:
+    roots = []
+    base_root = cache_root / "base"
+    if base_root.is_dir():
+        roots.append(base_root)
+    roots.extend(path for path in sorted((cache_root / "projects").glob("*/*"), key=str) if path.is_dir())
+    return roots
+
+
+def run_is_running(run_root: Path) -> bool:
+    metadata = run_root / "run.json"
+    if not metadata.is_file():
+        return False
+    try:
+        payload = json.loads(metadata.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(payload, dict) and payload.get("status") == "running"
 
 
 def find_log_retention_candidates_for_dir(
@@ -190,12 +214,22 @@ def find_category_candidates(
     candidates = []
     for path in sorted(category_root.iterdir(), key=lambda item: item.name):
         try:
-            mtime = path.stat().st_mtime
+            mtime = run_metadata_mtime(path) if category == "run" else path.stat().st_mtime
         except OSError:
             continue
         if mtime < cutoff:
             candidates.append(CleanCandidate(path=path, category=category, age_seconds=int(time.time() - mtime)))
     return candidates
+
+
+def run_metadata_mtime(path: Path) -> float:
+    metadata = path / "run.json"
+    try:
+        if metadata.is_file():
+            return metadata.stat().st_mtime
+        return path.stat().st_mtime
+    except OSError:
+        return path.stat().st_mtime
 
 
 def remove_path(path: Path) -> None:

--- a/cli/python/base_clean/tests/test_engine.py
+++ b/cli/python/base_clean/tests/test_engine.py
@@ -35,83 +35,71 @@ class BaseCleanTests(unittest.TestCase):
     def test_find_clean_candidates_only_includes_old_runtime_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
-            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
-            new_log = cache_root / "cli" / "demo" / "logs" / "new.log"
-            old_temp = cache_root / "cli" / "demo" / "tmp" / "old-run"
-            old_cache = cache_root / "cli" / "demo" / "cache" / "old-cache"
+            old_run = cache_root / "base" / "runs" / "old-run"
+            new_run = cache_root / "base" / "runs" / "new-run"
+            old_log = old_run / "logs" / "old.log"
+            new_log = new_run / "logs" / "new.log"
+            old_cache = cache_root / "base" / "cache" / "components" / "old-cache"
             durable_state = cache_root / "durable-state" / ".base.d" / "cli" / "demo" / "logs" / "durable.log"
 
-            old_temp.mkdir(parents=True)
+            old_run.mkdir(parents=True)
+            (new_run / "logs").mkdir(parents=True)
             old_cache.mkdir(parents=True)
             old_log.parent.mkdir(parents=True, exist_ok=True)
             durable_state.parent.mkdir(parents=True)
             for path in (old_log, new_log, durable_state):
                 path.write_text("x", encoding="utf-8")
+            (old_run / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
+            (new_run / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
 
             old_time = time.time() - 40 * 24 * 60 * 60
             new_time = time.time()
-            for path in (old_log, old_temp, old_cache, durable_state):
+            for path in (old_run / "run.json", old_cache, durable_state):
                 os.utime(path, (old_time, old_time))
-            os.utime(new_log, (new_time, new_time))
+            os.utime(new_run / "run.json", (new_time, new_time))
 
             candidates = engine.find_clean_candidates(cache_root, time.time() - 30 * 24 * 60 * 60)
 
         self.assertEqual(
             [(candidate.category, candidate.path.name) for candidate in candidates],
-            [("cache", "old-cache"), ("log", "old.log"), ("temp", "old-run")],
+            [("cache", "old-cache"), ("run", "old-run")],
         )
 
     def test_find_clean_candidates_logs_examined_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
-            (cache_root / "cli" / "demo" / "logs").mkdir(parents=True)
+            (cache_root / "base" / "runs").mkdir(parents=True)
             logger = mock.Mock()
 
             engine.find_clean_candidates(cache_root, time.time(), logger)
 
-        logger.debug.assert_any_call("Scanning Base CLI runtime root '%s'.", cache_root / "cli")
-        logger.debug.assert_any_call(
-            "Scanning %s runtime artifacts in '%s'.",
-            "log",
-            cache_root / "cli" / "demo" / "logs",
-        )
-        logger.debug.assert_any_call(
-            "Scanning %s runtime artifacts in '%s'.",
-            "temp",
-            cache_root / "cli" / "demo" / "tmp",
-        )
+        logger.debug.assert_any_call("Scanning runtime owner root '%s'.", cache_root / "base")
         logger.debug.assert_any_call(
             "Scanning %s runtime artifacts in '%s'.",
             "cache",
-            cache_root / "cli" / "demo" / "cache",
+            cache_root / "base" / "cache" / "components",
         )
 
     def test_find_log_retention_candidates_keeps_newest_logs_per_cli(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
-            demo_logs = cache_root / "cli" / "demo" / "logs"
-            other_logs = cache_root / "cli" / "other" / "logs"
-            demo_logs.mkdir(parents=True)
-            other_logs.mkdir(parents=True)
-            demo_old = demo_logs / "demo-1.log"
-            demo_middle = demo_logs / "demo-2.log"
-            demo_new = demo_logs / "demo-3.log"
-            demo_notes = demo_logs / "notes.txt"
-            other_old = other_logs / "other-1.log"
-            other_new = other_logs / "other-2.log"
-            for path in (demo_old, demo_middle, demo_new, demo_notes, other_old, other_new):
-                path.write_text("x", encoding="utf-8")
+            runs = cache_root / "base" / "runs"
+            demo_old, demo_middle, demo_new = (runs / name for name in ("demo-1", "demo-2", "demo-3"))
+            other_old, other_new = (runs / name for name in ("other-1", "other-2"))
+            for path in (demo_old, demo_middle, demo_new, other_old, other_new):
+                (path / "run.json").parent.mkdir(parents=True, exist_ok=True)
+                (path / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
 
             now = time.time()
             for offset, path in enumerate((demo_old, demo_middle, demo_new, other_old, other_new), start=1):
                 timestamp = now - (10 - offset)
-                os.utime(path, (timestamp, timestamp))
+                os.utime(path / "run.json", (timestamp, timestamp))
 
             candidates = engine.find_log_retention_candidates(cache_root, keep_count=1)
 
         self.assertEqual(
             [(candidate.category, candidate.path.name) for candidate in candidates],
-            [("log", "demo-1.log"), ("log", "demo-2.log"), ("log", "other-1.log")],
+            [("run", "demo-1"), ("run", "demo-2"), ("run", "demo-3"), ("run", "other-1")],
         )
 
     def test_remove_path_removes_files_and_directories(self) -> None:
@@ -132,11 +120,13 @@ class BaseCleanTests(unittest.TestCase):
     def test_clean_dry_run_reports_without_removing(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir) / "cache-root"
-            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
+            old_run = cache_root / "base" / "runs" / "old-run"
+            old_log = old_run / "logs" / "old.log"
             old_log.parent.mkdir(parents=True)
             old_log.write_text("x", encoding="utf-8")
+            (old_run / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
             old_time = time.time() - 40 * 24 * 60 * 60
-            os.utime(old_log, (old_time, old_time))
+            os.utime(old_run / "run.json", (old_time, old_time))
 
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
                 result = engine.main(["--older-than", "30d", "--dry-run"])
@@ -147,11 +137,13 @@ class BaseCleanTests(unittest.TestCase):
     def test_clean_removes_old_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir) / "cache-root"
-            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
+            old_run = cache_root / "base" / "runs" / "old-run"
+            old_log = old_run / "logs" / "old.log"
             old_log.parent.mkdir(parents=True)
             old_log.write_text("x", encoding="utf-8")
+            (old_run / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
             old_time = time.time() - 40 * 24 * 60 * 60
-            os.utime(old_log, (old_time, old_time))
+            os.utime(old_run / "run.json", (old_time, old_time))
 
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
                 result = engine.main(["--older-than", "30d"])
@@ -162,37 +154,42 @@ class BaseCleanTests(unittest.TestCase):
     def test_clean_keep_last_removes_old_logs_but_keeps_latest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir) / "cache-root"
-            logs_dir = cache_root / "cli" / "demo" / "logs"
-            logs_dir.mkdir(parents=True)
-            old_log = logs_dir / "old.log"
-            new_log = logs_dir / "new.log"
-            for path in (old_log, new_log):
+            runs_dir = cache_root / "base" / "runs"
+            old_run = runs_dir / "old-run"
+            new_run = runs_dir / "new-run"
+            old_log = old_run / "logs" / "old.log"
+            new_log = new_run / "logs" / "new.log"
+            for path, run in ((old_log, old_run), (new_log, new_run)):
+                path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text("x", encoding="utf-8")
+                (run / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
             now = time.time()
-            os.utime(old_log, (now - 10, now - 10))
-            os.utime(new_log, (now, now))
+            os.utime(old_run / "run.json", (now - 10, now - 10))
+            os.utime(new_run / "run.json", (now, now))
 
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
                 result = engine.main(["--keep-last", "1"])
 
             self.assertEqual(result, 0)
-            self.assertFalse(old_log.exists())
+            self.assertFalse(old_run.exists())
             self.assertTrue(new_log.exists())
 
     def test_clean_deduplicates_age_and_retention_matches(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir) / "cache-root"
-            old_log = cache_root / "cli" / "demo" / "logs" / "old.log"
+            old_run = cache_root / "base" / "runs" / "old-run"
+            old_log = old_run / "logs" / "old.log"
             old_log.parent.mkdir(parents=True)
             old_log.write_text("x", encoding="utf-8")
+            (old_run / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
             old_time = time.time() - 40 * 24 * 60 * 60
-            os.utime(old_log, (old_time, old_time))
+            os.utime(old_run / "run.json", (old_time, old_time))
 
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
                 result = engine.main(["--older-than", "30d", "--keep-last", "1"])
 
             self.assertEqual(result, 0)
-            self.assertFalse(old_log.exists())
+            self.assertFalse(old_run.exists())
 
     def test_clean_invalid_older_than_returns_usage_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_config/tests/test_engine.py
+++ b/cli/python/base_config/tests/test_engine.py
@@ -70,8 +70,8 @@ class BaseConfigCommandTests(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertEqual(json.loads(result.stdout), {})
-            log_dir = home / ".cache" / "base" / "cli" / "base_config" / "logs"
-            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 1)
+            log_dir = home / ".cache" / "base" / "base" / "runs"
+            self.assertEqual(len(tuple(log_dir.rglob("*.log"))), 1)
             history_path = home / ".cache" / "base" / HISTORY_PATH
             history_record = json.loads(history_path.read_text(encoding="utf-8").splitlines()[-1])
             self.assertEqual(history_record["raw_command"], "base_config")

--- a/cli/python/base_history/record.py
+++ b/cli/python/base_history/record.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from datetime import datetime, timezone
 
 import base_cli
@@ -25,6 +26,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--project")
     parser.add_argument("--project-root")
     parser.add_argument("--manifest")
+    parser.add_argument("--owner", default=os.environ.get("BASE_CLI_RUNTIME_OWNER", "base"))
+    parser.add_argument("--bundle-path")
     parser.add_argument("argv", nargs=argparse.REMAINDER)
     options = parser.parse_args(argv)
 
@@ -42,7 +45,9 @@ def main(argv: list[str] | None = None) -> int:
         project=options.project,
         project_root=options.project_root,
         manifest=options.manifest,
-        log_path=child_log_path(options.run_id, options.exit_code),
+        log_path=None,
+        owner=options.owner,
+        bundle_path=options.bundle_path,
     )
     return base_cli.ExitCode.SUCCESS
 

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -13,7 +13,7 @@ from base_history import engine
 
 
 def write_history_line(cache_root: Path, payload: dict | str) -> None:
-    path = cache_root / "history" / "runs.jsonl"
+    path = cache_root / "base" / "history" / "runs.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     text = payload if isinstance(payload, str) else json.dumps(payload)
     with path.open("a", encoding="utf-8") as handle:
@@ -291,7 +291,7 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertIn("# Base Local Activity Report", stdout)
         self.assertIn("History records: 0", stdout)
         self.assertIn("No command history records found.", stdout)
-        self.assertIn(str(cache_root / "history" / "runs.jsonl"), stdout)
+        self.assertIn(str(cache_root / "base" / "history" / "runs.jsonl"), stdout)
 
     def test_markdown_report_labels_local_time_when_requested(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -328,7 +328,7 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(
             payload["history_path"],
-            str((cache_root / "history" / "runs.jsonl").resolve(strict=False)),
+            str((cache_root / "base" / "history" / "runs.jsonl").resolve(strict=False)),
         )
         self.assertEqual(payload["summary"]["record_count"], 1)
         self.assertEqual(payload["summary"]["failure_count"], 0)

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -192,7 +192,7 @@ def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandO
     if options.path_only or options.tail or options.open_file:
         ctx.log.error("No Base CLI logs found.")
         return base_cli.ExitCode.FAILURE
-    print(f"No Base CLI logs found under {cache_root / 'cli'}.")
+    print(f"No Base CLI logs found under {cache_root / 'base' / 'runs'} or {cache_root / 'projects'}.")
     return base_cli.ExitCode.SUCCESS
 
 
@@ -438,20 +438,17 @@ def recent_logs(cache_root: Path, command_filter: str | None = None) -> list[Log
 
 
 def discover_log_entries(cache_root: Path) -> list[LogEntry]:
-    cli_root = cache_root / "cli"
-    if not cli_root.is_dir():
-        return []
-
     history_statuses = read_history_log_statuses(cache_root)
     entries: list[LogEntry] = []
-    for logs_dir in sorted(cli_root.glob("*/logs"), key=str):
-        if not logs_dir.is_dir():
+    for run_root in runtime_run_roots(cache_root):
+        logs_root = run_root / "logs"
+        if not logs_root.is_dir():
             continue
-        raw_command = logs_dir.parent.name
-        for path in sorted(logs_dir.glob("*.log"), key=lambda item: item.name):
+        for path in sorted(logs_root.rglob("*.log"), key=lambda item: str(item)):
             if not path.is_file():
                 continue
             history_status = history_status_for_log(history_statuses, run_id=path.stem, path=path)
+            raw_command = infer_raw_command_from_log_path(path)
             entries.append(
                 LogEntry(
                     command=history_status.command
@@ -466,6 +463,23 @@ def discover_log_entries(cache_root: Path) -> list[LogEntry]:
                 )
             )
     return entries
+
+
+def runtime_run_roots(cache_root: Path) -> list[Path]:
+    roots: list[Path] = []
+    roots.extend(path for path in sorted((cache_root / "base" / "runs").glob("*"), key=str) if path.is_dir())
+    roots.extend(
+        path
+        for path in sorted((cache_root / "projects").glob("*/*/runs/*"), key=str)
+        if path.is_dir()
+    )
+    return roots
+
+
+def infer_raw_command_from_log_path(path: Path) -> str:
+    if path.parent.name == "logs":
+        return "basectl"
+    return path.parent.name
 
 
 def read_history_log_statuses(cache_root: Path) -> HistoryLogStatusIndex:

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -444,7 +444,7 @@ def discover_log_entries(cache_root: Path) -> list[LogEntry]:
         logs_root = run_root / "logs"
         if not logs_root.is_dir():
             continue
-        for path in sorted(logs_root.rglob("*.log"), key=lambda item: str(item)):
+        for path in sorted(logs_root.rglob("*.log"), key=str):
             if not path.is_file():
                 continue
             history_status = history_status_for_log(history_statuses, run_id=path.stem, path=path)

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -13,14 +13,14 @@ from base_logs import engine
 
 
 def write_log(cache_root: Path, cli_name: str, run_id: str, text: str) -> Path:
-    path = cache_root / "cli" / cli_name / "logs" / f"{run_id}.log"
+    path = cache_root / "base" / "runs" / run_id / "logs" / "internal" / cli_name / f"{run_id}.log"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
     return path
 
 
 def write_history_line(cache_root: Path, payload: dict | str) -> None:
-    path = cache_root / "history" / "runs.jsonl"
+    path = cache_root / "base" / "history" / "runs.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     text = payload if isinstance(payload, str) else json.dumps(payload)
     with path.open("a", encoding="utf-8") as handle:
@@ -299,7 +299,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
                     status="ok",
                     exit_code=0,
                     ended_at="2026-06-01T01:01:00Z",
-                    log_path=str(cache_root / "cli" / "base_setup" / "logs" / "ok.log"),
+                    log_path=str(cache_root / "base" / "runs" / "ok-run" / "logs" / "primary.log"),
                 ),
             )
             write_history_line(
@@ -338,7 +338,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
                     "20260601T010000_aaaaaaaa",
                     status="ok",
                     exit_code=0,
-                    log_path=str(cache_root / "cli" / "base_setup" / "logs" / "ok.log"),
+                    log_path=str(cache_root / "base" / "runs" / "ok-run" / "logs" / "primary.log"),
                 ),
             )
 
@@ -351,7 +351,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
     def test_last_reports_missing_log_with_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
-            missing_log = cache_root / "cli" / "base_setup" / "logs" / "missing.log"
+            missing_log = cache_root / "base" / "runs" / "missing-run" / "logs" / "primary.log"
             write_history_line(
                 cache_root,
                 history_record(
@@ -468,7 +468,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertIn("No Base CLI logs found", stdout)
         self.assertIn(" DEBUG ", stderr)
         self.assertIn("cli=base_logs", stderr)
-        self.assertFalse((cache_root / "cli" / "base_logs").exists())
+        self.assertFalse((cache_root / "base" / "runs").exists())
 
     def test_path_errors_when_no_log_matches(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -95,7 +95,7 @@ def resolve_active_project(project_name: str) -> Project | None:
 
 def project_cache_path(workspace_root: Path) -> Path:
     workspace_key = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[:24]
-    return base_cache_root() / "projects" / f"{workspace_key}.json"
+    return base_cache_root() / "base" / "cache" / "discovery" / f"{workspace_key}.json"
 
 
 def read_project_cache(workspace_root: Path, entries: tuple[ManifestEntry, ...]) -> tuple[Project, ...] | None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,8 @@ reference. The filename should answer "what is this about?"
   apt-backed setup path, and bootstrap boundaries.
 - [Runtime Environment](runtime-environment.md) is the canonical reference for
   Base-managed environment variables, `~/.baserc`, and mutability rules.
+- [Cache Ownership And Layout](cache-ownership-and-layout.md) defines the
+  clean-slate Base-versus-project cache boundary and proposed run bundles.
 - [Base Bash Libraries](base-bash-libs.md) documents the standalone
   `base-bash-libs` package, Base's external reusable-library consumption path,
   Homebrew/core readiness path, and the post-migration boundary.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -613,8 +613,8 @@ keeps discovery predictable, but repeated YAML parsing still shows up in
 project-aware commands and shell completion.
 
 The implemented cache is intentionally narrow. Base stores discovered project
-metadata under the runtime cache root in `projects/`, keyed by the resolved
-workspace path. On each discovery run it still checks the immediate workspace
+metadata under `base/cache/discovery/`, keyed by the resolved workspace path.
+On each discovery run it still checks the immediate workspace
 children, but it reuses cached project names and paths when the manifest path,
 mtime, and size set is unchanged. A new checkout, manifest edit, or manifest
 removal changes that key data and forces a fresh parse.

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -131,11 +131,14 @@ ctx.manifest_path  # Path | None
 ctx.history_scope  # primary or internal
 ctx.history_parent_run_id  # parent basectl invocation ID, or None
 ctx.workspace_root # configured workspace root, or None
-ctx.state_dir      # Base cache root / cli / <cli-name>
-ctx.log_dir        # state_dir/logs
-ctx.cache_dir      # state_dir/cache
-ctx.temp_dir       # state_dir/tmp/<run-id>
-ctx.log_file       # log_dir/<run-id>.log, or None when persistent logging is disabled
+ctx.runtime_owner  # base or project
+ctx.owner_root     # owner namespace root under the cache root
+ctx.run_root       # this invocation's run bundle
+ctx.state_dir      # owner_root (compatibility alias)
+ctx.log_dir        # run_root/logs or run_root/logs/internal/<cli-name>
+ctx.cache_dir      # owner_root/cache/components/<cli-name>
+ctx.temp_dir       # run_root/tmp/<cli-name>/<run-id>
+ctx.log_file       # primary.log or an internal component log, or None when disabled
 ctx.config         # dict
 ctx.user_config    # typed user config from ~/.base.d/config.yaml
 ctx.environment    # str
@@ -157,19 +160,20 @@ artifact management.
 
 ## State Directories
 
-Base separates durable user state from disposable runtime artifacts.
-Durable config and project virtual environments live under `~/.base.d`.
-Per-run CLI logs, caches, and temp directories live under the Base runtime
-cache root.
+Base separates durable user state from disposable runtime artifacts. Durable
+config and project virtual environments live under `~/.base.d`. Per-run logs
+and temp directories live in owner-aware bundles under the Base runtime cache
+root.
 
 ```text
 <base-cache-root>/
-  cli/
-    <cli-name>/
-      logs/
-        <run-id>.log
-      cache/
-      tmp/
+  base/
+    history/runs.jsonl
+    runs/<run-id>/{run.json,logs/,tmp/}
+    cache/components/<cli-name>/
+  projects/<project>/<checkout-id>/
+    runs/<run-id>/{run.json,logs/,tmp/}
+    cache/components/<cli-name>/
         <run-id>/
 ```
 
@@ -187,9 +191,8 @@ Directory lifecycle:
 
 | Directory | Created | Removed |
 |---|---|---|
-| `logs/` | before command execution | never by default |
-| `cache/` | before command execution | explicit CLI logic only |
-| `tmp/<run-id>/` | before command execution | after command execution unless kept |
+| `run.json`, `logs/`, `tmp/` | before command execution | run-bundle cleanup |
+| `cache/components/` | when a component needs it | explicit CLI cleanup |
 
 Commands running with `ctx.dry_run` skip default `logs/`, `cache/`, and
 `tmp/<run-id>/` creation unless an explicit log file is supplied.

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -1,0 +1,173 @@
+# Base Cache Ownership And Layout
+
+> **STATUS** — Proposed runtime contract. This document defines the clean-slate
+> layout that will be implemented next; the current `cli/` layout is not part
+> of this contract.
+
+This document establishes the ownership boundary for files under
+`BASE_CACHE_DIR`. Base owns the control-plane runtime. A Base-compliant project
+owns its own runtime subtree. The distinction is made before choosing a
+component name, log file, or run identifier.
+
+The implementation baseline is an empty cache root. The first Base-owned
+invocation creates `base/`; the first project-owned invocation creates only
+that project's namespace under `projects/`. No directory is created merely
+because a project is listed in a workspace manifest.
+
+## Ownership model
+
+| Owner | Root | Examples | Owns |
+| --- | --- | --- | --- |
+| Base control plane | `base/` | `basectl`, `base_setup`, `base_projects`, `base_release`, `base_history` | Base orchestration, discovery, GitHub/release operations, and Base-internal diagnostics |
+| Base-compliant project | `projects/<project-id>/<checkout-id>/` | `base-demo`, `banyanlabs`, `bankbuddy` | Project-native commands, project-owned caches, and project execution evidence |
+
+`base` is a reserved owner. Base's own repository and Base-internal CLIs do
+not create a `projects/base` namespace. A project argument such as
+`basectl setup banyanlabs` identifies the target project in metadata; it does
+not make the Base setup implementation project-owned.
+
+Ownership follows the executable, not the command-line argument:
+
+- `basectl workspace status` writes only to the Base control-plane tree.
+- `basectl setup banyanlabs` writes its orchestration bundle under `base/`.
+- If setup launches a project-native process, that child process writes under
+  `projects/banyanlabs/<checkout-id>/` and is linked to the parent Base run.
+- `basectl test bankbuddy` has a Base parent run and a project-owned test run.
+- A CLI shipped by `base-demo` writes under the `base-demo` project tree even
+  when it is launched through a Base wrapper.
+
+The Base history index may contain metadata for both owners so that
+`basectl history` can provide one cross-project view. That index is metadata;
+raw project logs and caches remain in the project-owned tree.
+
+## Proposed directory tree
+
+With the cache root set to `~/Library/Caches/base`, the clean layout is:
+
+```text
+~/Library/Caches/base/
+├── base/
+│   ├── history/
+│   │   └── runs.jsonl
+│   ├── cache/
+│   │   ├── discovery/
+│   │   └── components/
+│   │       ├── base_projects/
+│   │       ├── base_setup/
+│   │       └── base_github_projects/
+│   └── runs/
+│       └── <base-run-id>/
+│           ├── run.json
+│           ├── logs/
+│           │   ├── primary.log
+│           │   └── internal/
+│           │       ├── base_setup/
+│           │       │   └── <child-run-id>.log
+│           │       └── base_projects/
+│           │           └── <child-run-id>.log
+│           └── tmp/
+│               └── <component>/<child-run-id>/
+└── projects/
+    ├── base-demo/
+    │   └── <checkout-id>/
+    │       ├── identity.json
+    │       ├── cache/
+    │       │   └── components/
+    │       └── runs/
+    │           └── <project-run-id>/
+    │               ├── run.json
+    │               ├── logs/
+    │               │   ├── primary.log
+    │               │   └── internal/
+    │               └── tmp/
+    ├── banyanlabs/
+    │   └── <checkout-id>/...
+    └── bankbuddy/
+        └── <checkout-id>/...
+```
+
+There is deliberately no top-level `cli/` directory. Internal component names
+are meaningful only inside a run's `logs/internal/` or persistent component
+cache. They are not ownership roots.
+
+## Directory meanings
+
+### `base/`
+
+The Base control-plane namespace. It contains only artifacts produced by Base
+itself. `basectl`, its Bash dispatch layer, and Base-owned Python CLIs use this
+root regardless of which project they inspect or modify.
+
+### `base/history/`
+
+The append-only cross-project command index. Each record includes the owner,
+project identity when known, parent/child run relationship, status, and a path
+to the relevant run bundle or log. It is not a raw log store.
+
+### `base/cache/`
+
+Reusable Base-owned state that can survive across runs. `discovery/` contains
+Base's project-discovery cache. `components/` contains persistent caches owned
+by individual Base components. This state is not tied to one diagnostic run.
+
+### `base/runs/`
+
+One directory per Base control-plane invocation. `run.json` is written at the
+start with `status: running` and finalized with timestamps, exit status,
+project metadata, and child references. `primary.log` contains top-level Base
+diagnostics. Normal command stdout remains stdout and is not captured here.
+
+### `projects/<project-id>/<checkout-id>/`
+
+The runtime namespace for one canonical project checkout. The project ID comes
+from the validated manifest name. The checkout ID is derived from the resolved
+checkout path so separate worktrees do not share runtime state accidentally.
+`identity.json` records the resolved project name, root, manifest, and identity
+version used to derive the path.
+
+### Project `cache/`
+
+Persistent, recomputable state owned by that project. A project can use
+component subdirectories without affecting Base's caches or another checkout's
+caches.
+
+### Project `runs/`
+
+Run-oriented bundles for project-native commands. A project run can have its
+own primary log and internal child logs. The parent Base run references the
+project run through the history index and `run.json` metadata.
+
+### `tmp/`
+
+Temporary files scoped to one run and component. Successful runs remove these
+directories automatically unless retention is requested. Failed or interrupted
+runs retain them for diagnosis until cleanup removes the completed bundle.
+
+## Runtime invariants
+
+1. Every public invocation has one owner and one top-level run bundle.
+2. Base-owned processes always resolve the `base/` owner explicitly.
+3. Project-owned processes resolve their project ID and checkout ID from the
+   validated manifest and canonical project root.
+4. Child processes inherit the owner and parent run ID; they cannot silently
+   create a new top-level namespace.
+5. `basectl logs` and `basectl clean` operate from run metadata and ownership
+   roots. They do not scan arbitrary application directories.
+6. `~/.base.d` remains durable user state and is outside this cache lifecycle.
+7. A fresh cache starts with no migration or legacy-layout compatibility work.
+
+## Retention and cleanup
+
+`basectl clean` operates on completed run bundles, with optional project and
+owner filters. It never removes an active run, durable `~/.base.d` state, or
+another application's cache root. Persistent component caches may be pruned by
+age, while history metadata is retained until an explicit history-retention
+policy is applied.
+
+## Implementation boundary
+
+The runtime API should receive an explicit owner scope rather than deriving a
+path from `App(name=...)`. Base components declare the Base owner. A
+Base-compliant project runtime declares the project owner after manifest
+validation. The resulting owner root, run root, component name, and checkout
+identity are then passed through the Python context and delegated environment.

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -1,8 +1,7 @@
 # Base Cache Ownership And Layout
 
-> **STATUS** — Proposed runtime contract. This document defines the clean-slate
-> layout that will be implemented next; the current `cli/` layout is not part
-> of this contract.
+> **STATUS** — Implemented clean-slate runtime contract. The legacy `cli/`
+> layout is intentionally unsupported; a cleared cache starts with this tree.
 
 This document establishes the ownership boundary for files under
 `BASE_CACHE_DIR`. Base owns the control-plane runtime. A Base-compliant project

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -58,7 +58,7 @@ Those questions need a structured index in addition to raw log discovery.
 Base writes a structured command history index under the Base cache root:
 
 ```text
-<base-cache-root>/history/runs.jsonl
+<base-cache-root>/base/history/runs.jsonl
 ```
 
 Each line is one JSON object. JSON Lines keeps writes append-only, easy to
@@ -98,7 +98,9 @@ A history record should include:
   "duration_ms": 12000,
   "exit_code": 0,
   "status": "ok",
-  "log_path": "~/Library/Caches/base/cli/base_setup/logs/20260610T101500_ab12cd.log",
+  "owner": "base",
+  "bundle_path": "~/Library/Caches/base/base/runs/20260610T101500_ab12cd",
+  "log_path": "~/Library/Caches/base/base/runs/20260610T101500_ab12cd/logs/primary.log",
   "base_version": "0.4.0",
   "os": "macos",
   "shell": "bash",
@@ -142,18 +144,18 @@ metadata and generated reports.
 
 ## Retention
 
-History belongs to the same local cache lifecycle as runtime logs. `basectl
-clean` should eventually understand history records and remove or compact
-records whose log files have been pruned.
+History belongs to the same local cache lifecycle as runtime logs. Cleanup
+removes run bundles but deliberately retains the append-only history index, so
+history can show that a recorded log or bundle is missing.
 
 The retention contract should be:
 
-- `basectl clean --older-than <age>` removes history records older than the age
-  when their corresponding logs are also eligible for removal.
-- `basectl clean --keep-last <count>` keeps history records for the retained log
-  files and prunes older records for that command family.
-- Orphaned history records may remain temporarily when cleanup cannot match the
-  log path safely, but `basectl history` should mark missing logs clearly.
+- `basectl clean --older-than <age>` removes completed run bundles and component
+  caches older than the age.
+- `basectl clean --keep-last <count>` retains the newest completed bundles per
+  owner namespace.
+- History records remain even when cleanup removes their referenced bundle, and
+  `basectl history` can mark those logs as missing.
 - Durable user state under `~/.base.d` is never cleaned by history retention.
 
 ## Shipped Commands

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -184,6 +184,12 @@ readonly by Base.
 | `BASE_INSTALL_DIR` | `install.sh` | Overrides the default source install directory. |
 | `BASE_BOOTSTRAP_MODE` | `bootstrap.sh` | Selects bootstrap mode when no command-line mode overrides it. |
 
+The clean-slate ownership boundary and proposed run-oriented layout for
+`BASE_CACHE_DIR` are documented in
+[Cache Ownership And Layout](cache-ownership-and-layout.md). That document is
+currently a design contract; the runtime still uses the existing layout until
+the implementation work lands.
+
 Additional setup and bootstrap `BASE_SETUP_*`, `BASE_BOOTSTRAP_*`, and
 `BASE_INSTALL_*` variables exist for tests, CI, and narrow command overrides.
 Those are command-specific inputs, not shell runtime contract variables.

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -109,6 +109,19 @@ script path. They describe the script being dispatched, not the user's project.
 | `BASE_BASH_COMMAND_SCRIPT` | Base | Physical path of the dispatched Bash script. | Do not set. Readonly before the command script is sourced. |
 | `BASE_BASH_BOOTSTRAP_SOURCE` | Base | Internal transient override used while `base_init.sh` loads the Bash stdlib so `__SCRIPT_DIR__` resolves to the command script. | Do not set. It is unset immediately after bootstrap and is not part of the public runtime contract. |
 
+## Cache And Run Variables
+
+The cache root is user-tunable; ownership and run identity are assigned by the
+launcher. See [Cache Ownership And Layout](cache-ownership-and-layout.md) for
+the resulting directory tree.
+
+| Variable | Owner | Meaning and impact | User changes |
+| --- | --- | --- | --- |
+| `BASE_CACHE_DIR` | User | Overrides the platform default Base cache root. | May be set before invoking Base. |
+| `BASE_CLI_RUNTIME_OWNER` | Base/project launcher | `base` for Base control-plane processes or `project` for a project-native process. | Do not set manually; launchers establish it. |
+| `BASE_CLI_RUN_ROOT` | Parent launcher | Points a Base-internal child at its parent run bundle so its raw log is placed under `logs/internal/`. Project launchers deliberately unset it before creating a project-owned bundle. | Do not set manually. |
+| `BASE_CLI_HISTORY_PARENT_RUN_ID` | Parent launcher | Links internal or project history records to the public Base invocation. | Do not set manually. |
+
 ## Project Runtime Variables
 
 Project runtime variables are set after Base resolves a project from an
@@ -184,11 +197,10 @@ readonly by Base.
 | `BASE_INSTALL_DIR` | `install.sh` | Overrides the default source install directory. |
 | `BASE_BOOTSTRAP_MODE` | `bootstrap.sh` | Selects bootstrap mode when no command-line mode overrides it. |
 
-The clean-slate ownership boundary and proposed run-oriented layout for
+The clean-slate ownership boundary and implemented run-oriented layout for
 `BASE_CACHE_DIR` are documented in
 [Cache Ownership And Layout](cache-ownership-and-layout.md). That document is
-currently a design contract; the runtime still uses the existing layout until
-the implementation work lands.
+the runtime contract for the owner-aware cache tree.
 
 Additional setup and bootstrap `BASE_SETUP_*`, `BASE_BOOTSTRAP_*`, and
 `BASE_INSTALL_*` variables exist for tests, CI, and narrow command overrides.

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -233,10 +233,13 @@ Important fields include:
 - `ctx.manifest_path`: nearest discovered Base manifest.
 - `ctx.history_scope`: whether this record is a primary or internal event.
 - `ctx.history_parent_run_id`: parent `basectl` invocation ID, when delegated.
-- `ctx.state_dir`: per-CLI runtime directory under the Base cache root.
-- `ctx.log_dir`: persistent log directory.
-- `ctx.cache_dir`: persistent cache directory.
-- `ctx.temp_dir`: per-run temp directory.
+- `ctx.runtime_owner`: `base` or `project`.
+- `ctx.owner_root`: owner namespace root under the Base cache root.
+- `ctx.run_root`: this invocation's run bundle.
+- `ctx.state_dir`: owner root (compatibility alias).
+- `ctx.log_dir`: run-bundle log directory.
+- `ctx.cache_dir`: persistent component cache directory.
+- `ctx.temp_dir`: per-run temp directory inside the bundle.
 - `ctx.log_file`: persistent log file for this run, or `None` when persistent
   logging is disabled.
 - `ctx.config`: merged configuration dictionary.
@@ -292,17 +295,16 @@ Commands running with `ctx.dry_run` also skip default `logs/`, `cache/`, and
 explicit file so tests and diagnostics can inspect dry-run logs when needed.
 
 For Python-backed commands with persistent logs, `base_cli.App` also writes a
-best-effort final history record to `<base-cache-root>/history/runs.jsonl`.
+best-effort final history record to `<base-cache-root>/base/history/runs.jsonl`.
 History records contain redacted command metadata, timing, exit status, project
 context when known, and a pointer to the raw log file. History writes are local
 only and do not fail the user command when the index cannot be updated.
 
 High-frequency tools can set `base_cli.App(max_log_files=<count>)` to keep at
-most that many default persistent log files for the CLI. Retention runs during
-startup after the current run's default log file is resolved, and the current
-run's log file is never pruned. Default log pruning uses the timestamp-prefixed
-run ID in each log filename rather than filesystem modification time. The
-policy is skipped for `ctx.dry_run`,
+most that many default persistent log files across the owner's run bundles.
+Retention runs during startup after the current run's default log file is
+resolved, and the current run's log file is never pruned. The policy is skipped
+for `ctx.dry_run`,
 `log_to_file=False`, and explicit `--log-file` paths so no-durable-write modes
 and caller-selected log locations stay under caller control. Use this as a
 small guardrail for busy local tools; `basectl clean` remains the broader
@@ -384,25 +386,15 @@ actionable message.
 
 ## Runtime Directories
 
-On macOS, current runtime state is rooted at `~/Library/Caches/base`:
-
-```text
-~/Library/Caches/base/cli/<cli-name>/
-  logs/
-  cache/
-  tmp/<run-id>/
-```
-
-On Linux and other non-macOS platforms, the default is `~/.cache/base`. Use
-`BASE_CACHE_DIR` to override the root for tests, CI, or unusual local
-environments.
-
-`logs/` and `cache/` are runtime artifacts that can be pruned with
-`basectl clean --older-than <age>`. Logs can also be pruned with
-`basectl clean --keep-last <count>`, which keeps the newest log files per CLI log
-directory. `tmp/<run-id>/` is deleted automatically after the command returns
-unless `--keep-temp` is set; retained temp entries can also be pruned by
-`basectl clean`.
+Runtime state is rooted at `~/Library/Caches/base` on macOS and `~/.cache/base`
+elsewhere. `BASE_CACHE_DIR` overrides the root. See
+[`docs/cache-ownership-and-layout.md`](../../../docs/cache-ownership-and-layout.md)
+for the owner-aware layout. Base control-plane commands use `base/`; a
+Base-compliant project's own commands use `projects/<project>/<checkout-id>/`.
+Each invocation is a run bundle containing `run.json`, `logs/`, and `tmp/`,
+while persistent component caches live in the owner's `cache/components/`.
+`basectl clean --older-than <age>` removes old bundles and component caches;
+`--keep-last <count>` retains the newest completed bundles per owner.
 
 Use `ctx.on_cleanup()` for cleanup work that should happen even when helper code
 does not own the main command wrapper:

--- a/lib/python/base_cli/_runtime.py
+++ b/lib/python/base_cli/_runtime.py
@@ -17,6 +17,7 @@ class RuntimeLayout:
     temp_dir: Path
 
 
+# pylint: disable=too-many-arguments
 def runtime_layout(
     cache_root: Path,
     cli_name: str,

--- a/lib/python/base_cli/_runtime.py
+++ b/lib/python/base_cli/_runtime.py
@@ -4,22 +4,42 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from .paths import runtime_owner_root
+
 
 @dataclass(frozen=True)
 class RuntimeLayout:
+    owner_root: Path
+    run_root: Path
     state_dir: Path
     log_dir: Path
     cache_dir: Path
     temp_dir: Path
 
 
-def runtime_layout(cache_root: Path, cli_name: str, run_id: str) -> RuntimeLayout:
-    state_dir = cache_root / "cli" / cli_name
+def runtime_layout(
+    cache_root: Path,
+    cli_name: str,
+    run_id: str,
+    *,
+    owner: str = "base",
+    project_name: str | None = None,
+    project_root: Path | None = None,
+    inherited_run_root: Path | None = None,
+) -> RuntimeLayout:
+    owner_root = runtime_owner_root(cache_root, owner, project_name, project_root)
+    run_root = inherited_run_root or owner_root / "runs" / run_id
+    state_dir = owner_root
+    log_dir = run_root / "logs"
+    if inherited_run_root is not None:
+        log_dir = log_dir / "internal" / cli_name
     return RuntimeLayout(
+        owner_root=owner_root,
+        run_root=run_root,
         state_dir=state_dir,
-        log_dir=state_dir / "logs",
-        cache_dir=state_dir / "cache",
-        temp_dir=state_dir / "tmp" / run_id,
+        log_dir=log_dir,
+        cache_dir=owner_root / "cache" / "components" / cli_name,
+        temp_dir=run_root / "tmp" / cli_name / run_id,
     )
 
 
@@ -37,7 +57,7 @@ def prune_log_files(
     logger: logging.Logger,
 ) -> None:
     candidates: list[tuple[str, Path]] = []
-    for path in log_dir.glob("*.log"):
+    for path in log_dir.rglob("*.log"):
         if _same_path(path, current_log_file):
             continue
         candidates.append((path.name, path))

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import json
 import os
 import sys
 from contextvars import ContextVar
@@ -19,6 +20,9 @@ from .paths import (
     discover_manifest,
     make_run_id,
     normalize_cli_name,
+    normalize_runtime_owner,
+    runtime_project_name,
+    runtime_project_root,
     resolve_base_home,
 )
 from .redaction import parameter_name_from_decls
@@ -166,7 +170,12 @@ class App:
     def _create_context(self, standard: dict[str, Any], sensitive_options: set[str], dry_run: bool = False) -> Context:
         del sensitive_options
         run_id = make_run_id()
-        manifest_path = discover_manifest(current_working_dir())
+        manifest_override = os.environ.get("BASE_CLI_PROJECT_MANIFEST")
+        manifest_path = (
+            Path(manifest_override).expanduser().resolve()
+            if manifest_override
+            else discover_manifest(current_working_dir())
+        )
         project_root = manifest_path.parent if manifest_path is not None else None
         explicit_config = Path(standard["config"]).expanduser() if standard.get("config") else None
         user_config = read_user_config()
@@ -178,7 +187,20 @@ class App:
         keep_temp = bool(standard.get("keep_temp") or config.get("keep_temp"))
 
         cache_root = base_cache_root()
-        layout = runtime_layout(cache_root, self.name, run_id)
+        runtime_owner = normalize_runtime_owner()
+        selected_project_root = runtime_project_root() or project_root
+        selected_project_name = runtime_project_name() or (selected_project_root.name if selected_project_root else None)
+        inherited_run_root = os.environ.get("BASE_CLI_RUN_ROOT") if runtime_owner == "base" else None
+        inherited_path = Path(inherited_run_root).expanduser().resolve() if inherited_run_root else None
+        layout = runtime_layout(
+            cache_root,
+            self.name,
+            run_id,
+            owner=runtime_owner,
+            project_name=selected_project_name,
+            project_root=selected_project_root,
+            inherited_run_root=inherited_path,
+        )
 
         log_file = Path(standard["log_file"]).expanduser() if standard.get("log_file") else None
         uses_default_log_file = log_file is None
@@ -189,20 +211,64 @@ class App:
             for directory in (layout.log_dir, layout.cache_dir, layout.temp_dir):
                 create_runtime_directory(directory, cache_root)
             if log_file is None:
-                log_file = layout.log_dir / f"{run_id}.log"
+                log_file = layout.log_dir / (f"{self.name}-{run_id}.log" if inherited_path else "primary.log")
             create_runtime_directory(log_file.parent, cache_root)
+        if inherited_path is None and not dry_run and self.log_to_file:
+            create_runtime_directory(layout.run_root, cache_root)
+            try:
+                (layout.run_root / "run.json").write_text(
+                    json.dumps(
+                        {
+                            "run_id": run_id,
+                            "owner": runtime_owner,
+                            "cli": self.name,
+                            "status": "running",
+                            "started_at": utc_now().isoformat(timespec="seconds").replace("+00:00", "Z"),
+                        },
+                        sort_keys=True,
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            except OSError:
+                pass
+        if runtime_owner == "project" and selected_project_root is not None and not dry_run and self.log_to_file:
+            try:
+                create_runtime_directory(layout.owner_root, cache_root)
+                identity_path = layout.owner_root / "identity.json"
+                if not identity_path.exists():
+                    identity_path.write_text(
+                        json.dumps(
+                            {
+                                "schema_version": 1,
+                                "project": selected_project_name,
+                                "project_root": str(selected_project_root),
+                                "manifest": str(manifest_path) if manifest_path is not None else None,
+                                "checkout_id": layout.owner_root.name,
+                            },
+                            sort_keys=True,
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
+            except OSError:
+                pass
         logger = configure_logger(self.name, log_file, debug, quiet=quiet)
         logger.debug("cli=%s run_id=%s environment=%s", self.name, run_id, environment)
         if self.max_log_files is not None and uses_default_log_file and log_file is not None:
-            prune_log_files(layout.log_dir, log_file, self.max_log_files, logger)
+            prune_log_files(layout.owner_root / "runs", log_file, self.max_log_files, logger)
 
         return Context(
             cli_name=self.name,
             run_id=run_id,
+            runtime_owner=runtime_owner,
+            owner_root=layout.owner_root,
+            run_root=layout.run_root,
             base_home=resolve_base_home(),
-            project_root=project_root,
+            project_root=selected_project_root,
             workspace_root=user_config.workspace.root,
             manifest_path=manifest_path,
+            project_name=selected_project_name,
             state_dir=layout.state_dir,
             log_dir=layout.log_dir,
             cache_dir=layout.cache_dir,

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -189,7 +189,9 @@ class App:
         cache_root = base_cache_root()
         runtime_owner = normalize_runtime_owner()
         selected_project_root = runtime_project_root() or project_root
-        selected_project_name = runtime_project_name() or (selected_project_root.name if selected_project_root else None)
+        selected_project_name = runtime_project_name() or (
+            selected_project_root.name if selected_project_root else None
+        )
         inherited_run_root = os.environ.get("BASE_CLI_RUN_ROOT") if runtime_owner == "base" else None
         inherited_path = Path(inherited_run_root).expanduser().resolve() if inherited_run_root else None
         layout = runtime_layout(

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -45,6 +45,9 @@ class Context:
     cleanup_hooks: list[Callable[[], None]] = field(default_factory=list)
     workspace_root: Path | None = None
     quiet: bool = False
+    runtime_owner: str = "base"
+    owner_root: Path | None = None
+    run_root: Path | None = None
 
     def on_cleanup(self, hook: Callable[[], None]) -> None:
         self.cleanup_hooks.append(hook)

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -170,7 +170,7 @@ def update_run_metadata(run_root: Path, record: dict[str, Any]) -> None:
         metadata_path.parent.mkdir(parents=True, exist_ok=True)
         metadata_path.write_text(json.dumps(metadata, sort_keys=True) + "\n", encoding="utf-8")
     except (OSError, TypeError, ValueError):
-        return
+        pass
 
 
 def append_history_line(path: Path, line: str) -> None:

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -19,7 +19,7 @@ from .redaction import REDACTED, is_secret_key, option_name_to_parameter, redact
 
 
 SCHEMA_VERSION = 1
-HISTORY_PATH = Path("history") / "runs.jsonl"
+HISTORY_PATH = Path("base") / "history" / "runs.jsonl"
 HISTORY_SCOPE_PRIMARY = "primary"
 HISTORY_SCOPE_INTERNAL = "internal"
 
@@ -40,6 +40,8 @@ def write_finished_record(
     try:
         record = build_finished_record(context, argv, sensitive_options, started_at, exit_code)
         write_history_record(record)
+        if context.run_root is not None and context.run_root.name == context.run_id:
+            update_run_metadata(context.run_root, record)
     except Exception as exc:  # pylint: disable=broad-exception-caught
         context.log.debug("Unable to write command history record: %s", exc)
 
@@ -65,6 +67,8 @@ def build_finished_record(
         "exit_code": exit_code,
         "status": "ok" if exit_code == 0 else "error",
         "log_path": compact_path(context.log_file),
+        "owner": context.runtime_owner,
+        "bundle_path": compact_path(context.run_root or context.state_dir),
         "os": normalized_os(),
     }
     optional_fields = {
@@ -93,6 +97,8 @@ def write_primary_record(
     project_root: str | None = None,
     manifest: str | None = None,
     log_path: str | None = None,
+    owner: str = "base",
+    bundle_path: str | None = None,
 ) -> None:
     """Write the user-facing record for a Bash-dispatched command."""
     ended_at = utc_now()
@@ -111,14 +117,22 @@ def write_primary_record(
         "os": normalized_os(),
         "scope": scope,
     }
+    resolved_bundle = Path(bundle_path).expanduser() if bundle_path else runtime_bundle_path()
+    resolved_log = Path(log_path).expanduser() if log_path else (
+        resolved_bundle / "logs" / "primary.log" if resolved_bundle is not None else None
+    )
     optional_fields = {
         "project": project,
         "project_root": compact_optional_path(Path(project_root)) if project_root else None,
         "manifest": compact_optional_path(Path(manifest)) if manifest else None,
-        "log_path": compact_optional_path(Path(log_path)) if log_path else None,
+        "log_path": compact_optional_path(resolved_log),
+        "owner": owner,
+        "bundle_path": compact_optional_path(resolved_bundle),
     }
     record.update({key: value for key, value in optional_fields.items() if value})
     write_history_record(record)
+    if resolved_bundle is not None:
+        update_run_metadata(resolved_bundle, record)
 
 
 def write_history_record(record: dict[str, Any]) -> None:
@@ -126,6 +140,37 @@ def write_history_record(record: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     append_history_line(path, f"{json.dumps(record, sort_keys=True)}\n")
     path.chmod(0o600)
+
+
+def runtime_bundle_path() -> Path | None:
+    value = os.environ.get("BASE_CLI_RUN_ROOT")
+    if not value:
+        return None
+    return Path(value).expanduser().resolve(strict=False)
+
+
+def update_run_metadata(run_root: Path, record: dict[str, Any]) -> None:
+    metadata_path = run_root / "run.json"
+    metadata: dict[str, Any] = {}
+    try:
+        if metadata_path.is_file():
+            loaded = json.loads(metadata_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                metadata = loaded
+        metadata.update(
+            {
+                "run_id": record.get("run_id"),
+                "owner": record.get("owner", metadata.get("owner", "base")),
+                "status": record.get("status"),
+                "exit_code": record.get("exit_code"),
+                "ended_at": record.get("ended_at"),
+                "command": record.get("command"),
+            }
+        )
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata_path.write_text(json.dumps(metadata, sort_keys=True) + "\n", encoding="utf-8")
+    except (OSError, TypeError, ValueError):
+        return
 
 
 def append_history_line(path: Path, line: str) -> None:

--- a/lib/python/base_cli/paths.py
+++ b/lib/python/base_cli/paths.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import hashlib
 import os
+import re
 import sys
 import time
 import uuid
@@ -56,6 +58,53 @@ def normalize_cli_name(name: str) -> str:
     if "." in stem:
         stem = stem.rsplit(".", 1)[0]
     return stem.replace(" ", "-")
+
+
+def normalize_runtime_owner(value: str | None = None) -> str:
+    """Return the runtime owner namespace for a command invocation."""
+    owner = (value or os.environ.get("BASE_CLI_RUNTIME_OWNER") or "base").strip().lower()
+    if owner not in {"base", "project"}:
+        raise ValueError("BASE_CLI_RUNTIME_OWNER must be 'base' or 'project'.")
+    return owner
+
+
+def runtime_project_name(value: str | None = None) -> str | None:
+    name = (value or os.environ.get("BASE_CLI_PROJECT_NAME") or "").strip()
+    return name or None
+
+
+def runtime_project_root(value: Path | str | None = None) -> Path | None:
+    candidate = value or os.environ.get("BASE_CLI_PROJECT_ROOT")
+    if not candidate:
+        return None
+    return Path(candidate).expanduser().resolve()
+
+
+def runtime_slug(value: str, fallback: str = "unnamed") -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip(".-_").lower()
+    return normalized or fallback
+
+
+def checkout_id(project_root: Path | None) -> str | None:
+    if project_root is None:
+        return None
+    digest = hashlib.sha256(str(project_root.expanduser().resolve()).encode("utf-8")).hexdigest()
+    return digest[:12]
+
+
+def runtime_owner_root(
+    cache_root: Path,
+    owner: str = "base",
+    project_name: str | None = None,
+    project_root: Path | None = None,
+) -> Path:
+    normalized_owner = normalize_runtime_owner(owner)
+    if normalized_owner == "base":
+        return cache_root / "base"
+
+    name = runtime_slug(project_name or "unnamed")
+    checkout = checkout_id(project_root) or "unknown"
+    return cache_root / "projects" / name / checkout
 
 
 def discover_manifest(start: Path) -> Path | None:

--- a/lib/python/base_cli/tests/test_app_log_retention.py
+++ b/lib/python/base_cli/tests/test_app_log_retention.py
@@ -29,7 +29,7 @@ class AppLogRetentionTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            log_dir = home / ".cache" / "base" / "cli" / "retention-demo" / "logs"
+            log_dir = home / ".cache" / "base" / "base" / "runs" / "seed" / "logs"
             oldest = log_dir / "20260620T120000_oldest.log"
             newest = log_dir / "20260621T120000_newest.log"
             write_log_file(oldest, 1)
@@ -42,7 +42,7 @@ class AppLogRetentionTests(unittest.TestCase):
             self.assertTrue(newest.exists())
             self.assertIsNotNone(seen["log_file"])
             self.assertTrue(seen["log_file"].exists())
-            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 2)
+            self.assertEqual(len(tuple((home / ".cache" / "base" / "base" / "runs").rglob("*.log"))), 2)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_prunes_by_filename_when_mtimes_disagree(self) -> None:
@@ -56,7 +56,7 @@ class AppLogRetentionTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            log_dir = home / ".cache" / "base" / "cli" / "retention-filename" / "logs"
+            log_dir = home / ".cache" / "base" / "base" / "runs" / "seed" / "logs"
             older_by_name = log_dir / "20260620T120000_old.log"
             newer_by_name = log_dir / "20260621T120000_new.log"
             write_log_file(older_by_name, 2)
@@ -69,7 +69,7 @@ class AppLogRetentionTests(unittest.TestCase):
             self.assertTrue(newer_by_name.exists())
             self.assertIsNotNone(seen["log_file"])
             self.assertTrue(seen["log_file"].exists())
-            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 2)
+            self.assertEqual(len(tuple((home / ".cache" / "base" / "base" / "runs").rglob("*.log"))), 2)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_preserves_current_log_file(self) -> None:
@@ -83,7 +83,7 @@ class AppLogRetentionTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            log_dir = home / ".cache" / "base" / "cli" / "retention-current" / "logs"
+            log_dir = home / ".cache" / "base" / "base" / "runs" / "seed" / "logs"
             old_a = log_dir / "old-a.log"
             old_b = log_dir / "old-b.log"
             write_log_file(old_a, 1)
@@ -96,7 +96,7 @@ class AppLogRetentionTests(unittest.TestCase):
             self.assertFalse(old_b.exists())
             self.assertIsNotNone(seen["log_file"])
             self.assertTrue(seen["log_file"].exists())
-            self.assertEqual(tuple(log_dir.glob("*.log")), (seen["log_file"],))
+            self.assertEqual(tuple((home / ".cache" / "base" / "base" / "runs").rglob("*.log")), (seen["log_file"],))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_keeps_logs_when_count_is_within_limit(self) -> None:
@@ -110,7 +110,7 @@ class AppLogRetentionTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            log_dir = home / ".cache" / "base" / "cli" / "retention-within-limit" / "logs"
+            log_dir = home / ".cache" / "base" / "base" / "runs" / "seed" / "logs"
             old_a = log_dir / "20260620T120000_a.log"
             old_b = log_dir / "20260621T120000_b.log"
             write_log_file(old_a, 1)
@@ -123,7 +123,7 @@ class AppLogRetentionTests(unittest.TestCase):
             self.assertTrue(old_b.exists())
             self.assertIsNotNone(seen["log_file"])
             self.assertTrue(seen["log_file"].exists())
-            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 3)
+            self.assertEqual(len(tuple((home / ".cache" / "base" / "base" / "runs").rglob("*.log"))), 3)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_is_disabled_by_default(self) -> None:
@@ -137,7 +137,7 @@ class AppLogRetentionTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            log_dir = home / ".cache" / "base" / "cli" / "retention-unset" / "logs"
+            log_dir = home / ".cache" / "base" / "base" / "runs" / "seed" / "logs"
             old_a = log_dir / "old-a.log"
             old_b = log_dir / "old-b.log"
             write_log_file(old_a, 1)
@@ -150,7 +150,7 @@ class AppLogRetentionTests(unittest.TestCase):
             self.assertTrue(old_b.exists())
             self.assertIsNotNone(seen["log_file"])
             self.assertTrue(seen["log_file"].exists())
-            self.assertEqual(len(tuple(log_dir.glob("*.log"))), 3)
+            self.assertEqual(len(tuple((home / ".cache" / "base" / "base" / "runs").rglob("*.log"))), 3)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_skips_no_durable_write_modes(self) -> None:
@@ -178,8 +178,8 @@ class AppLogRetentionTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir)
-            dry_log_dir = home / ".cache" / "base" / "cli" / "retention-dry-run" / "logs"
-            no_file_log_dir = home / ".cache" / "base" / "cli" / "retention-no-file" / "logs"
+            dry_log_dir = home / ".cache" / "base" / "base" / "runs" / "dry-seed" / "logs"
+            no_file_log_dir = home / ".cache" / "base" / "base" / "runs" / "no-file-seed" / "logs"
             dry_old = dry_log_dir / "old.log"
             no_file_old = no_file_log_dir / "old.log"
             write_log_file(dry_old, 1)

--- a/lib/python/base_cli/tests/test_app_runtime_boundary.py
+++ b/lib/python/base_cli/tests/test_app_runtime_boundary.py
@@ -13,15 +13,49 @@ def test_runtime_layout_names_base_cli_directories() -> None:
     runtime = importlib.import_module("base_cli._runtime")
     layout = runtime.runtime_layout(Path("/tmp/base-cache"), "demo", "run-123")
 
-    assert layout.state_dir == Path("/tmp/base-cache/cli/demo")
-    assert layout.log_dir == Path("/tmp/base-cache/cli/demo/logs")
-    assert layout.cache_dir == Path("/tmp/base-cache/cli/demo/cache")
-    assert layout.temp_dir == Path("/tmp/base-cache/cli/demo/tmp/run-123")
+    assert layout.owner_root == Path("/tmp/base-cache/base")
+    assert layout.run_root == Path("/tmp/base-cache/base/runs/run-123")
+    assert layout.state_dir == Path("/tmp/base-cache/base")
+    assert layout.log_dir == Path("/tmp/base-cache/base/runs/run-123/logs")
+    assert layout.cache_dir == Path("/tmp/base-cache/base/cache/components/demo")
+    assert layout.temp_dir == Path("/tmp/base-cache/base/runs/run-123/tmp/demo/run-123")
 
 
 def test_runtime_helpers_stay_out_of_public_api() -> None:
     assert "_runtime" not in base_cli.__all__
     assert "runtime_layout" not in base_cli.__all__
+
+
+def test_runtime_layout_is_checkout_scoped_for_project_owner() -> None:
+    runtime = importlib.import_module("base_cli._runtime")
+    layout = runtime.runtime_layout(
+        Path("/tmp/base-cache"),
+        "native-cli",
+        "run-123",
+        owner="project",
+        project_name="banyanlabs",
+        project_root=Path("/work/banyanlabs"),
+    )
+
+    assert layout.owner_root.parent.parent == Path("/tmp/base-cache/projects")
+    assert layout.owner_root.parent.name == "banyanlabs"
+    assert layout.run_root == layout.owner_root / "runs" / "run-123"
+    assert layout.log_dir == layout.run_root / "logs"
+
+
+def test_runtime_layout_places_inherited_base_children_under_internal_logs() -> None:
+    runtime = importlib.import_module("base_cli._runtime")
+    parent = Path("/tmp/base-cache/base/runs/parent")
+    layout = runtime.runtime_layout(
+        Path("/tmp/base-cache"),
+        "base_projects",
+        "child",
+        inherited_run_root=parent,
+    )
+
+    assert layout.run_root == parent
+    assert layout.log_dir == parent / "logs" / "internal" / "base_projects"
+    assert layout.temp_dir == parent / "tmp" / "base_projects" / "child"
 
 
 def test_runtime_directory_helpers_are_split_from_app_module() -> None:

--- a/lib/python/base_cli/tests/test_app_runtime_errors.py
+++ b/lib/python/base_cli/tests/test_app_runtime_errors.py
@@ -44,6 +44,6 @@ class AppRuntimeErrorTests(unittest.TestCase):
         self.assertEqual(exit_code, 1)
         self.assertIn("Error:", error)
         self.assertIn("Unable to create Base runtime directory", error)
-        self.assertIn(str(cache_root / "cli" / "cache-failure" / "logs"), error)
+        self.assertIn(str(cache_root / "base" / "runs"), error)
         self.assertIn("BASE_CACHE_DIR", error)
         self.assertNotIn("Traceback", error)

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -583,7 +583,9 @@ class BaseCliTests(unittest.TestCase):
             self.assertEqual(seen["name"], "Ada")
             self.assertFalse(seen["temp_dir"].exists())
             self.assertTrue(seen["cache_dir"].is_dir())
-            log_dir = home / ".cache" / "base" / "cli" / "demo" / "logs"
+            log_dir = home / ".cache" / "base" / "base" / "runs" / next(
+                path.name for path in (home / ".cache" / "base" / "base" / "runs").iterdir()
+            ) / "logs"
             self.assertTrue(log_dir.is_dir())
             log_files = tuple(log_dir.glob("*.log"))
             self.assertEqual(len(log_files), 1)
@@ -841,7 +843,7 @@ class BaseCliTests(unittest.TestCase):
 
             expected_cache_root = home / ".cache" / "base"
             self.assertEqual(result.exit_code, 0, result.output)
-            self.assertEqual(seen["state_dir"], expected_cache_root / "cli" / "cache-default")
+            self.assertEqual(seen["state_dir"], expected_cache_root / "base")
             self.assertTrue(expected_cache_root.is_dir())
             self.assertFalse(inherited_cache.exists())
 
@@ -877,7 +879,7 @@ class BaseCliTests(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertEqual(seen["home"], override_home)
-            self.assertEqual(seen["state_dir"], override_cache / "cli" / "cache-override")
+            self.assertEqual(seen["state_dir"], override_cache / "base")
             self.assertTrue(override_cache.is_dir())
             self.assertFalse((home / ".cache" / "base").exists())
 
@@ -925,9 +927,8 @@ class BaseCliTests(unittest.TestCase):
                 self.assertTrue(seen["debug"])
                 self.assertTrue(seen["temp_dir"].exists())
                 self.assertEqual(seen["log_file"], log_file)
-                self.assertEqual(
-                    seen["temp_dir"].parents[1],
-                    home / ".cache" / "base" / "cli" / "secret-tool",
+                self.assertTrue(
+                    seen["temp_dir"].is_relative_to(home / ".cache" / "base" / "base" / "runs")
                 )
                 self.assertEqual(seen["manifest_path"], manifest_path.resolve())
                 self.assertEqual(seen["project_root"], project.resolve())

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -15,7 +15,7 @@ from base_cli import history as history_helpers
 
 
 def read_history_records(cache_root: Path) -> list[dict]:
-    history_path = cache_root / "history" / "runs.jsonl"
+    history_path = cache_root / "base" / "history" / "runs.jsonl"
     return [json.loads(line) for line in history_path.read_text(encoding="utf-8").splitlines()]
 
 
@@ -72,7 +72,7 @@ class BaseCliHistoryTests(unittest.TestCase):
                     with mock.patch("base_cli.history.os.write", wraps=real_os_write) as os_write:
                         history_helpers.write_history_record(record)
 
-            history_path = cache_root / "history" / "runs.jsonl"
+            history_path = cache_root / "base" / "history" / "runs.jsonl"
             payloads = [call.args[1] for call in os_write.call_args_list]
             history_mode = history_path.stat().st_mode & 0o777
 
@@ -103,7 +103,7 @@ class BaseCliHistoryTests(unittest.TestCase):
                 with mock.patch("base_cli.history._fcntl", None):
                     history_helpers.write_history_record(record)
 
-            history_mode = (cache_root / "history" / "runs.jsonl").stat().st_mode & 0o777
+            history_mode = (cache_root / "base" / "history" / "runs.jsonl").stat().st_mode & 0o777
             records = read_history_records(cache_root)
 
         self.assertEqual(records, [record])
@@ -199,7 +199,10 @@ class BaseCliHistoryTests(unittest.TestCase):
         self.assertEqual(record["exit_code"], 0)
         self.assertEqual(record["status"], "ok")
         self.assertTrue(record["duration_ms"] >= 0)
-        self.assertTrue(record["log_path"].startswith("~/.cache/base/cli/history-demo/logs/"))
+        self.assertTrue(record["log_path"].startswith("~/.cache/base/base/runs/"))
+        self.assertTrue(record["log_path"].endswith("/logs/primary.log"))
+        self.assertEqual(record["owner"], "base")
+        self.assertTrue(record["bundle_path"].startswith("~/.cache/base/base/runs/"))
         self.assertIn("[REDACTED]", record["argv"])
         self.assertIn("https://[REDACTED]@example.invalid/path", record["argv"])
         self.assertNotIn("super-secret", json.dumps(record))
@@ -230,6 +233,44 @@ class BaseCliHistoryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(records[0]["scope"], "internal")
         self.assertEqual(records[0]["parent_run_id"], "parent-1")
+
+    @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
+    def test_project_owner_uses_checkout_scoped_run_bundle(self) -> None:
+        app = base_cli.App(name="project-native")
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            self.assertEqual(ctx.runtime_owner, "project")
+            self.assertEqual(ctx.project_name, "demo")
+            self.assertTrue(ctx.owner_root.parts[-2] == "demo")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            project = home / "work" / "demo"
+            home.mkdir()
+            project.mkdir(parents=True)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BASE_CLI_RUNTIME_OWNER": "project",
+                    "BASE_CLI_PROJECT_NAME": "demo",
+                    "BASE_CLI_PROJECT_ROOT": str(project),
+                },
+            ):
+                from base_cli.testing import invoke
+
+                result = invoke(
+                    app,
+                    [],
+                    home=home,
+                    cwd=project,
+                    manifest={"project": {"name": "demo"}},
+                )
+            records = read_history_records(home / ".cache" / "base")
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(records[0]["owner"], "project")
+        self.assertIn("/projects/demo/", records[0]["bundle_path"])
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_run_app_uses_explicit_argv_for_history_and_log_metadata(self) -> None:


### PR DESCRIPTION
## Summary

- implement the clean-slate owner-aware cache layout for Base and Base-compliant projects
- add run-oriented bundles with `run.json`, primary logs, internal child logs, and checkout-isolated project roots
- move history and project discovery caches under the Base namespace
- update logs, cleanup, runtime metadata, tests, and documentation

Closes #1678

## Validation

- `./bin/base-test` Python suite: 1014 passed, 1 skipped
- full shell/Bats suite: 797 passed
- `git diff --check`
- `shellcheck` on changed Bash launchers
