### PR TITLE
Render check errors at error severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Render blocking `basectl check` findings, remediation lines, and failure
+  summaries as `ERROR` in text output while preserving `WARN` for non-blocking
+  findings.
 - Finalized `basectl activate` run bundles and history after the runtime shell
   exits, while isolating commands entered in the shell from the activation run
   context.

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -1136,8 +1136,8 @@ setup_run_project_artifact_layer() {
                 "$(setup_recovery_project_venv "$project" "$resolved_root" "$project_venv_dir")"
         elif [[ "$action" == check ]]; then
             setup_run_project_pre_venv_layer precheck text "$manifest_path" "$project" "$resolved_root" "$project_venv_dir" "$remote_network" || true
-            log_warn "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
-            log_warn "$(setup_recovery_project_venv "$project" "$resolved_root" "$project_venv_dir")"
+            log_error "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
+            log_error "$(setup_recovery_project_venv "$project" "$resolved_root" "$project_venv_dir")"
         else
             log_warn "$_BASE_SETUP_VENV_HEALTH_MESSAGE"
             log_warn "$(setup_recovery_project_venv "$project" "$resolved_root" "$project_venv_dir")"
@@ -1172,7 +1172,7 @@ setup_run_project_artifact_layer() {
         return "$exit_code"
     fi
     if ((exit_code)) && [[ "$action" == check ]]; then
-        log_warn "Python project check layer found missing requirements."
+        log_error "Python project check layer found missing requirements."
         return "$exit_code"
     fi
     if ((exit_code)); then
@@ -1255,10 +1255,16 @@ setup_print_check_text_results() {
                     log_debug "${_BASE_SETUP_CHECK_DEBUG_MESSAGES[$i]}"
                 fi
                 ;;
-            warn|error)
+            warn)
                 log_warn "${_BASE_SETUP_CHECK_MESSAGES[$i]}"
                 if [[ -n "${_BASE_SETUP_CHECK_RECOVERIES[$i]}" ]]; then
                     log_warn "${_BASE_SETUP_CHECK_RECOVERIES[$i]}"
+                fi
+                ;;
+            error)
+                log_error "${_BASE_SETUP_CHECK_MESSAGES[$i]}"
+                if [[ -n "${_BASE_SETUP_CHECK_RECOVERIES[$i]}" ]]; then
+                    log_error "${_BASE_SETUP_CHECK_RECOVERIES[$i]}"
                 fi
                 ;;
             *)
