### PR TITLE
Tighten basectl doctor text formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 - Unified human-readable `basectl doctor` output across Base and project
   findings, including shared status styling and removal of redundant headings.
+- Tightened `basectl doctor` text spacing, aligned fix continuations, and
+  rendered final summaries as INFO logs.
 - Made `basectl history --command` accept comma-separated command filters with
   the same normalization and validation as `basectl logs --command`.
 - Replaced the generic setup-only summary after failed checks with guidance to

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -215,7 +215,6 @@ base_doctor_run_ci_runtime_text() {
     fi
 
     setup_print_runtime_chain_summary
-    printf '\n'
 
     base_doctor_print_collected_check_results
     if setup_profiles_enabled; then
@@ -228,20 +227,19 @@ base_doctor_run_ci_runtime_text() {
         errors=$((errors + $?))
     fi
 
-    printf '\n'
     if ((errors == 0)); then
         if [[ -n "$project" ]]; then
-            printf "Base CI doctor found no blocking issues for project '%s'.\n" "$project"
+            log_info "Base CI doctor found no blocking issues for project '$project'."
         else
-            printf 'Base CI doctor found no blocking issues.\n'
+            log_info 'Base CI doctor found no blocking issues.'
         fi
         return 0
     fi
 
     if [[ -n "$project" ]]; then
-        printf "Base CI doctor found %s blocking issue(s) for project '%s'.\n" "$errors" "$project"
+        log_info "Base CI doctor found $errors blocking issue(s) for project '$project'."
     else
-        printf 'Base CI doctor found %s blocking issue(s).\n' "$errors"
+        log_info "Base CI doctor found $errors blocking issue(s)."
     fi
     return 1
 }
@@ -391,7 +389,6 @@ base_doctor_subcommand_main() {
     fi
 
     setup_print_runtime_chain_summary
-    printf '\n'
 
     BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true setup_collect_base_check_results warn || true
     errors="$(base_doctor_count_check_errors)"
@@ -406,20 +403,19 @@ base_doctor_subcommand_main() {
         errors=$((errors + $?))
     fi
 
-    printf '\n'
     if ((errors == 0)); then
         if [[ -n "$project" ]]; then
-            printf "Base doctor found no blocking issues for project '%s'.\n" "$project"
+            log_info "Base doctor found no blocking issues for project '$project'."
         else
-            printf 'Base doctor found no blocking issues.\n'
+            log_info 'Base doctor found no blocking issues.'
         fi
         return 0
     fi
 
     if [[ -n "$project" ]]; then
-        printf "Base doctor found %s blocking issue(s) for project '%s'.\n" "$errors" "$project"
+        log_info "Base doctor found $errors blocking issue(s) for project '$project'."
     else
-        printf 'Base doctor found %s blocking issue(s).\n' "$errors"
+        log_info "Base doctor found $errors blocking issue(s)."
     fi
     return 1
 }

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -845,17 +845,19 @@ setup_print_doctor_finding() {
     local name="$3"
     local message="$4"
     local fix="${5:-}"
-    local color label padding reset
+    local color fix_indent label padding reset
 
     if setup_doctor_visual_status_enabled; then
         IFS=$'\t' read -r label color padding <<<"$(setup_doctor_status_visual_parts "$status")"
         reset=$'\033[0m'
         printf '%b%s%b%s  %-9s  %-26s  %s\n' "$color" "$label" "$reset" "$padding" "$finding_id" "$name" "$message"
+        fix_indent=9
     else
         printf '%-5s  %-9s  %-26s  %s\n' "$status" "$finding_id" "$name" "$message"
+        fix_indent=7
     fi
     if [[ -n "$fix" ]]; then
-        printf '       Fix: %s\n' "$fix"
+        printf '%*sFix: %s\n' "$fix_indent" '' "$fix"
     fi
 }
 

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -249,6 +249,11 @@ EOF
     local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
 
     create_doctor_success_stubs "$fake_bin" "$venv_python"
+    cat > "$fake_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh version test\n'
+EOF
+    chmod +x "$fake_bin/gh"
     write_doctor_tty_script "$script" "$fake_bin" "xterm-256color" "" ""
 
     run_tty_script "$script"
@@ -257,6 +262,9 @@ EOF
     normalized="$(normalize_tty_output "$output")"
     [[ "$normalized" == *$'\033[0;32m✓ ok\033[0m'*"BASE-D001"*"Homebrew"*"Homebrew is installed."* ]]
     [[ "$normalized" == *$'\033[0;32m✓ ok\033[0m'*"BASE-D004"*"Base virtualenv"*"Virtual environment is healthy at"* ]]
+    [[ "$normalized" != *"GitHub CLI:"*$'\n\n'* ]]
+    [[ "$normalized" == *" INFO "*"Base doctor found no blocking issues."* ]]
+    [[ "$normalized" != *$'\n\n'*"Base doctor found no blocking issues."* ]]
 }
 
 @test "basectl doctor --no-color disables visual status indicators on a tty" {
@@ -655,7 +663,9 @@ EOF
     [[ "$output" == *"Base doctor"* ]]
     [[ "$output" == *"error"*"Homebrew"*"Homebrew is not installed."* ]]
     [[ "$output" == *"Fix: Run 'basectl setup' to install Homebrew, or install it manually from https://brew.sh/."* ]]
-    [[ "$output" == *"Base doctor found"*"blocking issue(s)."* ]]
+    [[ "$output" == *$'\n       Fix: Run '\''basectl setup'\'' to install Homebrew, or install it manually from https://brew.sh/.'* ]]
+    [[ "$output" == *" INFO "*"Base doctor found"*"blocking issue(s)."* ]]
+    [[ "$output" != *$'\n\n'*"Base doctor found"* ]]
 }
 
 @test "basectl doctor rejects unsupported BASE_PLATFORM before Homebrew probes" {


### PR DESCRIPTION
## Summary

- remove redundant blank lines around doctor runtime findings and final summaries
- align `Fix:` continuation lines with the finding ID column in visual and plain text modes
- emit Base doctor and CI doctor final summaries through the INFO logger
- add regression assertions for runtime spacing, continuation indentation, and INFO summaries

Closes #1723

## Validation

- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -t cli/bash/commands/basectl/tests/doctor.bats cli/bash/commands/basectl/tests/ci.bats` (41 passed)
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats -t tests/integration/base_workflows.bats` (7 passed)
- `shellcheck cli/bash/commands/basectl/subcommands/doctor.sh`
- `shellcheck -e SC1091 cli/bash/commands/basectl/subcommands/setup_common.sh`
- `bash -n cli/bash/commands/basectl/subcommands/doctor.sh cli/bash/commands/basectl/subcommands/setup_common.sh`
- `git diff --check`

AI context was left unchanged because this is output-only polish with no command, architecture, or workflow contract change.