### PR TITLE
Refine basectl logs filtering and latest-failure UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Changed
+
+- Refined basectl logs with comma-separated --command filters, the
+  --latest path action, and the explicit last-failed report command.
+
 ### Fixed
 
 - Kept `basectl history` and `basectl logs` terminal tables aligned when command,

--- a/FAQ.md
+++ b/FAQ.md
@@ -361,8 +361,8 @@ the workspace.
 
 Use `basectl logs` to list recent command runs and `basectl logs --tail` to
 follow the newest log in real time. Filter by command name with
-`basectl logs --command setup`, print only the matching path with
-`basectl logs --path`, or open the newest matching log with
+`basectl logs --command setup,check`, print only the newest matching path with
+`basectl logs --latest`, or open the newest matching log with
 `basectl logs --open`. Base stores logs under the Base cache root, normally
 `~/Library/Caches/base` on macOS, so they do not accumulate under `~/.base.d`.
 Use command verbosity such as `basectl -v setup` when you want a new run to

--- a/README.md
+++ b/README.md
@@ -1092,8 +1092,8 @@ Show recent Base CLI logs with:
 
 ```bash
 basectl logs
-basectl logs --command check
-basectl logs --path
+basectl logs --command setup,check
+basectl logs --latest
 basectl logs --open
 basectl logs --tail
 basectl logs -v

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -88,7 +88,7 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
 - `basectl logs` lists recent Base CLI runtime logs and can print, open, or tail
   the newest matching log file.
-- `basectl logs last` prints the latest failed command metadata and a bounded
+- `basectl logs last-failed` prints the latest failed command metadata and a bounded
   redacted log tail, with optional JSON output for local automation.
 - `basectl history` lists recent structured Base command runs from the local
   history index and supports table, JSON, privacy-conscious reports, chronological

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -7,12 +7,12 @@ base_logs_subcommand_usage() {
     cat <<'EOF'
 Usage:
   basectl logs [options]
-  basectl logs last [--command <name>] [--lines <count>] [--format text|csv|tsv|yaml|json]
+  basectl logs last-failed [--command <name[,name...]>] [--lines <count>] [--format text|csv|tsv|yaml|json]
 
 Options:
-  --command <name>  Filter by basectl command or Python CLI name.
+  --command <name[,name...]>  Filter by one or more commands (comma-separated).
   --limit <count>   Number of recent log entries to list. Defaults to 10.
-  --path            Print the most recent matching log path only.
+  --latest          Print the newest matching log path only.
   --tail            Tail and follow the most recent matching log.
   --open            Open the most recent matching log in PAGER or EDITOR.
   --lines <count>   Line count to show before following with --tail. Defaults to 40.
@@ -21,7 +21,7 @@ Options:
   -h, --help        Show this help text.
 
 Surface recent Base CLI runtime logs from the Base cache root.
-"logs last" prints the latest failed command metadata and a bounded redacted log tail.
+"logs last-failed" prints the latest failed command metadata and a bounded redacted log tail.
 EOF
 }
 
@@ -29,18 +29,18 @@ base_logs_recent_usage() {
     cat <<'EOF'
 Usage:
   basectl logs [options]
-  basectl logs last [options]
+  basectl logs last-failed [options]
 
 Purpose:
   List recent Base CLI runtime logs, or inspect the newest matching log.
 
 Commands:
-  last  Print the latest failed command metadata and a bounded redacted log tail.
+  last-failed  Print the latest failed command metadata and a bounded redacted log tail.
 
 Options:
-  --command <name>  Filter by basectl command or Python CLI name.
+  --command <name[,name...]>  Filter by one or more commands (comma-separated).
   --limit <count>   Number of recent log entries to list. Defaults to 10.
-  --path            Print the most recent matching log path only.
+  --latest          Print the newest matching log path only.
   --tail            Tail and follow the most recent matching log.
   --open            Open the most recent matching log in PAGER or EDITOR.
   --lines <count>   Line count to show before following with --tail. Defaults to 40.
@@ -49,16 +49,16 @@ Options:
 EOF
 }
 
-base_logs_last_usage() {
+base_logs_last_failed_usage() {
     cat <<'EOF'
 Usage:
-  basectl logs last [options]
+  basectl logs last-failed [options]
 
 Purpose:
   Print the latest failed command metadata and a bounded redacted log tail.
 
 Options:
-  --command <name>   Filter by basectl command or Python CLI name.
+  --command <name[,name...]>  Select the latest failure for one or more commands.
   --lines <count>    Maximum log-tail lines to print. Defaults to 40.
   --format <format>  Output format: text, csv, tsv, yaml, or json. Defaults to text.
   -v                 Enable DEBUG logging for this subcommand.
@@ -69,6 +69,7 @@ EOF
 base_logs_help_target() {
     local expect_value=0
     local argument
+    local target=recent
 
     for argument in "$@"; do
         if ((expect_value)); then
@@ -79,13 +80,17 @@ base_logs_help_target() {
             --command|--limit|--lines|--format)
                 expect_value=1
                 ;;
-            last)
-                printf 'last\n'
-                return 0
+            last-failed)
+                target=last-failed
+                ;;
+            -* )
+                ;;
+            *)
+                target="unknown:$argument"
                 ;;
         esac
     done
-    printf 'recent\n'
+    printf '%s\n' "$target"
 }
 
 base_logs_args_request_help() {
@@ -102,14 +107,25 @@ base_logs_args_request_help() {
 base_logs_subcommand_main() {
     local wrapper="$BASE_HOME/bin/base-wrapper"
     local args=()
+    local help_target
 
     if base_logs_args_request_help "$@"; then
-        if [[ "$(base_logs_help_target "$@")" == last ]]; then
-            base_logs_last_usage
-        else
-            base_logs_recent_usage
-        fi
-        return 0
+        help_target="$(base_logs_help_target "$@")"
+        case "$help_target" in
+            last-failed)
+                base_logs_last_failed_usage
+                return 0
+                ;;
+            recent)
+                base_logs_recent_usage
+                return 0
+                ;;
+            unknown:*)
+                base_logs_subcommand_usage >&2
+                print_error "Unknown logs command '${help_target#unknown:}'. Supported commands: last-failed."
+                return 2
+                ;;
+        esac
     fi
 
     while (($# > 0)); do
@@ -131,7 +147,7 @@ base_logs_subcommand_main() {
                 args+=("$1" "$2")
                 shift 2
                 ;;
-            --command=*|--limit=*|--lines=*|--format=*|--path|--tail|--open)
+            --command=*|--limit=*|--lines=*|--format=*|--latest|--tail|--open)
                 args+=("$1")
                 shift
                 ;;

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -197,7 +197,7 @@ EOF
             COMP_CWORD=2; \
             _base_basectl_completion; \
             printf "logs_options=%s\n" "${COMPREPLY[*]}"; \
-            COMP_WORDS=(basectl logs last --); \
+            COMP_WORDS=(basectl logs last-failed --); \
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "logs_last_options=%s\n" "${COMPREPLY[*]}"; \
@@ -336,9 +336,9 @@ EOF
     [[ "$output" == *"prompt_options=--output --help"* ]]
     [[ "$output" == *"docs_options=--show-url"* ]]
     [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
-    [[ "$output" == *"logs_options=--command --limit --path --tail --open --lines"* ]]
+    [[ "$output" == *"logs_options=--command --limit --latest --tail --open --lines"* ]]
     [[ "$output" == *"logs_last_options=--command --lines --format"* ]]
-    [[ "$output" == *"logs_commands=last"* ]]
+    [[ "$output" == *"logs_commands=last-failed"* ]]
     [[ "$output" == *"history_options=--project --command --status --limit --format --report --oldest-first --last --since --until --local-time"* ]]
     [[ "$output" == *"trust_commands=status allow revoke"* ]]
     [[ "$output" == *"trust_projects=base demo"* ]]

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -153,7 +153,7 @@ load ./basectl_helpers.bash
         "repo installer-template" "ci setup" "ci check" "ci doctor"
         "release check" "release plan" "release notes" "release publish"
         "prompt list" "prompt product-self-review" "docs" "clean" "logs"
-        "logs last" "history" "config path" "config show" "config doctor" "gh issue list"
+        "logs last-failed" "history" "config path" "config show" "config doctor" "gh issue list"
         "gh issue create" "gh issue readiness" "gh issue start" "gh pr create"
         "gh pr status" "gh pr checks" "gh pr ready" "gh pr merge"
         "gh project doctor" "gh project configure" "gh project issue set-fields"

--- a/cli/bash/commands/basectl/tests/logs.bats
+++ b/cli/bash/commands/basectl/tests/logs.bats
@@ -20,12 +20,12 @@ exit 1
 EOF
     chmod +x "$python_bin"
 
-    run_basectl logs --command check --limit 3 --path
+    run_basectl logs --command check,doctor --limit 3 --latest
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_PROJECT=base"* ]]
     [[ "$output" == *"DISPLAY=basectl logs"* ]]
-    [[ "$output" == *"ARGS=--command check --limit 3 --path"* ]]
+    [[ "$output" == *"ARGS=--command check,doctor --limit 3 --latest"* ]]
 }
 
 @test "basectl logs forwards verbose flag to the Python logs layer" {
@@ -43,13 +43,13 @@ exit 1
 EOF
     chmod +x "$python_bin"
 
-    run_basectl logs -v --path
+    run_basectl logs -v --latest
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"ARGS=--debug --path"* ]]
+    [[ "$output" == *"ARGS=--debug --latest"* ]]
 }
 
-@test "basectl logs last forwards action and format to the Python logs layer" {
+@test "basectl logs last-failed forwards action and format to the Python logs layer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
 
     mkdir -p "$(dirname "$python_bin")"
@@ -64,10 +64,10 @@ exit 1
 EOF
     chmod +x "$python_bin"
 
-    run_basectl logs last --format json --lines 5
+    run_basectl logs last-failed --format json --lines 5
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"ARGS=last --format json --lines 5"* ]]
+    [[ "$output" == *"ARGS=last-failed --format json --lines 5"* ]]
 }
 
 @test "basectl logs prints help without requiring the Base Python venv" {
@@ -76,17 +76,18 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl logs [options]"* ]]
-    [[ "$output" == *"basectl logs last"* ]]
-    [[ "$output" == *"--command <name>"* ]]
-    [[ "$output" == *"--path"* ]]
+    [[ "$output" == *"basectl logs last-failed"* ]]
+    [[ "$output" == *"--command <name[,name...]>"* ]]
+    [[ "$output" == *"--latest"* ]]
+    [[ "$output" != *"--path"* ]]
     [[ "$output" != *"--format <format>"* ]]
 }
 
-@test "basectl logs last prints focused help" {
-    run_basectl logs last --help
+@test "basectl logs last-failed prints focused help" {
+    run_basectl logs last-failed --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl logs last [options]"* ]]
+    [[ "$output" == *"basectl logs last-failed [options]"* ]]
     [[ "$output" == *"--format <format>"* ]]
     [[ "$output" == *"--lines <count>"* ]]
     [[ "$output" != *"--limit"* ]]
@@ -108,7 +109,7 @@ EOF
     [[ "$output" == *"ERROR: Option '--limit' requires an argument."* ]]
     [[ "$output" != *"FATAL"* ]]
 
-    run_basectl logs last --format
+    run_basectl logs last-failed --format
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"ERROR: Option '--format' requires an argument."* ]]

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -53,7 +53,7 @@ class LogEntry:
 class LogCommandOptions:
     command_filter: str | None
     limit: int
-    path_only: bool
+    latest_only: bool
     tail: bool
     open_file: bool
     lines: int
@@ -111,9 +111,9 @@ def main(argv: list[str] | None = None) -> int:
 
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
-@base_cli.option("--command", "command_filter", help="Filter by basectl command or Python CLI name.")
+@base_cli.option("--command", "command_filter", help="Filter by command names (comma-separated).")
 @base_cli.option("--limit", default="10", help="Maximum log entries to list.")
-@base_cli.option("--path", "path_only", is_flag=True, help="Print the most recent matching log path only.")
+@base_cli.option("--latest", "latest_only", is_flag=True, help="Print the newest matching log path only.")
 @base_cli.option("--tail", is_flag=True, help="Tail and follow the most recent matching log.")
 @base_cli.option("--open", "open_file", is_flag=True, help="Open the most recent matching log in PAGER or EDITOR.")
 @base_cli.option("--lines", default="40", help="Line count to show before following.")
@@ -130,13 +130,14 @@ def run(
     action: str | None,
     command_filter: str | None,
     limit: str,
-    path_only: bool,
+    latest_only: bool,
     tail: bool,
     open_file: bool,
     lines: str,
     output_format: str,
 ) -> int:
     try:
+        normalize_command_filters(command_filter)
         limit_value = parse_positive_int("--limit", limit)
         line_count = parse_positive_int("--lines", lines)
         normalized_format = normalize_logs_format(output_format)
@@ -147,32 +148,32 @@ def run(
     options = LogCommandOptions(
         command_filter=command_filter,
         limit=limit_value,
-        path_only=path_only,
+        latest_only=latest_only,
         tail=tail,
         open_file=open_file,
         lines=line_count,
         output_format=normalized_format,
     )
-    selected_actions = sum(1 for selected in (path_only, tail, open_file) if selected)
+    selected_actions = sum(1 for selected in (latest_only, tail, open_file) if selected)
     validation_error = logs_command_validation_error(action, selected_actions)
     if validation_error is not None:
         ctx.log.error(validation_error)
         return base_cli.ExitCode.USAGE_ERROR
 
     cache_root = base_cache_root()
-    if action == "last":
+    if action == "last-failed":
         return run_last_failure(ctx, cache_root, options)
 
     return run_recent_logs(ctx, cache_root, options)
 
 
 def logs_command_validation_error(action: str | None, selected_actions: int) -> str | None:
-    if action is not None and action != "last":
-        return f"Unknown logs command '{action}'. Supported commands: last."
-    if action == "last" and selected_actions > 0:
-        return "`basectl logs last` does not accept --path, --tail, or --open."
+    if action is not None and action != "last-failed":
+        return f"Unknown logs command '{action}'. Supported commands: last-failed."
+    if action == "last-failed" and selected_actions > 0:
+        return "`basectl logs last-failed` does not accept --latest, --tail, or --open."
     if action is None and selected_actions > 1:
-        return "Choose only one of --path, --tail, or --open."
+        return "Choose only one of --latest, --tail, or --open."
     return None
 
 
@@ -194,7 +195,7 @@ def normalize_logs_format(value: str) -> str:
 
 
 def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandOptions) -> int:
-    if options.path_only or options.tail or options.open_file:
+    if options.latest_only or options.tail or options.open_file:
         ctx.log.error("No Base CLI logs found.")
         return base_cli.ExitCode.FAILURE
     if options.output_format == "json":
@@ -210,7 +211,7 @@ def report_no_logs(ctx: base_cli.Context, cache_root: Path, options: LogCommandO
 
 def run_with_entries(entries: list[LogEntry], options: LogCommandOptions) -> int:
     newest = entries[0]
-    if options.path_only:
+    if options.latest_only:
         print(newest.path)
         return base_cli.ExitCode.SUCCESS
     if options.tail:
@@ -285,16 +286,13 @@ def latest_failed_history_record(
     logger: Any | None = None,
 ) -> LastFailureRecord | None:
     records = read_failed_history_records(cache_root, logger=logger)
-    if command_filter:
-        normalized = normalize_command_filter(command_filter)
+    command_filters = normalize_command_filters(command_filter)
+    if command_filters:
         records = [
             record
             for record in records
-            if normalize_command_filter(record.command) == normalized
-            or (
-                record.raw_command is not None
-                and normalize_command_filter(record.raw_command) == normalized
-            )
+            if command_matches(record.command, command_filters)
+            or (record.raw_command is not None and command_matches(record.raw_command, command_filters))
         ]
     if not records:
         return None
@@ -466,13 +464,13 @@ def last_failure_to_json(record: LastFailureRecord, tail: LogTail) -> dict[str, 
 
 def recent_logs(cache_root: Path, command_filter: str | None = None) -> list[LogEntry]:
     entries = list(discover_log_entries(cache_root))
-    if command_filter:
-        normalized = normalize_command_filter(command_filter)
+    command_filters = normalize_command_filters(command_filter)
+    if command_filters:
         entries = [
             entry
             for entry in entries
-            if normalize_command_filter(entry.command) == normalized
-            or normalize_command_filter(entry.raw_command) == normalized
+            if command_matches(entry.command, command_filters)
+            or command_matches(entry.raw_command, command_filters)
         ]
     return sorted(entries, key=lambda entry: (entry.timestamp, entry.path.name), reverse=True)
 
@@ -656,8 +654,24 @@ def last_nonempty_line(path: Path) -> str | None:
 
 
 def normalize_command_filter(value: str) -> str:
-    normalized = value.removeprefix("base_")
+    normalized = value.strip().lower().removeprefix("base_")
     return normalized.replace("_", "-")
+
+
+def normalize_command_filters(value: str | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    parts = value.split(",")
+    if any(not part.strip() for part in parts):
+        raise ValueError("Option '--command' expects comma-separated command names without empty entries.")
+    normalized = tuple(dict.fromkeys(normalize_command_filter(part) for part in parts))
+    if not normalized or any(not command for command in normalized):
+        raise ValueError("Option '--command' expects at least one command name.")
+    return normalized
+
+
+def command_matches(value: str, command_filters: tuple[str, ...]) -> bool:
+    return normalize_command_filter(value) in command_filters
 
 
 def print_log_table(entries: list[LogEntry]) -> None:

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -146,9 +146,11 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
             entries = engine.recent_logs(cache_root)
             check_entries = engine.recent_logs(cache_root, command_filter="check")
+            setup_and_check_entries = engine.recent_logs(cache_root, command_filter="setup, check")
 
         self.assertEqual({entry.path: entry.command for entry in entries}, {check_path: "check", setup_path: "setup"})
         self.assertEqual([entry.path for entry in check_entries], [check_path])
+        self.assertEqual({entry.path for entry in setup_and_check_entries}, {check_path, setup_path})
 
     def test_status_comes_from_last_log_line(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -316,8 +318,8 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
             older = write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
             newer = write_log(cache_root, "base_projects", "20260601T010100_bbbbbbbb", "INFO projects\n")
 
-            status, stdout, stderr = invoke(["--path"], cache_root)
-            filter_status, filter_stdout, filter_stderr = invoke(["--command", "clean", "--path"], cache_root)
+            status, stdout, stderr = invoke(["--latest"], cache_root)
+            filter_status, filter_stdout, filter_stderr = invoke(["--command", "clean", "--latest"], cache_root)
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -326,7 +328,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertEqual(filter_stderr, "")
         self.assertEqual(filter_stdout.strip(), str(older))
 
-    def test_last_prints_latest_failed_history_record_with_redacted_tail(self) -> None:
+    def test_last_failed_prints_latest_failed_history_record_with_redacted_tail(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             older_log = write_log(cache_root, "base_setup", "20260601T010000_aaaaaaaa", "old failure\n")
@@ -371,7 +373,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 ),
             )
 
-            status, stdout, stderr = invoke(["last", "--lines", "2"], cache_root)
+            status, stdout, stderr = invoke(["last-failed", "--lines", "2"], cache_root)
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -388,7 +390,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertIn("https://[REDACTED]@example.com/repo.git", stdout)
         self.assertIn("--github-token [REDACTED]", stdout)
 
-    def test_last_reports_no_failure_state(self) -> None:
+    def test_last_failed_reports_no_failure_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             write_history_line(
@@ -401,13 +403,13 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 ),
             )
 
-            status, stdout, stderr = invoke(["last"], cache_root)
+            status, stdout, stderr = invoke(["last-failed"], cache_root)
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertIn("No failed Base command history found", stdout)
 
-    def test_last_reports_missing_log_with_metadata(self) -> None:
+    def test_last_failed_reports_missing_log_with_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             missing_log = cache_root / "base" / "runs" / "missing-run" / "logs" / "primary.log"
@@ -420,7 +422,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 ),
             )
 
-            status, stdout, stderr = invoke(["last"], cache_root)
+            status, stdout, stderr = invoke(["last-failed"], cache_root)
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -430,7 +432,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertNotIn("plain-secret", stdout)
         self.assertIn("API_KEY=[REDACTED]", stdout)
 
-    def test_last_json_output_has_stable_shape_and_redacted_tail(self) -> None:
+    def test_last_failed_json_output_has_stable_shape_and_redacted_tail(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             log_path = write_log(
@@ -448,7 +450,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 ),
             )
 
-            status, stdout, stderr = invoke(["last", "--format", "json", "--lines", "1"], cache_root)
+            status, stdout, stderr = invoke(["last-failed", "--format", "json", "--lines", "1"], cache_root)
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -465,9 +467,9 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertNotIn("db-secret", stdout)
         self.assertNotIn("token-secret", stdout)
 
-    def test_last_json_reports_no_failure_without_error(self) -> None:
+    def test_last_failed_json_reports_no_failure_without_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            status, stdout, stderr = invoke(["last", "--format", "json"], Path(tmpdir))
+            status, stdout, stderr = invoke(["last-failed", "--format", "json"], Path(tmpdir))
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -476,7 +478,7 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertFalse(payload["found"])
         self.assertIn("history_path", payload)
 
-    def test_last_can_filter_failures_by_command(self) -> None:
+    def test_last_failed_can_filter_failures_by_command_list(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             check_log = write_log(cache_root, "base_setup", "20260601T010000_aaaaaaaa", "check failed\n")
@@ -502,13 +504,21 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 ),
             )
 
-            status, stdout, stderr = invoke(["last", "--command", "check"], cache_root)
+            status, stdout, stderr = invoke(["last-failed", "--command", "setup, release"], cache_root)
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertIn("Command: check", stdout)
-        self.assertIn("check failed", stdout)
-        self.assertNotIn("release failed", stdout)
+        self.assertIn("Command: release", stdout)
+        self.assertIn("release failed", stdout)
+        self.assertNotIn("check failed", stdout)
+
+    def test_command_filter_rejects_empty_list_members(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, stdout, stderr = invoke(["--command", "check,,release"], Path(tmpdir))
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("without empty entries", stderr)
 
     def test_empty_log_set_is_not_an_error_for_table_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -529,9 +539,9 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertIn("cli=base_logs", stderr)
         self.assertFalse((cache_root / "base" / "runs").exists())
 
-    def test_path_errors_when_no_log_matches(self) -> None:
+    def test_latest_errors_when_no_log_matches(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            status, stdout, stderr = invoke(["--path"], Path(tmpdir))
+            status, stdout, stderr = invoke(["--latest"], Path(tmpdir))
 
         self.assertEqual(status, 1)
         self.assertEqual(stdout, "")
@@ -542,24 +552,36 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
             cache_root = Path(tmpdir)
             write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
 
-            status, stdout, stderr = invoke(["--path", "--open"], cache_root)
+            status, stdout, stderr = invoke(["--latest", "--open"], cache_root)
 
         self.assertEqual(status, 2)
         self.assertEqual(stdout, "")
         self.assertIn("Choose only one", stderr)
 
-    def test_last_rejects_file_actions_and_unknown_formats(self) -> None:
+    def test_last_failed_rejects_file_actions_and_unknown_formats(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
-            status, stdout, stderr = invoke(["last", "--path"], cache_root)
-            format_status, format_stdout, format_stderr = invoke(["last", "--format", "xml"], cache_root)
+            status, stdout, stderr = invoke(["last-failed", "--latest"], cache_root)
+            format_status, format_stdout, format_stderr = invoke(["last-failed", "--format", "xml"], cache_root)
 
         self.assertEqual(status, 2)
         self.assertEqual(stdout, "")
-        self.assertIn("does not accept --path", stderr)
+        self.assertIn("does not accept --latest", stderr)
         self.assertEqual(format_status, 2)
         self.assertEqual(format_stdout, "")
         self.assertIn("Unsupported output format 'xml'", format_stderr)
+
+    def test_old_logs_names_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            action_status, action_stdout, action_stderr = invoke(["last"], Path(tmpdir))
+            option_status, option_stdout, option_stderr = invoke(["--path"], Path(tmpdir))
+
+        self.assertEqual(action_status, 2)
+        self.assertEqual(action_stdout, "")
+        self.assertIn("Unknown logs command 'last'", action_stderr)
+        self.assertEqual(option_status, 2)
+        self.assertEqual(option_stdout, "")
+        self.assertIn("No such option '--path'", option_stderr)
 
     def test_json_format_is_supported_for_recent_logs(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -113,13 +113,13 @@ manifest trust.
 | `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network`, `--no-color` |
 | `basectl doctor explain <finding-id>` | Print local, deterministic guidance for a stable finding ID. | `--format <text\|json>` |
 | `basectl ci setup\|check\|doctor [project]` | Compatibility alias for the corresponding `--ci` mode command. | Same options, help, validation, and exit codes as the target command. |
-| `basectl logs` | List recent Base CLI runtime logs. | `--command <name>`, `--limit <count>` |
-| `basectl logs last` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name>`, `--lines <count>`, `--format <text\|csv\|tsv\|yaml\|json>` |
-| `basectl logs --path` | Print the newest matching log path only. | `--command <name>` |
+| `basectl logs` | List recent Base CLI runtime logs. | `--command <name[,name...]>`, `--limit <count>` |
+| `basectl logs last-failed` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name[,name...]>`, `--lines <count>`, `--format <text\|csv\|tsv\|yaml\|json>` |
+| `basectl logs --latest` | Print the newest matching log path only. | `--command <name[,name...]>` |
 | `basectl history` | List one record per public Base command invocation. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--limit <count>`, `--format <text\|csv\|tsv\|yaml\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
 | `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