@@ -1339,11 +1345,11 @@ setup_run_check() {
 
     setup_record_project_check_result "$project" error
     if [[ -n "$project" ]]; then
-        log_warn "Base CLI environment or project '$project' check found missing requirements."
-        log_warn "Run 'basectl setup $project' to reconcile the missing requirements."
+        log_error "Base CLI environment or project '$project' check found missing requirements."
+        log_error "Run 'basectl setup $project' to reconcile the missing requirements."
     else
-        log_warn "Base CLI environment check found missing requirements."
-        log_warn "Run 'basectl setup' to reconcile the missing requirements."
+        log_error "Base CLI environment check found missing requirements."
+        log_error "Run 'basectl setup' to reconcile the missing requirements."
     fi
     return 1
 }

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -53,6 +53,8 @@ load ./setup_helpers.bash
 
 @test "basectl check warns when Homebrew reports outdated Xcode Command Line Tools" {
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local warning_recovery_line
+    local warning_line
 
     create_brew_stub
     create_xcode_stubs
@@ -67,6 +69,10 @@ load ./setup_helpers.bash
     run_base_command check
 
     [ "$status" -eq 0 ]
+    warning_line="$(printf '%s\n' "$output" | grep -F "Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete.")"
+    warning_recovery_line="$(printf '%s\n' "$output" | grep -F "Update Xcode Command Line Tools from Software Update, or reinstall them with 'xcode-select --install'.")"
+    [[ "$warning_line" == *"WARN"* ]]
+    [[ "$warning_recovery_line" == *"WARN"* ]]
     [[ "$output" == *"Xcode Command Line Tools are installed, but Homebrew reports they are outdated or incomplete."* ]]
     [[ "$output" == *"Update Xcode Command Line Tools from Software Update, or reinstall them with 'xcode-select --install'."* ]]
     [[ "$output" == *"Base CLI environment check passed."* ]]
@@ -417,6 +423,10 @@ EOF
     local venv_dir="$TEST_HOME/.base.d/base/.venv"
     local workspace="$TEST_TMPDIR/workspace"
     local resolved_demo_root
+    local project_venv_error_line
+    local project_venv_recovery_error_line
+    local summary_error_line
+    local summary_recovery_error_line
 
     create_brew_stub
     create_xcode_stubs
@@ -432,6 +442,14 @@ EOF
     run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
 
     [ "$status" -eq 1 ]
+    project_venv_error_line="$(printf '%s\n' "$output" | grep -F "Virtual environment is missing at '$resolved_demo_root/.venv'.")"
+    project_venv_recovery_error_line="$(printf '%s\n' "$output" | grep -F "Run 'basectl setup demo --recreate-venv' to back up and recreate the project virtual environment.")"
+    summary_error_line="$(printf '%s\n' "$output" | grep -F "Base CLI environment or project 'demo' check found missing requirements.")"
+    summary_recovery_error_line="$(printf '%s\n' "$output" | grep -F "Run 'basectl setup demo' to reconcile the missing requirements.")"
+    [[ "$project_venv_error_line" == *"ERROR"* ]]
+    [[ "$project_venv_recovery_error_line" == *"ERROR"* ]]
+    [[ "$summary_error_line" == *"ERROR"* ]]
+    [[ "$summary_recovery_error_line" == *"ERROR"* ]]
     [ -f "$record_path" ]
     grep -Fq '"project": "demo"' "$record_path"
     grep -Fq '"command": "basectl check"' "$record_path"
@@ -441,6 +459,29 @@ EOF
         return 1
     fi
     [[ "$output" == *"Virtual environment is missing at '$resolved_demo_root/.venv'."* ]]
+}
+
+@test "basectl check reports a failing healthy project check layer as an error" {
+    local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local project_check_error_line
+    local workspace="$TEST_TMPDIR/workspace"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$base_venv_dir"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$workspace/demo/.venv" 1
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
+
+    [ "$status" -eq 1 ]
+    project_check_error_line="$(printf '%s\n' "$output" | grep -F "Python project check layer found missing requirements.")"
+    [[ "$project_check_error_line" == *"ERROR"* ]]
 }
 
 @test "basectl check uv-managed project does not require historical Base project venv" {
@@ -956,9 +997,22 @@ EOF
 }
 
 @test "basectl check fails when required components are missing" {
+    local homebrew_error_line
+    local homebrew_recovery_error_line
+    local summary_error_line
+    local summary_recovery_error_line
+
     run_base_command check
 
     [ "$status" -eq 1 ]
+    homebrew_error_line="$(printf '%s\n' "$output" | grep -F "Homebrew is not installed.")"
+    homebrew_recovery_error_line="$(printf '%s\n' "$output" | grep -F "Run 'basectl setup' to install Homebrew, or install it manually from https://brew.sh/.")"
+    summary_error_line="$(printf '%s\n' "$output" | grep -F "Base CLI environment check found missing requirements.")"
+    summary_recovery_error_line="$(printf '%s\n' "$output" | grep -F "Run 'basectl setup' to reconcile the missing requirements.")"
+    [[ "$homebrew_error_line" == *"ERROR"* ]]
+    [[ "$homebrew_recovery_error_line" == *"ERROR"* ]]
+    [[ "$summary_error_line" == *"ERROR"* ]]
+    [[ "$summary_recovery_error_line" == *"ERROR"* ]]
     [[ "$output" == *"Homebrew is not installed."* ]]
     [[ "$output" == *"Run 'basectl setup' to install Homebrew, or install it manually from https://brew.sh/."* ]]
     [[ "$output" == *"Xcode Command Line Tools are not installed."* ]]

--- a/cli/python/base_dev/profile_output.py
+++ b/cli/python/base_dev/profile_output.py
@@ -34,10 +34,13 @@ def print_check_results(
         )
     elif output_format == "text":
         for check in checks:
-            if check.ok:
+            status = doctor_status(check)
+            if status == "warn":
+                ctx.log.warning(check.message)
+            elif status == "ok":
                 ctx.log.info(check.message)
             else:
-                ctx.log.warning(check.message)
+                ctx.log.error(check.message)
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
         return base_cli.ExitCode.USAGE_ERROR

--- a/cli/python/base_dev/tests/test_profile_output.py
+++ b/cli/python/base_dev/tests/test_profile_output.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from base_dev import profile_output
+from base_dev.checks import DevCheck
+
+
+class ProfileCheckOutputTests(unittest.TestCase):
+    def test_text_output_routes_findings_by_status_and_preserves_exit_status(self) -> None:
+        warning_check = DevCheck(
+            name="optional-tool",
+            ok=False,
+            message="Optional developer tool is not installed.",
+            fix="Install the optional developer tool.",
+            status="warn",
+        )
+        error_check = DevCheck(
+            name="required-tool",
+            ok=False,
+            message="Required developer tool is not installed.",
+            fix="Install the required developer tool.",
+        )
+
+        warning_ctx = mock.Mock()
+        warning_status = profile_output.print_check_results(
+            warning_ctx,
+            (warning_check,),
+            output_format="text",
+            profiles=("dev",),
+        )
+
+        self.assertEqual(warning_status, 0)
+        warning_ctx.log.warning.assert_called_once_with(warning_check.message)
+        warning_ctx.log.error.assert_not_called()
+
+        error_ctx = mock.Mock()
+        error_status = profile_output.print_check_results(
+            error_ctx,
+            (error_check,),
+            output_format="text",
+            profiles=("dev",),
+        )
+
+        self.assertEqual(error_status, 1)
+        error_ctx.log.error.assert_called_once_with(error_check.message)
+        error_ctx.log.warning.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -17,6 +17,7 @@ from base_devenv.report import build_devenv_report
 from base_devenv.report import dumps_devenv_report_json
 from base_devenv.report import print_devenv_report_text
 
+from .checks import ArtifactCheck
 from .checks import check_to_json
 from .checks import checks_payload_to_json
 from .checks import checks_status
@@ -249,6 +250,20 @@ def read_default_manifest(ctx: base_cli.Context) -> BaseManifest:
     return read_manifest(default_manifest_path)
 
 
+def log_check_text_result(ctx: base_cli.Context, check: ArtifactCheck) -> None:
+    status = doctor_status(check)
+    if status == "warn":
+        log_result = ctx.log.warning
+    elif status == "ok":
+        log_result = ctx.log.info
+    else:
+        log_result = ctx.log.error
+
+    log_result(check.message)
+    if check.fix:
+        log_result("Fix: %s", check.fix)
+
+
 def check_manifest(
     ctx: base_cli.Context,
     default_manifest: BaseManifest,
@@ -267,12 +282,7 @@ def check_manifest(
     elif output_format == "text":
         ctx.log.info("Checking project '%s' manifest requirements.", manifest.project_name)
         for check in checks:
-            if check.ok:
-                ctx.log.info(check.message)
-            else:
-                ctx.log.warning(check.message)
-                if check.fix:
-                    ctx.log.warning("Fix: %s", check.fix)
+            log_check_text_result(ctx, check)
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
         return base_cli.ExitCode.USAGE_ERROR
@@ -292,12 +302,7 @@ def check_pre_venv_manifest(
         print(json.dumps([check_to_json(check) for check in checks], separators=(",", ":")))
     elif output_format == "text":
         for check in checks:
-            if check.ok:
-                ctx.log.info(check.message)
-            else:
-                ctx.log.warning(check.message)
-                if check.fix:
-                    ctx.log.warning("Fix: %s", check.fix)
+            log_check_text_result(ctx, check)
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
         return base_cli.ExitCode.USAGE_ERROR

--- a/cli/python/base_setup/tests/test_check_text_output.py
+++ b/cli/python/base_setup/tests/test_check_text_output.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from base_setup import checks as setup_checks
+from base_setup import engine
+from base_setup.manifest import BaseManifest
+from base_setup.tests.helpers import fake_context
+
+
+class ProjectCheckTextOutputTests(unittest.TestCase):
+    def test_check_manifest_text_routes_findings_by_status_and_preserves_exit_status(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+        error_check = setup_checks.ArtifactCheck(
+            name="required-artifact",
+            ok=False,
+            message="Required project artifact is not installed.",
+            fix="basectl setup demo",
+            finding_id="BASE-P040",
+            status="error",
+        )
+        warning_check = setup_checks.ArtifactCheck(
+            name="optional-artifact",
+            ok=False,
+            message="Optional project artifact is not installed.",
+            fix="Review the optional project artifact.",
+            finding_id="BASE-P033",
+            status="warn",
+        )
+
+        ctx = fake_context()
+        with mock.patch("base_setup.engine.manifest_checks", return_value=(error_check, warning_check)):
+            status = engine.check_manifest(ctx, default_manifest, manifest, output_format="text")
+
+        self.assertEqual(status, 1)
+        self.assertEqual(
+            ctx.log.error.call_args_list,
+            [
+                mock.call(error_check.message),
+                mock.call("Fix: %s", error_check.fix),
+            ],
+        )
+        self.assertEqual(
+            ctx.log.warning.call_args_list,
+            [
+                mock.call(warning_check.message),
+                mock.call("Fix: %s", warning_check.fix),
+            ],
+        )
+
+        warning_ctx = fake_context()
+        with mock.patch("base_setup.engine.manifest_checks", return_value=(warning_check,)):
+            warning_status = engine.check_manifest(
+                warning_ctx,
+                default_manifest,
+                manifest,
+                output_format="text",
+            )
+
+        self.assertEqual(warning_status, 0)
+        warning_ctx.log.error.assert_not_called()
+        self.assertEqual(
+            warning_ctx.log.warning.call_args_list,
+            [
+                mock.call(warning_check.message),
+                mock.call("Fix: %s", warning_check.fix),
+            ],
+        )
+
+    def test_check_pre_venv_text_routes_findings_by_status_and_preserves_exit_status(self) -> None:
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+        error_check = setup_checks.ArtifactCheck(
+            name="python-version",
+            ok=False,
+            message="The project Python requirement is not satisfied.",
+            fix="Install a supported Python version.",
+            finding_id="BASE-P170",
+            status="error",
+        )
+        warning_check = setup_checks.ArtifactCheck(
+            name="git-remote",
+            ok=False,
+            message="The Git remote could not be checked.",
+            fix="Review the Git remote manually.",
+            finding_id="BASE-P083",
+            status="warn",
+        )
+
+        ctx = fake_context()
+        with mock.patch(
+            "base_setup.engine.pre_venv_manifest_checks",
+            return_value=(error_check, warning_check),
+        ):
+            status = engine.check_pre_venv_manifest(ctx, manifest, output_format="text")
+
+        self.assertEqual(status, 1)
+        self.assertEqual(
+            ctx.log.error.call_args_list,
+            [
+                mock.call(error_check.message),
+                mock.call("Fix: %s", error_check.fix),
+            ],
+        )
+        self.assertEqual(
+            ctx.log.warning.call_args_list,
+            [
+                mock.call(warning_check.message),
+                mock.call("Fix: %s", warning_check.fix),
+            ],
+        )
+
+        warning_ctx = fake_context()
+        with mock.patch("base_setup.engine.pre_venv_manifest_checks", return_value=(warning_check,)):
+            warning_status = engine.check_pre_venv_manifest(
+                warning_ctx,
+                manifest,
+                output_format="text",
+            )
+
+        self.assertEqual(warning_status, 0)
+        warning_ctx.log.error.assert_not_called()
+        self.assertEqual(
+            warning_ctx.log.warning.call_args_list,
+            [
+                mock.call(warning_check.message),
+                mock.call("Fix: %s", warning_check.fix),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Route structured error findings and their remediation through the error logger while preserving warning and informational severities.
- Render missing project environments, failed project check layers, and final failed-check summaries as errors.
- Add regressions for Base, project-manifest, pre-venv, and developer-profile text output.

## Root cause

The check evaluators already distinguished blocking errors from non-blocking warnings and returned the correct exit status, but the text renderers collapsed every non-OK result into the warning logger. That produced an exit code of 1 with only WARN lines.

## User impact

Blocking findings now appear as ERROR in text output, matching the nonzero exit status. Advisory-only checks remain WARN and continue to exit 0. JSON output and check evaluation semantics are unchanged.

## Validation

- `./bin/base-test`: 1,032 Python tests passed, 1 skipped; 819 BATS tests passed.
- Focused Python and BATS severity regressions passed.
- Pylint, ShellCheck error-level checks, and `git diff --check` passed.
- A real `basectl check base-demo` smoke run exited 1 with blocking findings/remediation logged as ERROR and the GitHub authentication advisory retained as WARN.

Fixes #1708
