### PR TITLE
Align history and logs terminal tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Kept `basectl history` and `basectl logs` terminal tables aligned when command,
+  project, or run-ID values exceed their compact minimum widths.
 - Render blocking `basectl check` findings, remediation lines, and failure
   summaries as `ERROR` in text output while preserving `WARN` for non-blocking
   findings.

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -350,16 +350,13 @@ def filter_history(records: list[HistoryRecord], options: HistoryOptions) -> lis
 
 def print_history_table(records: list[HistoryRecord], *, local_time: bool = False) -> None:
     time_label = "TIME (LOCAL)" if local_time else "TIME (UTC)"
-    print(f"{time_label:<19}  {'COMMAND':<12}  {'PROJECT':<12}  {'STATUS':<6}  {'EXIT':<4}  LOG")
-    for record in records:
-        print(
-            f"{display_time(record, local_time=local_time):<19}  "
-            f"{record.command:<12}  "
-            f"{display_project(record):<12}  "
-            f"{record.status:<6}  "
-            f"{display_exit_code(record):<4}  "
-            f"{display_log_path(record)}"
-        )
+    columns = ((time_label, "time"), *history_output_columns()[1:])
+    base_cli.render_records(
+        history_output_records(records, local_time=local_time),
+        requested_format="text",
+        columns=columns,
+        minimum_widths=(19, 12, 12, 6, 4),
+    )
 
 
 def history_output_columns() -> tuple[tuple[str, str], ...]:

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -119,6 +119,40 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertIn("error", stdout)
         self.assertIn("missing", stdout)
 
