### PR TITLE
Show branch names when prune skips unmerged refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Show the names and retention reasons for ordinary unmerged branches during
+  local and GitHub remote branch pruning.
 - Reported GitHub merge-verification failures separately from unmerged branches
   during branch and worktree pruning, while retaining every unverified cleanup
   candidate and returning a nonzero status for incomplete prune scans.

--- a/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
@@ -250,6 +250,8 @@ base_gh_branch_prune_local() {
             merge_status=$?
         fi
         if ((merge_status == 1)); then
+            printf 'SKIP   %s  not confirmed merged into %s or through a merged GitHub PR; local branch retained\n' \
+                "$branch" "$default_branch"
             continue
         fi
         if ((merge_status != 0)); then
@@ -335,6 +337,8 @@ base_gh_branch_prune_github_branches() {
             merge_status=$?
         fi
         if ((merge_status == 1)); then
+            printf 'SKIP   origin/%s  no merged GitHub PR found for this branch; remote branch retained\n' \
+                "$branch"
             skipped_unmerged=$((skipped_unmerged + 1))
             continue
         fi

--- a/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
+++ b/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
@@ -253,6 +253,51 @@ load ./basectl_helpers.bash
     git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
 }
 
+@test "basectl gh branch prune reports ordinary unmerged local branches" {
+    local repo remote
+
+    repo="$TEST_TMPDIR/repo"
+    remote="$TEST_TMPDIR/remote.git"
+    create_tracked_repo_with_upstream "$repo" "$remote" "README.md" "hello"
+    git -C "$repo" switch -c unmerged-work >/dev/null
+    printf 'topic change\n' >> "$repo/README.md"
+    commit_all "$repo" "Topic change"
+    git -C "$repo" push -u origin unmerged-work >/dev/null 2>&1
+    git -C "$repo" switch master >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$*" == "pr list --head unmerged-work --state merged --json number --jq length" ]]; then
+    printf '0\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune --remote --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP   unmerged-work  not confirmed merged into master or through a merged GitHub PR; local branch retained"* ]]
+    [[ "$output" == *"SKIP   origin/unmerged-work  no merged GitHub PR found for this branch; remote branch retained"* ]]
+    [[ "$output" == *"Summary: 0 deleted remotely, 0 skipped worktree, 1 skipped unmerged, 0 failed."* ]]
+    git -C "$repo" show-ref --verify --quiet refs/heads/unmerged-work
+    git -C "$repo" ls-remote --exit-code --heads origin unmerged-work >/dev/null
+}
+
 @test "basectl gh branch prune --remote prints remote tracking refs separately" {
     local repo remote
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -421,10 +421,10 @@ candidates, reports branches attached to worktrees as skipped, and treats
 `--remote` as GitHub remote branch cleanup plus stale `origin/*` tracking-ref
 cleanup. Because Base usually uses squash merges, pruning checks GitHub PR state
 when Git ancestry does not prove the merge. A successful GitHub query with no
-merged PR keeps the branch as an ordinary unmerged skip. If the GitHub query
-cannot complete, pruning retains the branch or worktree, reports the underlying
-verification error, counts the incomplete check as a failure, and exits nonzero
-instead of classifying it as unmerged.
+merged PR keeps the branch as an ordinary unmerged skip and prints the retained
+branch name. If the GitHub query cannot complete, pruning retains the branch or
+worktree, reports the underlying verification error, counts the incomplete check
+as a failure, and exits nonzero instead of classifying it as unmerged.
 
 Remote branch pruning is deliberately conservative. Base deletes a GitHub branch
 only when GitHub confirms a merged pull request for that exact branch name. It


### PR DESCRIPTION
## Summary

- print each ordinary unmerged local branch with the reason it was retained
- print each ordinary unmerged GitHub branch with its exact branch name and retention reason
- preserve the existing summary counters and fail-closed distinction between an unmerged result and a GitHub verification failure
- add focused BATS coverage, update the GitHub workflow documentation, and record the UX improvement in the changelog

## Why

The previous output exposed only `skipped unmerged` counts for remote branches and omitted ordinary unmerged local branches entirely. That made similarly named local and remote refs difficult to distinguish during cleanup.

## Issue

Fixes #1703

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh-branch-worktree.bats` — 28 passed
- `shellcheck --severity=warning cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh`
- `bash -n cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh`
- `git diff --check`
- Python phase of `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1703-cache ./bin/base-test` — 1,028 passed, 1 skipped
- The complete repo-wide BATS matrix is delegated to required PR CI; the local run was stopped after 65 green tests because of the suite's interactive runtime.

## Demo Impact

None.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Relevant focused BATS and Python tests pass.
- [x] Documentation is updated when user-facing behavior changes.
- [x] Bug/UX behavior has regression coverage.
- [x] AI context does not need updating because the command boundary is unchanged.
- [x] PR includes `Fixes #1703`.
- [x] `Demo Impact` is explicitly `None.`
