### PR TITLE
Color all basectl log output with --color

### DIFF
--- a/bin/basectl
+++ b/bin/basectl
@@ -246,6 +246,10 @@ basectl_filter_runtime_args() {
                 export LOG_UTC=1
                 ;;
             --color)
+                # Propagate the explicit color choice to Python-backed child
+                # commands. The Bash stdlib consumes the flag itself, while
+                # Python logging needs an environment signal after delegation.
+                export BASE_CLI_COLOR=1
                 ;;
             *)
                 basectl_runtime_args+=("$1")

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -482,6 +482,24 @@ EOF
     [[ "$output" == *"ARGS=-m base_setup --dry-run demo"* ]]
 }
 
+@test "basectl propagates --color to explicit Base scripts" {
+    local script_path="$TEST_TMPDIR/color-script"
+
+    cat > "$script_path" <<'EOF'
+main() {
+    printf 'BASE_CLI_COLOR=%s\n' "${BASE_CLI_COLOR:-unset}"
+}
+EOF
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" "$script_path" --color
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BASE_CLI_COLOR=1"* ]]
+}
+
 @test "basectl treats path-like arguments as scripts before command names" {
     local script_path="$TEST_TMPDIR/demo-script"
 

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -219,6 +219,10 @@ one clock throughout the Bash and Python layers. The local offset is included
 in each timestamp; `--utc-wrapper` sets `LOG_UTC=1` and switches both layers to
 UTC for CI, support, or cross-machine diagnostics:
 
+When `basectl --color` is used on a terminal, Python user-facing logs use the
+same level colors as Bash logs. Persistent log files remain plain text, and
+`NO_COLOR` disables colors.
+
 ```text
 2026-05-23 12:31:04 -0700 INFO    cli/python/base_setup/engine.py:67 Reading Base manifest at '.../base_manifest.yaml'.
 2026-05-23 19:31:04 UTC INFO    cli/python/base_setup/engine.py:67 Reading Base manifest at '.../base_manifest.yaml'.

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -170,6 +170,7 @@ These variables are involved in normal shell startup rather than the full
 | `BASE_DEBUG` | User | Enables debug traces in Base-managed shell startup snippets and the runtime Bash rcfile. | Safe to set in `~/.baserc` or as a one-off environment variable. |
 | `LOG_DEBUG` | Base wrapper compatibility | Internal debug signal exported by wrapper/debug paths before the full runtime exists. The Python config layer treats `1` or `true` as a fallback for `BASE_CLI_LOG_LEVEL=debug` when `BASE_CLI_LOG_LEVEL` is unset. | Do not set directly; use wrapper debug flags or `BASE_CLI_LOG_LEVEL=debug` for Python CLI logs. |
 | `LOG_UTC` | Base wrapper compatibility | When set to `1`, switches Bash and Python CLI log presentation to UTC. It is set by `basectl --utc-wrapper`; persisted metadata is UTC regardless. | Prefer `basectl --utc-wrapper` for one-off CI or diagnostic runs. |
+| `BASE_CLI_COLOR` | Base wrapper compatibility | Internal signal exported by `basectl --color` so Python-backed child commands use the same terminal log colors as Bash. | Do not set directly; use `basectl --color`. `NO_COLOR` still disables colors. |
 
 The ordinary Bash/Zsh dotfile snippets derive `BASE_HOME` and add
 `$BASE_HOME/bin` to `PATH` so `basectl` is available in new terminals. When a

--- a/lib/python/base_cli/README.md
+++ b/lib/python/base_cli/README.md
@@ -278,7 +278,9 @@ def helper() -> None:
 `--quiet` suppresses INFO output on the user-facing stream but still shows
 warnings and errors. `--debug` and `--quiet` cannot be used together. Persistent
 log files still receive DEBUG-level detail, including INFO messages suppressed
-from stderr.
+from stderr. When `basectl --color` is used on a terminal, the user-facing
+Python logs use the same level colors as Bash logs; persistent log files remain
+plain text. `NO_COLOR` disables colors.
 
 Advanced tests and CI wrappers can call `base_cli.configure_logger(...,
 stream=..., formatter=...)` to capture user-facing logs or apply a custom

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -12,6 +12,15 @@ from .context import get_current_context
 from .paths import current_working_dir
 from .redaction import redact_argv
 
+_COLOR_RESET = "\033[0m"
+_LEVEL_COLORS = {
+    logging.DEBUG: "\033[0;36m",
+    logging.INFO: "\033[0;32m",
+    logging.WARNING: "\033[0;33m",
+    logging.ERROR: "\033[0;31m",
+    logging.CRITICAL: "\033[0;31m",
+}
+
 
 # pylint: disable=too-many-arguments
 def configure_logger(
@@ -30,15 +39,16 @@ def configure_logger(
         handler.close()
         logger.removeHandler(handler)
 
-    user_handler = logging.StreamHandler(stream)
+    user_stream = stream if stream is not None else sys.stderr
+    user_handler = logging.StreamHandler(user_stream)
     user_handler.setLevel(_user_stream_level(debug, quiet))
-    user_handler.setFormatter(_handler_formatter(formatter))
+    user_handler.setFormatter(_handler_formatter(formatter, use_color=_use_color(user_stream)))
     logger.addHandler(user_handler)
 
     if log_file is not None:
         file_handler = SecureLogFileHandler(log_file, encoding="utf-8")
         file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(_handler_formatter(formatter))
+        file_handler.setFormatter(_handler_formatter(formatter, use_color=False))
         logger.addHandler(file_handler)
     return logger
 
@@ -51,10 +61,19 @@ def _user_stream_level(debug: bool, quiet: bool) -> int:
     return logging.INFO
 
 
-def _handler_formatter(formatter: logging.Formatter | None) -> logging.Formatter:
+def _handler_formatter(formatter: logging.Formatter | None, *, use_color: bool) -> logging.Formatter:
     if formatter is not None:
         return formatter
-    return BaseCliFormatter()
+    return BaseCliFormatter(use_color=use_color)
+
+
+def _use_color(stream: TextIO) -> bool:
+    return (
+        os.environ.get("BASE_CLI_COLOR") == "1"
+        and "NO_COLOR" not in os.environ
+        and hasattr(stream, "isatty")
+        and stream.isatty()
+    )
 
 
 def secure_log_file_permissions(log_file: Path) -> None:
@@ -82,8 +101,9 @@ def _secure_log_file_open_flags(mode: str) -> int:
 
 
 class BaseCliFormatter(logging.Formatter):
-    def __init__(self, *, use_utc: bool | None = None) -> None:
+    def __init__(self, *, use_utc: bool | None = None, use_color: bool = False) -> None:
         self.use_utc = use_utc if use_utc is not None else os.environ.get("LOG_UTC") == "1"
+        self.use_color = use_color
         datefmt = "%Y-%m-%d %H:%M:%S UTC" if self.use_utc else "%Y-%m-%d %H:%M:%S %z"
         super().__init__(datefmt=datefmt)
         self.converter = time.gmtime if self.use_utc else time.localtime
@@ -92,7 +112,11 @@ class BaseCliFormatter(logging.Formatter):
         timestamp = self.formatTime(record, self.datefmt)
         source = _source_path(record)
         level = _level_name(record)
-        return f"{timestamp} {level:<7} {source}:{record.lineno} {record.getMessage()}"
+        line = f"{timestamp} {level:<7} {source}:{record.lineno} {record.getMessage()}"
+        if not self.use_color:
+            return line
+        color = _LEVEL_COLORS.get(record.levelno)
+        return f"{color}{line}{_COLOR_RESET}" if color else line
 
 
 def _level_name(record: logging.LogRecord) -> str:

--- a/lib/python/base_cli/tests/test_logging.py
+++ b/lib/python/base_cli/tests/test_logging.py
@@ -14,6 +14,10 @@ from base_cli.logging import BaseCliFormatter
 
 
 class ConfigureLoggerTests(unittest.TestCase):
+    class _TtyStream(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
     def test_configure_logger_accepts_custom_stream(self) -> None:
         stream = io.StringIO()
         logger = base_cli.configure_logger("custom-stream", None, debug=False, stream=stream)
@@ -53,6 +57,43 @@ class ConfigureLoggerTests(unittest.TestCase):
             logger.info("hello utc")
 
         self.assertRegex(stream.getvalue(), r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC INFO")
+
+    def test_configure_logger_colors_python_user_stream_when_requested(self) -> None:
+        stream = self._TtyStream()
+
+        with mock.patch.dict(os.environ, {"BASE_CLI_COLOR": "1"}, clear=True):
+            logger = base_cli.configure_logger("color-stream", None, debug=False, stream=stream)
+            logger.info("hello color")
+
+        self.assertIn("\033[0;32m", stream.getvalue())
+        self.assertIn("hello color", stream.getvalue())
+        self.assertTrue(stream.getvalue().endswith("\033[0m\n"))
+
+    def test_configure_logger_keeps_persistent_logs_plain_when_user_stream_is_colored(self) -> None:
+        stream = self._TtyStream()
+
+        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.dict(os.environ, {"BASE_CLI_COLOR": "1"}, clear=True):
+            log_file = Path(tmpdir) / "color.log"
+            logger = base_cli.configure_logger("color-file", log_file, debug=False, stream=stream)
+            logger.info("hello file")
+            for handler in logger.handlers:
+                handler.flush()
+
+            log_text = log_file.read_text(encoding="utf-8")
+
+        self.assertIn("\033[0;32m", stream.getvalue())
+        self.assertNotIn("\033[", log_text)
+        self.assertIn("hello file", log_text)
+
+    def test_configure_logger_honors_no_color_for_requested_user_stream(self) -> None:
+        stream = self._TtyStream()
+
+        with mock.patch.dict(os.environ, {"BASE_CLI_COLOR": "1", "NO_COLOR": "1"}, clear=True):
+            logger = base_cli.configure_logger("no-color-stream", None, debug=False, stream=stream)
+            logger.info("hello plain")
+
+        self.assertNotIn("\033[", stream.getvalue())
+        self.assertIn("hello plain", stream.getvalue())
 
     def test_configure_logger_uses_custom_formatter_for_file_handler(self) -> None:
         formatter = logging.Formatter("%(levelname)s:%(message)s")


### PR DESCRIPTION
## What changed

- Propagate basectl's explicit `--color` choice to Python-backed child commands.
- Apply the same level colors to Python terminal log output.
- Keep persistent log files plain and honor `NO_COLOR` and TTY detection.
- Add launcher, logger, and documentation coverage.

## Root cause

The Bash stdlib consumed `--color` and colored Bash records, but Python's logger only honored the timestamp mode and had no color signal or terminal formatter.

## Validation

- `python -m pytest`: 1,046 passed, 1 skipped
- Full BATS suite: 827 passed
- ShellCheck, Bash syntax, and `git diff --check` passed

Fixes #1730
