### PR TITLE
Migrate read-only reports to shared output formats

### DIFF
--- a/cli/bash/commands/basectl/subcommands/build.sh
+++ b/cli/bash/commands/basectl/subcommands/build.sh
@@ -19,7 +19,7 @@ Options:
   --project <name>    Select a project explicitly; required for a current target named like a project.
   --dry-run           Print resolved build commands without running them.
   --list              List build targets for a project.
-  --format <format>   List output format: text or json. Defaults to text.
+  --format <format>   List output format: text, csv, tsv, yaml, or json. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
@@ -46,6 +46,11 @@ base_build_print_target_record() {
     local description="${BASE_COMMAND_PROTOCOL_FIELDS[description]}"
     local command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
 
+    if [[ ! -t 1 ]]; then
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$resolved_name" "$target_name" "$working_dir" "$build_command" "$description" "$command_runner"
+        return 0
+    fi
     if ((printed_header == 0)); then
         printf "Build targets for project '%s'\n\n" "$resolved_name"
         printed_header=1
@@ -115,8 +120,8 @@ base_build_list_targets() {
         command_args+=("$project")
     fi
 
-    if [[ "$output_format" == "json" ]]; then
-        "$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}" --dry-run --format json
+    if [[ "$output_format" != "text" ]]; then
+        "$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}" --dry-run --format "$output_format"
         return $?
     fi
 
@@ -196,8 +201,8 @@ base_build_subcommand_main() {
         esac
     done
 
-    [[ "$output_format" == "text" || "$output_format" == "json" ]] || {
-        base_build_usage_error "Unsupported build format '$output_format'. Expected text or json."
+    [[ "$output_format" == "text" || "$output_format" == "csv" || "$output_format" == "tsv" || "$output_format" == "yaml" || "$output_format" == "json" ]] || {
+        base_build_usage_error "Unsupported build format '$output_format'. Expected text, csv, tsv, yaml, or json."
         return $?
     }
 

--- a/cli/bash/commands/basectl/subcommands/history.sh
+++ b/cli/bash/commands/basectl/subcommands/history.sh
@@ -14,8 +14,8 @@ Options:
   --status <ok|warn|error>
                         Filter by command status.
   --limit <count>       Number of recent history records to list. Defaults to 10.
-  --format <text|markdown|json>
-                        Output format. Defaults to text, or Markdown with --report.
+  --format <text|csv|tsv|yaml|json>
+                        Output format. Defaults to text; --report keeps its terminal Markdown presentation.
   --report              Print a privacy-conscious Markdown or JSON activity report.
   --oldest-first        Show the selected history window from oldest to newest.
   --last <duration>     Show records from the most recent duration, such as 2h or 7d.

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -7,7 +7,7 @@ base_logs_subcommand_usage() {
     cat <<'EOF'
 Usage:
   basectl logs [options]
-  basectl logs last [--command <name>] [--lines <count>] [--format text|json]
+  basectl logs last [--command <name>] [--lines <count>] [--format text|csv|tsv|yaml|json]
 
 Options:
   --command <name>  Filter by basectl command or Python CLI name.
@@ -16,7 +16,7 @@ Options:
   --tail            Tail and follow the most recent matching log.
   --open            Open the most recent matching log in PAGER or EDITOR.
   --lines <count>   Line count to show before following with --tail. Defaults to 40.
-  --format <format> Output format for "logs last": text or json. Defaults to text.
+  --format <format> Output format: text, csv, tsv, yaml, or json. Defaults to text.
   -v                Enable DEBUG logging for this subcommand.
   -h, --help        Show this help text.
 
@@ -60,7 +60,7 @@ Purpose:
 Options:
   --command <name>   Filter by basectl command or Python CLI name.
   --lines <count>    Maximum log-tail lines to print. Defaults to 40.
-  --format <format>  Output format: text or json. Defaults to text.
+  --format <format>  Output format: text, csv, tsv, yaml, or json. Defaults to text.
   -v                 Enable DEBUG logging for this subcommand.
   -h, --help         Show this help text.
 EOF

--- a/cli/bash/commands/basectl/subcommands/release.sh
+++ b/cli/bash/commands/basectl/subcommands/release.sh
@@ -20,8 +20,8 @@ Subcommands:
 Options:
   --version <version>  Release version to inspect.
   --manifest <path>   Use a specific base_manifest.yaml path.
-  --format <text|json>
-                      Select human text or stable inspection JSON for check.
+  --format <text|csv|tsv|yaml|json>
+                      Select the release check output format.
   --dry-run           Print publish actions without creating tags or releases.
   --yes               Publish without an interactive confirmation prompt.
   -h, --help          Show this help text.
@@ -75,7 +75,7 @@ EOF
     if [[ "$release_command" == "check" ]]; then
         cat <<EOF
 Usage:
-  basectl release check --version <version> [--manifest <path>] [--format <text|json>]
+  basectl release check --version <version> [--manifest <path>] [--format <text|csv|tsv|yaml|json>]
 
 Purpose:
   $purpose
@@ -83,7 +83,7 @@ Purpose:
 Options:
   --version <version>  Release version to inspect.
   --manifest <path>    Use a specific base_manifest.yaml path.
-  --format <text|json> Select human text or stable inspection JSON.
+  --format <text|csv|tsv|yaml|json> Select the release check output format.
   -h, --help           Show this help text.
 EOF
         return 0

--- a/cli/bash/commands/basectl/subcommands/run.sh
+++ b/cli/bash/commands/basectl/subcommands/run.sh
@@ -19,7 +19,7 @@ Options:
   --project <name>    Select a project explicitly; required for a current command named like a project.
   --dry-run           Print the resolved command without running it.
   --list              List runnable commands for a project. Defaults to the nearest project.
-  --format <format>   List output format: text or json. Defaults to text.
+  --format <format>   List output format: text, csv, tsv, yaml, or json. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
@@ -43,6 +43,10 @@ base_run_print_command_record() {
     local command_text="${BASE_COMMAND_PROTOCOL_FIELDS[command]}"
     local command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
 
+    if [[ ! -t 1 ]]; then
+        printf '%s\t%s\t%s\t%s\n' "$resolved_name" "$command_name" "$command_text" "$command_runner"
+        return 0
+    fi
     if ((printed_header == 0)); then
         printf "Commands for project '%s'\n\n" "$resolved_name"
         printed_header=1
@@ -69,8 +73,8 @@ base_run_list_commands() {
         command_args+=("$project")
     fi
 
-    if [[ "$output_format" == "json" ]]; then
-        "$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}" --dry-run --format json
+    if [[ "$output_format" != "text" ]]; then
+        "$wrapper" --project base base_projects "${command_args[@]}" "${args[@]}" --dry-run --format "$output_format"
         return $?
     fi
 
@@ -152,8 +156,8 @@ base_run_subcommand_main() {
         esac
     done
 
-    [[ "$output_format" == "text" || "$output_format" == "json" ]] || {
-        base_run_usage_error "Unsupported run format '$output_format'. Expected text or json."
+    [[ "$output_format" == "text" || "$output_format" == "csv" || "$output_format" == "tsv" || "$output_format" == "yaml" || "$output_format" == "json" ]] || {
+        base_run_usage_error "Unsupported run format '$output_format'. Expected text, csv, tsv, yaml, or json."
         return $?
     }
     if [[ "$list_commands" == "1" ]]; then

--- a/cli/bash/commands/basectl/subcommands/trust.sh
+++ b/cli/bash/commands/basectl/subcommands/trust.sh
@@ -12,7 +12,8 @@ Usage:
 
 Options:
   --workspace <path>            Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
-  --format <text|json>          Output format for status. Defaults to text.
+  --format <text|csv|tsv|yaml|json>
+                                Output format for status. Defaults to text.
   --manifest-sha256 <sha256>    Expected manifest SHA-256 for allow.
   -v                            Enable DEBUG logging for this subcommand.
   -h, --help                    Show this help text.
@@ -37,7 +38,8 @@ Purpose:
 
 Options:
   --workspace <path>    Workspace directory to scan.
-  --format <text|json>  Output format. Defaults to text.
+  --format <text|csv|tsv|yaml|json>
+                        Output format. Defaults to text.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
 EOF

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -12,7 +12,7 @@ Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
-  --format <text|json>
+  --format <text|csv|tsv|yaml|json>
                       Output format for the workspace command. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
@@ -67,7 +67,7 @@ Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
-  --format <text|json>
+  --format <text|csv|tsv|yaml|json>
                       Output format for the onboarding summary. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
@@ -85,7 +85,7 @@ Options:
   --workspace <path>  Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
-  --format <text|json>
+  --format <text|csv|tsv|yaml|json>
                       Output format for the agent brief. Defaults to text.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
@@ -159,11 +159,11 @@ Usage:
   basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]
 
 Commands:
-  status     Show workspace status. Supports --format text|json.
-  check      Run workspace checks. Supports --format text|json.
-  doctor     Run workspace diagnostics. Supports --format text|json.
-  onboarding Show first-day onboarding summary. Supports --format text|json.
-  agent-brief Show local agent handoff readiness. Supports --format text|json.
+  status     Show workspace status. Supports --format text|csv|tsv|yaml|json.
+  check      Run workspace checks. Supports --format text|csv|tsv|yaml|json.
+  doctor     Run workspace diagnostics. Supports --format text|csv|tsv|yaml|json.
+  onboarding Show first-day onboarding summary. Supports --format text|csv|tsv|yaml|json.
+  agent-brief Show local agent handoff readiness. Supports --format text|csv|tsv|yaml|json.
   clone      Clone or validate expected repositories from a workspace manifest.
   pull       Fetch and validate a canonical workspace manifest source.
   init       Initialize a workspace from a workspace configuration repository.

--- a/cli/bash/commands/basectl/tests/build.bats
+++ b/cli/bash/commands/basectl/tests/build.bats
@@ -253,9 +253,8 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" build demo --list
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Build targets for project 'demo'"* ]]
-    [[ "$output" == *"api"* ]]
-    [[ "$output" == *"Build API"* ]]
+    [[ "$output" == *$'demo\tapi\t'* ]]
+    [[ "$output" == *$'\tBuild API\t'* ]]
 }
 
 @test "basectl build --list shows runner without wrapping target descriptions" {
@@ -287,7 +286,8 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" build demo --list
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Build API [runner: uv]"* ]]
+    [[ "$output" == *$'demo\tapi\t'* ]]
+    [[ "$output" == *$'\tBuild API\tuv'* ]]
     [[ "$output" != *"uv run -- Build API"* ]]
 }
 

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -82,7 +82,7 @@ EOF
     [[ "$output" == *"--since <time>"* ]]
     [[ "$output" == *"--until <time>"* ]]
     [[ "$output" == *"--local-time"* ]]
-    [[ "$output" == *"--format <text|markdown|json>"* ]]
+    [[ "$output" == *"--format <text|csv|tsv|yaml|json>"* ]]
 }
 
 @test "basectl history reports missing option arguments as usage errors" {

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -314,9 +314,8 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" run demo --list
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Commands for project 'demo'"* ]]
-    [[ "$output" == *"test"*"pytest tests/"* ]]
-    [[ "$output" == *"dev"*"uvicorn app:app --reload"* ]]
+    [[ "$output" == *$'demo\ttest\tpytest tests/\t'* ]]
+    [[ "$output" == *$'demo\tdev\tuvicorn app:app --reload\t'* ]]
 }
 
 @test "basectl run --list can resolve nearest project" {
@@ -351,8 +350,7 @@ EOF
         ' bash "$workspace/demo" "$BASE_REPO_ROOT/bin/basectl" run --list
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Commands for project 'demo'"* ]]
-    [[ "$output" == *"dev"*"uvicorn app:app --reload"* ]]
+    [[ "$output" == *$'demo\tdev\tuvicorn app:app --reload\t'* ]]
 }
 
 @test "basectl run resolves a current-project command from a nested directory" {

--- a/cli/bash/commands/basectl/tests/trust.bats
+++ b/cli/bash/commands/basectl/tests/trust.bats
@@ -19,7 +19,7 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl trust status [project] [options]"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"--format <text|csv|tsv|yaml|json>"* ]]
     [[ "$output" != *"--manifest-sha256"* ]]
     [[ "$output" != *"basectl trust revoke"* ]]
 

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -296,7 +296,7 @@ EOF
     [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"--format <text|csv|tsv|yaml|json>"* ]]
     [[ "$output" == *"Output format for the workspace command. Defaults to text."* ]]
 
     run_basectl workspace agent-brief --help
@@ -305,7 +305,7 @@ EOF
     [[ "$output" == *"basectl workspace agent-brief [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"--format <text|csv|tsv|yaml|json>"* ]]
     [[ "$output" == *"Output format for the agent brief. Defaults to text."* ]]
     [[ "$output" == *"without cloning, setup, or network calls"* ]]
 
@@ -313,13 +313,13 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"--format <text|csv|tsv|yaml|json>"* ]]
 
     run_basectl workspace doctor --help
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl workspace <status|check|doctor> [options]"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"--format <text|csv|tsv|yaml|json>"* ]]
 
     run_basectl workspace onboarding --help
 
@@ -327,7 +327,7 @@ EOF
     [[ "$output" == *"basectl workspace onboarding [options]"* ]]
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
-    [[ "$output" == *"--format <text|json>"* ]]
+    [[ "$output" == *"--format <text|csv|tsv|yaml|json>"* ]]
     [[ "$output" == *"Output format for the onboarding summary. Defaults to text."* ]]
 
     run_basectl workspace clone --help

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -91,7 +91,12 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--command", "command_filter", help="Filter by basectl command name.")
 @base_cli.option("--status", "status_filter", help="Filter by status: ok, warn, or error.")
 @base_cli.option("--limit", default="10", help="Maximum history records to list.")
-@base_cli.option("--format", "output_format", default="text", help="Output format: text, markdown, or json.")
+@base_cli.option(
+    "--format",
+    "output_format",
+    default="text",
+    help="Output format: text, csv, tsv, yaml, or json.",
+)
 @base_cli.option("--report", is_flag=True, help="Print a privacy-conscious local activity report.")
 @base_cli.option("--oldest-first", is_flag=True, help="Show the selected history window from oldest to newest.")
 @base_cli.option("--last", "last_window", help="Show records from the most recent duration, such as 2h or 7d.")
@@ -110,7 +115,7 @@ def main(argv: list[str] | None = None) -> int:
     is_flag=True,
     help="Render text and Markdown timestamps in local time; defaults to UTC.",
 )
-# pylint: disable=too-many-arguments,too-many-positional-arguments
+# pylint: disable=too-many-arguments,too-many-branches,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
     project_filter: str | None,
@@ -149,6 +154,17 @@ def run(
         history_report = build_history_report(cache_root, records)
         if options.output_format == "json":
             print(json.dumps(history_report_to_json(history_report), indent=2, sort_keys=True))
+        elif options.output_format in {"csv", "tsv", "yaml"} or not base_cli.is_terminal():
+            report_payload = history_report_to_json(history_report)
+            if options.output_format == "yaml":
+                base_cli.render_document(report_payload, requested_format="yaml")
+            else:
+                base_cli.render_document(
+                    report_payload,
+                    requested_format="tsv" if options.output_format == "markdown" else options.output_format,
+                    records_key="recent",
+                    columns=history_output_columns(),
+                )
         else:
             print_history_report_markdown(history_report, local_time=options.local_time)
         return base_cli.ExitCode.SUCCESS
@@ -157,9 +173,19 @@ def run(
         print(json.dumps([record.to_json() for record in records], indent=2))
         return base_cli.ExitCode.SUCCESS
     if not records:
-        print(f"No Base command history found under {cache_root / HISTORY_PATH}.")
+        if options.output_format == "yaml":
+            base_cli.render_records([], requested_format="yaml", columns=history_output_columns())
+        elif options.output_format not in {"csv", "tsv"} and base_cli.is_terminal():
+            print(f"No Base command history found under {cache_root / HISTORY_PATH}.")
         return base_cli.ExitCode.SUCCESS
-    print_history_table(records, local_time=options.local_time)
+    if options.output_format in {"csv", "tsv", "yaml"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            history_output_records(records, local_time=options.local_time),
+            requested_format=options.output_format,
+            columns=history_output_columns(),
+        )
+    else:
+        print_history_table(records, local_time=options.local_time)
     return base_cli.ExitCode.SUCCESS
 
 
@@ -171,17 +197,21 @@ def normalize_optional_filter(value: str | None) -> str | None:
 
 def normalize_format(value: str) -> str:
     normalized = value.strip().lower()
-    if normalized not in {"text", "json"}:
-        raise ValueError(f"Unsupported output format '{value}'. Expected one of: text, json.")
+    if normalized not in base_cli.PUBLIC_OUTPUT_FORMATS:
+        raise ValueError(
+            f"Unsupported output format '{value}'. Expected one of: {', '.join(base_cli.PUBLIC_OUTPUT_FORMATS)}."
+        )
     return normalized
 
 
 def normalize_report_format(value: str) -> str:
     normalized = value.strip().lower()
     if normalized == "text":
-        return "markdown"
-    if normalized not in {"markdown", "json"}:
-        raise ValueError(f"Unsupported report output format '{value}'. Expected one of: markdown, json.")
+        return "text"
+    if normalized not in {"markdown", *base_cli.PUBLIC_OUTPUT_FORMATS}:
+        raise ValueError(
+            f"Unsupported report output format '{value}'. Expected one of: text, csv, tsv, yaml, json."
+        )
     return normalized
 
 
@@ -330,6 +360,31 @@ def print_history_table(records: list[HistoryRecord], *, local_time: bool = Fals
             f"{display_exit_code(record):<4}  "
             f"{display_log_path(record)}"
         )
+
+
+def history_output_columns() -> tuple[tuple[str, str], ...]:
+    return (
+        ("TIME", "time"),
+        ("COMMAND", "command"),
+        ("PROJECT", "project"),
+        ("STATUS", "status"),
+        ("EXIT", "exit"),
+        ("LOG", "log"),
+    )
+
+
+def history_output_records(records: list[HistoryRecord], *, local_time: bool = False) -> list[dict[str, Any]]:
+    return [
+        {
+            "time": display_time(record, local_time=local_time),
+            "command": record.command,
+            "project": display_project(record),
+            "status": record.status,
+            "exit": display_exit_code(record),
+            "log": display_log_path(record),
+        }
+        for record in records
+    ]
 
 
 def display_time(record: HistoryRecord, *, local_time: bool = False) -> str:

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -52,12 +52,17 @@ def history_record(
 
 
 def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
-    stdout = io.StringIO()
+    stdout = TerminalStringIO()
     stderr = io.StringIO()
     with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
         with redirect_stdout(stdout), redirect_stderr(stderr):
             status = engine.main(args)
     return status, stdout.getvalue(), stderr.getvalue()
+
+
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
 
 
 class BaseHistoryTests(unittest.TestCase):
@@ -421,16 +426,18 @@ class BaseHistoryTests(unittest.TestCase):
     def test_invalid_options_report_usage_errors(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             status, stdout, stderr = invoke(["--limit", "0"], Path(tmpdir))
-            format_status, _format_stdout, format_stderr = invoke(["--format", "yaml"], Path(tmpdir))
-            report_status, _report_stdout, report_stderr = invoke(["--report", "--format", "yaml"], Path(tmpdir))
+            format_status, format_stdout, format_stderr = invoke(["--format", "yaml"], Path(tmpdir))
+            report_status, report_stdout, report_stderr = invoke(["--report", "--format", "yaml"], Path(tmpdir))
 
         self.assertEqual(status, 2)
         self.assertEqual(stdout, "")
         self.assertIn("Option '--limit' must be greater than zero", stderr)
-        self.assertEqual(format_status, 2)
-        self.assertIn("Unsupported output format 'yaml'", format_stderr)
-        self.assertEqual(report_status, 2)
-        self.assertIn("Unsupported report output format 'yaml'", report_stderr)
+        self.assertEqual(format_status, 0)
+        self.assertEqual(format_stderr, "")
+        self.assertEqual(report_status, 0)
+        self.assertEqual(report_stderr, "")
+        self.assertIn("[]", format_stdout)
+        self.assertIn("schema_version", report_stdout)
 
     def test_click_usage_errors_use_delegated_display_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -117,7 +117,12 @@ def main(argv: list[str] | None = None) -> int:
 @base_cli.option("--tail", is_flag=True, help="Tail and follow the most recent matching log.")
 @base_cli.option("--open", "open_file", is_flag=True, help="Open the most recent matching log in PAGER or EDITOR.")
 @base_cli.option("--lines", default="40", help="Line count to show before following.")
-@base_cli.option("--format", "output_format", default="text", help="Output format for logs last: text or json.")
+@base_cli.option(
+    "--format",
+    "output_format",
+    default="text",
+    help="Output format: text, csv, tsv, yaml, or json.",
+)
 @base_cli.argument("action", required=False)
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
@@ -149,7 +154,7 @@ def run(
         output_format=normalized_format,
     )
     selected_actions = sum(1 for selected in (path_only, tail, open_file) if selected)
-    validation_error = logs_command_validation_error(action, normalized_format, selected_actions)
+    validation_error = logs_command_validation_error(action, selected_actions)
     if validation_error is not None:
         ctx.log.error(validation_error)
         return base_cli.ExitCode.USAGE_ERROR
@@ -161,13 +166,11 @@ def run(
     return run_recent_logs(ctx, cache_root, options)
 
 
-def logs_command_validation_error(action: str | None, output_format: str, selected_actions: int) -> str | None:
+def logs_command_validation_error(action: str | None, selected_actions: int) -> str | None:
     if action is not None and action != "last":
         return f"Unknown logs command '{action}'. Supported commands: last."
     if action == "last" and selected_actions > 0:
         return "`basectl logs last` does not accept --path, --tail, or --open."
-    if action is None and output_format != "text":
-        return "Option '--format' is only supported with `basectl logs last`."
     if action is None and selected_actions > 1:
         return "Choose only one of --path, --tail, or --open."
     return None
@@ -183,8 +186,10 @@ def run_recent_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommand
 
 def normalize_logs_format(value: str) -> str:
     normalized = value.strip().lower()
-    if normalized not in {"text", "json"}:
-        raise ValueError(f"Unsupported output format '{value}'. Expected one of: text, json.")
+    if normalized not in base_cli.PUBLIC_OUTPUT_FORMATS:
+        raise ValueError(
+            f"Unsupported output format '{value}'. Expected one of: {', '.join(base_cli.PUBLIC_OUTPUT_FORMATS)}."
+        )
     return normalized
 
 
@@ -192,7 +197,14 @@ def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandO
     if options.path_only or options.tail or options.open_file:
         ctx.log.error("No Base CLI logs found.")
         return base_cli.ExitCode.FAILURE
-    print(f"No Base CLI logs found under {cache_root / 'base' / 'runs'} or {cache_root / 'projects'}.")
+    if options.output_format == "json":
+        print("[]")
+    elif options.output_format == "yaml":
+        base_cli.render_records([], requested_format="yaml", columns=log_output_columns())
+    elif options.output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+        return base_cli.ExitCode.SUCCESS
+    else:
+        print(f"No Base CLI logs found under {cache_root / 'base' / 'runs'} or {cache_root / 'projects'}.")
     return base_cli.ExitCode.SUCCESS
 
 
@@ -206,7 +218,15 @@ def run_with_entries(entries: list[LogEntry], options: LogCommandOptions) -> int
     if options.open_file:
         return open_log(newest.path)
 
-    print_log_table(entries[: options.limit])
+    selected = entries[: options.limit]
+    if options.output_format in {"csv", "tsv", "yaml", "json"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            log_output_records(selected),
+            requested_format=options.output_format,
+            columns=log_output_columns(),
+        )
+    else:
+        print_log_table(selected)
     return base_cli.ExitCode.SUCCESS
 
 
@@ -227,6 +247,18 @@ def run_last_failure(ctx: base_cli.Context, cache_root: Path, options: LogComman
                     sort_keys=True,
                 )
             )
+        elif options.output_format == "yaml":
+            base_cli.render_document(
+                {
+                    "schema_version": 1,
+                    "found": False,
+                    "history_path": redact_history_text(str(history_path)),
+                    "message": "No failed Base command history found.",
+                },
+                requested_format="yaml",
+            )
+        elif options.output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+            return base_cli.ExitCode.SUCCESS
         else:
             print(f"No failed Base command history found under {history_path}.")
         return base_cli.ExitCode.SUCCESS
@@ -234,6 +266,14 @@ def run_last_failure(ctx: base_cli.Context, cache_root: Path, options: LogComman
     tail = last_failure_tail(record, options.lines)
     if options.output_format == "json":
         print(json.dumps(last_failure_to_json(record, tail), indent=2, sort_keys=True))
+    elif options.output_format == "yaml":
+        base_cli.render_document(last_failure_to_json(record, tail), requested_format="yaml")
+    elif options.output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            [last_failure_output_record(record)],
+            requested_format=options.output_format,
+            columns=last_failure_output_columns(),
+        )
     else:
         print_last_failure_text(record, tail)
     return base_cli.ExitCode.SUCCESS
@@ -630,6 +670,55 @@ def print_log_table(entries: list[LogEntry]) -> None:
             f"{entry.status:<6}  "
             f"{compact_path(entry.path)}"
         )
+
+
+def log_output_columns() -> tuple[tuple[str, str], ...]:
+    return (
+        ("TIME", "time"),
+        ("COMMAND", "command"),
+        ("RUN ID", "run_id"),
+        ("STATUS", "status"),
+        ("EXIT", "exit"),
+        ("PATH", "path"),
+    )
+
+
+def log_output_records(entries: list[LogEntry]) -> list[dict[str, Any]]:
+    return [
+        {
+            "time": f"{entry.timestamp:%Y-%m-%d %H:%M:%S}",
+            "command": entry.command,
+            "run_id": entry.run_id,
+            "status": entry.status,
+            "exit": entry.exit_code if entry.exit_code is not None else "-",
+            "path": compact_path(entry.path),
+        }
+        for entry in entries
+    ]
+
+
+def last_failure_output_columns() -> tuple[tuple[str, str], ...]:
+    return (
+        ("TIME", "time"),
+        ("COMMAND", "command"),
+        ("PROJECT", "project"),
+        ("STATUS", "status"),
+        ("EXIT", "exit"),
+        ("RUN ID", "run_id"),
+        ("LOG", "log"),
+    )
+
+
+def last_failure_output_record(record: LastFailureRecord) -> dict[str, Any]:
+    return {
+        "time": display_last_value(record.ended_at),
+        "command": redact_history_text(record.command),
+        "project": redact_history_text(record.project) if record.project else "-",
+        "status": redact_history_text(record.status),
+        "exit": record.exit_code if record.exit_code is not None else "-",
+        "run_id": redact_history_text(record.run_id),
+        "log": display_last_log_path(record),
+    }
 
 
 def tail_log(path: Path, lines: int) -> int:

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -63,7 +63,7 @@ def history_record(  # pylint: disable=too-many-arguments
 
 
 def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
-    stdout = io.StringIO()
+    stdout = TerminalStringIO()
     stderr = io.StringIO()
     with mock.patch.dict(
         os.environ,
@@ -72,6 +72,11 @@ def invoke(args: list[str], cache_root: Path) -> tuple[int, str, str]:
         with redirect_stdout(stdout), redirect_stderr(stderr):
             status = engine.main(args)
     return status, stdout.getvalue(), stderr.getvalue()
+
+
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
 
 
 class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-methods
@@ -526,16 +531,16 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertEqual(format_stdout, "")
         self.assertIn("Unsupported output format 'xml'", format_stderr)
 
-    def test_json_format_is_only_supported_for_last(self) -> None:
+    def test_json_format_is_supported_for_recent_logs(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
 
             status, stdout, stderr = invoke(["--format", "json"], cache_root)
 
-        self.assertEqual(status, 2)
-        self.assertEqual(stdout, "")
-        self.assertIn("only supported with `basectl logs last`", stderr)
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn('"command":"clean"', stdout)
 
     def test_invalid_count_options_report_usage_errors(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Protocol
@@ -100,6 +99,12 @@ def build_targets_for_project(
     target_names: tuple[str, ...],
     output_format: str = "text",
 ) -> int:
+    if output_format != "command-protocol":
+        try:
+            base_cli.resolve_output_format(output_format)
+        except base_cli.OutputFormatError as exc:
+            ctx.log.error(str(exc))
+            return base_cli.ExitCode.USAGE_ERROR
     try:
         manifest = read_manifest(project.manifest_path)
         targets = selected_build_targets(project, manifest, target_names)
@@ -161,6 +166,12 @@ def list_build_targets_for_project(
     project: ProjectLike,
     output_format: str = "text",
 ) -> int:
+    if output_format != "command-protocol":
+        try:
+            base_cli.resolve_output_format(output_format)
+        except base_cli.OutputFormatError as exc:
+            ctx.log.error(str(exc))
+            return base_cli.ExitCode.USAGE_ERROR
     try:
         manifest = read_manifest(project.manifest_path)
         targets = all_build_targets(project, manifest)
@@ -168,44 +179,55 @@ def list_build_targets_for_project(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    if output_format == "command-protocol":
-        records = [
-            build_target_record(
-                project,
-                manifest,
-                target_name,
-                target_config,
-                working_dir,
-                manifest_command_trust_required=False,
-            )
-            for target_name, target_config, working_dir in targets
-        ]
-        print(dumps_records("build-target", records))
-    elif output_format == "json":
-        print(
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "project": {
-                        "name": project.name,
-                        "root": str(project.root),
-                        "manifest_path": str(project.manifest_path),
-                    },
-                    "targets": [
-                        {
-                            "name": target_name,
-                            "working_dir": str(working_dir),
-                            "command": target_config.command,
-                            "description": target_config.description,
-                            "runner": target_config.runner,
-                        }
-                        for target_name, target_config, working_dir in targets
-                    ],
-                },
-                indent=2,
-            )
+    records = [
+        build_target_record(
+            project,
+            manifest,
+            target_name,
+            target_config,
+            working_dir,
+            manifest_command_trust_required=False,
         )
-    elif output_format == "text":
+        for target_name, target_config, working_dir in targets
+    ]
+    if output_format == "command-protocol":
+        print(dumps_records("build-target", records))
+    elif output_format in {"json", "yaml"}:
+        base_cli.render_document(
+            {
+                "schema_version": 1,
+                "project": {
+                    "name": project.name,
+                    "root": str(project.root),
+                    "manifest_path": str(project.manifest_path),
+                },
+                "targets": [
+                    {
+                        "name": target_name,
+                        "working_dir": str(working_dir),
+                        "command": target_config.command,
+                        "description": target_config.description,
+                        "runner": target_config.runner,
+                    }
+                    for target_name, target_config, working_dir in targets
+                ],
+            },
+            requested_format=output_format,
+        )
+    elif output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            records,
+            requested_format=output_format,
+            columns=(
+                ("PROJECT", "project_name"),
+                ("TARGET", "target_name"),
+                ("WORKING DIR", "working_dir"),
+                ("COMMAND", "command"),
+                ("DESCRIPTION", "description"),
+                ("RUNNER", "runner"),
+            ),
+        )
+    else:
         for target_name, target_config, working_dir in targets:
             print_build_target(
                 project,
@@ -215,9 +237,6 @@ def list_build_targets_for_project(
                 working_dir,
                 manifest_command_trust_required=False,
             )
-    else:
-        ctx.log.error("Unsupported build-target-list output format '%s'.", output_format)
-        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import json
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import base_cli
@@ -48,7 +48,6 @@ from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_init import workspace_init_command
 from base_projects.workspace_pull_command import workspace_pull_command
 from base_projects.workspace_onboarding import workspace_onboarding_summary
-from base_projects.workspace_report_json import dumps_json
 from base_projects.workspace_report_json import workspace_check_to_json
 from base_projects.workspace_report_json import workspace_doctor_to_json
 from base_projects.workspace_report_json import workspace_agent_brief_to_json
@@ -256,8 +255,7 @@ def workspace_status_command(
     output_format: str = "text",
     workspace_manifest: str | None = None,
 ) -> int:
-    if output_format not in ("text", "json"):
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+    if not validate_report_format(ctx, output_format):
         return base_cli.ExitCode.USAGE_ERROR
 
     try:
@@ -270,10 +268,22 @@ def workspace_status_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    if output_format == "json":
-        print(dumps_json(workspace_status_to_json(workspace_root, statuses, manifest)))
-    else:
-        print_workspace_status(workspace_root, statuses, manifest)
+    if not emit_workspace_report(
+        ctx,
+        workspace_status_to_json(workspace_root, statuses, manifest),
+        output_format,
+        records_key="projects",
+        columns=(
+            ("PROJECT", "name"),
+            ("STATUS", "status"),
+            ("PATH", "path"),
+            ("VENV", "venv"),
+            ("MANIFEST", "manifest"),
+            ("LAST CHECK", "last_check"),
+        ),
+        text_renderer=lambda: print_workspace_status(workspace_root, statuses, manifest),
+    ):
+        return base_cli.ExitCode.USAGE_ERROR
 
     if any(project.status == "error" for project in statuses):
         return base_cli.ExitCode.FAILURE
@@ -286,8 +296,7 @@ def workspace_check_command(
     output_format: str = "text",
     workspace_manifest: str | None = None,
 ) -> int:
-    if output_format not in ("text", "json"):
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+    if not validate_report_format(ctx, output_format):
         return base_cli.ExitCode.USAGE_ERROR
 
     try:
@@ -298,10 +307,15 @@ def workspace_check_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    if output_format == "json":
-        print(dumps_json(workspace_check_to_json(workspace_root, results, manifest)))
-    else:
-        print_workspace_check(workspace_root, results, manifest)
+    if not emit_workspace_report(
+        ctx,
+        workspace_check_to_json(workspace_root, results, manifest),
+        output_format,
+        records_key="projects",
+        columns=(("PROJECT", "name"), ("STATUS", "status"), ("PATH", "path"), ("MANIFEST", "manifest")),
+        text_renderer=lambda: print_workspace_check(workspace_root, results, manifest),
+    ):
+        return base_cli.ExitCode.USAGE_ERROR
 
     if any(result.status == "error" for result in results):
         return base_cli.ExitCode.FAILURE
@@ -314,8 +328,7 @@ def workspace_doctor_command(
     output_format: str = "text",
     workspace_manifest: str | None = None,
 ) -> int:
-    if output_format not in ("text", "json"):
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+    if not validate_report_format(ctx, output_format):
         return base_cli.ExitCode.USAGE_ERROR
 
     try:
@@ -326,10 +339,15 @@ def workspace_doctor_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    if output_format == "json":
-        print(dumps_json(workspace_doctor_to_json(workspace_root, results, manifest)))
-    else:
-        print_workspace_doctor(workspace_root, results, manifest)
+    if not emit_workspace_report(
+        ctx,
+        workspace_doctor_to_json(workspace_root, results, manifest),
+        output_format,
+        records_key="projects",
+        columns=(("PROJECT", "name"), ("STATUS", "status"), ("PATH", "path"), ("MANIFEST", "manifest")),
+        text_renderer=lambda: print_workspace_doctor(workspace_root, results, manifest),
+    ):
+        return base_cli.ExitCode.USAGE_ERROR
 
     return min(workspace_error_count(results), 125)
 
@@ -340,8 +358,7 @@ def workspace_onboarding_command(
     output_format: str = "text",
     workspace_manifest: str | None = None,
 ) -> int:
-    if output_format not in ("text", "json"):
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+    if not validate_report_format(ctx, output_format):
         return base_cli.ExitCode.USAGE_ERROR
 
     try:
@@ -355,10 +372,21 @@ def workspace_onboarding_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    if output_format == "json":
-        print(dumps_json(workspace_onboarding_to_json(summary)))
-    else:
-        print_workspace_onboarding(summary)
+    if not emit_workspace_report(
+        ctx,
+        workspace_onboarding_to_json(summary),
+        output_format,
+        records_key="repositories",
+        columns=(
+            ("REPOSITORY", "repository"),
+            ("REQUIRED", "required"),
+            ("STATUS", "status"),
+            ("PATH", "path"),
+            ("VENV", "venv"),
+        ),
+        text_renderer=lambda: print_workspace_onboarding(summary),
+    ):
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 
@@ -368,8 +396,7 @@ def workspace_agent_brief_command(
     output_format: str = "text",
     workspace_manifest: str | None = None,
 ) -> int:
-    if output_format not in ("text", "json"):
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+    if not validate_report_format(ctx, output_format):
         return base_cli.ExitCode.USAGE_ERROR
 
     try:
@@ -383,11 +410,57 @@ def workspace_agent_brief_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    if output_format == "json":
-        print(dumps_json(workspace_agent_brief_to_json(brief)))
-    else:
-        print_workspace_agent_brief(brief)
+    if not emit_workspace_report(
+        ctx,
+        workspace_agent_brief_to_json(brief),
+        output_format,
+        records_key="repositories",
+        columns=(
+            ("REPOSITORY", "repository"),
+            ("PROJECT", "project"),
+            ("PATH", "path"),
+            ("SCOPE", "scope"),
+            ("HANDOFF", "handoff_status"),
+            ("VENV", "venv"),
+        ),
+        text_renderer=lambda: print_workspace_agent_brief(brief),
+    ):
+        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
+
+
+def validate_report_format(ctx: base_cli.Context, output_format: str) -> bool:
+    try:
+        base_cli.resolve_output_format(output_format)
+    except base_cli.OutputFormatError as exc:
+        ctx.log.error(str(exc))
+        return False
+    return True
+
+
+# pylint: disable=too-many-arguments
+def emit_workspace_report(
+    ctx: base_cli.Context,
+    document: dict,
+    output_format: str,
+    *,
+    records_key: str,
+    columns: Sequence[tuple[str, str]],
+    text_renderer: Callable[[], None],
+) -> bool:
+    try:
+        resolved = base_cli.render_document(
+            document,
+            requested_format=output_format,
+            records_key=records_key,
+            columns=columns,
+        )
+    except base_cli.OutputFormatError as exc:
+        ctx.log.error(str(exc))
+        return False
+    if resolved == "text":
+        text_renderer()
+    return True
 
 
 def log_workspace_status_discovery(
@@ -647,6 +720,12 @@ def list_run_commands_command(
     workspace: str | None,
     output_format: str = "text",
 ) -> int:
+    if output_format != "command-protocol":
+        try:
+            base_cli.resolve_output_format(output_format)
+        except base_cli.OutputFormatError as exc:
+            ctx.log.error(str(exc))
+            return base_cli.ExitCode.USAGE_ERROR
     try:
         if project_name:
             project = resolve_named_project(ctx, project_name, workspace)
@@ -662,45 +741,52 @@ def list_run_commands_command(
         ctx.log.error("Project '%s' does not declare runnable commands in '%s'.", project.name, project.manifest_path)
         return base_cli.ExitCode.FAILURE
 
+    records = [
+        named_command_record(
+            project.name,
+            project.root,
+            project.manifest_path,
+            command_name,
+            command_config,
+        )
+        for command_name, command_config in commands.items()
+    ]
     if output_format == "command-protocol":
         print(
-            dumps_records(
-                "named-command",
-                [
-                    named_command_record(
-                        project.name,
-                        project.root,
-                        project.manifest_path,
-                        command_name,
-                        command_config,
-                    )
+            dumps_records("named-command", records)
+        )
+    elif output_format in {"json", "yaml"}:
+        base_cli.render_document(
+            {
+                "schema_version": 1,
+                "project": {
+                    "name": project.name,
+                    "root": str(project.root),
+                    "manifest_path": str(project.manifest_path),
+                },
+                "commands": [
+                    {
+                        "name": command_name,
+                        "command": command_config.command,
+                        "runner": command_config.runner,
+                    }
                     for command_name, command_config in commands.items()
                 ],
-            )
+            },
+            requested_format=output_format,
         )
-    elif output_format == "json":
-        print(
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "project": {
-                        "name": project.name,
-                        "root": str(project.root),
-                        "manifest_path": str(project.manifest_path),
-                    },
-                    "commands": [
-                        {
-                            "name": command_name,
-                            "command": command_config.command,
-                            "runner": command_config.runner,
-                        }
-                        for command_name, command_config in commands.items()
-                    ],
-                },
-                indent=2,
-            )
+    elif output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            records,
+            requested_format=output_format,
+            columns=(
+                ("PROJECT", "project_name"),
+                ("COMMAND", "command_name"),
+                ("COMMAND LINE", "command"),
+                ("RUNNER", "runner"),
+            ),
         )
-    elif output_format == "text":
+    else:
         for command_name, command_config in commands.items():
             print(
                 _named_command_output(
@@ -711,9 +797,6 @@ def list_run_commands_command(
                     command_config,
                 )
             )
-    else:
-        ctx.log.error("Unsupported run-commands output format '%s'.", output_format)
-        return base_cli.ExitCode.USAGE_ERROR
     return base_cli.ExitCode.SUCCESS
 
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -67,6 +67,11 @@ def write_versioned_python_bin(python_bin: Path, version: str) -> None:
 _engine_homes: list[Path] = []
 
 
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
 def base_route_fields(
     base_home: Path,
     project: str,
@@ -204,7 +209,8 @@ def invoke_engine(
     user_config: str | None = None,
     extra_env: dict[str, str] | None = None,
 ) -> tuple[int, str, str]:
-    stdout = io.StringIO()
+    workspace_commands = {"status", "check", "doctor", "onboarding", "agent-brief", "run-commands"}
+    stdout = TerminalStringIO() if any(argument in workspace_commands for argument in args) else io.StringIO()
     stderr = io.StringIO()
     if user_config is not None:
         config_path = home / ".base.d" / "config.yaml"

--- a/cli/python/base_projects/tests/test_workspace_agent_brief.py
+++ b/cli/python/base_projects/tests/test_workspace_agent_brief.py
@@ -82,13 +82,18 @@ def write_ready_python(project_root: Path, home: Path, project: str) -> None:
     python_bin.chmod(0o755)
 
 
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
 def invoke_engine(
     args: list[str],
     base_home: Path,
     home: Path,
     extra_env: dict[str, str] | None = None,
 ) -> tuple[int, str, str]:
-    stdout = io.StringIO()
+    stdout = TerminalStringIO()
     stderr = io.StringIO()
     env = {
         "HOME": str(home),

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -84,8 +84,13 @@ def write_default_manifest(base_home: Path) -> None:
     )
 
 
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
 def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
-    stdout = io.StringIO()
+    stdout = TerminalStringIO()
     stderr = io.StringIO()
     env = {
         "HOME": str(home),

--- a/cli/python/base_projects/tests/test_workspace_onboarding.py
+++ b/cli/python/base_projects/tests/test_workspace_onboarding.py
@@ -60,8 +60,13 @@ def write_workspace_manifest(path: Path) -> None:
     )
 
 
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
 def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
-    stdout = io.StringIO()
+    stdout = TerminalStringIO()
     stderr = io.StringIO()
     env = {
         "HOME": str(home),

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -120,28 +120,38 @@ def build_release_context(ctx: base_cli.Context, args: ReleaseArguments) -> Rele
 
 def release_check_command(ctx: ReleaseContext, *, output_format: str = "text") -> int:
     findings = release_findings(ctx)
+    inspection_status = release_inspection_status(findings)
+    payload = {
+        "schema_version": 1,
+        "command": "release check",
+        "status": inspection_status,
+        "data": {
+            "project": ctx.manifest.project_name,
+            "version": ctx.version,
+            "tag_name": ctx.tag_name,
+            "manifest_path": str(ctx.manifest_path),
+            "findings": [
+                {"status": finding.status, "name": finding.name, "message": finding.message}
+                for finding in findings
+            ],
+        },
+        "error": None,
+    }
     if output_format == "json":
-        inspection_status = release_inspection_status(findings)
-        print(
-            render_inspection_json(
-                command="release check",
-                status=inspection_status,
-                data={
-                    "project": ctx.manifest.project_name,
-                    "version": ctx.version,
-                    "tag_name": ctx.tag_name,
-                    "manifest_path": str(ctx.manifest_path),
-                    "findings": [
-                        {"status": finding.status, "name": finding.name, "message": finding.message}
-                        for finding in findings
-                    ],
-                },
-            ),
-            end="",
-        )
+        print(render_inspection_json(command="release check", status=inspection_status, data=payload["data"]), end="")
         if inspection_status == "error":
             return base_cli.ExitCode.FAILURE
         return base_cli.ExitCode.SUCCESS
+    if output_format == "yaml":
+        base_cli.render_document(payload, requested_format="yaml")
+        return base_cli.ExitCode.FAILURE if inspection_status == "error" else base_cli.ExitCode.SUCCESS
+    if output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            payload["data"]["findings"],
+            requested_format=output_format,
+            columns=(("STATUS", "status"), ("NAME", "name"), ("MESSAGE", "message")),
+        )
+        return base_cli.ExitCode.FAILURE if inspection_status == "error" else base_cli.ExitCode.SUCCESS
     print(f"\nRelease check for {ctx.manifest.project_name} v{ctx.version}\n")
     for finding in findings:
         print(f"{finding.status:<5}  {finding.name:<14}  {finding.message}")

--- a/cli/python/base_release/release_parser.py
+++ b/cli/python/base_release/release_parser.py
@@ -77,9 +77,10 @@ def parse_release_option(
     if arg == "--format":
         require_check_option(command, "--format")
         state.output_format = read_release_option_value(arguments, index, "--format")
-        if state.output_format not in ("text", "json"):
+        if state.output_format not in base_cli.PUBLIC_OUTPUT_FORMATS:
             raise ReleaseUsageError(
-                f"Unsupported release check format '{state.output_format}'. Expected text or json."
+                f"Unsupported release check format '{state.output_format}'. Expected one of: "
+                f"{', '.join(base_cli.PUBLIC_OUTPUT_FORMATS)}."
             )
         return index + 2
     if arg == "--dry-run":
@@ -117,7 +118,7 @@ def selected_release_check_format(arguments: tuple[str, ...]) -> str:
     for index, argument in enumerate(arguments):
         if argument == "--format" and index + 1 < len(arguments):
             candidate = arguments[index + 1]
-            if candidate in ("text", "json"):
+            if candidate in base_cli.PUBLIC_OUTPUT_FORMATS:
                 selected = candidate
     return selected
 
@@ -126,7 +127,7 @@ def print_usage(file: TextIO = sys.stdout) -> None:
     command = base_cli.delegated_display_command("base_release")
     print(
         f"""Usage:
-  {command} check --version <version> [--manifest <path>] [--format <text|json>]
+  {command} check --version <version> [--manifest <path>] [--format <text|csv|tsv|yaml|json>]
   {command} plan --version <version> [--manifest <path>]
   {command} notes --version <version> [--manifest <path>]
   {command} publish --version <version> [--manifest <path>] [--dry-run] [--yes]

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -43,7 +43,7 @@ def pushd(path: Path):
 
 
 def run_engine(args: list[str], cwd: Path, extra_env: dict[str, str] | None = None) -> tuple[int, str, str]:
-    stdout = io.StringIO()
+    stdout = TerminalStringIO()
     stderr = io.StringIO()
     env = {
         "BASE_CLI_DISPLAY_COMMAND": "",
@@ -58,6 +58,11 @@ def run_engine(args: list[str], cwd: Path, extra_env: dict[str, str] | None = No
             with pushd(cwd), redirect_stdout(stdout), redirect_stderr(stderr):
                 status = main(args)
     return status, stdout.getvalue(), stderr.getvalue()
+
+
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
 
 
 def write_release_project(
@@ -135,7 +140,7 @@ class ReleaseUsageTests(unittest.TestCase):
     def test_json_usage_error_stays_structured_after_later_invalid_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             status, stdout, stderr = run_engine(
-                ["check", "--format", "json", "--format", "yaml"],
+                ["check", "--format", "json", "--format", "xml"],
                 Path(tmpdir),
                 {"BASE_CLI_DISPLAY_COMMAND": "basectl release"},
             )

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -48,10 +47,17 @@ def main(argv: list[str] | None = None) -> int:
     "--workspace",
     help="Workspace directory to scan. Defaults to workspace.root, then BASE_HOME's parent.",
 )
-@base_cli.option("--format", "output_format", default="text", help="Output format: text or json.")
+@base_cli.option(
+    "--format",
+    "output_format",
+    default="text",
+    help="Output format: text, csv, tsv, yaml, or json.",
+)
 def status_command(ctx: base_cli.Context, project: str | None, workspace: str | None, output_format: str) -> int:
-    if output_format not in {"text", "json"}:
-        ctx.log.error("Unsupported output format '%s'. Expected one of: text, json.", output_format)
+    try:
+        base_cli.resolve_output_format(output_format)
+    except base_cli.OutputFormatError as exc:
+        ctx.log.error(str(exc))
         return base_cli.ExitCode.USAGE_ERROR
 
     if project is None:
@@ -65,8 +71,17 @@ def status_command(ctx: base_cli.Context, project: str | None, workspace: str | 
         return base_cli.ExitCode.FAILURE
 
     trust_status = ManifestCommandTrustStore().status(identity)
+    payload = status_payload(trust_status)
     if output_format == "json":
-        print(json.dumps(status_payload(trust_status), indent=2, sort_keys=True))
+        base_cli.render_document(payload, requested_format="json")
+    elif output_format == "yaml":
+        base_cli.render_document(payload, requested_format="yaml")
+    elif output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            [trust_output_record(payload)],
+            requested_format=output_format,
+            columns=trust_output_columns(),
+        )
     else:
         print_status_text(trust_status, surfaces)
     return base_cli.ExitCode.SUCCESS
@@ -166,16 +181,21 @@ def workspace_status_command(ctx: base_cli.Context, workspace: str | None, outpu
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "projects": [status_payload(trust_status) for trust_status, _surfaces in statuses],
+    }
     if output_format == "json":
-        print(
-            json.dumps(
-                {
-                    "schema_version": SCHEMA_VERSION,
-                    "projects": [status_payload(trust_status) for trust_status, _surfaces in statuses],
-                },
-                indent=2,
-                sort_keys=True,
-            )
+        base_cli.render_document(payload, requested_format="json")
+        return base_cli.ExitCode.SUCCESS
+    if output_format == "yaml":
+        base_cli.render_document(payload, requested_format="yaml")
+        return base_cli.ExitCode.SUCCESS
+    if output_format in {"csv", "tsv"} or not base_cli.is_terminal():
+        base_cli.render_records(
+            [trust_output_record(status_payload(trust_status)) for trust_status, _surfaces in statuses],
+            requested_format=output_format,
+            columns=trust_output_columns(),
         )
         return base_cli.ExitCode.SUCCESS
 
@@ -271,6 +291,16 @@ def status_payload(trust_status: TrustStatus) -> dict[str, Any]:
         if isinstance(changed_project, dict) and isinstance(changed_project.get("manifest_sha256"), str):
             payload["recorded_manifest_sha256"] = changed_project["manifest_sha256"]
     return payload
+
+
+def trust_output_columns() -> tuple[tuple[str, str], ...]:
+    return (("PROJECT", "project"), ("STATUS", "status"), ("REASON", "reason"))
+
+
+def trust_output_record(payload: dict[str, Any]) -> dict[str, Any]:
+    project = payload.get("project")
+    project_name = project.get("name", "-") if isinstance(project, dict) else "-"
+    return {"project": project_name, "status": payload.get("status", "-"), "reason": payload.get("reason", "-")}
 
 
 def allow_command_text(identity: ManifestCommandTrustIdentity) -> str:

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -297,9 +297,9 @@ class ManifestCommandTrustTests(unittest.TestCase):
         )
         self.assertNotIn("metadata-only", result.stdout)
         self.assertEqual(text_result.exit_code, 0, text_result.output)
-        self.assertIn("trust is allowed for project 'allowed'", text_result.stdout)
-        self.assertIn("manifest changed", text_result.stdout)
-        self.assertIn("trust is blocked for project 'fresh'", text_result.stdout)
+        self.assertIn("allowed\tallowed\tallowed", text_result.stdout)
+        self.assertIn("changed\tblocked\tmanifest_changed", text_result.stdout)
+        self.assertIn("fresh\tblocked\tnot_allowed", text_result.stdout)
         self.assertNotIn("metadata-only", text_result.stdout)
 
     def test_status_for_project_without_commands_keeps_json_v1_and_omits_text_guidance(self) -> None:
@@ -330,7 +330,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertEqual(payload["reason"], "not_allowed")
         self.assertIn("allow_command", payload)
         self.assertEqual(text_result.exit_code, 0, text_result.output)
-        self.assertIn("trust is not required", text_result.stdout)
+        self.assertIn("docs\tblocked\tnot_allowed", text_result.stdout)
         self.assertNotIn("trust allow", text_result.stdout)
 
     def test_workspace_status_adds_context_projects_only_for_implicit_workspace(self) -> None:
@@ -429,15 +429,16 @@ class ManifestCommandTrustTests(unittest.TestCase):
             workspace = root / "work"
             manifest_path = write_all_command_surfaces_manifest(workspace / "demo")
 
-            result = invoke(
-                engine.app,
-                ["status", "demo", "--workspace", str(workspace)],
-                home=home,
-                env={"BASE_HOME": str(workspace / "base")},
-            )
+            with mock.patch("base_cli.is_terminal", return_value=True):
+                result = invoke(
+                    engine.app,
+                    ["status", "demo", "--workspace", str(workspace)],
+                    home=home,
+                    env={"BASE_HOME": str(workspace / "base")},
+                )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("Review first:", result.stdout)
+        self.assertIn("Manifest command trust is blocked for project 'demo'.", result.stdout)
         self.assertIn("basectl run demo --list", result.stdout)
         self.assertIn("basectl build demo --list", result.stdout)
         self.assertIn("basectl test demo --dry-run", result.stdout)
@@ -461,15 +462,16 @@ class ManifestCommandTrustTests(unittest.TestCase):
             )
             current_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
 
-            result = invoke(
-                engine.app,
-                ["status", "demo", "--workspace", str(workspace)],
-                home=home,
-                env={"BASE_HOME": str(workspace / "base")},
-            )
+            with mock.patch("base_cli.is_terminal", return_value=True):
+                result = invoke(
+                    engine.app,
+                    ["status", "demo", "--workspace", str(workspace)],
+                    home=home,
+                    env={"BASE_HOME": str(workspace / "base")},
+                )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("manifest changed", result.stdout)
+        self.assertIn("Manifest command trust is blocked for project 'demo': manifest changed.", result.stdout)
         self.assertIn(f"Recorded Manifest SHA-256: {identity.manifest_sha256}", result.stdout)
         self.assertIn(f"Manifest SHA-256: {current_digest}", result.stdout)
         self.assertIn("basectl test demo --dry-run", result.stdout)

--- a/lib/python/base_cli/__init__.py
+++ b/lib/python/base_cli/__init__.py
@@ -6,7 +6,15 @@ from .context import Context, get_current_context
 from .exit_codes import ExitCode
 from .inspection import inspection_envelope, render_inspection_json
 from .logging import configure_logger, log_critical, log_debug, log_error, log_info, log_warning
-from .output import OutputFormatError, is_terminal, output_format_choices, render_records, resolve_output_format
+from .output import (
+    OutputFormatError,
+    PUBLIC_OUTPUT_FORMATS,
+    is_terminal,
+    output_format_choices,
+    render_document,
+    render_records,
+    resolve_output_format,
+)
 
 __all__ = [
     "App",
@@ -27,9 +35,11 @@ __all__ = [
     "log_info",
     "log_warning",
     "OutputFormatError",
+    "PUBLIC_OUTPUT_FORMATS",
     "is_terminal",
     "output_format_choices",
     "option",
+    "render_document",
     "render_records",
     "resolve_output_format",
     "run_app",

--- a/lib/python/base_cli/output.py
+++ b/lib/python/base_cli/output.py
@@ -130,9 +130,12 @@ def render_document(
         target.write(yaml.safe_dump(dict(document), sort_keys=False, allow_unicode=True))
         return resolved
 
-    raw_records = document.get(records_key) if records_key else None
-    if isinstance(raw_records, list):
-        records = [record for record in raw_records if isinstance(record, Mapping)]
+    if records_key:
+        candidate = document.get(records_key)
+        if isinstance(candidate, list):
+            records = [record for record in candidate if isinstance(record, Mapping)]
+        else:
+            records = [document]
     else:
         records = [document]
     selected_columns = columns or _document_columns(records)

--- a/lib/python/base_cli/output.py
+++ b/lib/python/base_cli/output.py
@@ -98,11 +98,66 @@ def render_records(
     return resolved
 
 
+def render_document(
+    document: Mapping[str, Any],
+    *,
+    requested_format: str | None,
+    records_key: str | None = None,
+    columns: Sequence[tuple[str, str]] | None = None,
+    stream: TextIO | None = None,
+) -> str:
+    """Render a structured report or leave terminal text to its existing renderer.
+
+    Structured formats preserve the complete document.  Delimited output uses
+    the selected record list (or the document itself) and never emits report
+    prose, headers, or footers.  A terminal ``text`` request returns ``text``
+    without writing so the caller can keep its established human report.
+    """
+
+    target = stream if stream is not None else sys.stdout
+    resolved = resolve_output_format(requested_format, stream=target)
+    if resolved == "text":
+        return resolved
+    if resolved == "json":
+        target.write(json.dumps(dict(document), indent=2))
+        target.write("\n")
+        return resolved
+    if resolved == "yaml":
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - environment guard
+            raise RuntimeError("PyYAML is required for YAML output.") from exc
+        target.write(yaml.safe_dump(dict(document), sort_keys=False, allow_unicode=True))
+        return resolved
+
+    raw_records = document.get(records_key) if records_key else None
+    if isinstance(raw_records, list):
+        records = [record for record in raw_records if isinstance(record, Mapping)]
+    else:
+        records = [document]
+    selected_columns = columns or _document_columns(records)
+    render_records(
+        records,
+        requested_format=resolved,
+        columns=selected_columns,
+        stream=target,
+    )
+    return resolved
+
+
+def _document_columns(records: Sequence[Mapping[str, Any]]) -> list[tuple[str, str]]:
+    if not records:
+        return []
+    return [(str(key).upper(), str(key)) for key in records[0]]
+
+
 def _cell_value(value: Any) -> str:
     if value is None:
         return ""
     if isinstance(value, bool):
         return "true" if value else "false"
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, separators=(",", ":"))
     return str(value)
 
 


### PR DESCRIPTION
Closes #1694

## Summary
- migrate workspace reports, history, logs, trust, and release checks to the shared output contract
- add YAML/CSV/TSV/JSON output while preserving existing JSON envelopes
- make text output TTY-aware and update build/run listing adapters and help

## Validation
- 207 focused Python tests passed (27 subtests)
- 7 shared renderer tests passed
- 54 focused BATS tests passed
- pylint and git diff --check passed