### PR TITLE
Make projects list format-complete and TTY-aware

### DIFF
--- a/cli/bash/commands/basectl/subcommands/projects.sh
+++ b/cli/bash/commands/basectl/subcommands/projects.sh
@@ -10,7 +10,7 @@ Usage:
 
 Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
-  --format <format>   Output format for list: text or json.
+  --format <format>   Output format for list: text, csv, tsv, yaml, or json.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 

--- a/cli/bash/commands/basectl/tests/projects.bats
+++ b/cli/bash/commands/basectl/tests/projects.bats
@@ -146,6 +146,7 @@ EOF
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl projects list [options]"* ]]
     [[ "$output" == *"--format <format>"* ]]
+    [[ "$output" == *"text, csv, tsv, yaml, or json"* ]]
 }
 
 @test "basectl projects reports unknown command as a usage error" {
@@ -165,7 +166,7 @@ EOF
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
-    printf 'ERROR: Unsupported output format '\''xml'\''. Expected one of: text, json.\n' >&2
+    printf 'ERROR: Unsupported output format '\''xml'\''. Expected one of: text, csv, tsv, yaml, json.\n' >&2
     exit 2
 fi
 printf 'unexpected projects list python args: %s\n' "$*" >&2

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -83,7 +83,12 @@ def main(argv: list[str] | None = None) -> int:
     help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
 )
 @base_cli.option("--project", "project_name", help="Select a project explicitly.")
-@base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
+@base_cli.option(
+    "--format",
+    "output_format",
+    default="text",
+    help="Output format: text, csv, tsv, yaml, or json.",
+)
 @base_cli.option("--manifest", "workspace_manifest", help="Local workspace manifest to read.")
 @base_cli.option("--source", "workspace_manifest_source", help="Canonical workspace manifest source URL or path.")
 @base_cli.option("--path", "workspace_config_path", help="Workspace configuration repository checkout path.")
@@ -203,9 +208,12 @@ def build_target_list_project_command(
 
 
 def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_format: str = "text") -> int:
-    if output_format not in ("text", "json", "command-protocol"):
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json, command-protocol.", output_format)
-        return base_cli.ExitCode.USAGE_ERROR
+    if output_format != "command-protocol":
+        try:
+            base_cli.resolve_output_format(output_format)
+        except base_cli.OutputFormatError as exc:
+            ctx.log.error(str(exc))
+            return base_cli.ExitCode.USAGE_ERROR
 
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
@@ -214,14 +222,6 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_f
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    if output_format == "json":
-        print(
-            json.dumps(
-                [{"name": project.name, "path": str(project.root)} for project in projects],
-                separators=(",", ":"),
-            )
-        )
-        return base_cli.ExitCode.SUCCESS
     if output_format == "command-protocol":
         print(
             dumps_records(
@@ -237,8 +237,16 @@ def list_projects_command(ctx: base_cli.Context, workspace: str | None, output_f
         )
         return base_cli.ExitCode.SUCCESS
 
-    for project in projects:
-        print(f"{project.name}\t{project.root}")
+    try:
+        base_cli.render_records(
+            ({"name": project.name, "path": str(project.root)} for project in projects),
+            requested_format=output_format,
+            columns=(("PROJECT", "name"), ("PATH", "path")),
+            footer=f"{len(projects)} project(s).",
+        )
+    except base_cli.OutputFormatError as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -473,6 +473,40 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertEqual(json.loads(stdout), [{"name": "demo", "path": str((workspace / "demo").resolve())}])
 
+    def test_projects_list_supports_csv_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "custom"
+            base_home = Path(tmpdir) / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(
+                ["list", "--workspace", str(workspace), "--format", "csv"],
+                base_home,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, f"demo,{(workspace / 'demo').resolve()}\n")
+
+    def test_projects_list_supports_yaml_format(self) -> None:
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "custom"
+            base_home = Path(tmpdir) / "base"
+            base_home.mkdir()
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = run_engine(
+                ["list", "--workspace", str(workspace), "--format", "yaml"],
+                base_home,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(yaml.safe_load(stdout), [{"name": "demo", "path": str((workspace / "demo").resolve())}])
+
     def test_workspace_status_reports_manifest_and_venv_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -22,6 +22,12 @@ results are represented as no rows for delimited output and an empty list for
 JSON/YAML. Diagnostics and errors are written to stderr so that structured
 stdout remains safe for automation.
 
+## `basectl projects list`
+
+The table and delimited forms use the columns `PROJECT` then `PATH`. CSV and
+TSV contain those two fields without a header. JSON and YAML contain a list of
+objects with `name` and `path` keys, preserving the existing JSON shape.
+
 The internal `command-protocol` format is a private Base-to-Base interface and
 is not part of the public output-format choices. Artifact-producing commands,
 such as `export-context --format markdown|zip`, keep their command-specific


### PR DESCRIPTION
## Summary
- route projects list through the shared output renderer
- show a table with a summary on terminals and headerless TSV when redirected
- add explicit CSV, TSV, YAML, and JSON support while preserving the existing JSON shape
- update help, tests, and output-format documentation

## Validation
- focused projects-list pytest
- focused projects-list BATS suite
- shared renderer plus projects-list pytest
- git diff --check

Closes #1693