### PR TITLE
Finalize activate run history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Finalized `basectl activate` run bundles and history after the runtime shell
+  exits, while isolating commands entered in the shell from the activation run
+  context.
 - Show the names and retention reasons for ordinary unmerged branches during
   local and GitHub remote branch pruning.
 - Reported GitHub merge-verification failures separately from unmerged branches

--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -147,5 +147,5 @@ base_activate_subcommand_main() {
     if ! base_activate_shell_is_bash "$activate_shell"; then
         fatal_error "basectl activate requires Bash. BASE_ACTIVATE_SHELL='$activate_shell' is not supported. Unset BASE_ACTIVATE_SHELL to use the default Bash runtime shell."
     fi
-    exec "$activate_shell" --rcfile "$shell_rc"
+    "$activate_shell" --rcfile "$shell_rc"
 }

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -3,7 +3,69 @@
 load ./basectl_helpers.bash
 
 
-@test "basectl activate resolves a project and execs a project subshell" {
+setup_activate_lifecycle_fixture() {
+    ACTIVATE_CACHE_ROOT="$TEST_TMPDIR/cache"
+    ACTIVATE_HISTORY_STATE="$TEST_TMPDIR/activate-history-state"
+    ACTIVATE_SHELL_STATE="$TEST_TMPDIR/activate-shell-state"
+    ACTIVATE_SHELL_STATUS="$1"
+    ACTIVATE_WORKSPACE="$TEST_TMPDIR/workspace"
+    ACTIVATE_BASE_PYTHON="$TEST_HOME/.base.d/base/.venv/bin/python"
+    ACTIVATE_PROJECT_PYTHON="$ACTIVATE_WORKSPACE/demo/.venv/bin/python"
+    ACTIVATE_SHELL="$TEST_TMPDIR/fake-bash"
+
+    unset \
+        BASE_CLI_RUNTIME_OWNER \
+        BASE_CLI_RUN_ID \
+        BASE_CLI_RUN_ROOT \
+        BASE_CLI_PRIMARY_LOG \
+        BASE_CLI_HISTORY_PARENT_RUN_ID \
+        BASE_CLI_HISTORY_STARTED_AT \
+        BASE_CLI_HISTORY_SCOPE \
+        BASE_CLI_HISTORY_PROJECT \
+        BASE_CLI_HISTORY_PROJECT_ROOT \
+        BASE_CLI_HISTORY_MANIFEST \
+        BASE_CLI_PROJECT_NAME \
+        BASE_CLI_PROJECT_ROOT \
+        BASE_CLI_PROJECT_MANIFEST
+
+    mkdir -p "$(dirname "$ACTIVATE_BASE_PYTHON")" "$(dirname "$ACTIVATE_PROJECT_PYTHON")" \
+        "$ACTIVATE_WORKSPACE/demo"
+    cat > "$ACTIVATE_BASE_PYTHON" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_history.record" ]]; then
+    printf '%s\n' "$*" >> "${BASE_TEST_ACTIVATE_HISTORY_STATE:?}"
+    exit 0
+fi
+printf 'unexpected activate lifecycle python args: %s\n' "$*" >&2
+exit 1
+EOF
+    cp "$ACTIVATE_BASE_PYTHON" "$ACTIVATE_PROJECT_PYTHON"
+    cat > "$ACTIVATE_SHELL" <<'EOF'
+#!/usr/bin/env bash
+grep -Fq '"status":"running"' "${BASE_CLI_RUN_ROOT:?}/run.json" || exit 97
+[[ ! -s "${BASE_TEST_ACTIVATE_HISTORY_STATE:?}" ]] || exit 98
+"$BASH" -c 'trap "exit 42" INT; kill -s INT "$$"; exit 99'
+[[ $? -eq 42 ]] || exit 99
+{
+    printf 'run-status=running\n'
+    printf 'history-before-exit=absent\n'
+    printf 'int-disposition=catchable\n'
+} > "${BASE_TEST_ACTIVATE_SHELL_STATE:?}"
+
+exit "$BASE_TEST_ACTIVATE_SHELL_STATUS"
+EOF
+    chmod +x "$ACTIVATE_BASE_PYTHON" "$ACTIVATE_PROJECT_PYTHON" "$ACTIVATE_SHELL"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$ACTIVATE_WORKSPACE/demo/base_manifest.yaml"
+    ACTIVATE_WORKSPACE="$(cd "$ACTIVATE_WORKSPACE" && pwd -P)"
+}
+
+
+@test "basectl activate resolves a project and launches a project subshell" {
     local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
     local project_python="$workspace/demo/.venv/bin/python"
@@ -51,6 +113,84 @@ EOF
     [[ "$output" == *"BASE_PROJECT_MANIFEST=$workspace/demo/base_manifest.yaml"* ]]
     [[ "$output" == *"BASE_PROJECT_VENV_DIR=$workspace/demo/.venv"* ]]
     [[ "$output" == *"PWD=$workspace/demo"* ]]
+}
+
+@test "basectl activate finalizes a successful runtime shell and records primary project history" {
+    local run_root run_id run_json history_call
+
+    setup_activate_lifecycle_fixture 0
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_CACHE_DIR="$ACTIVATE_CACHE_ROOT" \
+        BASE_ACTIVATE_SHELL="$ACTIVATE_SHELL" \
+        BASE_TEST_ACTIVATE_HISTORY_STATE="$ACTIVATE_HISTORY_STATE" \
+        BASE_TEST_ACTIVATE_SHELL_STATE="$ACTIVATE_SHELL_STATE" \
+        BASE_TEST_ACTIVATE_SHELL_STATUS="$ACTIVATE_SHELL_STATUS" \
+        BASE_TEST_PROJECT_ROOT="$ACTIVATE_WORKSPACE/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -eq 0 ]
+    grep -Fqx "run-status=running" "$ACTIVATE_SHELL_STATE"
+    grep -Fqx "history-before-exit=absent" "$ACTIVATE_SHELL_STATE"
+    grep -Fqx "int-disposition=catchable" "$ACTIVATE_SHELL_STATE"
+    run_root="$(find "$ACTIVATE_CACHE_ROOT/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -n "$run_root" ]
+    run_id="$(basename -- "$run_root")"
+    run_id="${run_id%%__*}"
+    run_json="$(cat "$run_root/run.json")"
+    [[ "$run_json" == *'"status":"ok"'* ]]
+    [[ "$run_json" == *'"exit_code":0'* ]]
+    [ -f "$ACTIVATE_HISTORY_STATE" ]
+    [ "$(wc -l < "$ACTIVATE_HISTORY_STATE")" -eq 1 ]
+    history_call="$(cat "$ACTIVATE_HISTORY_STATE")"
+    [[ "$history_call" == *"-m base_history.record --command activate "* ]]
+    [[ "$history_call" == *" --run-id $run_id "* ]]
+    [[ "$history_call" == *" --exit-code 0 --scope primary --owner base "* ]]
+    [[ "$history_call" == *" --bundle-path $run_root "* ]]
+    [[ "$history_call" == *" --project demo --project-root $ACTIVATE_WORKSPACE/demo "* ]]
+    [[ "$history_call" == *" --manifest $ACTIVATE_WORKSPACE/demo/base_manifest.yaml "* ]]
+    [[ "$history_call" == *" -- basectl activate demo" ]]
+}
+
+@test "basectl activate propagates and records a failed runtime shell exit" {
+    local run_root run_id run_json history_call
+
+    setup_activate_lifecycle_fixture 23
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_CACHE_DIR="$ACTIVATE_CACHE_ROOT" \
+        BASE_ACTIVATE_SHELL="$ACTIVATE_SHELL" \
+        BASE_TEST_ACTIVATE_HISTORY_STATE="$ACTIVATE_HISTORY_STATE" \
+        BASE_TEST_ACTIVATE_SHELL_STATE="$ACTIVATE_SHELL_STATE" \
+        BASE_TEST_ACTIVATE_SHELL_STATUS="$ACTIVATE_SHELL_STATUS" \
+        BASE_TEST_PROJECT_ROOT="$ACTIVATE_WORKSPACE/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -eq 23 ]
+    grep -Fqx "run-status=running" "$ACTIVATE_SHELL_STATE"
+    grep -Fqx "history-before-exit=absent" "$ACTIVATE_SHELL_STATE"
+    grep -Fqx "int-disposition=catchable" "$ACTIVATE_SHELL_STATE"
+    run_root="$(find "$ACTIVATE_CACHE_ROOT/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -n "$run_root" ]
+    run_id="$(basename -- "$run_root")"
+    run_id="${run_id%%__*}"
+    run_json="$(cat "$run_root/run.json")"
+    [[ "$run_json" == *'"status":"error"'* ]]
+    [[ "$run_json" == *'"exit_code":23'* ]]
+    [ -f "$ACTIVATE_HISTORY_STATE" ]
+    [ "$(wc -l < "$ACTIVATE_HISTORY_STATE")" -eq 1 ]
+    history_call="$(cat "$ACTIVATE_HISTORY_STATE")"
+    [[ "$history_call" == *"-m base_history.record --command activate "* ]]
+    [[ "$history_call" == *" --run-id $run_id "* ]]
+    [[ "$history_call" == *" --exit-code 23 --scope primary --owner base "* ]]
+    [[ "$history_call" == *" --bundle-path $run_root "* ]]
+    [[ "$history_call" == *" --project demo --project-root $ACTIVATE_WORKSPACE/demo "* ]]
+    [[ "$history_call" == *" --manifest $ACTIVATE_WORKSPACE/demo/base_manifest.yaml "* ]]
+    [[ "$history_call" == *" -- basectl activate demo" ]]
 }
 
 @test "basectl activate honors BASE_PROJECT_VENV_DIR override" {
@@ -309,7 +449,7 @@ EOF
     [[ "$output" == *"interactive Base Bash runtime shell"* ]]
 }
 
