### PR TITLE
Add shared basectl output-format renderer

### DIFF
--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -1,0 +1,28 @@
+# basectl output formats
+
+Base report commands share one output contract.
+
+When `--format` is omitted, or when `--format text` is selected, Base checks
+whether stdout is an interactive terminal:
+
+- terminal output is a human-readable table with column headers and a summary
+  footer;
+- redirected or piped output is tab-delimited rows with no header or footer.
+
+Explicit machine-readable formats are independent of the terminal:
+
+- `--format csv` emits comma-separated, headerless rows with CSV quoting;
+- `--format tsv` emits tab-separated, headerless rows;
+- `--format yaml` emits one YAML document;
+- `--format json` emits one JSON document.
+
+Delimited formats use the command's documented, stable column order. JSON and
+YAML preserve the command's documented record shape and field names. Empty
+results are represented as no rows for delimited output and an empty list for
+JSON/YAML. Diagnostics and errors are written to stderr so that structured
+stdout remains safe for automation.
+
+The internal `command-protocol` format is a private Base-to-Base interface and
+is not part of the public output-format choices. Artifact-producing commands,
+such as `export-context --format markdown|zip`, keep their command-specific
+format semantics.

--- a/lib/python/base_cli/__init__.py
+++ b/lib/python/base_cli/__init__.py
@@ -6,6 +6,7 @@ from .context import Context, get_current_context
 from .exit_codes import ExitCode
 from .inspection import inspection_envelope, render_inspection_json
 from .logging import configure_logger, log_critical, log_debug, log_error, log_info, log_warning
