### PR TITLE
Report prune verification failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Reported GitHub merge-verification failures separately from unmerged branches
+  during branch and worktree pruning, while retaining every unverified cleanup
+  candidate and returning a nonzero status for incomplete prune scans.
 - Consolidated each public invocation into one run ID, one `run.json`, and one
   `logs/primary.log`; delegated Bash/Python phases now share the DEBUG-level
   diagnostic stream and produce one history row. Legacy internal logs and

--- a/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
@@ -173,9 +173,15 @@ base_gh_branch_github_merged() {
     local branch="$1"
     local count
 
-    base_gh_prune_github_ready || return 2
-    count="$(gh pr list --head "$branch" --state merged --json number --jq 'length' 2>/dev/null)" || return 2
-    [[ "$count" =~ ^[0-9]+$ ]] || return 2
+    if ! base_gh_prune_github_ready; then
+        base_gh_error "GitHub merge verification requires the GitHub CLI 'gh' on PATH."
+        return 2
+    fi
+    count="$(base_gh_run pr list --head "$branch" --state merged --json number --jq 'length')" || return 2
+    if [[ ! "$count" =~ ^[0-9]+$ ]]; then
+        base_gh_error "GitHub merge verification returned an invalid result for branch '$branch'."
+        return 2
+    fi
     ((count > 0))
 }
 
@@ -198,6 +204,7 @@ base_gh_branch_cleanup_merged() {
     fi
     if ((rc == 2)); then
         [[ -z "$merge_source_var" ]] || printf -v "$merge_source_var" '%s' unknown
+        return 2
     fi
     return 1
 }
