### PR TITLE
Document and complete public output formats

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -9,6 +9,12 @@ Base rejects `--option=value` syntax before command delegation. Arguments after
 `--` belong to the delegated project command and may use that command's native
 syntax.
 
+For report commands documented with `text|csv|tsv|yaml|json`, an omitted
+`--format` (or `--format text`) is a pretty table on a terminal and headerless
+TSV when stdout is redirected. See [Output formats](output-formats.md) for
+stable field order, JSON/YAML compatibility, stderr behavior, and the
+command-specific exceptions.
+
 `basectl` exposes `-v` as the public command-level debug switch. Direct
 `base_cli` package standard options such as `--debug`, `--quiet`, `--log-file`,
 `--config` and `--environment` are private to Python package execution and are

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -1,6 +1,8 @@
 # basectl output formats
 
-Base report commands share one output contract.
+Base report commands share one output contract. The contract applies to
+`basectl projects list`, workspace reports, lifecycle listings, trust status,
+release checks, and the `history` and `logs last` reports.
 
 When `--format` is omitted, or when `--format text` is selected, Base checks
 whether stdout is an interactive terminal:
@@ -22,13 +24,71 @@ results are represented as no rows for delimited output and an empty list for
 JSON/YAML. Diagnostics and errors are written to stderr so that structured
 stdout remains safe for automation.
 
+The default is therefore convenient for both use cases:
+
+```text
+basectl workspace status                  # pretty table in a terminal
+basectl workspace status | tee status.tsv # headerless TSV rows
+basectl workspace status --format json   # one stable JSON document
+```
+
+The terminal check is made on stdout, so redirecting stdout changes only the
+default `text` presentation. An explicitly selected `--format text` follows
+the same rule. Logging, warnings, and usage errors stay on stderr and never
+become rows in a structured stdout stream.
+
+## Stable report columns
+
+Delimited output has no header row. Its fields always follow the command's
+documented order:
+
+| Report | Field order |
+|---|---|
+| `projects list` | `PROJECT`, `PATH` |
+| `workspace status` | `PROJECT`, `STATUS`, `PATH`, `VENV`, `MANIFEST`, `LAST CHECK` |
+| `workspace check` / `workspace doctor` | `PROJECT`, `STATUS`, `PATH`, `MANIFEST` |
+| `workspace onboarding` | `REPOSITORY`, `REQUIRED`, `STATUS`, `PATH`, `VENV` |
+| `workspace agent-brief` | `REPOSITORY`, `PROJECT`, `PATH`, `SCOPE`, `HANDOFF`, `VENV` |
+| `run --list` | `PROJECT`, `COMMAND`, `COMMAND LINE`, `RUNNER` |
+| `build --list` | `PROJECT`, `TARGET`, `WORKING DIR`, `COMMAND`, `DESCRIPTION`, `RUNNER` |
+| `trust status` | `PROJECT`, `STATUS`, `REASON` |
+| `release check` | `STATUS`, `NAME`, `MESSAGE` |
+| `history` | `TIME`, `COMMAND`, `PROJECT`, `STATUS`, `EXIT`, `LOG` |
+| `logs last` | `TIME`, `COMMAND`, `PROJECT`, `STATUS`, `EXIT`, `RUN ID`, `LOG` |
+
+CSV and TSV values are emitted in this order without a header. CSV applies
+standard quoting when a value contains a comma, quote, or newline; TSV keeps
+the same field order with tab delimiters. JSON and YAML retain each command's
+documented record names and envelope shape rather than converting the table
+headers into API keys. Existing JSON payloads remain backward compatible while
+CSV/TSV provide a row-oriented view of the same records.
+
+Empty reports emit no rows in CSV/TSV and an empty list (or the command's
+existing empty document) in JSON/YAML.
+
+## Help and completion
+
+Every report using this contract lists its valid public values in `--help` and
+shell completion: `text`, `csv`, `tsv`, `yaml`, and `json`. Completion also
+preserves command-specific choices for non-contract commands, such as
+`export-context --format markdown|zip` and legacy inspection commands that
+support only `text|json`.
+
+## Exceptions
+
+`command-protocol` is an internal Base-to-Base transport used by wrappers and
+completion. It is intentionally not a public completion or automation format.
+`history --report` is a separate activity-report contract and continues to use
+`--format markdown|json`; its Markdown output is intended for people, while its
+JSON output is a report document rather than the row list from plain
+`basectl history`. Artifact-producing commands, such as
+`export-context --format markdown|zip`, keep their command-specific format
+semantics. Setup, check, doctor, repository inspection, and GitHub inspection
+commands likewise retain their existing `text|json` contracts until they are
+individually migrated.
+
 ## `basectl projects list`
 
 The table and delimited forms use the columns `PROJECT` then `PATH`. CSV and
 TSV contain those two fields without a header. JSON and YAML contain a list of
 objects with `name` and `path` keys, preserving the existing JSON shape.
