### PR TITLE
Document superseded PR cleanup for AI workflows

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -131,6 +131,13 @@ should include:
 The issue owns milestone and Project tracking. PRs should inherit relevant
 labels but should not be added as duplicate Project items by default.
 
+When a PR is closed because another PR supersedes it, the agent owns the full
+close-and-cleanup operation: verify the replacement, link it in the closing
+comment, delete the remote head branch, remove agent-created local branches and
+worktrees, and verify cleanup. Preserve user-owned or dirty worktrees unless
+the user explicitly approves removal, and do not hand failed cleanup back as a
+user task.
+
 ## Validation
 
 Prefer the narrowest check that proves the change, then broaden when shared

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,9 @@ For implementation work, use Base's issue-backed workflow:
   architecture, command surface, manifest model, release status, or durable
   workflow guidance.
 
+For a pull request superseded by another pull request, follow the
+superseded-PR close-and-cleanup rule in `AGENTS.md` before ending the session.
+
 Follow `CONTRIBUTING.md` for contribution flow and `STANDARDS.md` for coding
 standards. Prefer existing Base helpers, structured parsers, and local command
 patterns over new one-off conventions.

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -52,6 +52,7 @@ jobs:
           grep -q '^## Add or change artifact setup$' skills.md
           grep -q '^## Change shell startup behavior$' skills.md
           grep -q '^## Release or Homebrew-facing changes$' skills.md
+          grep -q '^## Close a superseded pull request$' skills.md
 
   create:
     name: Create skills.md PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,21 @@ Before modifying files in this repository, classify the request.
 - After merge, sync `main`, remove the worktree, and delete local and remote
   branches.
 
+### Superseded Pull Request Closure
+
+- If a pull request is closed because another pull request supersedes it,
+  closure and cleanup are one operation. Do not leave the head branch as a
+  user follow-up.
+- Verify that the replacement pull request contains the work, add a closing
+  comment linking it, close the superseded pull request, delete its remote head
+  branch, remove agent-created local branches and worktrees, and verify that
+  the branch and worktree are gone.
+- Do not delete a user-owned or dirty worktree without explicit approval. If a
+  cleanup step fails, keep ownership of the blocker and report it as unfinished
+  work rather than handing the cleanup back to the user.
+- Ordinary closed pull requests are not automatically branch-cleanup
+  candidates; use this flow only when supersession has been established.
+
 See `docs/github-workflow.md` for the full policy, including PR body sections,
 milestones, GitHub Projects, and cleanup rules.
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -438,6 +438,55 @@ a merged GitHub PR, then deletes the now-free local branch when safe. Resolve an
 reported GitHub verification failures and rerun the preview before applying it
 with `--yes`.
 
+## Superseded Pull Requests
+
+A pull request closed because another pull request supersedes it has a
+different lifecycle from an ordinary abandoned or rejected pull request. The
+agent that makes the supersession decision owns the cleanup; it must not leave
+the branch as a follow-up task for the user.
+
+Before closing, verify that the replacement pull request carries the work and
+record the relationship in the closing comment, for example:
+
+```text
+Superseded by #1700. The implementation and follow-up fixes landed there.
+```
+
+For an open pull request, the GitHub CLI can perform the close and remote head
+branch deletion together:
+
+```bash
+gh pr close <number> \
+  --comment "Superseded by #<replacement>. The implementation landed there." \
+  --delete-branch
+```
+
+`basectl gh` does not currently provide a dedicated PR-close wrapper, so raw
+`gh` is the supported fallback for this operation. If the pull request was
+already closed, delete its remote head ref only after the same replacement
+verification:
+
+```bash
+gh api --method DELETE \
+  repos/<owner>/<repo>/git/refs/heads/<head-branch>
+```
+
+Then remove the agent-created local branch and worktree when they are not
+current, user-owned, or dirty. Do not remove a user-owned or dirty worktree
+without explicit approval. Verify the result before ending the task:
+
+```bash
+git worktree list
+git branch --list <head-branch>
+git ls-remote --heads origin <head-branch>
+```
+
+All three checks should show that no agent-owned branch or worktree remains.
+If any cleanup step fails, report the exact blocker and continue to own the
+follow-up; do not present it as routine cleanup the user must perform. Ordinary
+closed pull requests are not candidates for this flow unless a replacement has
+been explicitly established.
+
 ## Pull Requests
 
 Base pull requests are issue-backed by default. The issue is the planning

--- a/skills.md
+++ b/skills.md
@@ -37,6 +37,24 @@ requests for Base.
 - See `docs/github-workflow.md` for the full policy, including milestones and
   GitHub Projects.
 
+## Close a superseded pull request
+
+Use this workflow when a pull request will not merge because another pull
+request carries its implementation. Treat the close decision and branch
+cleanup as one operation for every AI tool and human contributor:
+
+- verify that the replacement pull request contains the superseded work;
+- add a closing comment linking the replacement pull request;
+- close the superseded pull request and delete its remote head branch;
+- remove agent-created local branches and worktrees, then verify cleanup;
+- preserve user-owned or dirty worktrees unless the user explicitly approves
+  their removal; and
+- keep ownership of any failed cleanup instead of making it a user follow-up.
+
+Do not apply this cleanup to an ordinary closed pull request without an
+established replacement. See `docs/github-workflow.md` for the detailed close,
+delete, and verification procedure.
+
 ## Debug and verify Base behavior
 
 Use this workflow when investigating failed Base commands, broken setup/check/

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -69,6 +69,34 @@ def test_active_project_guidance_uses_repo_named_project_language() -> None:
     assert "use that title only as the migration source" in issue_metadata_section
 
 
+def test_superseded_pr_cleanup_guidance_is_shared_across_ai_tools() -> None:
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    skills = (REPO_ROOT / "skills.md").read_text(encoding="utf-8")
+    workflow = GITHUB_WORKFLOW_DOC.read_text(encoding="utf-8")
+    ai_context = (REPO_ROOT / ".ai-context" / "WORKFLOWS.md").read_text(encoding="utf-8")
+    copilot = (REPO_ROOT / ".github" / "copilot-instructions.md").read_text(encoding="utf-8")
+
+    normalized = {
+        "agents": " ".join(agents.split()),
+        "skills": " ".join(skills.split()),
+        "workflow": " ".join(workflow.split()),
+        "ai_context": " ".join(ai_context.split()),
+    }
+    for text in normalized.values():
+        assert "replacement" in text
+        assert "cleanup" in text
+
+    assert "closing comment" in normalized["agents"]
+    assert "delete its remote head branch" in normalized["agents"]
+    assert "agent-created local branches and worktrees" in normalized["skills"]
+    assert "user-owned or dirty worktree" in normalized["workflow"]
+    assert "cleanup step fails" in normalized["workflow"]
+    assert "gh pr close <number>" in normalized["workflow"]
+    assert "gh api --method DELETE" in normalized["workflow"]
+
+    assert "superseded-PR close-and-cleanup rule in `AGENTS.md`" in copilot
+
+
 def test_contract_registry_maps_initial_review_contracts_to_enforcement() -> None:
     text = CONTRACTS_DOC.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- make superseded-PR close/cleanup an explicit tool-independent rule for agents and contributors
- align AGENTS.md, skills.md, AI context, Copilot guidance, and detailed GitHub workflow docs
- add contract and workflow validation for required safety and cleanup language

Closes #1704

## Validation
- /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_contract_hardening.py tests/test_github_workflows.py tests/test_bootstrap_docs.py -q
- git diff --check