-| `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name>` |
-| `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name>`, `--lines <count>` |
+| `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name[,name...]>` |
+| `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name[,name...]>`, `--lines <count>` |
 | `basectl clean` | Remove old Base runtime logs, temp files, and cache entries. | `--older-than <age>`, `--keep-last <count>`, `--dry-run` |
 | `basectl config path` | Print the local Base config path. | none |
 | `basectl config show` | Show local Base config as redacted JSON. | none |

--- a/docs/macos-install-validation.md
+++ b/docs/macos-install-validation.md
@@ -153,7 +153,7 @@ Run:
 ```bash
 basectl check
 basectl doctor
-basectl logs --path
+basectl logs --latest
 basectl logs --command setup
 ```
 
@@ -161,7 +161,7 @@ Accept the health checks when:
 
 - `basectl check` exits zero
 - `basectl doctor` reports no error findings
-- `basectl logs --path` prints the log directory path
+- `basectl logs --latest` prints the newest matching log path
 - `basectl logs --command setup` can read recent setup logs without a traceback
 
 `basectl test base` is safe to run from a Homebrew-managed Base install, but it
@@ -253,7 +253,7 @@ basectl check
 basectl doctor
 basectl check base
 basectl doctor base
-basectl logs --path
+basectl logs --latest
 basectl logs --command setup
 basectl test base
 basectl demo base -- --non-interactive

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,7 +1,7 @@
 # Local Observability Model
 
 > **STATUS** — `basectl history`, the local history index,