@@ -226,7 +233,7 @@ base_gh_branch_delete_remote() {
 base_gh_branch_prune_local() {
     local dry_run="$1"
     local default_branch="$2"
-    local branch current_branch merge_source worktree_path upstream
+    local branch current_branch merge_source merge_status worktree_path upstream
     local deleted=0 skipped_worktree=0 skipped_upstream=0 failed=0 candidates=0
 
     current_branch="$(git branch --show-current)"
@@ -237,7 +244,17 @@ base_gh_branch_prune_local() {
         [[ -z "$branch" || "$branch" == "$default_branch" || "$branch" == "$current_branch" ]] && continue
 
         merge_source=""
-        if ! base_gh_branch_cleanup_merged "$branch" "$default_branch" merge_source; then
+        if base_gh_branch_cleanup_merged "$branch" "$default_branch" merge_source; then
+            merge_status=0
+        else
+            merge_status=$?
+        fi
+        if ((merge_status == 1)); then
+            continue
+        fi
+        if ((merge_status != 0)); then
+            printf 'SKIP   %s  GitHub merge verification unavailable; local branch retained\n' "$branch"
+            failed=$((failed + 1))
             continue
         fi
         candidates=$((candidates + 1))
@@ -272,7 +289,7 @@ base_gh_branch_prune_local() {
         fi
     done < <(git branch --format='%(refname:short)')
 
-    if ((candidates == 0)); then
+    if ((candidates == 0 && failed == 0)); then
         printf 'No merged local branches found.\n'
     fi
     if ((skipped_worktree > 0)); then
@@ -281,21 +298,25 @@ base_gh_branch_prune_local() {
     printf 'Summary: %s %s, %s skipped worktree, %s skipped upstream, %s failed.\n' \
         "$deleted" "$([[ "$dry_run" -eq 1 ]] && printf 'would delete' || printf 'deleted')" \
         "$skipped_worktree" "$skipped_upstream" "$failed"
-    return "$failed"
+    if ((failed > 0)); then
+        return 1
+    fi
+    return 0
 }
 
 base_gh_branch_prune_github_branches() {
     local dry_run="$1"
     local default_branch="$2"
-    local branch current_branch worktree_path remote_branches
+    local branch current_branch merge_status worktree_path remote_branches
     local deleted=0 skipped_worktree=0 skipped_unmerged=0 failed=0 candidates=0 found=0
 
     printf 'GitHub branches\n'
     if ! base_gh_prune_github_ready; then
-        printf 'SKIP   GitHub branch cleanup requires the GitHub CLI `gh` on PATH.\n'
-        printf 'Summary: 0 %s, 0 skipped worktree, 0 skipped unmerged, 0 failed.\n' \
+        base_gh_error "GitHub merge verification requires the GitHub CLI 'gh' on PATH."
+        printf 'SKIP   GitHub merge verification unavailable; remote branches retained\n'
+        printf 'Summary: 0 %s, 0 skipped worktree, 0 skipped unmerged, 1 failed.\n' \
             "$([[ "$dry_run" -eq 1 ]] && printf 'would delete remotely' || printf 'deleted remotely')"
-        return 0
+        return 1
     fi
 
     current_branch="$(git branch --show-current)"
@@ -308,8 +329,18 @@ base_gh_branch_prune_github_branches() {
         found=1
         [[ "$branch" == "$default_branch" || "$branch" == "$current_branch" ]] && continue
 
-        if ! base_gh_branch_github_merged "$branch"; then
+        if base_gh_branch_github_merged "$branch"; then
+            merge_status=0
+        else
+            merge_status=$?
+        fi
+        if ((merge_status == 1)); then
             skipped_unmerged=$((skipped_unmerged + 1))
+            continue
+        fi
+        if ((merge_status != 0)); then
+            printf 'SKIP   origin/%s  GitHub merge verification unavailable; remote branch retained\n' "$branch"
+            failed=$((failed + 1))
             continue
         fi
         candidates=$((candidates + 1))
@@ -335,13 +366,16 @@ base_gh_branch_prune_github_branches() {
 
     if ((found == 0)); then
         printf 'No GitHub remote branches found.\n'
-    elif ((candidates == 0)); then
+    elif ((candidates == 0 && failed == 0)); then
         printf 'No merged GitHub remote branches found.\n'
     fi
     printf 'Summary: %s %s, %s skipped worktree, %s skipped unmerged, %s failed.\n' \
         "$deleted" "$([[ "$dry_run" -eq 1 ]] && printf 'would delete remotely' || printf 'deleted remotely')" \
         "$skipped_worktree" "$skipped_unmerged" "$failed"
-    return "$failed"
+    if ((failed > 0)); then
+        return 1
+    fi
+    return 0
 }
 
 base_gh_branch_prune_remote_tracking_refs() {
@@ -422,7 +456,11 @@ base_gh_branch_prune() {
         base_gh_branch_prune_remote_tracking_refs "$dry_run" || status=$?
     fi
     if ((dry_run)); then
-        printf 'Run with --yes to apply these changes.\n'
+        if ((status == 0)); then
+            printf 'Run with --yes to apply these changes.\n'
+        else
+            printf 'Resolve the reported failures and rerun before using --yes.\n'
+        fi
     fi
     return "$status"
 }
@@ -461,7 +499,7 @@ base_gh_worktree_prune_delete_branch() {
 
 base_gh_worktree_prune() {
     local dry_run=1 default_branch current_worktree
-    local path branch merge_source physical_path
+    local path branch merge_source merge_status physical_path
     local removed=0 skipped_current=0 skipped_dirty=0 skipped_unmerged=0 failed=0 candidates=0
 
     while (($#)); do
@@ -518,13 +556,19 @@ base_gh_worktree_prune() {
             continue
         fi
         merge_source=""
-        if ! base_gh_branch_cleanup_merged "$branch" "$default_branch" merge_source; then
-            if [[ "$merge_source" == unknown ]]; then
-                printf 'SKIP   %s (%s)  branch is not confirmed merged into %s or a merged GitHub PR\n' "$path" "$branch" "$default_branch"
-            else
-                printf 'SKIP   %s (%s)  branch is not merged into %s or a merged GitHub PR\n' "$path" "$branch" "$default_branch"
-            fi
+        if base_gh_branch_cleanup_merged "$branch" "$default_branch" merge_source; then
+            merge_status=0
+        else
+            merge_status=$?
+        fi
+        if ((merge_status == 1)); then
+            printf 'SKIP   %s (%s)  branch is not merged into %s or a merged GitHub PR\n' "$path" "$branch" "$default_branch"
             skipped_unmerged=$((skipped_unmerged + 1))
+            continue
+        fi
+        if ((merge_status != 0)); then
+            printf 'SKIP   %s (%s)  GitHub merge verification unavailable; worktree retained\n' "$path" "$branch"
+            failed=$((failed + 1))
             continue
         fi
 
@@ -552,9 +596,16 @@ base_gh_worktree_prune() {
         "$removed" "$([[ "$dry_run" -eq 1 ]] && printf 'would remove' || printf 'removed')" \
         "$skipped_current" "$skipped_dirty" "$skipped_unmerged" "$failed"
     if ((dry_run)); then
-        printf 'Run with --yes to apply these changes.\n'
+        if ((failed == 0)); then
+            printf 'Run with --yes to apply these changes.\n'
+        else
+            printf 'Resolve the reported failures and rerun before using --yes.\n'
+        fi
     fi
-    return "$failed"
+    if ((failed > 0)); then
+        return 1
+    fi
+    return 0
 }
 
 base_gh_do_branch() {

--- a/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
+++ b/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
@@ -93,6 +93,36 @@ load ./basectl_helpers.bash
     [[ "$output" == *"global=preexisting"* ]]
 }
 
+@test "basectl gh branch prune keeps failure status when 256 verifications fail" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            git() {
+                local index
+                case "$1 $2" in
+                    "branch --show-current")
+                        printf "master\n"
+                        ;;
+                    "branch --format=%(refname:short)")
+                        for ((index = 1; index <= 256; index++)); do
+                            printf "unverified-%s\n" "$index"
+                        done
+                        ;;
+                    *)
+                        return 99
+                        ;;
+                esac
+            }
+            base_gh_branch_cleanup_merged() { return 2; }
+            base_gh_branch_prune_local 1 master >/dev/null
+        '
+
+    [ "$status" -eq 1 ]
+}
+
 @test "basectl gh branch prune falls back to main when default branch is unknown" {
     local repo
 
@@ -412,6 +442,85 @@ EOF
     ! git -C "$repo" ls-remote --exit-code --heads origin squash-remote >/dev/null
 }
 
+@test "basectl gh branch prune --remote reports GitHub merge verification failures" {
+    local repo remote
+
+    repo="$TEST_TMPDIR/repo"
+    remote="$TEST_TMPDIR/remote.git"
+    create_tracked_repo_with_upstream "$repo" "$remote" "README.md" "hello"
+    git -C "$repo" switch -c lookup-failure >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Topic commit"
+    git -C "$repo" push -u origin lookup-failure >/dev/null 2>&1
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" branch -D lookup-failure >/dev/null 2>&1
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$*" == "pr list --head lookup-failure --state merged --json number --jq length" ]]; then
+    printf 'failed to connect to api.github.com\n' >&2
+    exit 1
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -e -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune --remote
+        ' bash "$repo"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed to connect to api.github.com"* ]]
+    [[ "$output" == *"SKIP   origin/lookup-failure  GitHub merge verification unavailable; remote branch retained"* ]]
+    [[ "$output" == *"Summary: 0 would delete remotely, 0 skipped worktree, 0 skipped unmerged, 1 failed."* ]]
+    [[ "$output" == *"Resolve the reported failures and rerun before using --yes."* ]]
+    git -C "$repo" ls-remote --exit-code --heads origin lookup-failure >/dev/null
+}
+
+@test "basectl gh branch prune --remote fails closed when gh is unavailable" {
+    local repo remote
+
+    repo="$TEST_TMPDIR/repo"
+    remote="$TEST_TMPDIR/remote.git"
+    create_tracked_repo_with_upstream "$repo" "$remote" "README.md" "hello"
+    git -C "$repo" switch -c unverified-remote >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Topic commit"
+    git -C "$repo" push -u origin unverified-remote >/dev/null 2>&1
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" branch -D unverified-remote >/dev/null 2>&1
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        "$BASH" -e -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_prune_github_ready() { return 1; }
+            base_gh_subcommand_main branch prune --remote
+        ' bash "$repo"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ERROR: GitHub merge verification requires the GitHub CLI 'gh' on PATH."* ]]
+    [[ "$output" == *"SKIP   GitHub merge verification unavailable; remote branches retained"* ]]
+    [[ "$output" == *"Summary: 0 would delete remotely, 0 skipped worktree, 0 skipped unmerged, 1 failed."* ]]
+    [[ "$output" == *"Resolve the reported failures and rerun before using --yes."* ]]
+    git -C "$repo" ls-remote --exit-code --heads origin unverified-remote >/dev/null
+}
+
 @test "basectl gh branch prune --remote skips branches attached to worktrees" {
     local repo remote worktree
 
@@ -499,6 +608,51 @@ EOF
     [[ "$output" == *"DELETE squash-work"* ]]
     [[ "$output" == *"Summary: 1 deleted, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
     ! git -C "$repo" show-ref --verify --quiet refs/heads/squash-work
+}
+
+@test "basectl gh branch prune reports GitHub merge verification failures" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c lookup-failure >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Topic commit"
+    git -C "$repo" switch master >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$*" == "pr list --head lookup-failure --state merged --json number --jq length" ]]; then
+    printf 'failed to connect to api.github.com\n' >&2
+    exit 1
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -e -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune
+        ' bash "$repo"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed to connect to api.github.com"* ]]
+    [[ "$output" == *"SKIP   lookup-failure  GitHub merge verification unavailable; local branch retained"* ]]
+    [[ "$output" == *"Summary: 0 would delete, 0 skipped worktree, 0 skipped upstream, 1 failed."* ]]
+    [[ "$output" == *"Resolve the reported failures and rerun before using --yes."* ]]
+    git -C "$repo" show-ref --verify --quiet refs/heads/lookup-failure
 }
 
 @test "basectl gh worktree prune defaults to dry-run" {
@@ -604,9 +758,21 @@ EOF
     git -C "$repo" switch master >/dev/null
     git -C "$repo" worktree add "$worktree" unmerged-work >/dev/null 2>&1
 
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "pr list --head unmerged-work --state merged --json number --jq length" ]]; then
+    printf '0\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
         bash -c '
             cd "$1"
             source "$BASE_HOME/base_init.sh"
@@ -615,10 +781,57 @@ EOF
         ' bash "$repo"
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"SKIP   "*"/unmerged-worktree (unmerged-work)  branch is not confirmed merged into master or a merged GitHub PR"* ]]
+    [[ "$output" == *"SKIP   "*"/unmerged-worktree (unmerged-work)  branch is not merged into master or a merged GitHub PR"* ]]
     [[ "$output" == *"Summary: 0 removed, 1 skipped current/default, 0 skipped dirty, 1 skipped unmerged, 0 failed."* ]]
     [ -d "$worktree" ]
     git -C "$repo" show-ref --verify --quiet refs/heads/unmerged-work
+}
+
+@test "basectl gh worktree prune reports GitHub merge verification failures" {
+    local repo worktree
+
+    repo="$TEST_TMPDIR/repo"
+    worktree="$TEST_TMPDIR/lookup-failure-worktree"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c lookup-failure >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Topic commit"
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" worktree add "$worktree" lookup-failure >/dev/null 2>&1
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$*" == "pr list --head lookup-failure --state merged --json number --jq length" ]]; then
+    printf 'failed to connect to api.github.com\n' >&2
+    exit 1
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -e -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main worktree prune --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed to connect to api.github.com"* ]]
+    [[ "$output" == *"SKIP   "*"/lookup-failure-worktree (lookup-failure)  GitHub merge verification unavailable; worktree retained"* ]]
+    [[ "$output" == *"Summary: 0 removed, 1 skipped current/default, 0 skipped dirty, 0 skipped unmerged, 1 failed."* ]]
+    [ -d "$worktree" ]
+    git -C "$repo" show-ref --verify --quiet refs/heads/lookup-failure
 }
 
 @test "basectl gh worktree prune removes squash-merged worktrees confirmed by GitHub" {

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -420,7 +420,11 @@ The command is dry-run by default. It reports merged local branches as delete
 candidates, reports branches attached to worktrees as skipped, and treats
 `--remote` as GitHub remote branch cleanup plus stale `origin/*` tracking-ref
 cleanup. Because Base usually uses squash merges, pruning checks GitHub PR state
-when available and falls back to Git ancestry when offline.
+when Git ancestry does not prove the merge. A successful GitHub query with no
+merged PR keeps the branch as an ordinary unmerged skip. If the GitHub query
+cannot complete, pruning retains the branch or worktree, reports the underlying
+verification error, counts the incomplete check as a failure, and exits nonzero
+instead of classifying it as unmerged.
 
 Remote branch pruning is deliberately conservative. Base deletes a GitHub branch
 only when GitHub confirms a merged pull request for that exact branch name. It
@@ -430,7 +434,9 @@ local worktree. After safe GitHub branches are deleted, Base prunes stale local
 
 Worktree pruning is also dry-run by default. It removes only clean, non-current
 worktrees whose branches are confirmed merged into the default branch or through
-a merged GitHub PR, then deletes the now-free local branch when safe.
+a merged GitHub PR, then deletes the now-free local branch when safe. Resolve any
+reported GitHub verification failures and rerun the preview before applying it
+with `--yes`.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

- preserve the merged-PR lookup's three states so a successful zero result remains distinct from an unavailable or failed GitHub query
- route failed lookups through the shared GitHub wrapper, retain every unverified branch or worktree, count the incomplete scan as failed, and return a nonzero status
- apply the same behavior to local branches, remote branches, and worktrees; replace the apply hint with retry guidance after an incomplete dry run
- add deterministic BATS coverage for command failures, missing `gh`, `set -e`, successful zero-result queries, and failure-count exit wrapping; update workflow docs and the changelog

## Issue

Fixes #1698

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh-branch-worktree.bats` — 27 passed after rebasing onto current `origin/main`
- `shellcheck --severity=warning cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh`
- `bash -n cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh`
- `git diff --check origin/main...HEAD`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1698-cache-final ./bin/base-test` — 1,028 passed, 1 skipped in Python; 816 BATS tests passed
- after two non-overlapping commits landed on `main`, rebased cleanly and reran the 27 focused BATS tests plus ShellCheck, Bash syntax, and diff checks

## Demo Impact

None.

## Notes

The cleanup decision remains fail-closed: verification failures never make deletion more aggressive. This changes diagnostics and exit truthfulness only.

No `.ai-context/` update is needed because the product boundary and command surface are unchanged; the user-facing workflow contract is documented in `docs/github-workflow.md`.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
