### PR TITLE
Support comma-separated history command filters

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -129,7 +129,8 @@ are documented in `docs/inspection-json.md`.
 - `basectl clean` - remove old Base runtime logs, temp files, and cache entries.
 - `basectl logs` - list, print, open, or tail recent Base CLI runtime logs.
 - `basectl history` - list recent structured Base command runs from the local
-  history index, with `--format json` for scripts and `--report` for a
+  history index, with comma-separated OR filters such as
+  `--command check,doctor`, `--format json` for scripts, and `--report` for a
   privacy-conscious Markdown or JSON activity report.
 - `basectl config <path|show|doctor>` - inspect Base's machine-local user
   config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Made `basectl history --command` accept comma-separated command filters with
+  the same normalization and validation as `basectl logs --command`.
 - Replaced the generic setup-only summary after failed checks with guidance to
   follow each finding's fix and rerun the check; activation-backed environment
   checks now mention project activation.

--- a/cli/bash/commands/basectl/subcommands/history.sh
+++ b/cli/bash/commands/basectl/subcommands/history.sh
@@ -10,7 +10,7 @@ Usage:
 
 Options:
   --project <name>      Filter by Base project name.
-  --command <name>      Filter by basectl command name.
+  --command <name[,name...]>  Filter by one or more basectl commands (comma-separated).
   --status <ok|warn|error>
                         Filter by command status.
   --limit <count>       Number of recent history records to list. Defaults to 10.

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -75,6 +75,8 @@ EOF
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl history [options]"* ]]
     [[ "$output" == *"--project <name>"* ]]
+    [[ "$output" == *"--command <name[,name...]>"* ]]
+    [[ "$output" == *"one or more basectl commands (comma-separated)"* ]]
     [[ "$output" == *"--report"* ]]
     [[ "$output" != *"--include-internal"* ]]
     [[ "$output" == *"--oldest-first"* ]]

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 
 import base_cli
+from base_cli.command_filters import command_matches
+from base_cli.command_filters import normalize_command_filters
 from base_cli.history import HISTORY_PATH
 from base_cli.history import HISTORY_SCOPE_INTERNAL
 from base_cli.history import HISTORY_SCOPE_PRIMARY
@@ -54,7 +56,7 @@ class HistoryRecord:
 @dataclass(frozen=True)
 class HistoryOptions:
     project: str | None
-    command: str | None
+    command: tuple[str, ...]
     status: str | None
     limit: int
     output_format: str
