### PR TITLE
Harden runtime bundle metadata and logs

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -553,6 +553,10 @@ basectl_initialize_run_bundle() {
     printf '{"run_id":"%s","owner":"base","status":"running","started_at":"%s"}\n' \
         "$run_id" "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" >"$run_root/run.json"
     printf '%s basectl start run_id=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" "$run_id" >>"$BASE_CLI_PRIMARY_LOG"
+    chmod 600 "$run_root/run.json" "$BASE_CLI_PRIMARY_LOG" || {
+        basectl_error "Unable to secure Base run bundle '$run_root'. Check file permissions."
+        return 1
+    }
 }
 
 basectl_finalize_run_bundle() {
@@ -569,6 +573,7 @@ basectl_finalize_run_bundle() {
         "$([[ "$exit_code" == 0 ]] && printf ok || printf error)" "$exit_code" \
         "${BASE_CLI_HISTORY_STARTED_AT:-}" \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" >"$tmp_file" && mv -f "$tmp_file" "$run_root/run.json"
+    chmod 600 "$run_root/run.json" "${BASE_CLI_PRIMARY_LOG:-$run_root/logs/primary.log}" || return 1
 }
 
 basectl_history_record() {

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -3,6 +3,29 @@
 load ./basectl_helpers.bash
 
 
+@test "basectl run bundle metadata and primary log are private" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local run_root
+
+    run env \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            basectl_initialize_run_bundle || exit $?
+            printf "%s\n" "$BASE_CLI_RUN_ROOT"
+            basectl_finalize_run_bundle 0 || exit $?
+        '
+
+    [ "$status" -eq 0 ]
+    run_root="${lines[0]}"
+    [ -f "$run_root/run.json" ]
+    [ -f "$run_root/logs/primary.log" ]
+    [ "$(find "$run_root/run.json" -perm 600 -print)" = "$run_root/run.json" ]
+    [ "$(find "$run_root/logs/primary.log" -perm 600 -print)" = "$run_root/logs/primary.log" ]
+}
+
+
 @test "basectl prints help when no command is given in a non-interactive shell" {
     run_basectl
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -211,13 +211,14 @@ Every run gets two streams:
 
 | Stream | Destination | Level | Format |
 |---|---|---|---|
-| user | stderr | INFO by default, DEBUG with `--debug` | Base-style timestamp, level, source, message |
-| persistent | `ctx.log_file` when enabled | DEBUG | Base-style timestamp, level, source, message |
+| user | stderr | INFO by default, DEBUG with `--debug` | UTC timestamp, level, source, message |
+| persistent | `ctx.log_file` when enabled | DEBUG | UTC timestamp, level, source, message |
 
-Python user-facing logs should visually align with Bash `lib_std.sh` logs:
+Python user-facing logs should visually align with Bash `lib_std.sh` logs while
+making the timezone explicit:
 
 ```text
-2026-05-23 12:31:04 INFO    cli/python/base_setup/engine.py:67 Reading Base manifest at '.../base_manifest.yaml'.
+2026-05-23 19:31:04 UTC INFO    cli/python/base_setup/engine.py:67 Reading Base manifest at '.../base_manifest.yaml'.
 ```
 
 `base_cli` logs invocation metadata at DEBUG level:

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -113,8 +113,10 @@ by individual Base components. This state is not tied to one diagnostic run.
 
 One directory per Base control-plane invocation. `run.json` is written at the
 start with `status: running` and finalized with timestamps, exit status,
-project metadata, and child references. `primary.log` contains top-level Base
-diagnostics. Normal command stdout remains stdout and is not captured here.
+project metadata, command arguments, and parent/child references when known.
+Run metadata and the primary log are private (`0600`). `primary.log` contains
+top-level Base diagnostics. Normal command stdout remains stdout and is not
+captured here.
 
 ### `projects/<project-id>/<checkout-id>/`
 
@@ -141,6 +143,18 @@ project run through the history index and `run.json` metadata.
 Temporary files scoped to one run and component. Successful runs remove these
 directories automatically unless retention is requested. Failed or interrupted
 runs retain them for diagnosis until cleanup removes the completed bundle.
+
+## Timestamps and permissions
+
+Persisted history, run metadata, primary logs, and Python CLI logs use UTC.
+Python CLI log lines include an explicit `UTC` marker; run IDs use UTC-based
+timestamps as well. `basectl history` keeps its existing UTC default and can
+render human-readable views in local time with `--local-time`.
+
+History and run artifacts are user-private by default. History and metadata
+files are created with mode `0600`; raw log files use the same mode. Directory
+permissions remain controlled by the host cache filesystem and do not change
+the ownership boundary described above.
 
 ## Runtime invariants
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -199,6 +199,11 @@ errors.
 `basectl logs` should remain the command for opening or tailing raw log files.
 `basectl history` should point to logs, not replace them.
 
+Raw Python CLI logs use UTC timestamps with an explicit `UTC` marker. The
+primary run log uses ISO-8601 UTC timestamps, and history JSON retains canonical
+UTC timestamps; only human-readable history/report views can opt into local
+time with `--local-time`.
+
 `basectl logs last` bridges those surfaces for the common failure case. It reads
 the local history index, finds the latest failed run, prints command metadata,
 and includes a bounded redacted tail of the recorded log when the log still

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -281,7 +281,8 @@ from stderr.
 Advanced tests and CI wrappers can call `base_cli.configure_logger(...,
 stream=..., formatter=...)` to capture user-facing logs or apply a custom
 formatter without replacing Base's logger setup. Leave those arguments as
-`None` to keep the default stderr stream and `BaseCliFormatter`.
+`None` to keep the default stderr stream and `BaseCliFormatter`. Base CLI log
+timestamps are rendered in UTC and include an explicit `UTC` marker.
 
 Commands that inspect runtime artifacts can use `base_cli.App(log_to_file=False)`
 to keep the standard context, `--debug`, and `--quiet` behavior without creating
@@ -391,7 +392,8 @@ elsewhere. `BASE_CACHE_DIR` overrides the root. See
 [`docs/cache-ownership-and-layout.md`](../../../docs/cache-ownership-and-layout.md)
 for the owner-aware layout. Base control-plane commands use `base/`; a
 Base-compliant project's own commands use `projects/<project>/<checkout-id>/`.
-Each invocation is a run bundle containing `run.json`, `logs/`, and `tmp/`,
+Each invocation is a run bundle containing private (`0600`) `run.json`,
+`logs/`, and `tmp/`,
 while persistent component caches live in the owner's `cache/components/`.
 `basectl clean --older-than <age>` removes old bundles and component caches;
 `--keep-last <count>` retains the newest completed bundles per owner.

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -41,6 +41,7 @@ def _require_click():
     return click
 
 
+# pylint: disable=too-many-statements
 class App:
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
@@ -218,20 +219,23 @@ class App:
         if inherited_path is None and not dry_run and self.log_to_file:
             create_runtime_directory(layout.run_root, cache_root)
             try:
-                (layout.run_root / "run.json").write_text(
-                    json.dumps(
-                        {
-                            "run_id": run_id,
-                            "owner": runtime_owner,
-                            "cli": self.name,
-                            "status": "running",
-                            "started_at": utc_now().isoformat(timespec="seconds").replace("+00:00", "Z"),
-                        },
-                        sort_keys=True,
-                    )
-                    + "\n",
+                run_metadata = {
+                    "run_id": run_id,
+                    "owner": runtime_owner,
+                    "cli": self.name,
+                    "status": "running",
+                    "started_at": utc_now().isoformat(timespec="seconds").replace("+00:00", "Z"),
+                    "project": selected_project_name,
+                    "project_root": str(selected_project_root) if selected_project_root else None,
+                    "manifest": str(manifest_path) if manifest_path else None,
+                    "workspace_root": str(user_config.workspace.root) if user_config.workspace.root else None,
+                }
+                run_metadata_path = layout.run_root / "run.json"
+                run_metadata_path.write_text(
+                    json.dumps(run_metadata, sort_keys=True) + "\n",
                     encoding="utf-8",
                 )
+                run_metadata_path.chmod(0o600)
             except OSError:
                 pass
         if runtime_owner == "project" and selected_project_root is not None and not dry_run and self.log_to_file:
@@ -253,6 +257,7 @@ class App:
                         + "\n",
                         encoding="utf-8",
                     )
+                identity_path.chmod(0o600)
             except OSError:
                 pass
         logger = configure_logger(self.name, log_file, debug, quiet=quiet)

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -167,8 +167,21 @@ def update_run_metadata(run_root: Path, record: dict[str, Any]) -> None:
                 "command": record.get("command"),
             }
         )