+    def test_text_table_expands_columns_for_long_command_and_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(
+                cache_root,
+                history_record(
+                    "long",
+                    "export-context",
+                    project="base-bash-libs",
+                    ended_at="2026-06-10T10:16:00Z",
+                    log_path="~/logs/long.log",
+                ),
+            )
+            write_history_line(
+                cache_root,
+                history_record(
+                    "short",
+                    "check",
+                    ended_at="2026-06-10T10:15:00Z",
+                    log_path="~/logs/short.log",
+                ),
+            )
+
+            status, stdout, stderr = invoke([], cache_root)
+
+        self.assertEqual((status, stderr), (0, ""))
+        lines = stdout.splitlines()
+        log_column = lines[0].index("LOG")
+        self.assertEqual(next(line for line in lines if "~/logs/long.log" in line).index("~/logs/long.log"), log_column)
+        self.assertEqual(
+            next(line for line in lines if "~/logs/short.log" in line).index("~/logs/short.log"),
+            log_column,
+        )
+
     def test_local_time_changes_text_label_but_json_remains_canonical(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -661,15 +661,19 @@ def normalize_command_filter(value: str) -> str:
 
 
 def print_log_table(entries: list[LogEntry]) -> None:
-    print(f"{'TIME':<19}  {'COMMAND':<12}  {'RUN ID':<24}  {'STATUS':<6}  PATH")
-    for entry in entries:
-        print(
-            f"{entry.timestamp:%Y-%m-%d %H:%M:%S}  "
-            f"{entry.command:<12}  "
-            f"{entry.run_id:<24}  "
-            f"{entry.status:<6}  "
-            f"{compact_path(entry.path)}"
-        )
+    columns = (
+        ("TIME", "time"),
+        ("COMMAND", "command"),
+        ("RUN ID", "run_id"),
+        ("STATUS", "status"),
+        ("PATH", "path"),
+    )
+    base_cli.render_records(
+        log_output_records(entries),
+        requested_format="text",
+        columns=columns,
+        minimum_widths=(19, 12, 24, 6),
+    )
 
 
 def log_output_columns() -> tuple[tuple[str, str], ...]:

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -280,6 +280,36 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertIn("clean", stdout)
         self.assertIn("20260601T010000_aaaaaaaa", stdout)
 
+    def test_table_expands_columns_for_long_command_and_run_id(self) -> None:
+        stdout = TerminalStringIO()
+        entries = [
+            engine.LogEntry(
+                command="export-context",
+                raw_command="base_export_context",
+                run_id="20260718T192921_abcdefghijkl",
+                path=Path("/tmp/short.log"),
+                timestamp=engine.datetime(2026, 7, 18, 19, 29, 21, tzinfo=engine.timezone.utc),
+                status="ok",
+            ),
+            engine.LogEntry(
+                command="check",
+                raw_command="base_setup",
+                run_id="20260718T192922_a",
+                path=Path("/tmp/longer.log"),
+                timestamp=engine.datetime(2026, 7, 18, 19, 29, 22, tzinfo=engine.timezone.utc),
+                status="error",
+            ),
+        ]
+
+        with redirect_stdout(stdout):
+            engine.print_log_table(entries)
+
+        lines = stdout.getvalue().splitlines()
+        path_column = lines[0].index("PATH")
+        self.assertEqual(lines[1].index(engine.compact_path(entries[0].path)), path_column)
+        self.assertEqual(lines[2].index(engine.compact_path(entries[1].path)), path_column)
+        self.assertIn("TIME", lines[0])
+
     def test_path_prints_most_recent_matching_log(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -42,6 +42,14 @@ explanation, and broader future report generation.
 files, and prints a table with command, run id, status, and path. It also
 supports opening, tailing, or printing the newest matching log path.
 
+The human-readable `logs` and `history` tables share Base's output renderer.
+Columns retain compact minimum widths and expand to fit the selected values, so
+long commands, project names, and run IDs do not shift later cells away from
+their headers. Paths remain in the final, unpadded column. History uses
+`TIME (UTC)` by default and `TIME (LOCAL)` with `--local-time`; the log-list
+column remains labeled `TIME` because legacy entries can fall back to local
+file modification times.
+
 This is useful when the user already knows they need raw logs. It is less useful
 when they want to answer questions such as:
 

--- a/lib/python/base_cli/output.py
+++ b/lib/python/base_cli/output.py
@@ -54,6 +54,7 @@ def resolve_output_format(
     return normalized
 
 
+# pylint: disable=too-many-arguments
 def render_records(
     records: Iterable[Mapping[str, Any]],
     *,
@@ -61,13 +62,15 @@ def render_records(
     columns: Sequence[tuple[str, str]],
     stream: TextIO | None = None,
     footer: str | None = None,
+    minimum_widths: Sequence[int] | None = None,
 ) -> str:
     """Render records according to the shared public output contract.
 
     The returned string is also written to *stream* when supplied (or stdout
     when omitted).  JSON and YAML retain the mapping shape supplied by the
     caller; delimited formats use the explicit ``columns`` order and never
-    emit a header or footer.
+    emit a header or footer. ``minimum_widths`` applies only to terminal table
+    columns; values can still expand beyond those widths.
     """
 
     target = stream if stream is not None else sys.stdout
@@ -94,7 +97,7 @@ def render_records(
         target.write(yaml.safe_dump(record_list, sort_keys=False, allow_unicode=True))
         return resolved
 
-    _write_table(target, record_list, columns, footer)
+    _write_table(target, record_list, columns, footer, minimum_widths)
     return resolved
 
 
@@ -169,13 +172,21 @@ def _write_table(
     records: Sequence[Mapping[str, Any]],
     columns: Sequence[tuple[str, str]],
     footer: str | None,
+    minimum_widths: Sequence[int] | None,
 ) -> None:
+    selected_minimums = minimum_widths or ()
+    if len(selected_minimums) > len(columns):
+        raise ValueError("minimum_widths cannot contain more entries than columns")
+
     if not records:
         if footer:
             stream.write(f"{footer}\n")
         return
 
-    widths = [len(header) for header, _key in columns]
+    widths = [
+        max(len(header), selected_minimums[index] if index < len(selected_minimums) else 0)
+        for index, (header, _key) in enumerate(columns)
+    ]
     rows: list[list[str]] = []
     for record in records:
         row = [_cell_value(record.get(key)) for _header, key in columns]

--- a/lib/python/base_cli/tests/test_output.py
+++ b/lib/python/base_cli/tests/test_output.py
@@ -36,6 +36,54 @@ class OutputTest(unittest.TestCase):
             "PROJECT   PATH\nbase      /work/base\ndemo,one  /work/demo\tone\n\n2 projects.\n",
         )
 
+    def test_terminal_table_honors_minimum_widths(self) -> None:
+        stream = _Stream(terminal=True)
+
+        render_records(
+            ({"name": "base", "path": "/work/base"},),
+            requested_format="text",
+            columns=COLUMNS,
+            stream=stream,
+            minimum_widths=(12,),
+        )
+
+        lines = stream.getvalue().splitlines()
+        path_column = lines[0].index("PATH")
+        self.assertEqual(path_column, 14)
+        self.assertEqual(lines[1].index("/work/base"), path_column)
+
+    def test_terminal_table_expands_beyond_minimum_widths(self) -> None:
+        stream = _Stream(terminal=True)
+
+        render_records(
+            (
+                {"name": "base", "path": "/work/base"},
+                {"name": "base-bash-libs", "path": "/work/base-bash-libs"},
+            ),
+            requested_format="text",
+            columns=COLUMNS,
+            stream=stream,
+            minimum_widths=(12,),
+        )
+
+        lines = stream.getvalue().splitlines()
+        path_column = lines[0].index("PATH")
+        self.assertEqual(path_column, len("base-bash-libs") + 2)
+        self.assertEqual(lines[1].index("/work/base"), path_column)
+        self.assertEqual(lines[2].index("/work/base-bash-libs"), path_column)
+
+    def test_terminal_table_rejects_excess_minimum_widths(self) -> None:
+        stream = _Stream(terminal=True)
+
+        with self.assertRaisesRegex(ValueError, "more entries than columns"):
+            render_records(
+                RECORDS,
+                requested_format="text",
+                columns=COLUMNS,
+                stream=stream,
+                minimum_widths=(1, 2, 3),
+            )
+
     def test_text_is_tsv_when_redirected(self) -> None:
         stream = _Stream(terminal=False)
 


### PR DESCRIPTION
## Summary

- add optional minimum column widths to the shared `base_cli.render_records` terminal renderer
- route history and logs terminal tables through that renderer while preserving existing columns, timestamp semantics, and machine formats
- add long-value alignment regressions and document the shared table behavior

## Root cause

History and logs still used command-local fixed-width loops after the shared output renderer became canonical. Commands, project names, or run IDs wider than the legacy minimums shifted the later `LOG` and `PATH` columns.

## User impact

Long values now expand their own columns without breaking the alignment of later columns. Redirected TSV and structured JSON/YAML/CSV output remain unchanged.

## Validation

- focused Python: 54 passed
- touched-file pylint: passed
- focused history/logs BATS: 12 passed
- full Python: 1034 passed, 1 skipped, 250 subtests passed
- full BATS: 818 passed
- `git diff --check`: passed

Fixes #1709
Refs #1682
Supersedes the useful behavior from commit `4f927e4f31b216590727fb597419552d6e9518ac`, which never had a pull request.
