### PR TITLE
Scope project venv overrides to the active project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Prevented `basectl activate` from reusing a virtual environment override owned
+  by a different active project.
 - Unified human-readable `basectl doctor` output across Base and project
   findings, including shared status styling and removal of redundant headings.
 - Tightened `basectl doctor` text spacing, aligned fix continuations, and

--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -4,12 +4,19 @@
 _base_project_command_helpers_sourced=1
 readonly _base_project_command_helpers_sourced
 
+base_project_venv_override_applies() {
+    local project="$1"
+
+    [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]] || return 1
+    [[ -z "${BASE_PROJECT:-}" || "${BASE_PROJECT:-}" == "$project" ]]
+}
+
 base_project_venv_dir() {
     local project="$1"
     local project_root="${2:-}"
     local route_venv_dir="${3:-}"
 
-    if [[ -n "${BASE_PROJECT_VENV_DIR:-}" ]]; then
+    if base_project_venv_override_applies "$project"; then
         printf '%s\n' "$BASE_PROJECT_VENV_DIR"
         return 0
     fi
@@ -47,11 +54,11 @@ base_project_venv_fix() {
     local venv_dir="${3:-}"
     local uses_uv_manager="${4:-false}"
 
-    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" && "$uses_uv_manager" == true ]]; then
+    if ! base_project_venv_override_applies "$project" && [[ "$uses_uv_manager" == true ]]; then
         printf "Run 'uv sync' in '%s' first." "$project_root"
         return 0
     fi
-    if [[ -z "${BASE_PROJECT_VENV_DIR:-}" ]] && base_project_venv_uses_project_local_default "$project" "$project_root" "$venv_dir"; then
+    if ! base_project_venv_override_applies "$project" && base_project_venv_uses_project_local_default "$project" "$project_root" "$venv_dir"; then
         printf "Run 'basectl setup %s' first. To keep using an external Base-managed virtual environment, set python.venv_location: external in base_manifest.yaml or export BASE_PROJECT_VENV_DIR." "$project"
         return 0
     fi

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -233,6 +233,48 @@ EOF
     [[ "$output" == *"BASE_PROJECT_VENV_DIR=$TEST_TMPDIR/custom-venv"* ]]
 }
 
+@test "basectl activate ignores a venv override owned by another active project" {
+    local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local project_python="$workspace/demo/.venv/bin/python"
+    local fake_bash="$TEST_TMPDIR/fake-bash"
+
+    mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
+    cat > "$base_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
+    base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
+    exit 0
+fi
+printf 'unexpected activate resolver args: %s\n' "$*" >&2
+exit 1
+EOF
+    cat > "$fake_bash" <<'EOF'
+#!/usr/bin/env bash
+printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
+printf 'BASE_PROJECT_VENV_DIR=%s\n' "$BASE_PROJECT_VENV_DIR"
+EOF
+    printf '#!/usr/bin/env bash\n' > "$project_python"
+    chmod +x "$base_python" "$project_python" "$fake_bash"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_ACTIVATE_SHELL="$fake_bash" \
+        BASE_PROJECT=base \
+        BASE_PROJECT_VENV_DIR="$TEST_HOME/.base.d/base/.venv" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        "$BASE_REPO_ROOT/bin/basectl" activate demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_PROJECT=demo"* ]]
+    [[ "$output" == *"BASE_PROJECT_VENV_DIR=$workspace/demo/.venv"* ]]
+    [[ "$output" != *"BASE_PROJECT_VENV_DIR=$TEST_HOME/.base.d/base/.venv"* ]]
+}
+
 @test "basectl activate prefers uv project .venv when python manager is uv" {
     local base_python="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"

--- a/cli/bash/commands/basectl/tests/project-command-helpers.bats
+++ b/cli/bash/commands/basectl/tests/project-command-helpers.bats
@@ -30,6 +30,35 @@ source_project_command_helpers() {
     [ "$output" = "$TEST_TMPDIR/custom-venv" ]
 }
 
+@test "project command helper ignores venv overrides owned by another project" {
+    source_project_command_helpers
+
+    local project_root="$TEST_TMPDIR/demo"
+    local route_venv_dir="$project_root/.venv"
+    local inherited_venv_dir="$TEST_TMPDIR/base/.venv"
+
+    HOME="$TEST_HOME"
+    BASE_PROJECT=base
+    BASE_PROJECT_VENV_DIR="$inherited_venv_dir"
+
+    run base_project_venv_dir demo "$project_root" "$route_venv_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$route_venv_dir" ]
+
+    run base_project_venv_fix demo "$project_root" "$route_venv_dir" true
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "Run 'uv sync' in '$project_root' first." ]
+
+    BASE_PROJECT=demo
+
+    run base_project_venv_dir demo "$project_root" "$route_venv_dir"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$inherited_venv_dir" ]
+}
+
 @test "project command helper resolves uv-managed project venv directories" {
     source_project_command_helpers
 


### PR DESCRIPTION
## Summary

- scope `BASE_PROJECT_VENV_DIR` overrides to an unbound shell or the currently active project
- fall back to resolved route metadata when an inherited override belongs to another project
- use the same ownership predicate for missing-venv recovery guidance
- add helper and public `basectl activate` regressions plus an Unreleased changelog entry

This prevents an active Base runtime from contaminating a later `basectl activate base-demo` invocation with Base's control-plane virtualenv. Nested commands such as `basectl doctor base-demo` now see the project route instead of incorrectly treating `~/.base.d/base/.venv` as the `base-demo` environment.

## Issue

Fixes #1728

Related prior work: #1368 and #173.

## Validation

- regression proof before the fix: the new helper and public activation tests failed against the inherited Base venv
- `bats --print-output-on-failure cli/bash/commands/basectl/tests/project-command-helpers.bats cli/bash/commands/basectl/tests/activate.bats` — 26 passed
- `bash -n cli/bash/commands/basectl/subcommands/project_command_helpers.sh cli/bash/commands/basectl/subcommands/activate.sh`
- `shellcheck cli/bash/commands/basectl/subcommands/project_command_helpers.sh cli/bash/commands/basectl/subcommands/activate.sh`
- `git diff --check`
- `./bin/base-test` — 1,043 Python tests passed, 1 skipped; 826 BATS tests passed

## Demo Impact

None.

## Notes

Documentation and `.ai-context/` are not changed because this restores the existing documented override-ownership contract and does not change the public command surface or schema.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current worktree.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof.
- [x] Documentation impact was evaluated.
- [x] AI context impact was evaluated.
- [x] PR includes `Fixes #1728`.
- [x] Demo Impact is explicitly stated.