+from .output import OutputFormatError, is_terminal, output_format_choices, render_records, resolve_output_format
 
 __all__ = [
     "App",
@@ -25,6 +26,11 @@ __all__ = [
     "log_error",
     "log_info",
     "log_warning",
+    "OutputFormatError",
+    "is_terminal",
+    "output_format_choices",
     "option",
+    "render_records",
+    "resolve_output_format",
     "run_app",
 ]

--- a/lib/python/base_cli/output.py
+++ b/lib/python/base_cli/output.py
@@ -1,0 +1,133 @@
+"""Shared output-format resolution and rendering for Base CLIs."""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, TextIO
+
+
+PUBLIC_OUTPUT_FORMATS = ("text", "csv", "tsv", "yaml", "json")
+
+
+class OutputFormatError(ValueError):
+    """Raised when a public output format is not supported."""
+
+
+def output_format_choices() -> str:
+    """Return the public choices in help/error-message order."""
+
+    return "|".join(PUBLIC_OUTPUT_FORMATS)
+
+
+def is_terminal(stream: TextIO | None = None) -> bool:
+    """Return whether *stream* is an interactive terminal."""
+
+    candidate = stream if stream is not None else sys.stdout
+    try:
+        return bool(candidate.isatty())
+    except (AttributeError, OSError):
+        return False
+
+
+def resolve_output_format(
+    requested: str | None,
+    *,
+    stream: TextIO | None = None,
+) -> str:
+    """Resolve a requested format, making text TTY-aware.
+
+    ``text`` is intentionally a presentation mode rather than a wire format:
+    it renders a table for terminals and tab-delimited rows for redirected or
+    piped output.  Omitting the format follows the same policy.
+    """
+
+    normalized = (requested or "text").lower()
+    if normalized not in PUBLIC_OUTPUT_FORMATS:
+        raise OutputFormatError(
+            f"Unsupported output format '{requested}'. Expected one of: {', '.join(PUBLIC_OUTPUT_FORMATS)}."
+        )
+    if normalized == "text" and not is_terminal(stream):
+        return "tsv"
+    return normalized
+
+
+def render_records(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    requested_format: str | None,
+    columns: Sequence[tuple[str, str]],
+    stream: TextIO | None = None,
+    footer: str | None = None,
+) -> str:
+    """Render records according to the shared public output contract.
+
+    The returned string is also written to *stream* when supplied (or stdout
+    when omitted).  JSON and YAML retain the mapping shape supplied by the
+    caller; delimited formats use the explicit ``columns`` order and never
+    emit a header or footer.
+    """
+
+    target = stream if stream is not None else sys.stdout
+    record_list = [dict(record) for record in records]
+    resolved = resolve_output_format(requested_format, stream=target)
+
+    if resolved in ("csv", "tsv"):
+        delimiter = "," if resolved == "csv" else "\t"
+        writer = csv.writer(target, delimiter=delimiter, lineterminator="\n")
+        for record in record_list:
+            writer.writerow([_cell_value(record.get(key)) for _header, key in columns])
+        return resolved
+
+    if resolved == "json":
+        target.write(json.dumps(record_list, separators=(",", ":")))
+        target.write("\n")
+        return resolved
+
+    if resolved == "yaml":
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - environment guard
+            raise RuntimeError("PyYAML is required for YAML output.") from exc
+        target.write(yaml.safe_dump(record_list, sort_keys=False, allow_unicode=True))
+        return resolved
+
+    _write_table(target, record_list, columns, footer)
+    return resolved
+
+
+def _cell_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _write_table(
+    stream: TextIO,
+    records: Sequence[Mapping[str, Any]],
+    columns: Sequence[tuple[str, str]],
+    footer: str | None,
+) -> None:
+    if not records:
+        if footer:
+            stream.write(f"{footer}\n")
+        return
+
+    widths = [len(header) for header, _key in columns]
+    rows: list[list[str]] = []
+    for record in records:
+        row = [_cell_value(record.get(key)) for _header, key in columns]
+        rows.append(row)
+        widths = [max(width, len(value)) for width, value in zip(widths, row)]
+
+    stream.write("  ".join(header.ljust(width) for (header, _key), width in zip(columns, widths)).rstrip())
+    stream.write("\n")
+    for row in rows:
+        stream.write("  ".join(value.ljust(width) for value, width in zip(row, widths)).rstrip())
+        stream.write("\n")
+    if footer:
+        stream.write(f"\n{footer}\n")

--- a/lib/python/base_cli/tests/test_output.py
+++ b/lib/python/base_cli/tests/test_output.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+
+from base_cli.output import OutputFormatError
+from base_cli.output import render_records
+from base_cli.output import resolve_output_format
+
+
+class _Stream(io.StringIO):
+    def __init__(self, *, terminal: bool) -> None:
+        super().__init__()
+        self.terminal = terminal
+
+    def isatty(self) -> bool:
+        return self.terminal
+
+
+RECORDS = (
+    {"name": "base", "path": "/work/base"},
+    {"name": "demo,one", "path": "/work/demo\tone"},
+)
+COLUMNS = (("PROJECT", "name"), ("PATH", "path"))
+
+
+class OutputTest(unittest.TestCase):
+    def test_text_is_pretty_on_terminal(self) -> None:
+        stream = _Stream(terminal=True)
+
+        render_records(RECORDS, requested_format="text", columns=COLUMNS, stream=stream, footer="2 projects.")
+
+        self.assertEqual(
+            stream.getvalue(),
+            "PROJECT   PATH\nbase      /work/base\ndemo,one  /work/demo\tone\n\n2 projects.\n",
+        )
+
+    def test_text_is_tsv_when_redirected(self) -> None:
+        stream = _Stream(terminal=False)
+
+        render_records(RECORDS, requested_format="text", columns=COLUMNS, stream=stream, footer="ignored")
+
+        self.assertEqual(stream.getvalue(), "base\t/work/base\ndemo,one\t\"/work/demo\tone\"\n")
+
+    def test_csv_quotes_cells_and_has_no_header(self) -> None:
+        stream = _Stream(terminal=True)
+
+        render_records(RECORDS, requested_format="csv", columns=COLUMNS, stream=stream, footer="ignored")
+
+        self.assertEqual(stream.getvalue(), "base,/work/base\n\"demo,one\",/work/demo\tone\n")
+
+    def test_json_preserves_record_shape(self) -> None:
+        stream = _Stream(terminal=True)
+
+        render_records(RECORDS, requested_format="json", columns=COLUMNS, stream=stream)
+
+        self.assertEqual(json.loads(stream.getvalue()), list(RECORDS))
+
+    def test_yaml_preserves_record_shape(self) -> None:
+        import yaml
+
+        stream = _Stream(terminal=True)
+
+        render_records(RECORDS, requested_format="yaml", columns=COLUMNS, stream=stream)
+
+        self.assertEqual(yaml.safe_load(stream.getvalue()), list(RECORDS))
+
+    def test_resolve_rejects_unknown_format(self) -> None:
+        with self.assertRaisesRegex(OutputFormatError, "Expected one of: text, csv, tsv, yaml, json"):
+            resolve_output_format("xml")
+
+    def test_empty_tty_result_keeps_footer(self) -> None:
+        stream = _Stream(terminal=True)
+
+        render_records((), requested_format="text", columns=COLUMNS, stream=stream, footer="0 projects.")
+
+        self.assertEqual(stream.getvalue(), "0 projects.\n")


### PR DESCRIPTION
## Summary
- add shared TTY-aware text, CSV, TSV, YAML, and JSON rendering helpers
- keep delimited output headerless and diagnostics separate from stdout
- document the shared contract and cover resolution, quoting, empty output, and structured serialization

## Validation
- focused output pytest
- base_cli unittest suite
- git diff --check

Closes #1692