+        for key in (
+            "argv",
+            "manifest",
+            "parent_run_id",
+            "project",
+            "project_root",
+            "raw_command",
+            "scope",
+            "workspace_root",
+        ):
+            if key in record and record[key] is not None:
+                metadata[key] = record[key]
         metadata_path.parent.mkdir(parents=True, exist_ok=True)
         metadata_path.write_text(json.dumps(metadata, sort_keys=True) + "\n", encoding="utf-8")
+        metadata_path.chmod(0o600)
     except (OSError, TypeError, ValueError):
         pass
 

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import sys
+import time
 from pathlib import Path
 from typing import TextIO
 
@@ -82,7 +83,9 @@ def _secure_log_file_open_flags(mode: str) -> int:
 
 class BaseCliFormatter(logging.Formatter):
     def __init__(self) -> None:
-        super().__init__(datefmt="%Y-%m-%d %H:%M:%S")
+        super().__init__(datefmt="%Y-%m-%d %H:%M:%S UTC")
+
+    converter = time.gmtime
 
     def format(self, record: logging.LogRecord) -> str:
         timestamp = self.formatTime(record, self.datefmt)

--- a/lib/python/base_cli/paths.py
+++ b/lib/python/base_cli/paths.py
@@ -49,7 +49,7 @@ def use_working_dir(path: Path | None) -> Iterator[None]:
 
 
 def make_run_id() -> str:
