### PR TITLE
Use one run ID and one primary diagnostic log per invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored local-time defaults for interactive Python CLI logs so Bash and
+  Python output from one local run share a clock. `--utc-wrapper` remains the
+  explicit UTC mode, while persisted history, run metadata, and run IDs remain
+  canonical UTC; updated the cache, observability, and Base CLI documentation.
+
 ## [1.7.0] - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Consolidated each public invocation into one run ID, one `run.json`, and one
+  `logs/primary.log`; delegated Bash/Python phases now share the DEBUG-level
+  diagnostic stream and produce one history row. Legacy internal logs and
+  history rows are ignored by discovery and reporting.
 - Restored local-time defaults for interactive Python CLI logs so Bash and
   Python output from one local run share a clock. `--utc-wrapper` remains the
   explicit UTC mode, while persisted history, run metadata, and run IDs remain

--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,6 @@ basectl history --command check --status error
 basectl history --format json
 basectl history --report
 basectl history --report --format json
-basectl history --include-internal
 basectl history --oldest-first
 basectl history --last 2h --oldest-first
 basectl history --since 2026-07-17 --until 2026-07-18
@@ -1124,11 +1123,11 @@ basectl history --local-time
 `<base-cache-root>/base/history/runs.jsonl`. Each invocation also has a
 run-oriented bundle under `<base-cache-root>/base/runs/<run-id>/`, while
 project-native commands use `<base-cache-root>/projects/<project>/<checkout>/`.