@@ -88,7 +90,11 @@ def main(argv: list[str] | None = None) -> int:
 
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.option("--project", "project_filter", help="Filter by Base project name.")
-@base_cli.option("--command", "command_filter", help="Filter by basectl command name.")
+@base_cli.option(
+    "--command",
+    "command_filter",
+    help="Filter by one or more basectl commands (comma-separated).",
+)
 @base_cli.option("--status", "status_filter", help="Filter by status: ok, warn, or error.")
 @base_cli.option("--limit", default="10", help="Maximum history records to list.")
 @base_cli.option(
@@ -134,7 +140,7 @@ def run(
         since, until = resolve_time_window(last_window, since_value, until_value)
         options = HistoryOptions(
             project=project_filter,
-            command=command_filter,
+            command=normalize_command_filters(command_filter),
             status=normalize_optional_filter(status_filter),
             limit=parse_positive_int("--limit", limit),
             output_format=normalize_report_format(output_format) if report else normalize_format(output_format),
@@ -338,7 +344,7 @@ def filter_history(records: list[HistoryRecord], options: HistoryOptions) -> lis
     if options.project:
         filtered = [record for record in filtered if record.project == options.project]
     if options.command:
-        filtered = [record for record in filtered if record.command == options.command]
+        filtered = [record for record in filtered if command_matches(record.command, options.command)]
     if options.status:
         filtered = [record for record in filtered if record.status == options.status]
     if options.since is not None:

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -296,6 +296,26 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertEqual(payload[0]["status"], "error")
         self.assertFalse(payload[0]["log_exists"])
 
+    def test_command_filter_accepts_comma_separated_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            write_history_line(cache_root, history_record("check-run", "check", ended_at="2026-06-10T10:10:00Z"))
+            write_history_line(cache_root, history_record("doctor-run", "doctor", ended_at="2026-06-10T10:15:00Z"))
+            write_history_line(cache_root, history_record("setup-run", "setup", ended_at="2026-06-10T10:20:00Z"))
+
+            status, stdout, stderr = invoke(
+                ["--command", " CHECK, base_doctor ", "--format", "json"],
+                cache_root,
+            )
+            payload = json.loads(stdout)
+            invalid_status, invalid_stdout, invalid_stderr = invoke(["--command", "check,,doctor"], cache_root)
+
+        self.assertEqual((status, stderr), (0, ""))
+        self.assertEqual([record["run_id"] for record in payload], ["doctor-run", "check-run"])
+        self.assertEqual(invalid_status, 2)
+        self.assertEqual(invalid_stdout, "")
+        self.assertIn("without empty entries", invalid_stderr)
+
     def test_history_hides_legacy_internal_records(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Any
 
 import base_cli
+from base_cli.command_filters import command_matches
+from base_cli.command_filters import normalize_command_filters
 from base_cli.history import HISTORY_PATH
 from base_cli.history import compact_path
 from base_cli.history import display_command
@@ -668,27 +670,6 @@ def last_nonempty_line(path: Path) -> str | None:
             if stripped:
                 last_line = stripped
     return last_line
-
-
-def normalize_command_filter(value: str) -> str:
-    normalized = value.strip().lower().removeprefix("base_")
-    return normalized.replace("_", "-")
-
-
-def normalize_command_filters(value: str | None) -> tuple[str, ...]:
-    if value is None:
-        return ()
-    parts = value.split(",")
-    if any(not part.strip() for part in parts):
-        raise ValueError("Option '--command' expects comma-separated command names without empty entries.")
-    normalized = tuple(dict.fromkeys(normalize_command_filter(part) for part in parts))
-    if not normalized or any(not command for command in normalized):
-        raise ValueError("Option '--command' expects at least one command name.")
-    return normalized
-
-
-def command_matches(value: str, command_filters: tuple[str, ...]) -> bool:
-    return normalize_command_filter(value) in command_filters
 
 
 def print_log_table(entries: list[LogEntry]) -> None:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -116,7 +116,7 @@ manifest trust.
 | `basectl logs` | List recent Base CLI runtime logs. | `--command <name[,name...]>`, `--limit <count>` |
 | `basectl logs last-failed` | Print the latest failed command metadata plus a bounded redacted log tail. | `--command <name[,name...]>`, `--lines <count>`, `--format <text\|csv\|tsv\|yaml\|json>` |
 | `basectl logs --latest` | Print the newest matching log path only. | `--command <name[,name...]>` |
-| `basectl history` | List one record per public Base command invocation. | `--project <name>`, `--command <name>`, `--status <ok\|warn\|error>`, `--limit <count>`, `--format <text\|csv\|tsv\|yaml\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
+| `basectl history` | List one record per public Base command invocation. | `--project <name>`, `--command <name[,name...]>`, `--status <ok\|warn\|error>`, `--limit <count>`, `--format <text\|csv\|tsv\|yaml\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
 | `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
 | `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name[,name...]>` |
 | `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name[,name...]>`, `--lines <count>` |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -186,7 +186,9 @@ TIME                 COMMAND   PROJECT  STATUS  EXIT  LOG
 Expected options:
 
 - `--project <name>` filters by Base project name.
-- `--command <name>` filters by command.
+- `--command <name[,name...]>` filters by one or more commands using a
+  comma-separated OR list; names are trimmed, case-insensitive, and accept the
+  same `base_`/underscore normalization as log filters.
 - `--status <ok|warn|error>` filters by status.
 - `--limit <count>` limits the number of rows.
 - `--format json` prints structured records for scripts.

--- a/lib/python/base_cli/command_filters.py
+++ b/lib/python/base_cli/command_filters.py
@@ -1,0 +1,30 @@
+"""Shared command-name filter normalization for Base reports."""
+
+from __future__ import annotations
+
+
+def normalize_command_filter(value: str) -> str:
+    """Normalize one public or internal command name for matching."""
+
+    normalized = value.strip().lower().removeprefix("base_")
+    return normalized.replace("_", "-")
+
+
+def normalize_command_filters(value: str | None) -> tuple[str, ...]:
+    """Normalize a comma-separated command filter and reject empty entries."""
+
+    if value is None:
+        return ()
+    parts = value.split(",")
+    if any(not part.strip() for part in parts):
+        raise ValueError("Option '--command' expects comma-separated command names without empty entries.")
+    normalized = tuple(dict.fromkeys(normalize_command_filter(part) for part in parts))
+    if not normalized or any(not command for command in normalized):
+        raise ValueError("Option '--command' expects at least one command name.")
+    return normalized
+
+
+def command_matches(value: str, command_filters: tuple[str, ...]) -> bool:
+    """Return whether a command value matches one of the normalized filters."""
+
+    return normalize_command_filter(value) in command_filters


### PR DESCRIPTION
## Summary

- accept comma-separated OR command filters in `basectl history --command`
- share command-filter normalization between history and logs
- update history help, docs, AI context, changelog, and regression coverage

Closes #1720

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q` (1040 passed, 1 skipped, 251 subtests)
- `PYTHONPATH=cli/python:lib/python /Users/rameshhp/.base.d/base/.venv/bin/pylint cli/python/base_history/engine.py cli/python/base_history/tests/test_engine.py cli/python/base_logs/engine.py lib/python/base_cli/command_filters.py`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -t cli/bash/commands/basectl/tests/history.bats cli/bash/commands/basectl/tests/help.bats`
- `bash -n cli/bash/commands/basectl/subcommands/history.sh`
- `shellcheck cli/bash/commands/basectl/subcommands/history.sh cli/bash/commands/basectl/subcommands/logs.sh lib/shell/completions/basectl_completion.sh`
- `git diff --check`

`basectl test base` was also attempted, but the linked worktree is correctly blocked by the existing manifest trust gate; the command printed the explicit `basectl trust allow` review flow.