-    timestamp = time.strftime("%Y%m%dT%H%M%S")
+    timestamp = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
     return f"{timestamp}_{uuid.uuid4().hex[:8]}"
 
 

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines,too-many-public-methods
 
 import importlib.util
 import io
+import json
 import logging
 import os
 import tempfile
+import time
 import unittest
 from contextlib import contextmanager, redirect_stderr
 from pathlib import Path
@@ -192,6 +194,9 @@ class BaseCliTests(unittest.TestCase):
                 formatted = BaseCliFormatter().format(record)
 
         self.assertIn(f"{external.resolve()}:7 hello", formatted)
+
+    def test_base_cli_formatter_uses_utc_converter(self) -> None:
+        self.assertIs(BaseCliFormatter.converter, time.gmtime)
 
     def test_config_precedence_excludes_implicit_system_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -587,11 +592,14 @@ class BaseCliTests(unittest.TestCase):
                 path.name for path in (home / ".cache" / "base" / "base" / "runs").iterdir()
             ) / "logs"
             self.assertTrue(log_dir.is_dir())
+            run_metadata = log_dir.parent / "run.json"
+            self.assertEqual(run_metadata.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(json.loads(run_metadata.read_text(encoding="utf-8"))["status"], "ok")
             log_files = tuple(log_dir.glob("*.log"))
             self.assertEqual(len(log_files), 1)
             self.assertEqual(log_files[0].stat().st_mode & 0o777, 0o600)
             self.assertFalse((home / ".base.d" / "cli").exists())
-            self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} INFO\s+")
+            self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC INFO\s+")
             self.assertIn("hello Ada", result.stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -114,6 +114,12 @@ class BaseCliHistoryTests(unittest.TestCase):
             cache_root = Path(tmpdir) / "cache"
             project_root = Path(tmpdir) / "work" / "demo"
             manifest = project_root / "base_manifest.yaml"
+            bundle = cache_root / "base" / "runs" / "parent-1"
+            bundle.mkdir(parents=True)
+            (bundle / "run.json").write_text(
+                json.dumps({"run_id": "parent-1", "owner": "base", "status": "running"}) + "\n",
+                encoding="utf-8",
+            )
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
                 history_helpers.write_primary_record(
                     command="test",
@@ -125,8 +131,11 @@ class BaseCliHistoryTests(unittest.TestCase):
                     project="demo",
                     project_root=str(project_root),
                     manifest=str(manifest),
+                    bundle_path=str(bundle),
                 )
             record = read_history_records(cache_root)[0]
+            metadata = json.loads((bundle / "run.json").read_text(encoding="utf-8"))
+            metadata_mode = (bundle / "run.json").stat().st_mode & 0o777
 
         self.assertEqual(record["command"], "test")
         self.assertEqual(record["raw_command"], "basectl")
@@ -136,6 +145,12 @@ class BaseCliHistoryTests(unittest.TestCase):
         self.assertEqual(record["project_root"], str(project_root.resolve()))
         self.assertEqual(record["manifest"], str(manifest.resolve()))
         self.assertEqual(record["status"], "error")
+        self.assertEqual(metadata["project"], "demo")
+        self.assertEqual(metadata["project_root"], str(project_root.resolve()))
+        self.assertEqual(metadata["manifest"], str(manifest.resolve()))
+        self.assertEqual(metadata["raw_command"], "basectl")
+        self.assertEqual(metadata["scope"], "internal")
+        self.assertEqual(metadata_mode, 0o600)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_app_records_successful_command_history_with_redacted_metadata(self) -> None:


### PR DESCRIPTION
## Summary\n\n- retain project, manifest, command, and parent metadata in finalized run.json\n- make run metadata and shell-created primary logs private (0600)\n- emit UTC-marked Python CLI log timestamps and UTC-based run IDs\n- document the metadata, timestamp, and permission contract\n- add regression coverage for Bash bundle permissions and Python metadata/timestamps\n\n## Validation\n\n- 1,016 Python tests passed, 1 skipped\n- 798 BATS tests passed\n- focused setup smoke passed\n- pylint, ShellCheck, bash -n, and git diff --check passed\n\nCloses #1680