-> `basectl history --report`, and `basectl logs last` are implemented as
+> `basectl history --report`, and `basectl logs last-failed` are implemented as
 > local-only slices.
 > `basectl explain last-error`, a broader `basectl report` bundle, and history
 > cleanup integration are tracked but not scheduled longer-term future work.
@@ -9,7 +9,7 @@
 Tracker: [#396](https://github.com/basefoundry/base/issues/396)
 
 Base currently exposes raw runtime logs through `basectl logs`, latest-failure
-evidence through `basectl logs last`, structured local command metadata through
+evidence through `basectl logs last-failed`, structured local command metadata through
 `basectl history`, and a redacted local activity summary through
 `basectl history --report`. This document defines the local observability
 layer: shipped command history and activity reports, future last-error
@@ -221,12 +221,17 @@ timestamps, and history JSON retains canonical UTC timestamps. Only
 human-readable history/report views can opt into local time with
 `--local-time`.
 
-`basectl logs last` bridges those surfaces for the common failure case. It reads
+`basectl logs last-failed` bridges those surfaces for the common failure case. It reads
 the local history index, finds the latest failed run, prints command metadata,
 and includes a bounded redacted tail of the recorded log when the log still
 exists. It also supports `--format json` for local automation. If the log path
 is missing or the file was cleaned, it still reports the available history
 metadata and says that the recorded log file is missing.
+
+For recent-log inspection, `--command <name[,name...]>` accepts a comma-separated
+OR filter such as `--command setup,check`; each name is normalized in the same
+way as a single command filter. `--latest` prints only the newest matching log
+path, while `--tail` and `--open` operate on that same newest matching log.
 
 The report mode summarizes selected recent history records with:
 
@@ -247,13 +252,13 @@ rendering Markdown or JSON.
 ### `basectl explain last-error`
 
 `basectl explain last-error` should build on the local evidence surfaced by
-`basectl logs last`. It should find the latest failed history record, inspect
+`basectl logs last-failed`. It should find the latest failed history record, inspect
 its linked log file if present, and print a deterministic local summary:
 
 - command, project, exit code, and time
 - likely failing subsystem when detectable
 - the most relevant log tail
-- suggested next commands such as `basectl logs --path` or `basectl doctor`
+- suggested next commands such as `basectl logs --latest` or `basectl doctor`
 
 The explanation should be rule-based. It should not call external services.
 
@@ -285,7 +290,7 @@ The shipped first slice is:
 1. Add history recording and `basectl history`. **Shipped.**
 2. Add `basectl history --report` for local history/log activity summaries.
    **Shipped.**
-3. Add `basectl logs last` for latest-failure metadata and bounded redacted log
+3. Add `basectl logs last-failed` for latest-failure metadata and bounded redacted log
    tails. **Shipped.**
 
 ### Unscheduled Future Work

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -2,7 +2,7 @@
 
 Base report commands share one output contract. The contract applies to
 `basectl projects list`, workspace reports, lifecycle listings, trust status,
-release checks, and the `history` and `logs last` reports.
+release checks, and the `history` and `logs last-failed` reports.
 
 When `--format` is omitted, or when `--format text` is selected, Base checks
 whether stdout is an interactive terminal:
@@ -54,7 +54,7 @@ documented order:
 | `trust status` | `PROJECT`, `STATUS`, `REASON` |
 | `release check` | `STATUS`, `NAME`, `MESSAGE` |
 | `history` | `TIME`, `COMMAND`, `PROJECT`, `STATUS`, `EXIT`, `LOG` |
-| `logs last` | `TIME`, `COMMAND`, `PROJECT`, `STATUS`, `EXIT`, `RUN ID`, `LOG` |
+| `logs last-failed` | `TIME`, `COMMAND`, `PROJECT`, `STATUS`, `EXIT`, `RUN ID`, `LOG` |
 
 CSV and TSV values are emitted in this order without a header. CSV applies
 standard quoting when a value contains a comma, quote, or newline; TSV keeps

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -177,7 +177,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 |---|---|
 | `basectl check [project] [--profile]` | Quick pass/fail readiness check |
 | `basectl doctor [project] [--profile]` | Human-readable findings + fix commands |
-| `basectl logs [--tail\|--command\|--path\|--open]` | Inspect runtime logs |
+| `basectl logs [--tail\|--command\|--latest\|--open]` | Inspect runtime logs |
 | `basectl history [--format json]` | Inspect structured local command history with ordering and time-window filters |
 | `basectl history --report [--format json]` | Summarize local command history and log metadata without raw log dumps |
 | `basectl config path\|show\|doctor` | Machine-local config |

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -507,7 +507,7 @@ _base_basectl_completion_format_values() {
         trust:allow|trust:revoke|workspace:clone|workspace:pull|workspace:init|workspace:configure|release:plan|release:notes|logs:|build:|run:)
             format_values="text json"
             ;;
-        release:check|logs:last|trust:status)
+        release:check|logs:last-failed|trust:status)
             format_values="text csv tsv yaml json"
             ;;
     esac