-
-The internal `command-protocol` format is a private Base-to-Base interface and
-is not part of the public output-format choices. Artifact-producing commands,
-such as `export-context --format markdown|zip`, keep their command-specific
-format semantics.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -430,7 +430,7 @@ _base_basectl_completion_lifecycle_candidates() {
         return 0
     fi
     if [[ "$previous" == --format ]]; then
-        _base_basectl_completion_compgen "text json" "$current"
+        _base_basectl_completion_compgen "text csv tsv yaml json" "$current"
         return 0
     fi
     if [[ "$current" == -* ]]; then
@@ -477,6 +477,42 @@ _base_basectl_completion_compgen() {
     while IFS= read -r candidate; do
         COMPREPLY+=("$candidate")
     done < <(compgen -W "$words" -- "$current")
+}
+
+_base_basectl_completion_format_values() {
+    local command="${COMP_WORDS[1]:-}"
+    local subcommand="${COMP_WORDS[2]:-}"
+    local format_values="text json"
+    local index
+
+    case "$command" in
+        projects|build|run|release|logs|trust|workspace)
+            format_values="text csv tsv yaml json"
+            ;;
+        history)
+            format_values="text csv tsv yaml json"
+            for ((index = 2; index < COMP_CWORD; index += 1)); do
+                if [[ "${COMP_WORDS[index]:-}" == "--report" ]]; then
+                    format_values="markdown json"
+                    break
+                fi
+            done
+            ;;
+        export-context)
+            format_values="markdown zip"
+            ;;
+    esac
+
+    case "$command:$subcommand" in
+        trust:allow|trust:revoke|workspace:clone|workspace:pull|workspace:init|workspace:configure|release:plan|release:notes|logs:|build:|run:)
+            format_values="text json"
+            ;;
+        release:check|logs:last|trust:status)
+            format_values="text csv tsv yaml json"
+            ;;
+    esac
+
+    printf '%s\n' "$format_values"
 }
 
 _base_basectl_completion_profiles() {
@@ -577,6 +613,10 @@ _base_basectl_completion() {
     fi
 
     command="${COMP_WORDS[1]:-}"
+    if [[ "${COMP_WORDS[COMP_CWORD - 1]:-}" == "--format" ]]; then
+        _base_basectl_completion_compgen "$(_base_basectl_completion_format_values)" "$cur"
+        return 0
+    fi
     case "$command" in
         activate)
             _base_basectl_completion_project_or_options \

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -505,7 +505,7 @@ _base_basectl_completion() {
         projects)
             _arguments '2:projects command:(list)' \
                 '--workspace[Workspace directory to scan]:path:_files' \
-                '--format[Output format]:format:(text json)' \
+                '--format[Output format]:format:(text csv tsv yaml json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         trust)
@@ -514,7 +514,7 @@ _base_basectl_completion() {
                     _arguments '2:trust command:(status allow revoke)' \
                         '3::Base project:->projects' \
                         '--workspace[Workspace directory to scan]:path:_files' \
-                        '--format[Output format]:format:(text json)' \
+                        '--format[Output format]:format:(text csv tsv yaml json)' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 allow)
@@ -544,7 +544,7 @@ _base_basectl_completion() {
                     _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
-                        '--format[Output format]:format:(text json)' \
+                        '--format[Output format]:format:(text csv tsv yaml json)' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 clone)
@@ -659,7 +659,7 @@ _base_basectl_completion() {
                 '--project[Select a project explicitly]:Base project:->projects' \
                 '--dry-run[Print resolved build commands without running them]' \
                 '--list[List build targets]' \
-                '--format[List output format]:format:(text json)' \
+                '--format[List output format]:format:(text csv tsv yaml json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '2:Project or build target:->build_values' '*:Build target:->build_values'
             if [[ "$state" == projects ]]; then
@@ -683,7 +683,7 @@ _base_basectl_completion() {
                 '--project[Select a project explicitly]:Base project:->projects' \
                 '--dry-run[Print the resolved command without running it]' \
                 '--list[List runnable project commands]' \
-                '--format[List output format]:format:(text json)' \
+                '--format[List output format]:format:(text csv tsv yaml json)' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '2:Project or command:->run_values' '3:Project command:->run_values'
             if [[ "$state" == projects ]]; then
@@ -862,7 +862,7 @@ _base_basectl_completion() {
                     _arguments '2:release command:(check plan notes publish)' \
                         '--version[Release version]:version:' \
                         '--manifest[Use a specific manifest]:path:_files' \
-                        '--format[Output format]:format:(text json)' \
+                        '--format[Output format]:format:(text csv tsv yaml json)' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 plan|notes)
@@ -895,7 +895,7 @@ _base_basectl_completion() {
                 _arguments '2:logs command:(last)' \
                     '--command[Filter by command]:command:' \
                     '--lines[Maximum log-tail lines]:count:' \
-                    '--format[Output format]:format:(text json)' \
+                    '--format[Output format]:format:(text csv tsv yaml json)' \
                     '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             else
                 _arguments '2:logs command:(last)' \
@@ -909,18 +909,33 @@ _base_basectl_completion() {
             fi
             ;;
         history)
-            _arguments '--project[Filter by Base project]:project:' \
-                '--command[Filter by command]:command:' \
-                '--status[Filter by status]:status:(ok warn error)' \
-                '--limit[Number of records]:count:' \
-                '--format[Output format]:format:(text json)' \
-                '--report[Print a privacy-conscious Markdown or JSON activity report]' \
-                '--oldest-first[Show the selected history window from oldest to newest]' \
-                '--last[Show records from the most recent duration]:duration:' \
-                '--since[Include records at or after a timestamp]:time:' \
-                '--until[Exclude records at or after a timestamp]:time:' \
-                '--local-time[Render text and Markdown timestamps in local time; defaults to UTC]' \
-                '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            if (( ${words[(I)--report]} )); then
+                _arguments '--project[Filter by Base project]:project:' \
+                    '--command[Filter by command]:command:' \
+                    '--status[Filter by status]:status:(ok warn error)' \
+                    '--limit[Number of records]:count:' \
+                    '--format[Output format]:format:(markdown json)' \
+                    '--report[Print a privacy-conscious Markdown or JSON activity report]' \
+                    '--oldest-first[Show the selected history window from oldest to newest]' \
+                    '--last[Show records from the most recent duration]:duration:' \
+                    '--since[Include records at or after a timestamp]:time:' \
+                    '--until[Exclude records at or after a timestamp]:time:' \
+                    '--local-time[Render text and Markdown timestamps in local time; defaults to UTC]' \
+                    '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            else
+                _arguments '--project[Filter by Base project]:project:' \
+                    '--command[Filter by command]:command:' \
+                    '--status[Filter by status]:status:(ok warn error)' \
+                    '--limit[Number of records]:count:' \
+                    '--format[Output format]:format:(text csv tsv yaml json)' \
+                    '--report[Print a privacy-conscious Markdown or JSON activity report]' \
+                    '--oldest-first[Show the selected history window from oldest to newest]' \
+                    '--last[Show records from the most recent duration]:duration:' \
+                    '--since[Include records at or after a timestamp]:time:' \
+                    '--until[Exclude records at or after a timestamp]:time:' \
+                    '--local-time[Render text and Markdown timestamps in local time; defaults to UTC]' \
+                    '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+            fi
             ;;
         config)
             _arguments '2:config command:(path show doctor)' \

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -387,6 +387,40 @@ run_zsh_positional_completion() {
     assert_zsh_completion_options_match_help gh-project-configure gh project configure
 }
 
+@test "format completions expose public values and preserve exceptions" {
+    local public_values=$'text\ncsv\ntsv\nyaml\njson'
+    local legacy_values=$'text\njson'
+    local report_values=$'markdown\njson'
+    local artifact_values=$'markdown\nzip'
+    local specs
+
+    run bash_completion_candidates basectl projects list --format ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "$public_values" ]
+
+    run bash_completion_candidates basectl history --report --format ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "$report_values" ]
+
+    run bash_completion_candidates basectl setup --format ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "$legacy_values" ]
+
+    run bash_completion_candidates basectl export-context --format ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "$artifact_values" ]
+
+    command -v zsh >/dev/null 2>&1 || return 0
+    specs="$(zsh_completion_specs basectl projects list --format "")"
+    [[ "$specs" == *"format:(text csv tsv yaml json)"* ]]
+    specs="$(zsh_completion_specs basectl setup --format "")"
+    [[ "$specs" == *"format:(text json)"* ]]
+    specs="$(zsh_completion_specs basectl export-context --format "")"
+    [[ "$specs" == *"format:(markdown zip)"* ]]
+    specs="$(zsh_completion_specs basectl history --report --format "")"
+    [[ "$specs" == *"format:(markdown json)"* ]]
+}
+
 @test "Bash help completion mirrors command and nested leaf candidates" {
     local direct nested
 


### PR DESCRIPTION
## Summary
- document the TTY-aware text default, stable row ordering, structured-output guarantees, and format exceptions
- complete Bash and Zsh `--format` value completion for migrated reports
- add completion regression coverage for public and command-specific formats

Closes #1695

Depends on #1692, #1693, and #1694.

## Validation
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/help.bats cli/bash/commands/basectl/tests/projects.bats cli/bash/commands/basectl/tests/run.bats cli/bash/commands/basectl/tests/build.bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/history.bats cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/trust.bats cli/bash/commands/basectl/tests/release.bats`
- `git diff --check`