-@test "basectl activate rejects non-Bash BASE_ACTIVATE_SHELL before exec" {
+@test "basectl activate rejects non-Bash BASE_ACTIVATE_SHELL before launch" {
     local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
     local project_python="$workspace/demo/.venv/bin/python"

--- a/cli/bash/commands/basectl/tests/runtime-shell.bats
+++ b/cli/bash/commands/basectl/tests/runtime-shell.bats
@@ -174,11 +174,154 @@ EOF
     [[ "$output" == *"demo:$venv_dir"* ]]
 }
 
+@test "Base runtime shell releases activation invocation context after startup" {
+    local project_root="$TEST_TMPDIR/demo"
+    local venv_dir="$TEST_TMPDIR/demo-venv"
+    local activation_run_root="$TEST_TMPDIR/activation-run"
+    local activation_log="$activation_run_root/logs/primary.log"
+    local history_state="$TEST_TMPDIR/runtime-history-state"
+    local nested_run_root nested_run_json history_call variable
+
+    mkdir -p "$project_root" "$venv_dir/bin" "$activation_run_root/logs" "$activation_run_root/tmp"
+    touch "$project_root/base_manifest.yaml" "$activation_log"
+    printf '%s\n' '{"run_id":"activation-run-id","owner":"base","status":"running","started_at":"2026-07-20T00:00:00Z"}' > "$activation_run_root/run.json"
+    cat > "$venv_dir/bin/activate" <<'EOF'
+VIRTUAL_ENV="$BASE_PROJECT_VENV_DIR"
+export VIRTUAL_ENV
+EOF
+    cat > "$venv_dir/bin/python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
+    printf 'startup-run-root=%s\n' "${BASE_CLI_RUN_ROOT:-unset}" >&2
+    printf 'startup-primary-log=%s\n' "${BASE_CLI_PRIMARY_LOG:-unset}" >&2
+    printf 'startup-history-scope=%s\n' "${BASE_CLI_HISTORY_SCOPE:-unset}" >&2
+    base_test_protocol_begin activation-source 0
+    base_test_protocol_end
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
+    printf 'demo\t%s/demo\n' "${BASE_TEST_WORKSPACE:?}"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_history.record" ]]; then
+    printf '%s\n' "$*" >> "${BASE_TEST_RUNTIME_HISTORY_STATE:?}"
+    exit 0
+fi
+printf 'unexpected base_projects args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$venv_dir/bin/python"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$TEST_TMPDIR/user-cache" \
+        BASE_CLI_LOG_LEVEL=warning \
+        BASE_TEST_RUNTIME_HISTORY_STATE="$history_state" \
+        BASE_TEST_WORKSPACE="$TEST_TMPDIR" \
+        BASE_PROJECT=demo \
+        BASE_PROJECT_ROOT="$project_root" \
+        BASE_PROJECT_MANIFEST="$project_root/base_manifest.yaml" \
+        BASE_PROJECT_VENV_DIR="$venv_dir" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=activation-run-id \
+        BASE_CLI_RUN_ROOT="$activation_run_root" \
+        BASE_CLI_PRIMARY_LOG="$activation_log" \
+        BASE_CLI_KEEP_TEMP=true \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=activation-run-id \
+        BASE_CLI_HISTORY_STARTED_AT=2026-07-20T00:00:00Z \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        BASE_CLI_HISTORY_PROJECT=demo \
+        BASE_CLI_HISTORY_PROJECT_ROOT="$project_root" \
+        BASE_CLI_HISTORY_MANIFEST="$project_root/base_manifest.yaml" \
+        BASE_CLI_PROJECT_NAME=demo \
+        BASE_CLI_PROJECT_ROOT="$project_root" \
+        BASE_CLI_PROJECT_MANIFEST="$project_root/base_manifest.yaml" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            for variable in \
+                BASE_CLI_RUNTIME_OWNER \
+                BASE_CLI_RUN_ID \
+                BASE_CLI_RUN_ROOT \
+                BASE_CLI_PRIMARY_LOG \
+                BASE_CLI_HISTORY_PARENT_RUN_ID \
+                BASE_CLI_HISTORY_STARTED_AT \
+                BASE_CLI_HISTORY_SCOPE \
+                BASE_CLI_HISTORY_PROJECT \
+                BASE_CLI_HISTORY_PROJECT_ROOT \
+                BASE_CLI_HISTORY_MANIFEST \
+                BASE_CLI_PROJECT_NAME \
+                BASE_CLI_PROJECT_ROOT \
+                BASE_CLI_PROJECT_MANIFEST; do \
+                if declare -p "$variable" >/dev/null 2>&1; then \
+                    printf "body-%s=set:%s\n" "$variable" "${!variable}"; \
+                else \
+                    printf "body-%s=unset\n" "$variable"; \
+                fi; \
+            done; \
+            printf "body-BASE_PROJECT=%s\n" "$BASE_PROJECT"; \
+            printf "body-BASE_PROJECT_ROOT=%s\n" "$BASE_PROJECT_ROOT"; \
+            printf "body-BASE_PROJECT_MANIFEST=%s\n" "$BASE_PROJECT_MANIFEST"; \
+            printf "body-BASE_PROJECT_VENV_DIR=%s\n" "$BASE_PROJECT_VENV_DIR"; \
+            printf "body-BASE_CACHE_DIR=%s\n" "$BASE_CACHE_DIR"; \
+            printf "body-BASE_CLI_LOG_LEVEL=%s\n" "$BASE_CLI_LOG_LEVEL"; \
+            printf "body-BASE_CLI_KEEP_TEMP=%s\n" "$BASE_CLI_KEEP_TEMP"; \
+            "$BASE_HOME/bin/basectl" projects list --workspace "$BASE_TEST_WORKSPACE"; \
+            printf "nested-status=%s\n" "$?"'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"startup-run-root=$activation_run_root"* ]]
+    [[ "$output" == *"startup-primary-log=$activation_log"* ]]
+    [[ "$output" == *"startup-history-scope=internal"* ]]
+    for variable in \
+        BASE_CLI_RUNTIME_OWNER \
+        BASE_CLI_RUN_ID \
+        BASE_CLI_RUN_ROOT \
+        BASE_CLI_PRIMARY_LOG \
+        BASE_CLI_HISTORY_PARENT_RUN_ID \
+        BASE_CLI_HISTORY_STARTED_AT \
+        BASE_CLI_HISTORY_SCOPE \
+        BASE_CLI_HISTORY_PROJECT \
+        BASE_CLI_HISTORY_PROJECT_ROOT \
+        BASE_CLI_HISTORY_MANIFEST \
+        BASE_CLI_PROJECT_NAME \
+        BASE_CLI_PROJECT_ROOT \
+        BASE_CLI_PROJECT_MANIFEST; do
+        [[ "$output" == *"body-$variable=unset"* ]]
+    done
+    [[ "$output" == *"body-BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"body-BASE_PROJECT_ROOT=$project_root"* ]]
+    [[ "$output" == *"body-BASE_PROJECT_MANIFEST=$project_root/base_manifest.yaml"* ]]
+    [[ "$output" == *"body-BASE_PROJECT_VENV_DIR=$venv_dir"* ]]
+    [[ "$output" == *"body-BASE_CACHE_DIR=$TEST_TMPDIR/user-cache"* ]]
+    [[ "$output" == *"body-BASE_CLI_LOG_LEVEL=warning"* ]]
+    [[ "$output" == *"body-BASE_CLI_KEEP_TEMP=true"* ]]
+    [[ "$output" == *$'demo\t'"$TEST_TMPDIR/demo"* ]]
+    [[ "$output" == *"nested-status=0"* ]]
+
+    grep -Fq '"status":"running"' "$activation_run_root/run.json"
+    nested_run_root="$(find "$TEST_TMPDIR/user-cache/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -n "$nested_run_root" ]
+    [ "$(find "$TEST_TMPDIR/user-cache/base/runs" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ]
+    nested_run_json="$(cat "$nested_run_root/run.json")"
+    [[ "$nested_run_json" == *'"status":"ok"'* ]]
+    [[ "$nested_run_json" == *'"exit_code":0'* ]]
+    [ "$(wc -l < "$history_state")" -eq 1 ]
+    history_call="$(cat "$history_state")"
+    [[ "$history_call" == *"-m base_history.record --command projects "* ]]
+    [[ "$history_call" == *" --scope primary --owner base --bundle-path $nested_run_root "* ]]
+    [[ "$history_call" != *"$activation_run_root"* ]]
+}
+
 @test "Base runtime shell reports activation source resolution failures clearly" {
     local project_root="$TEST_TMPDIR/demo"
     local venv_dir="$TEST_TMPDIR/demo-venv"
+    local activation_run_root="$TEST_TMPDIR/failed-activation-run"
+    local activation_log="$activation_run_root/logs/primary.log"
 
-    mkdir -p "$project_root" "$venv_dir/bin"
+    mkdir -p "$project_root" "$venv_dir/bin" "$activation_run_root/logs" "$activation_run_root/tmp"
+    touch "$activation_log"
+    printf '%s\n' '{"run_id":"failed-activation-run-id","owner":"base","status":"running","started_at":"2026-07-20T00:00:00Z"}' > "$activation_run_root/run.json"
     cat > "$venv_dir/bin/activate" <<'EOF'
 VIRTUAL_ENV="$BASE_PROJECT_VENV_DIR"
 export VIRTUAL_ENV
@@ -201,13 +344,26 @@ EOF
         BASE_PROJECT_ROOT="$project_root" \
         BASE_PROJECT_MANIFEST="$project_root/base_manifest.yaml" \
         BASE_PROJECT_VENV_DIR="$venv_dir" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=failed-activation-run-id \
+        BASE_CLI_RUN_ROOT="$activation_run_root" \
+        BASE_CLI_PRIMARY_LOG="$activation_log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=failed-activation-run-id \
+        BASE_CLI_HISTORY_STARTED_AT=2026-07-20T00:00:00Z \
+        BASE_CLI_HISTORY_SCOPE=internal \
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c 'printf "shell-continued\n"'
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '\
+            printf "shell-continued\n"; \
+            printf "body-run-root=%s\n" "${BASE_CLI_RUN_ROOT-unset}"; \
+            printf "body-history-scope=%s\n" "${BASE_CLI_HISTORY_SCOPE-unset}"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"activate.source[1]"* ]]
     [[ "$output" == *".base/missing.sh"* ]]
     [[ "$output" == *"ERROR: Unable to resolve project activation scripts for 'demo'."* ]]
+    [[ "$output" == *"shell-continued"* ]]
+    [[ "$output" == *"body-run-root=unset"* ]]
+    [[ "$output" == *"body-history-scope=unset"* ]]
 }
 
 @test "Base runtime shell loads base_init before user bashrc and owns final prompt" {

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -118,6 +118,13 @@ to this same file, which always captures DEBUG-level diagnostics even when the
 terminal is showing INFO. Normal command stdout remains stdout and is not
 captured here.
 
+An interactive `basectl activate` bundle remains `running` while the runtime
+shell is open. Shell startup inherits that bundle's run context for its
+diagnostics, but Base clears the context before the prompt so commands entered
+in the shell follow the normal independent run and history policy for recordable
+commands. The activation bundle is finalized and recorded after the runtime
+shell exits.
+
 ### `projects/<project-id>/<checkout-id>/`
 
 The runtime namespace for one canonical project checkout. The project ID comes

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -215,9 +215,17 @@ shell, but activation itself is Bash so Base can load the Bash standard library,
 project virtual environment, manifest-declared `activate.source` scripts, and
 runtime prompt consistently.
 
+The activated shell inherits the `activate` invocation's run context only while
+its rcfile performs startup, so startup diagnostics stay in the activation run
+bundle. The rcfile clears launcher-only run and history variables before the
+prompt; recordable `basectl` commands entered interactively therefore follow the
+normal policy for independent run bundles and history rows. When the shell
+exits, the waiting activation launcher finalizes the activation bundle with the
+shell's exit status and records the single `activate` history row.
+
 `BASE_ACTIVATE_SHELL` may point to a different Bash executable, such as a
 Homebrew-managed Bash. It must not point to Zsh or another non-Bash shell. Base
-rejects non-Bash values before exec so users see a direct configuration error
+rejects non-Bash values before launch so users see a direct configuration error
 instead of a Bash-rcfile failure from the target shell.
 
 Zsh-specific aliases, options, completions, and prompt customizations are not

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -244,4 +244,29 @@ _base_runtime_main() {
     _base_runtime_debug "complete"
 }
 
-_base_runtime_main || return $?
+_base_runtime_release_launcher_context() {
+    unset \
+        BASE_CLI_RUNTIME_OWNER \
+        BASE_CLI_RUN_ID \
+        BASE_CLI_RUN_ROOT \
+        BASE_CLI_PRIMARY_LOG \
+        BASE_CLI_HISTORY_PARENT_RUN_ID \
+        BASE_CLI_HISTORY_STARTED_AT \
+        BASE_CLI_HISTORY_SCOPE \
+        BASE_CLI_HISTORY_PROJECT \
+        BASE_CLI_HISTORY_PROJECT_ROOT \
+        BASE_CLI_HISTORY_MANIFEST \
+        BASE_CLI_PROJECT_NAME \
+        BASE_CLI_PROJECT_ROOT \
+        BASE_CLI_PROJECT_MANIFEST
+}
+
+_base_runtime_entrypoint() {
+    local status=0
+
+    _base_runtime_main || status=$?
+    _base_runtime_release_launcher_context
+    return "$status"
+}
+
+_base_runtime_entrypoint || return $?


### PR DESCRIPTION
## Summary

- keep the `basectl activate` launcher alive until the runtime shell exits so the shared finalizer records the activation bundle, project context, history row, and exact shell exit status
- retain activation run/log context through runtime-shell startup, then clear launcher-only `BASE_CLI_*` state before the prompt so recordable commands entered in the shell create independent primary runs
- preserve user-tunable command settings such as `BASE_CLI_KEEP_TEMP`; document the lifecycle boundary and add regression coverage for success, nonzero exit, startup failure, inherited context, nested commands, and signal disposition

## Issue

Fixes #1707

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats --print-output-on-failure cli/bash/commands/basectl/tests/activate.bats cli/bash/commands/basectl/tests/runtime-shell.bats` — 23 passed
- inherited-launcher-context reproduction with every run/history variable pre-seeded — lifecycle test passed and created a fresh activation bundle
- real PTY smoke test — activation context was absent at the prompt, Ctrl-C interrupted a foreground command with status 130, an in-shell `basectl projects list` created its own completed primary bundle/history row, and activation finalized once on exit
- `bash -n cli/bash/commands/basectl/subcommands/activate.sh lib/bash/runtime/bashrc`
- `shellcheck --severity=warning cli/bash/commands/basectl/subcommands/activate.sh lib/bash/runtime/bashrc cli/bash/commands/basectl/tests/activate.bats cli/bash/commands/basectl/tests/runtime-shell.bats`
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CACHE_DIR=/private/tmp/base-1707-full-final2.QbAn6V ./bin/base-test` — 1,029 passed, 1 skipped in Python; 821 BATS tests passed

## Demo Impact

None.

## Notes

Recognized leaf-validation failures remain observable; this does not change the history policy for `basectl activate` without a project.

No `.ai-context/` update is needed because the product boundary and command surface are unchanged; the runtime and cache lifecycle contract is documented in `docs/runtime-environment.md` and `docs/cache-ownership-and-layout.md`.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