@@ -798,11 +798,11 @@ _base_basectl_completion() {
             ;;
         logs)
             if ((COMP_CWORD == 2)) && [[ "$cur" != -* ]]; then
-                _base_basectl_completion_compgen "last" "$cur"
-            elif [[ "${COMP_WORDS[2]:-}" == last ]]; then
+                _base_basectl_completion_compgen "last-failed" "$cur"
+            elif [[ "${COMP_WORDS[2]:-}" == last-failed ]]; then
                 _base_basectl_completion_compgen "--command --lines --format -v -h --help" "$cur"
             else
-                _base_basectl_completion_compgen "--command --limit --path --tail --open --lines -v -h --help" "$cur"
+                _base_basectl_completion_compgen "--command --limit --latest --tail --open --lines -v -h --help" "$cur"
             fi
             ;;
         history)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -891,17 +891,17 @@ _base_basectl_completion() {
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         logs)
-            if [[ "${words[3]:-}" == last ]]; then
-                _arguments '2:logs command:(last)' \
-                    '--command[Filter by command]:command:' \
+            if [[ "${words[3]:-}" == last-failed ]]; then
+                _arguments '2:logs command:(last-failed)' \
+                    '--command[Select latest failure by command]:command:' \
                     '--lines[Maximum log-tail lines]:count:' \
                     '--format[Output format]:format:(text csv tsv yaml json)' \
                     '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             else
