### PR TITLE
Clarify basectl logs action conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Refined basectl logs with comma-separated --command filters, the
   --latest path action, and the explicit last-failed report command.
+- Clarified basectl logs action conflicts and help for --latest, --tail, and
+  --open.
 
 ### Fixed
 

--- a/cli/bash/commands/basectl/subcommands/logs.sh
+++ b/cli/bash/commands/basectl/subcommands/logs.sh
@@ -12,7 +12,7 @@ Usage:
 Options:
   --command <name[,name...]>  Filter by one or more commands (comma-separated).
   --limit <count>   Number of recent log entries to list. Defaults to 10.
-  --latest          Print the newest matching log path only.
+  --latest          Print the newest matching log path only. Use --tail or --open to consume it.
   --tail            Tail and follow the most recent matching log.
   --open            Open the most recent matching log in PAGER or EDITOR.
   --lines <count>   Line count to show before following with --tail. Defaults to 40.
@@ -40,7 +40,7 @@ Commands:
 Options:
   --command <name[,name...]>  Filter by one or more commands (comma-separated).
   --limit <count>   Number of recent log entries to list. Defaults to 10.
-  --latest          Print the newest matching log path only.
+  --latest          Print the newest matching log path only. Use --tail or --open to consume it.
   --tail            Tail and follow the most recent matching log.
   --open            Open the most recent matching log in PAGER or EDITOR.
   --lines <count>   Line count to show before following with --tail. Defaults to 40.

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -113,7 +113,12 @@ def main(argv: list[str] | None = None) -> int:
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.option("--command", "command_filter", help="Filter by command names (comma-separated).")
 @base_cli.option("--limit", default="10", help="Maximum log entries to list.")
-@base_cli.option("--latest", "latest_only", is_flag=True, help="Print the newest matching log path only.")
+@base_cli.option(
+    "--latest",
+    "latest_only",
+    is_flag=True,
+    help="Print the newest matching log path only; use --tail or --open to consume it.",
+)
 @base_cli.option("--tail", is_flag=True, help="Tail and follow the most recent matching log.")
 @base_cli.option("--open", "open_file", is_flag=True, help="Open the most recent matching log in PAGER or EDITOR.")
 @base_cli.option("--lines", default="40", help="Line count to show before following.")
@@ -154,8 +159,7 @@ def run(
         lines=line_count,
         output_format=normalized_format,
     )
-    selected_actions = sum(1 for selected in (latest_only, tail, open_file) if selected)
-    validation_error = logs_command_validation_error(action, selected_actions)
+    validation_error = logs_command_validation_error(action, latest_only, tail, open_file)
     if validation_error is not None:
         ctx.log.error(validation_error)
         return base_cli.ExitCode.USAGE_ERROR
@@ -167,11 +171,24 @@ def run(
     return run_recent_logs(ctx, cache_root, options)
 
 
-def logs_command_validation_error(action: str | None, selected_actions: int) -> str | None:
+def logs_command_validation_error(
+    action: str | None,
+    latest_only: bool,
+    tail: bool,
+    open_file: bool,
+) -> str | None:
+    selected_actions = sum(1 for selected in (latest_only, tail, open_file) if selected)
     if action is not None and action != "last-failed":
         return f"Unknown logs command '{action}'. Supported commands: last-failed."
     if action == "last-failed" and selected_actions > 0:
         return "`basectl logs last-failed` does not accept --latest, --tail, or --open."
+    if action is None and latest_only and (tail or open_file):
+        return (
+            "`--latest` prints the newest matching log path only and cannot be combined with `--tail` or `--open`; "
+            "use `--tail` or `--open` alone to consume that log."
+        )
+    if action is None and tail and open_file:
+        return "Choose only one of --tail or --open."
     if action is None and selected_actions > 1:
         return "Choose only one of --latest, --tail, or --open."
     return None

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -552,11 +552,21 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
             cache_root = Path(tmpdir)
             write_log(cache_root, "base_clean", "20260601T010000_aaaaaaaa", "INFO clean\n")
 
-            status, stdout, stderr = invoke(["--latest", "--open"], cache_root)
+            latest_status, latest_stdout, latest_stderr = invoke(["--latest", "--open"], cache_root)
+            tail_status, tail_stdout, tail_stderr = invoke(["--latest", "--tail"], cache_root)
+            both_status, both_stdout, both_stderr = invoke(["--tail", "--open"], cache_root)
 
-        self.assertEqual(status, 2)
-        self.assertEqual(stdout, "")
-        self.assertIn("Choose only one", stderr)
+        self.assertEqual(latest_status, 2)
+        self.assertEqual(latest_stdout, "")
+        self.assertIn("cannot be combined with `--tail` or `--open`", latest_stderr)
+        self.assertIn("use `--tail` or `--open` alone", latest_stderr)
+        self.assertEqual(tail_status, 2)
+        self.assertEqual(tail_stdout, "")
+        self.assertIn("cannot be combined with `--tail` or `--open`", tail_stderr)
+        self.assertIn("use `--tail` or `--open` alone", tail_stderr)
+        self.assertEqual(both_status, 2)
+        self.assertEqual(both_stdout, "")
+        self.assertIn("Choose only one of --tail or --open", both_stderr)
 
     def test_last_failed_rejects_file_actions_and_unknown_formats(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -231,7 +231,10 @@ metadata and says that the recorded log file is missing.
 For recent-log inspection, `--command <name[,name...]>` accepts a comma-separated
 OR filter such as `--command setup,check`; each name is normalized in the same
 way as a single command filter. `--latest` prints only the newest matching log
-path, while `--tail` and `--open` operate on that same newest matching log.
+path, while `--tail` and `--open` operate on that same newest matching log. These
+actions are mutually exclusive: `--latest` is path-only and cannot be combined
+with `--tail` or `--open`; use either consuming action by itself when you want to
+read or follow the newest log.
 
 The report mode summarizes selected recent history records with:
 


### PR DESCRIPTION
## Summary

- explain that `--latest` is a path-only action and cannot be combined with `--tail` or `--open`
- provide actionable conflict guidance for `--latest` combinations and concise guidance for `--tail` plus `--open`
- align CLI help, shell help, observability docs, changelog, and regression tests

Closes #1717

## Validation

- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_logs/tests/test_engine.py -q`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -t cli/bash/commands/basectl/tests/logs.bats cli/bash/commands/basectl/tests/help.bats`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_observability_docs.py tests/test_contract_hardening.py -q`
- `bash -n cli/bash/commands/basectl/subcommands/logs.sh`
- `shellcheck cli/bash/commands/basectl/subcommands/logs.sh lib/shell/completions/basectl_completion.sh`
- `git diff --check`