### PR TITLE
Complete temporary run retention coverage

### DIFF
--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -69,6 +69,64 @@ load ./basectl_helpers.bash
 }
 
 
+@test "basectl removes temp data after a recognized command failure by default" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local run_root
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            log_debug() { :; }
+            basectl_do_setup() {
+                mkdir -p "$BASE_CLI_RUN_ROOT/tmp/base_setup"
+                printf "temporary\\n" >"$BASE_CLI_RUN_ROOT/tmp/base_setup/file.txt"
+                return 7
+            }
+            basectl_history_record() { :; }
+            basectl_main setup
+        '
+
+    [ "$status" -eq 7 ]
+    run_root="$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -n "$run_root" ]
+    [ ! -e "$run_root/tmp" ]
+    [ -f "$run_root/run.json" ]
+    [ -f "$run_root/logs/primary.log" ]
+}
+
+
+@test "basectl preserves temp data after a recognized command failure when requested" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local run_root
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            log_debug() { :; }
+            basectl_do_setup() {
+                mkdir -p "$BASE_CLI_RUN_ROOT/tmp/base_setup"
+                printf "temporary\\n" >"$BASE_CLI_RUN_ROOT/tmp/base_setup/file.txt"
+                return 7
+            }
+            basectl_history_record() { :; }
+            basectl_main --keep-temp setup
+        '
+
+    [ "$status" -eq 7 ]
+    run_root="$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -n "$run_root" ]
+    [ -f "$run_root/tmp/base_setup/file.txt" ]
+    [ -f "$run_root/run.json" ]
+    [ -f "$run_root/logs/primary.log" ]
+}
+
+
 @test "basectl labels run bundle directories without changing the run ID" {
     run env \
         BASE_HOME="$BASE_REPO_ROOT" \

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -166,6 +166,11 @@ The retention contract should be:
   caches older than the age.
 - `basectl clean --keep-last <count>` retains the newest completed bundles per
   owner namespace.
+- Per-run temporary data is diagnostic-only: `basectl` removes the complete
+  `tmp/` tree after every recognized command, regardless of success or failure,
+  unless `basectl --keep-temp <command>` (or the documented Python retention
+  setting) is used. Run metadata, history, and `logs/primary.log` remain
+  available either way.
 - History records remain even when cleanup removes their referenced bundle, and
   `basectl history` can mark those logs as missing.
 - Durable user state under `~/.base.d` is never cleaned by history retention.


### PR DESCRIPTION
## Summary

- add failed-run coverage for default temp cleanup and explicit retention
- document the per-run temporary-data contract in the observability guide
- keep run metadata, history, and the primary log available in both modes

## Why

The retention implementation is already on `main`; this PR completes issue #1685's
remaining acceptance coverage and documentation. Temporary data is diagnostic-only
and should not accumulate after successful or failed commands unless the user
explicitly opts in with `--keep-temp` (or the documented Python retention setting).

## Validation

- `bats cli/bash/commands/basectl/tests/runtime-dispatch.bats` — 29 passed
- `BASE_BASH_LIBS_DIR=... env -u BASE_HOME ./bin/base-test` — 1043 passed, 1 skipped
- `PYTHONPATH=lib/python python3 -m unittest lib/python/base_cli/tests/test_base_cli.py lib/python/base_cli/tests/test_app_runtime_boundary.py` — 49 passed, 14 skipped
- `git diff --check`
- ShellCheck reports only the existing SC2016 informational warnings in the Bats file

## Project and AI context

- Base Project item moved to `In Progress`; merge/closure should move it to `Done`.
- `.ai-context/` unchanged: this is completion coverage and documentation for an
  already-shipped runtime contract, with no new product or architecture decision.

Fixes #1685