-                _arguments '2:logs command:(last)' \
-                    '--command[Filter by command]:command:' \
+                _arguments '2:logs command:(last-failed)' \
+                    '--command[Filter by command list]:command:' \
                     '--limit[Number of entries]:count:' \
-                    '--path[Print most recent log path]' \
+                    '--latest[Print newest matching log path]' \
                     '--tail[Tail and follow most recent log]' \
                     '--open[Open most recent log]' \
                     '--lines[Lines to show before following]:count:' \

--- a/lib/shell/completions/tests/completions.bats
+++ b/lib/shell/completions/tests/completions.bats
@@ -354,7 +354,7 @@ run_zsh_positional_completion() {
     assert_bash_completion_options_match_help prompt-list prompt list
     assert_bash_completion_options_match_help prompt-render prompt product-self-review
     assert_bash_completion_options_match_help logs logs
-    assert_bash_completion_options_match_help logs-last logs last
+    assert_bash_completion_options_match_help logs-last-failed logs last-failed
     assert_bash_completion_options_match_help gh-issue-readiness gh issue readiness
     assert_bash_completion_options_match_help gh-branch-stale gh branch stale
     assert_bash_completion_options_match_help gh-branch-prune gh branch prune
@@ -379,7 +379,7 @@ run_zsh_positional_completion() {
     assert_zsh_completion_options_match_help prompt-list prompt list
     assert_zsh_completion_options_match_help prompt-render prompt product-self-review
     assert_zsh_completion_options_match_help logs logs
-    assert_zsh_completion_options_match_help logs-last logs last
+    assert_zsh_completion_options_match_help logs-last-failed logs last-failed
     assert_zsh_completion_options_match_help gh-issue-readiness gh issue readiness
     assert_zsh_completion_options_match_help gh-branch-stale gh branch stale
     assert_zsh_completion_options_match_help gh-branch-prune gh branch prune
@@ -529,7 +529,7 @@ run_zsh_positional_completion() {
 
     run_zsh_positional_completion basectl logs ""
     [ "$status" -eq 0 ]
-    [[ "$output" == *"positional=2:logs command:(last)"* ]]
+    [[ "$output" == *"positional=2:logs command:(last-failed)"* ]]
 
     run_zsh_positional_completion basectl config ""
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- accept comma-separated OR command filters for `basectl logs --command`
- replace `--path` with `--latest` and rename `logs last` to `logs last-failed`
- update Bash/Zsh completions, help, docs, changelog, and focused regression coverage

Closes #1713

## Validation
- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_logs/tests/test_engine.py -q` (26 passed)
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -t cli/bash/commands/basectl/tests/logs.bats` (6 passed)
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -t lib/shell/completions/tests/completions.bats` (31 passed)
- documentation/contract pytest selection (89 passed)
- `bash -n`, ShellCheck, and `git diff --check`