-The default view shows one primary row
-per public `basectl` command; delegated Python and resolver steps remain linked
-as internal records and can be shown with `--include-internal`. History records
-point to raw logs instead of replacing them, and malformed history lines are
-ignored while listing recent runs. `--report` prints a privacy-conscious local activity
+The default view shows one row per public `basectl` command. Delegated Python
+and resolver steps share that invocation's run ID and `logs/primary.log`; they
+are not separate history records. History records point to raw logs instead of
+replacing them, and malformed or legacy internal rows are ignored while listing
+recent runs. `--report` prints a privacy-conscious local activity
 summary with recent commands, failure counts, common failing command families,
 and log file locations. Use `--oldest-first` for chronological display,
 `--last 2h` for a relative window, or `--since`/`--until` for explicit bounds.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -552,7 +552,7 @@ basectl_initialize_run_bundle() {
     export BASE_CLI_HISTORY_PARENT_RUN_ID="$run_id"
     printf '{"run_id":"%s","owner":"base","status":"running","started_at":"%s"}\n' \
         "$run_id" "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" >"$run_root/run.json"
-    printf '%s basectl start run_id=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" "$run_id" >>"$BASE_CLI_PRIMARY_LOG"
+    : >"$BASE_CLI_PRIMARY_LOG"
     chmod 600 "$run_root/run.json" "$BASE_CLI_PRIMARY_LOG" || {
         basectl_error "Unable to secure Base run bundle '$run_root'. Check file permissions."
         return 1
@@ -564,9 +564,6 @@ basectl_finalize_run_bundle() {
 
     run_root="${BASE_CLI_RUN_ROOT:-}"
     [[ -n "$run_root" && -d "$run_root" ]] || return 0
-    printf '%s basectl finish status=%s exit_code=%s\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" \
-        "$([[ "$exit_code" == 0 ]] && printf ok || printf error)" "$exit_code" >>"${BASE_CLI_PRIMARY_LOG:-$run_root/logs/primary.log}"
     tmp_file="$run_root/run.json.tmp"
     printf '{"run_id":"%s","owner":"base","status":"%s","exit_code":%s,"started_at":"%s","ended_at":"%s"}\n' \
         "${BASE_CLI_RUN_ID:-$(basename -- "$run_root")}" \

--- a/cli/bash/commands/basectl/subcommands/history.sh
+++ b/cli/bash/commands/basectl/subcommands/history.sh
@@ -17,7 +17,6 @@ Options:
   --format <text|markdown|json>
                         Output format. Defaults to text, or Markdown with --report.
   --report              Print a privacy-conscious Markdown or JSON activity report.
-  --include-internal    Include delegated internal steps in the output.
   --oldest-first        Show the selected history window from oldest to newest.
   --last <duration>     Show records from the most recent duration, such as 2h or 7d.
   --since <time>        Include records at or after an ISO-8601 or short timestamp.
@@ -45,10 +44,6 @@ base_history_subcommand_main() {
                 shift
                 ;;
             --report)
-                args+=("$1")
-                shift
-                ;;
-            --include-internal)
                 args+=("$1")
                 shift
                 ;;

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -331,7 +331,7 @@ EOF
     [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
     [[ "$output" == *"logs_last_options=--command --lines --format"* ]]
     [[ "$output" == *"logs_commands=last"* ]]
-    [[ "$output" == *"history_options=--project --command --status --limit --format --report --include-internal --oldest-first --last --since --until --local-time"* ]]
+    [[ "$output" == *"history_options=--project --command --status --limit --format --report --oldest-first --last --since --until --local-time"* ]]
     [[ "$output" == *"trust_commands=status allow revoke"* ]]
     [[ "$output" == *"trust_projects=base demo"* ]]
     [[ "$output" == *"trust_status_options=--workspace --format"* ]]

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -19,11 +19,11 @@ exit 1
 EOF
     chmod +x "$python_bin"
 
-    run_basectl history --project demo --command check --status error --limit 3 --format json --include-internal --oldest-first --last 2h --since 2026-06-10 --until 2026-06-11 --local-time
+    run_basectl history --project demo --command check --status error --limit 3 --format json --oldest-first --last 2h --since 2026-06-10 --until 2026-06-11 --local-time
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_PROJECT=base"* ]]
-    [[ "$output" == *"ARGS=--project demo --command check --status error --limit 3 --format json --include-internal --oldest-first --last 2h --since 2026-06-10 --until 2026-06-11 --local-time"* ]]
+    [[ "$output" == *"ARGS=--project demo --command check --status error --limit 3 --format json --oldest-first --last 2h --since 2026-06-10 --until 2026-06-11 --local-time"* ]]
 }
 
 @test "basectl history forwards report mode to the Python history layer" {
@@ -76,7 +76,7 @@ EOF
     [[ "$output" == *"basectl history [options]"* ]]
     [[ "$output" == *"--project <name>"* ]]
     [[ "$output" == *"--report"* ]]
-    [[ "$output" == *"--include-internal"* ]]
+    [[ "$output" != *"--include-internal"* ]]
     [[ "$output" == *"--oldest-first"* ]]
     [[ "$output" == *"--last <duration>"* ]]
     [[ "$output" == *"--since <time>"* ]]

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -59,7 +59,6 @@ class HistoryOptions:
     limit: int
     output_format: str
     report: bool
-    include_internal: bool
     local_time: bool
     oldest_first: bool
     since: datetime | None
@@ -94,7 +93,6 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--limit", default="10", help="Maximum history records to list.")
 @base_cli.option("--format", "output_format", default="text", help="Output format: text, markdown, or json.")
 @base_cli.option("--report", is_flag=True, help="Print a privacy-conscious local activity report.")
-@base_cli.option("--include-internal", is_flag=True, help="Include delegated internal steps in the output.")
 @base_cli.option("--oldest-first", is_flag=True, help="Show the selected history window from oldest to newest.")
 @base_cli.option("--last", "last_window", help="Show records from the most recent duration, such as 2h or 7d.")
 @base_cli.option(
@@ -121,7 +119,6 @@ def run(
     limit: str,
     output_format: str,
     report: bool,
-    include_internal: bool,
     local_time: bool,
     oldest_first: bool,
     last_window: str | None,
@@ -137,7 +134,6 @@ def run(
             limit=parse_positive_int("--limit", limit),
             output_format=normalize_report_format(output_format) if report else normalize_format(output_format),
             report=report,
-            include_internal=include_internal,
             local_time=local_time,
             oldest_first=oldest_first,
             since=since,
@@ -306,8 +302,9 @@ def parse_timestamp(value: str) -> datetime:
 
 def filter_history(records: list[HistoryRecord], options: HistoryOptions) -> list[HistoryRecord]:
     filtered = records
-    if not options.include_internal:
-        filtered = [record for record in filtered if record.scope != HISTORY_SCOPE_INTERNAL]
+    # Internal phases share their parent's run and primary log.  Ignore any
+    # legacy internal records so old caches do not reintroduce duplicate UX.
+    filtered = [record for record in filtered if record.scope != HISTORY_SCOPE_INTERNAL]
     if options.project:
         filtered = [record for record in filtered if record.project == options.project]
     if options.command:

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -257,21 +257,16 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertEqual(payload[0]["status"], "error")
         self.assertFalse(payload[0]["log_exists"])
 
-    def test_history_hides_internal_records_unless_requested(self) -> None:
+    def test_history_hides_legacy_internal_records(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             write_history_line(cache_root, history_record("primary", "test"))
             write_history_line(cache_root, history_record("child", "projects", scope="internal"))
 
             status, stdout, stderr = invoke([], cache_root)
-            trace_status, trace_stdout, trace_stderr = invoke(["--include-internal"], cache_root)
-
         self.assertEqual((status, stderr), (0, ""))
         self.assertIn("test", stdout)
         self.assertNotIn("projects", stdout)
-        self.assertEqual((trace_status, trace_stderr), (0, ""))
-        self.assertIn("test", trace_stdout)
-        self.assertIn("projects", trace_stdout)
 
     def test_empty_history_set_is_not_an_error_for_table_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -444,18 +444,20 @@ def discover_log_entries(cache_root: Path) -> list[LogEntry]:
         logs_root = run_root / "logs"
         if not logs_root.is_dir():
             continue
-        for path in sorted(logs_root.rglob("*.log"), key=str):
+        # A run has exactly one persisted diagnostic stream.  Ignore legacy
+        # component logs so old cache contents cannot surface duplicate runs.
+        for path in sorted(logs_root.glob("primary.log"), key=str):
             if not path.is_file():
                 continue
-            history_status = history_status_for_log(history_statuses, run_id=path.stem, path=path)
-            raw_command = infer_raw_command_from_log_path(path)
+            history_status = history_status_for_log(history_statuses, run_id=run_root.name, path=path)
+            raw_command = raw_command_for_log(path)
             entries.append(
                 LogEntry(
                     command=history_status.command
                     if history_status is not None and history_status.command is not None
                     else infer_display_command(raw_command, path),
                     raw_command=raw_command,
-                    run_id=path.stem,
+                    run_id=run_root.name,
                     path=path,
                     timestamp=entry_timestamp(path),
                     status=history_status.status if history_status is not None else infer_status(path),
@@ -477,9 +479,21 @@ def runtime_run_roots(cache_root: Path) -> list[Path]:
 
 
 def infer_raw_command_from_log_path(path: Path) -> str:
-    if path.parent.name == "logs":
-        return "basectl"
-    return path.parent.name
+    return "basectl" if path.parent.name == "logs" else path.parent.name
+
+
+def raw_command_for_log(path: Path) -> str:
+    """Resolve the command identity without encoding it in the log filename."""
+    metadata_path = path.parent.parent / "run.json"
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError):
+        metadata = {}
+    if isinstance(metadata, dict):
+        value = optional_string(metadata.get("raw_command")) or optional_string(metadata.get("cli"))
+        if value:
+            return value
+    return infer_raw_command_from_log_path(path)
 
 
 def read_history_log_statuses(cache_root: Path) -> HistoryLogStatusIndex:
@@ -558,7 +572,8 @@ def first_lines(path: Path, limit: int) -> list[str]:
 
 
 def entry_timestamp(path: Path) -> datetime:
-    match = RUN_ID_RE.match(path.stem)
+    run_id = path.parent.parent.name if path.name == "primary.log" else path.stem
+    match = RUN_ID_RE.match(run_id)
     if match is not None:
         try:
             return datetime.strptime(match.group("stamp"), "%Y%m%dT%H%M%S")

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -13,9 +13,14 @@ from base_logs import engine
 
 
 def write_log(cache_root: Path, cli_name: str, run_id: str, text: str) -> Path:
-    path = cache_root / "base" / "runs" / run_id / "logs" / "internal" / cli_name / f"{run_id}.log"
+    run_root = cache_root / "base" / "runs" / run_id
+    path = run_root / "logs" / "primary.log"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+    (run_root / "run.json").write_text(
+        json.dumps({"run_id": run_id, "cli": cli_name}) + "\n",
+        encoding="utf-8",
+    )
     return path
 
 

--- a/cli/python/base_setup/ci_json.py
+++ b/cli/python/base_setup/ci_json.py
@@ -13,6 +13,7 @@ import base_cli
 LOG_LINE_RE = re.compile(
     r"^\d{4}-\d{2}-\d{2}\s+"
     r"\d{2}:\d{2}:\d{2}\s+"
+    r"(?:UTC|[+-]\d{4})?\s*"
     r"[A-Z]+\s+"
     r"\S+\s+"
     r"(?P<message>.*)$"

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -128,17 +128,17 @@ ctx.base_home      # Path | None
 ctx.project_name   # selected project name, or None
 ctx.project_root   # Path | None
 ctx.manifest_path  # Path | None
-ctx.history_scope  # primary or internal
-ctx.history_parent_run_id  # parent basectl invocation ID, or None
+ctx.history_scope  # public history scope (internal children are not indexed)
+ctx.history_parent_run_id  # shared parent run ID, or None
 ctx.workspace_root # configured workspace root, or None
 ctx.runtime_owner  # base or project
 ctx.owner_root     # owner namespace root under the cache root
 ctx.run_root       # this invocation's run bundle
 ctx.state_dir      # owner_root (compatibility alias)
-ctx.log_dir        # run_root/logs or run_root/logs/internal/<cli-name>
+ctx.log_dir        # run_root/logs
 ctx.cache_dir      # owner_root/cache/components/<cli-name>
 ctx.temp_dir       # run_root/tmp/<cli-name>/<run-id>
-ctx.log_file       # primary.log or an internal component log, or None when disabled
+ctx.log_file       # run_root/logs/primary.log, or None when disabled
 ctx.config         # dict
 ctx.user_config    # typed user config from ~/.base.d/config.yaml
 ctx.environment    # str

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -211,15 +211,23 @@ Every run gets two streams:
 
 | Stream | Destination | Level | Format |
 |---|---|---|---|
-| user | stderr | INFO by default, DEBUG with `--debug` | UTC timestamp, level, source, message |
-| persistent | `ctx.log_file` when enabled | DEBUG | UTC timestamp, level, source, message |
+| user | stderr | INFO by default, DEBUG with `--debug` | Local timestamp (or UTC with `--utc-wrapper`), level, source, message |
+| persistent | `ctx.log_file` when enabled | DEBUG | Local timestamp (or UTC with `--utc-wrapper`), level, source, message |
 
-Python user-facing logs should visually align with Bash `lib_std.sh` logs while
-making the timezone explicit:
+Python user-facing logs default to the host's local timezone so a local run has
+one clock throughout the Bash and Python layers. The local offset is included
+in each timestamp; `--utc-wrapper` sets `LOG_UTC=1` and switches both layers to
+UTC for CI, support, or cross-machine diagnostics:
 
 ```text
+2026-05-23 12:31:04 -0700 INFO    cli/python/base_setup/engine.py:67 Reading Base manifest at '.../base_manifest.yaml'.
 2026-05-23 19:31:04 UTC INFO    cli/python/base_setup/engine.py:67 Reading Base manifest at '.../base_manifest.yaml'.
 ```
+
+The timestamp policy for persisted data is separate: `run.json`, history
+records, primary run lifecycle entries, and UTC-based run IDs remain in UTC.
+This keeps machine-readable metadata stable while keeping interactive logs
+natural to read on the local machine.
 
 `base_cli` logs invocation metadata at DEBUG level:
 

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -58,12 +58,7 @@ With the cache root set to `~/Library/Caches/base`, the clean layout is:
 │       └── <base-run-id>/
 │           ├── run.json
 │           ├── logs/
-│           │   ├── primary.log
-│           │   └── internal/
-│           │       ├── base_setup/
-│           │       │   └── <child-run-id>.log
-│           │       └── base_projects/
-│           │           └── <child-run-id>.log
+│           │   └── primary.log
 │           └── tmp/
 │               └── <component>/<child-run-id>/
 └── projects/
@@ -76,8 +71,7 @@ With the cache root set to `~/Library/Caches/base`, the clean layout is:
     │           └── <project-run-id>/
     │               ├── run.json
     │               ├── logs/
-    │               │   ├── primary.log
-    │               │   └── internal/
+    │               │   └── primary.log
     │               └── tmp/
     ├── banyanlabs/
     │   └── <checkout-id>/...
@@ -85,9 +79,9 @@ With the cache root set to `~/Library/Caches/base`, the clean layout is:
         └── <checkout-id>/...
 ```
 
-There is deliberately no top-level `cli/` directory. Internal component names
-are meaningful only inside a run's `logs/internal/` or persistent component
-cache. They are not ownership roots.
+There is deliberately no top-level `cli/` directory. Component names are
+meaningful only inside persistent component caches; they are not ownership
+roots or separate log identities.
 
 ## Directory meanings
 
@@ -114,8 +108,10 @@ by individual Base components. This state is not tied to one diagnostic run.
 One directory per Base control-plane invocation. `run.json` is written at the
 start with `status: running` and finalized with timestamps, exit status,
 project metadata, command arguments, and parent/child references when known.
-Run metadata and the primary log are private (`0600`). `primary.log` contains
-top-level Base diagnostics. Normal command stdout remains stdout and is not
+Run metadata and the primary log are private (`0600`). `primary.log` is the
+single diagnostic stream for the invocation. Bash and Python children append
+to this same file, which always captures DEBUG-level diagnostics even when the
+terminal is showing INFO. Normal command stdout remains stdout and is not
 captured here.
 
 ### `projects/<project-id>/<checkout-id>/`
@@ -134,8 +130,8 @@ caches.
 
 ### Project `runs/`
 
-Run-oriented bundles for project-native commands. A project run can have its
-own primary log and internal child logs. The parent Base run references the
+Run-oriented bundles for project-native commands. Each project invocation also
+has one run ID and one `logs/primary.log`; the parent Base run references the
 project run through the history index and `run.json` metadata.
 
 ### `tmp/`

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -146,10 +146,14 @@ runs retain them for diagnosis until cleanup removes the completed bundle.
 
 ## Timestamps and permissions
 
-Persisted history, run metadata, primary logs, and Python CLI logs use UTC.
-Python CLI log lines include an explicit `UTC` marker; run IDs use UTC-based
-timestamps as well. `basectl history` keeps its existing UTC default and can
-render human-readable views in local time with `--local-time`.
+Persisted history, run metadata, and primary run lifecycle entries use UTC.
+Run IDs use UTC-based timestamps so bundle names remain sortable across hosts.
+Python CLI log streams (stderr and the per-run log file) use the host's local
+timezone by default, matching the Bash logger during local runs. The local
+offset is included in Python log lines. Pass `basectl --utc-wrapper ...` to set
+`LOG_UTC=1` and render both Bash and Python log streams in UTC for CI, support,
+or cross-machine diagnostics. `basectl history` keeps its existing UTC default
+and can render human-readable views in local time with `--local-time`.
 
 History and run artifacts are user-private by default. History and metadata
 files are created with mode `0600`; raw log files use the same mode. Directory

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -109,7 +109,7 @@ manifest trust.
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
 | `basectl logs last` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name>`, `--lines <count>`, `--format <text\|json>` |
 | `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |
-| `basectl history` | List recent user-facing Base command history records. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--limit <count>`, `--format <text\|json>`, `--include-internal`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
+| `basectl history` | List one record per public Base command invocation. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--limit <count>`, `--format <text\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
 | `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
 | `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name>` |
 | `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name>`, `--lines <count>` |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -199,10 +199,15 @@ errors.
 `basectl logs` should remain the command for opening or tailing raw log files.
 `basectl history` should point to logs, not replace them.
 
-Raw Python CLI logs use UTC timestamps with an explicit `UTC` marker. The
-primary run log uses ISO-8601 UTC timestamps, and history JSON retains canonical
-UTC timestamps; only human-readable history/report views can opt into local
-time with `--local-time`.
+Raw Python CLI logs use the host's local timezone by default, with the local
+numeric offset included in each timestamp. This matches the Bash logger for a
+local run. `basectl --utc-wrapper ...` sets `LOG_UTC=1` and switches both log
+layers to UTC for CI, support, or cross-machine diagnostics.
+
+The primary run log uses ISO-8601 UTC timestamps, run IDs use UTC-based
+timestamps, and history JSON retains canonical UTC timestamps. Only
+human-readable history/report views can opt into local time with
+`--local-time`.
 
 `basectl logs last` bridges those surfaces for the common failure case. It reads
 the local history index, finds the latest failed run, prints command metadata,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -67,14 +67,13 @@ inspect with ordinary tools, and easy to recover when one line is malformed.
 History writes are best-effort:
 
 - write a primary completion record for a public `basectl` command
-- retain internal Python/helper completion records linked to that primary
-  invocation
+- keep delegated Python/helper completion details in the shared primary log,
+  rather than creating extra history rows
 - never fail the user command because the history file cannot be written
 - ignore malformed history lines while warning in debug output
 
-The default `basectl history` view shows primary public-command records. Internal
-records remain in the local index and can be inspected with
-`basectl history --include-internal`.
+`basectl history` shows one record per public invocation. Legacy internal rows
+are ignored so old caches do not reintroduce duplicate command entries.
 
 ## Record Shape
 
@@ -180,8 +179,8 @@ Expected options:
 - `--format json` prints structured records for scripts.
 - `--report` prints a Markdown activity report by default.
 - `--report --format json` prints the same report as deterministic JSON.
-- `--include-internal` includes delegated resolver, routing, bootstrap, and
-  trust-gate records linked to each primary command.
+- Delegated resolver, routing, bootstrap, and trust-gate phases are represented
+  in the parent run's single primary log, not as separate history records.
 - `--oldest-first` reverses the selected window from newest-to-oldest to
   oldest-to-newest; the default remains newest-first.
 - `--last <duration>` selects a relative window such as `30m`, `2h`, or `7d`.

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -119,7 +119,7 @@ the resulting directory tree.
 | --- | --- | --- | --- |
 | `BASE_CACHE_DIR` | User | Overrides the platform default Base cache root. | May be set before invoking Base. |
 | `BASE_CLI_RUNTIME_OWNER` | Base/project launcher | `base` for Base control-plane processes or `project` for a project-native process. | Do not set manually; launchers establish it. |
-| `BASE_CLI_RUN_ROOT` | Parent launcher | Points a Base-internal child at its parent run bundle so its raw log is placed under `logs/internal/`. Project launchers deliberately unset it before creating a project-owned bundle. | Do not set manually. |
+| `BASE_CLI_RUN_ROOT` | Parent launcher | Points a Base-internal child at its parent run bundle so it reuses the parent's run ID and `logs/primary.log`. Project launchers deliberately unset it before creating a project-owned bundle. | Do not set manually. |
 | `BASE_CLI_HISTORY_PARENT_RUN_ID` | Parent launcher | Links internal or project history records to the public Base invocation. | Do not set manually. |
 
 ## Project Runtime Variables

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -169,6 +169,7 @@ These variables are involved in normal shell startup rather than the full
 | `BASE_ENABLE_ZSH_DEFAULTS` | Base | Generated preference controlling optional Base Zsh defaults. | Change with `basectl update-profile --defaults` or `--no-defaults`, not by editing files directly. |
 | `BASE_DEBUG` | User | Enables debug traces in Base-managed shell startup snippets and the runtime Bash rcfile. | Safe to set in `~/.baserc` or as a one-off environment variable. |
 | `LOG_DEBUG` | Base wrapper compatibility | Internal debug signal exported by wrapper/debug paths before the full runtime exists. The Python config layer treats `1` or `true` as a fallback for `BASE_CLI_LOG_LEVEL=debug` when `BASE_CLI_LOG_LEVEL` is unset. | Do not set directly; use wrapper debug flags or `BASE_CLI_LOG_LEVEL=debug` for Python CLI logs. |
+| `LOG_UTC` | Base wrapper compatibility | When set to `1`, switches Bash and Python CLI log presentation to UTC. It is set by `basectl --utc-wrapper`; persisted metadata is UTC regardless. | Prefer `basectl --utc-wrapper` for one-off CI or diagnostic runs. |
 
 The ordinary Bash/Zsh dotfile snippets derive `BASE_HOME` and add
 `$BASE_HOME/bin` to `PATH` so `basectl` is available in new terminals. When a

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -231,8 +231,9 @@ Important fields include:
 - `ctx.project_root`: directory containing the nearest `base_manifest.yaml`.
 - `ctx.workspace_root`: configured workspace root from `~/.base.d/config.yaml`.
 - `ctx.manifest_path`: nearest discovered Base manifest.
-- `ctx.history_scope`: whether this record is a primary or internal event.
-- `ctx.history_parent_run_id`: parent `basectl` invocation ID, when delegated.
+- `ctx.history_scope`: compatibility scope marker; delegated children are not
+  written as separate history events.
+- `ctx.history_parent_run_id`: shared parent `basectl` invocation ID, when delegated.
 - `ctx.runtime_owner`: `base` or `project`.
 - `ctx.owner_root`: owner namespace root under the Base cache root.
 - `ctx.run_root`: this invocation's run bundle.
@@ -240,7 +241,7 @@ Important fields include:
 - `ctx.log_dir`: run-bundle log directory.
 - `ctx.cache_dir`: persistent component cache directory.
 - `ctx.temp_dir`: per-run temp directory inside the bundle.
-- `ctx.log_file`: persistent log file for this run, or `None` when persistent
+- `ctx.log_file`: the run's shared `logs/primary.log`, or `None` when persistent
   logging is disabled.
 - `ctx.config`: merged configuration dictionary.
 - `ctx.user_config`: typed user configuration from `~/.base.d/config.yaml`.

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -282,7 +282,12 @@ Advanced tests and CI wrappers can call `base_cli.configure_logger(...,
 stream=..., formatter=...)` to capture user-facing logs or apply a custom
 formatter without replacing Base's logger setup. Leave those arguments as
 `None` to keep the default stderr stream and `BaseCliFormatter`. Base CLI log
-timestamps are rendered in UTC and include an explicit `UTC` marker.
+timestamps use the host's local timezone and include its numeric offset by
+default. When the wrapper sets `LOG_UTC=1` (for example via
+`basectl --utc-wrapper`), they use UTC and include an explicit `UTC` marker.
+
+This setting affects log presentation only. Run metadata, history records, and
+run IDs retain their canonical UTC representation.
 
 Commands that inspect runtime artifacts can use `base_cli.App(log_to_file=False)`
 to keep the standard context, `--debug`, and `--quiet` behavior without creating

--- a/lib/python/base_cli/_runtime.py
+++ b/lib/python/base_cli/_runtime.py
@@ -31,9 +31,9 @@ def runtime_layout(
     owner_root = runtime_owner_root(cache_root, owner, project_name, project_root)
     run_root = inherited_run_root or owner_root / "runs" / run_id
     state_dir = owner_root
+    # Every public invocation owns one run bundle and one diagnostic log.
+    # Child processes inherit that bundle instead of creating component logs.
     log_dir = run_root / "logs"
-    if inherited_run_root is not None:
-        log_dir = log_dir / "internal" / cli_name
     return RuntimeLayout(
         owner_root=owner_root,
         run_root=run_root,

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -33,6 +33,24 @@ DISPLAY_COMMAND_ENV = "BASE_CLI_DISPLAY_COMMAND"
 _INVOCATION_ARGV: ContextVar[list[str] | None] = ContextVar("base_cli_invocation_argv", default=None)
 
 
+def _default_log_file(layout: Any, inherited_path: Path | None) -> Path:
+    if inherited_path is not None:
+        return Path(
+            os.environ.get(
+                "BASE_CLI_PRIMARY_LOG",
+                str(layout.log_dir / "primary.log"),
+            )
+        ).expanduser()
+    return layout.log_dir / "primary.log"
+
+
+def _history_scope(inherited_path: Path | None) -> str:
+    return os.environ.get(
+        "BASE_CLI_HISTORY_SCOPE",
+        HISTORY_SCOPE_INTERNAL if inherited_path is not None else "primary",
+    )
+
+
 def _require_click():
     try:
         import click
@@ -215,15 +233,7 @@ class App:
             for directory in (layout.log_dir, layout.cache_dir, layout.temp_dir):
                 create_runtime_directory(directory, cache_root)
             if log_file is None:
-                if inherited_path is not None:
-                    log_file = Path(
-                        os.environ.get(
-                            "BASE_CLI_PRIMARY_LOG",
-                            str(layout.log_dir / "primary.log"),
-                        )
-                    ).expanduser()
-                else:
-                    log_file = layout.log_dir / "primary.log"
+                log_file = _default_log_file(layout, inherited_path)
             create_runtime_directory(log_file.parent, cache_root)
         if inherited_path is None and not dry_run and self.log_to_file:
             create_runtime_directory(layout.run_root, cache_root)
@@ -274,10 +284,6 @@ class App:
         if self.max_log_files is not None and uses_default_log_file and log_file is not None:
             prune_log_files(layout.owner_root / "runs", log_file, self.max_log_files, logger)
 
-        history_scope = os.environ.get(
-            "BASE_CLI_HISTORY_SCOPE",
-            HISTORY_SCOPE_INTERNAL if inherited_path is not None else "primary",
-        )
         return Context(
             cli_name=self.name,
             run_id=run_id,
@@ -302,7 +308,7 @@ class App:
             log=logger,
             user_config=user_config,
             dry_run=dry_run,
-            history_scope=history_scope,
+            history_scope=_history_scope(inherited_path),
             history_parent_run_id=os.environ.get("BASE_CLI_HISTORY_PARENT_RUN_ID") or None,
         )
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -12,7 +12,7 @@ from ._runtime import create_runtime_directory, prune_log_files, runtime_layout
 from .config import load_config, read_user_config
 from .context import Context, reset_current_context, set_current_context
 from .exit_codes import ExitCode
-from .history import utc_now, write_finished_record
+from .history import HISTORY_SCOPE_INTERNAL, utc_now, write_finished_record
 from .logging import configure_logger, log_invocation
 from .paths import (
     base_cache_root,
@@ -170,7 +170,6 @@ class App:
 
     def _create_context(self, standard: dict[str, Any], sensitive_options: set[str], dry_run: bool = False) -> Context:
         del sensitive_options
-        run_id = make_run_id()
         manifest_override = os.environ.get("BASE_CLI_PROJECT_MANIFEST")
         manifest_path = (
             Path(manifest_override).expanduser().resolve()
@@ -195,6 +194,8 @@ class App:
         )
         inherited_run_root = os.environ.get("BASE_CLI_RUN_ROOT") if runtime_owner == "base" else None
         inherited_path = Path(inherited_run_root).expanduser().resolve() if inherited_run_root else None
+        inherited_run_id = os.environ.get("BASE_CLI_RUN_ID") if inherited_path is not None else None
+        run_id = inherited_run_id or (inherited_path.name if inherited_path is not None else make_run_id())
         layout = runtime_layout(
             cache_root,
             self.name,
@@ -214,7 +215,15 @@ class App:
             for directory in (layout.log_dir, layout.cache_dir, layout.temp_dir):
                 create_runtime_directory(directory, cache_root)
             if log_file is None:
-                log_file = layout.log_dir / (f"{self.name}-{run_id}.log" if inherited_path else "primary.log")
+                if inherited_path is not None:
+                    log_file = Path(
+                        os.environ.get(
+                            "BASE_CLI_PRIMARY_LOG",
+                            str(layout.log_dir / "primary.log"),
+                        )
+                    ).expanduser()
+                else:
+                    log_file = layout.log_dir / "primary.log"
             create_runtime_directory(log_file.parent, cache_root)
         if inherited_path is None and not dry_run and self.log_to_file:
             create_runtime_directory(layout.run_root, cache_root)
@@ -265,6 +274,10 @@ class App:
         if self.max_log_files is not None and uses_default_log_file and log_file is not None:
             prune_log_files(layout.owner_root / "runs", log_file, self.max_log_files, logger)
 
+        history_scope = os.environ.get(
+            "BASE_CLI_HISTORY_SCOPE",
+            HISTORY_SCOPE_INTERNAL if inherited_path is not None else "primary",
+        )
         return Context(
             cli_name=self.name,
             run_id=run_id,
@@ -289,7 +302,7 @@ class App:
             log=logger,
             user_config=user_config,
             dry_run=dry_run,
-            history_scope=os.environ.get("BASE_CLI_HISTORY_SCOPE", "primary"),
+            history_scope=history_scope,
             history_parent_run_id=os.environ.get("BASE_CLI_HISTORY_PARENT_RUN_ID") or None,
         )
 

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -35,7 +35,10 @@ def write_finished_record(
     started_at: datetime,
     exit_code: int,
 ) -> None:
-    if context.dry_run or context.log_file is None:
+    # Base-dispatched child commands share the parent's run bundle and
+    # diagnostic stream.  Their completion is an implementation detail, so
+    # keep history at the public-invocation level as well.
+    if context.dry_run or context.log_file is None or context.history_scope == HISTORY_SCOPE_INTERNAL:
         return
     try:
         record = build_finished_record(context, argv, sensitive_options, started_at, exit_code)

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -82,10 +82,11 @@ def _secure_log_file_open_flags(mode: str) -> int:
 
 
 class BaseCliFormatter(logging.Formatter):
-    def __init__(self) -> None:
-        super().__init__(datefmt="%Y-%m-%d %H:%M:%S UTC")
-
-    converter = time.gmtime
+    def __init__(self, *, use_utc: bool | None = None) -> None:
+        self.use_utc = use_utc if use_utc is not None else os.environ.get("LOG_UTC") == "1"
+        datefmt = "%Y-%m-%d %H:%M:%S UTC" if self.use_utc else "%Y-%m-%d %H:%M:%S %z"
+        super().__init__(datefmt=datefmt)
+        self.converter = time.gmtime if self.use_utc else time.localtime
 
     def format(self, record: logging.LogRecord) -> str:
         timestamp = self.formatTime(record, self.datefmt)

--- a/lib/python/base_cli/tests/test_app_runtime_boundary.py
+++ b/lib/python/base_cli/tests/test_app_runtime_boundary.py
@@ -43,7 +43,7 @@ def test_runtime_layout_is_checkout_scoped_for_project_owner() -> None:
     assert layout.log_dir == layout.run_root / "logs"
 
 
-def test_runtime_layout_places_inherited_base_children_under_internal_logs() -> None:
+def test_runtime_layout_places_inherited_base_children_in_the_shared_logs_dir() -> None:
     runtime = importlib.import_module("base_cli._runtime")
     parent = Path("/tmp/base-cache/base/runs/parent")
     layout = runtime.runtime_layout(
@@ -54,7 +54,7 @@ def test_runtime_layout_places_inherited_base_children_under_internal_logs() -> 
     )
 
     assert layout.run_root == parent
-    assert layout.log_dir == parent / "logs" / "internal" / "base_projects"
+    assert layout.log_dir == parent / "logs"
     assert layout.temp_dir == parent / "tmp" / "base_projects" / "child"
 
 

--- a/lib/python/base_cli/tests/test_base_cli.py
+++ b/lib/python/base_cli/tests/test_base_cli.py
@@ -195,8 +195,19 @@ class BaseCliTests(unittest.TestCase):
 
         self.assertIn(f"{external.resolve()}:7 hello", formatted)
 
-    def test_base_cli_formatter_uses_utc_converter(self) -> None:
-        self.assertIs(BaseCliFormatter.converter, time.gmtime)
+    def test_base_cli_formatter_defaults_to_local_converter(self) -> None:
+        with mock.patch.dict(os.environ, {"LOG_UTC": ""}):
+            formatter = BaseCliFormatter()
+
+        self.assertFalse(formatter.use_utc)
+        self.assertIs(formatter.converter, time.localtime)
+
+    def test_base_cli_formatter_uses_utc_converter_when_requested(self) -> None:
+        with mock.patch.dict(os.environ, {"LOG_UTC": "1"}):
+            formatter = BaseCliFormatter()
+
+        self.assertTrue(formatter.use_utc)
+        self.assertIs(formatter.converter, time.gmtime)
 
     def test_config_precedence_excludes_implicit_system_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -581,7 +592,7 @@ class BaseCliTests(unittest.TestCase):
             from base_cli.testing import invoke
 
             stderr = io.StringIO()
-            with redirect_stderr(stderr):
+            with redirect_stderr(stderr), mock.patch.dict(os.environ, {"LOG_UTC": ""}):
                 result = invoke(app, ["--name", "Ada"], home=home)
 
             self.assertEqual(result.exit_code, 0, result.output)
@@ -599,7 +610,7 @@ class BaseCliTests(unittest.TestCase):
             self.assertEqual(len(log_files), 1)
             self.assertEqual(log_files[0].stat().st_mode & 0o777, 0o600)
             self.assertFalse((home / ".base.d" / "cli").exists())
-            self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC INFO\s+")
+            self.assertRegex(result.stderr, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (?:UTC|[+-]\d{4}) INFO\s+")
             self.assertIn("hello Ada", result.stderr)
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -223,31 +223,40 @@ class BaseCliHistoryTests(unittest.TestCase):
         self.assertNotIn("super-secret", json.dumps(record))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
-    def test_app_records_internal_scope_and_parent_run_id(self) -> None:
+    def test_app_reuses_parent_run_and_does_not_record_internal_history(self) -> None:
         app = base_cli.App(name="history-internal")
+
+        seen = {}
 
         @app.command()
         def main(ctx: base_cli.Context) -> None:
             self.assertEqual(ctx.history_scope, "internal")
             self.assertEqual(ctx.history_parent_run_id, "parent-1")
+            seen["run_id"] = ctx.run_id
+            seen["log_file"] = ctx.log_file
 
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir) / "home"
+            run_root = home / ".cache" / "base" / "base" / "runs" / "parent-1"
+            primary_log = run_root / "logs" / "primary.log"
             with mock.patch.dict(
                 os.environ,
                 {
                     "HOME": str(home),
                     "BASE_CACHE_DIR": str(home / ".cache" / "base"),
+                    "BASE_CLI_RUN_ROOT": str(run_root),
+                    "BASE_CLI_RUN_ID": "parent-1",
+                    "BASE_CLI_PRIMARY_LOG": str(primary_log),
                     "BASE_CLI_HISTORY_SCOPE": "internal",
                     "BASE_CLI_HISTORY_PARENT_RUN_ID": "parent-1",
                 },
             ):
                 status = base_cli.run_app(app, [])
-            records = read_history_records(home / ".cache" / "base")
 
         self.assertEqual(status, 0)
-        self.assertEqual(records[0]["scope"], "internal")
-        self.assertEqual(records[0]["parent_run_id"], "parent-1")
+        self.assertEqual(seen["run_id"], "parent-1")
+        self.assertEqual(seen["log_file"], primary_log)
+        self.assertFalse((home / ".cache" / "base" / "base" / "history" / "runs.jsonl").exists())
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_project_owner_uses_checkout_scoped_run_bundle(self) -> None:

--- a/lib/python/base_cli/tests/test_logging.py
+++ b/lib/python/base_cli/tests/test_logging.py
@@ -35,7 +35,7 @@ class ConfigureLoggerTests(unittest.TestCase):
     def test_configure_logger_defaults_to_stderr_and_base_formatter(self) -> None:
         stream = io.StringIO()
 
-        with mock.patch.object(sys, "stderr", stream):
+        with mock.patch.object(sys, "stderr", stream), mock.patch.dict(os.environ, {"LOG_UTC": ""}):
             logger = base_cli.configure_logger("default-stream", None, debug=False)
             logger.info("hello default")
 
@@ -43,6 +43,16 @@ class ConfigureLoggerTests(unittest.TestCase):
         self.assertIsInstance(handler.formatter, BaseCliFormatter)
         self.assertIn("INFO", stream.getvalue())
         self.assertIn("hello default", stream.getvalue())
+        self.assertRegex(stream.getvalue(), r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{4} INFO")
+
+    def test_configure_logger_honors_log_utc(self) -> None:
+        stream = io.StringIO()
+
+        with mock.patch.dict(os.environ, {"LOG_UTC": "1"}):
+            logger = base_cli.configure_logger("utc-stream", None, debug=False, stream=stream)
+            logger.info("hello utc")
+
+        self.assertRegex(stream.getvalue(), r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC INFO")
 
     def test_configure_logger_uses_custom_formatter_for_file_handler(self) -> None:
         formatter = logging.Formatter("%(levelname)s:%(message)s")

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -766,7 +766,7 @@ _base_basectl_completion() {
             fi
             ;;
         history)
-            _base_basectl_completion_compgen "--project --command --status --limit --format --report --include-internal --oldest-first --last --since --until --local-time -v -h --help" "$cur"
+            _base_basectl_completion_compgen "--project --command --status --limit --format --report --oldest-first --last --since --until --local-time -v -h --help" "$cur"
             ;;
         config)
             if ((COMP_CWORD == 2)); then

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -915,7 +915,6 @@ _base_basectl_completion() {
                 '--limit[Number of records]:count:' \
                 '--format[Output format]:format:(text json)' \
                 '--report[Print a privacy-conscious Markdown or JSON activity report]' \
-                '--include-internal[Include delegated internal steps in the output]' \
                 '--oldest-first[Show the selected history window from oldest to newest]' \
                 '--last[Show records from the most recent duration]:duration:' \
                 '--since[Include records at or after a timestamp]:time:' \

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -599,7 +599,7 @@ run_zsh_positional_completion() {
     )"
 
     [[ "$block" == *"--report"* ]]
-    [[ "$block" == *"--include-internal"* ]]
+    [[ "$block" != *"--include-internal"* ]]
     [[ "$block" == *"--oldest-first"* ]]
     [[ "$block" == *"--last"* ]]
     [[ "$block" == *"--since"* ]]


### PR DESCRIPTION
## Summary: one run ID, one run.json, one logs/primary.log, and one public history row per Base invocation. ## Validation: full Base Python and Bats suites; isolated check smoke test. ## Issue: Closes #1682; Refs basefoundry/base-bash-libs#185.