### PR TITLE
Suppress duplicate mise setup output

### DIFF
--- a/cli/python/base_setup/mise_delegate.py
+++ b/cli/python/base_setup/mise_delegate.py
@@ -220,7 +220,7 @@ def reconcile_mise(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool)
 
     require_mise_trusted_for_setup(manifest, project_root, mise_path, mise_bin)
     ctx.log.info("Installing mise-managed tools from '%s'.", mise_path)
-    process.run_command(ctx, command, cwd=project_root)
+    process.run_command(ctx, command, cwd=project_root, echo_output=False)
 
 
 def require_mise_trusted_for_setup(

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -101,6 +101,7 @@ def run_command(
     command: list[str],
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
+    echo_output: bool = True,
 ) -> None:
     stdout_recorder = CommandOutputRecorder()
     stderr_recorder = CommandOutputRecorder()
@@ -116,12 +117,12 @@ def run_command(
         threads = (
             threading.Thread(
                 target=_tee_stream,
-                args=(ctx, stdout_pipe, sys.stdout, "stdout", stdout_recorder),
+                args=(ctx, stdout_pipe, sys.stdout if echo_output else None, "stdout", stdout_recorder),
                 daemon=True,
             ),
             threading.Thread(
                 target=_tee_stream,
-                args=(ctx, stderr_pipe, sys.stderr, "stderr", stderr_recorder),
+                args=(ctx, stderr_pipe, sys.stderr if echo_output else None, "stderr", stderr_recorder),
                 daemon=True,
             ),
         )
@@ -257,7 +258,7 @@ def _log_lines(ctx: base_cli.Context, label: str, text: str, pending: str) -> st
 def _tee_stream(
     ctx: base_cli.Context,
     stream: BinaryIO,
-    target: TextIO,
+    target: TextIO | None,
     label: str,
     recorder: CommandOutputRecorder,
 ) -> None:
@@ -267,7 +268,8 @@ def _tee_stream(
             chunk = os.read(stream.fileno(), 4096)
             if not chunk:
                 break
-            _write_bytes(target, chunk)
+            if target is not None:
+                _write_bytes(target, chunk)
             text = chunk.decode(errors="replace")
             recorder.append(text)
             pending = _log_lines(ctx, label, text, pending)

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -1049,6 +1049,29 @@ class ProcessTests(unittest.TestCase):
         self.assertIn("Command stdout: install stdout", debug_messages)
         self.assertIn("Command stderr: install stderr", debug_messages)
 
+    def test_run_command_can_log_without_echoing_stdout_and_stderr(self) -> None:
+        ctx = fake_context()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('install stdout'); "
+                "print('install stderr', file=sys.stderr)"
+            ),
+        ]
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            process.run_command(ctx, command, echo_output=False)
+
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(stderr.getvalue(), "")
+        debug_messages = [call.args[0] % call.args[1:] for call in ctx.log.debug.call_args_list]
+        self.assertIn("Command stdout: install stdout", debug_messages)
+        self.assertIn("Command stderr: install stderr", debug_messages)
+
 
     def test_run_command_failure_includes_bounded_stdout_and_stderr_tail(self) -> None:
         ctx = fake_context()

--- a/cli/python/base_setup/tests/test_mise.py
+++ b/cli/python/base_setup/tests/test_mise.py
@@ -140,7 +140,12 @@ class MiseTests(unittest.TestCase):
                 delegates.reconcile_mise(ctx, manifest, dry_run=False)
 
         run_installer.assert_called_once_with(ctx, remote_installers.MISE_REMOTE_INSTALLER, dry_run=False)
-        run_command.assert_called_once_with(ctx, [str(mise_path), "install"], cwd=project_root.resolve())
+        run_command.assert_called_once_with(
+            ctx,
+            [str(mise_path), "install"],
+            cwd=project_root.resolve(),
+            echo_output=False,
+        )
 
     def test_mise_requires_yes_before_linux_debian_bootstrap(self) -> None:
         ctx = fake_context()
@@ -178,7 +183,12 @@ class MiseTests(unittest.TestCase):
             ):
                 delegates.reconcile_mise(ctx, manifest, dry_run=False)
 
-        run_command.assert_called_once_with(ctx, ["mise", "install"], cwd=project_root.resolve())
+        run_command.assert_called_once_with(
+            ctx,
+            ["mise", "install"],
+            cwd=project_root.resolve(),
+            echo_output=False,
+        )
 
     def test_mise_setup_refuses_untrusted_project_config_before_install(self) -> None:
         ctx = fake_context()


### PR DESCRIPTION
## Summary

- Add an opt-in process runner mode that captures and logs command output without echoing it directly to the terminal.
- Use that mode for setup-time mise install so the success line is not printed twice.
- Preserve captured stdout and stderr for failure diagnostics and leave other commands unchanged.

## Validation

- Focused mise, process, and artifact tests: 70 passed, 35 subtests passed.
- Full Python suite: 1047 passed, 1 skipped.
- Source-checkout Bats suite: 827 passed.
- git diff --check.
- The basectl test base wrapper was not executed because its manifest trust gate requires an explicit trust approval for the new worktree; no trust state was changed.

## AI context

- No .ai-context update needed; this is an internal setup output behavior fix.

Closes #1732
