### PR TITLE
Skip setup on no-op Git updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1613,9 +1613,10 @@ basectl update bankbuddy
 Omitting the project is equivalent to `basectl update base`. This command is
 intentionally conservative. In a source checkout, it only runs from the selected
 project repository's default branch, requires tracked project files to be clean,
-pulls the latest changes through Git, and then runs `basectl setup <project>`.
-Untracked files do not block the update; Git still stops the pull if an incoming
-tracked file would overwrite them.
+pulls the latest changes through Git, and runs `basectl setup <project>` only
+when the pull changes the checked-out revision. Untracked files do not block the
+update; Git still stops the pull if an incoming tracked file would overwrite
+them.
 
 In a Homebrew-managed install, the Base update path remains Base-only:
 `basectl update` runs the Base package upgrade,

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -31,7 +31,7 @@ Options:
 
 Purpose:
   Update a Base-managed project from Git, or update Base through Homebrew for
-  Homebrew installs, then run basectl setup for the selected project.
+  Homebrew installs. Git updates run setup when the selected project changes.
 
 Notes:
   - When project is omitted, Base updates project 'base'.
@@ -485,7 +485,7 @@ base_update_subcommand_main() {
 
     if ((dry_run)); then
         log_info "[DRY-RUN] Would update project '$resolved_project' repository at '$repo'."
-        log_info "[DRY-RUN] Would run 'basectl setup $resolved_project' after updating."
+        log_info "[DRY-RUN] Would run 'basectl setup $resolved_project' if the Git update changes the repository."
         return 0
     fi
 
@@ -504,11 +504,12 @@ base_update_subcommand_main() {
 
     if [[ "$before_revision" == "$after_revision" ]]; then
         log_info "Project '$resolved_project' repository is already up to date on '$update_branch' at '$after_revision'."
+        log_info "Skipping basectl setup $resolved_project because the repository did not change."
     else
         log_info "Project '$resolved_project' repository updated from '$before_revision' to '$after_revision' on '$update_branch'."
+        log_info "Running basectl setup $resolved_project after update."
+        base_update_run_setup "$base_home" "$resolved_project" || return $?
     fi
 
-    log_info "Running basectl setup $resolved_project after update."
-    base_update_run_setup "$base_home" "$resolved_project" || return $?
     log_info "Project '$resolved_project' update is complete."
 }

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -20,6 +20,7 @@ assert_status() {
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl update [project] [options]"* ]]
     [[ "$output" == *"Update a Base-managed project from Git, or update Base through Homebrew"* ]]
+    [[ "$output" == *"Git updates run setup when the selected project changes."* ]]
     [[ "$output" == *"When project is omitted, Base updates project 'base'."* ]]
     [[ "$output" == *"Tracked project files must be clean"* ]]
     [[ "$output" == *"brew upgrade basefoundry/base/base"* ]]
@@ -41,7 +42,7 @@ assert_status() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would update project 'base' repository at '$BASE_REPO_ROOT'."* ]]
-    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup base' after updating."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup base' if the Git update changes the repository."* ]]
 }
 
 @test "basectl update dry-run resolves a named project" {
@@ -70,7 +71,7 @@ assert_status() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would update project 'demo' repository at '$project_root'."* ]]
-    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup demo' after updating."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup demo' if the Git update changes the repository."* ]]
 }
 
 @test "basectl update rejects multiple project arguments" {
@@ -387,12 +388,20 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$repo" \
+        BASE_TEST_AFTER_UPDATE="$TEST_TMPDIR/after-update" \
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
             base_update_source_git_library() { :; }
             git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
-            base_update_head_revision() { printf "%s\n" abc1234; }
+            base_update_head_revision() {
+                if [[ -f "$BASE_TEST_AFTER_UPDATE" ]]; then
+                    printf "%s\n" new5678
+                else
+                    touch "$BASE_TEST_AFTER_UPDATE"
+                    printf "%s\n" old1234
+                fi
+            }
             base_update_run_setup() { printf "setup ran\n"; }
             base_update_subcommand_main
         '
@@ -424,7 +433,7 @@ EOF
     [[ "$output" != *"setup should not run"* ]]
 }
 
-@test "basectl update reports already up-to-date repositories" {
+@test "basectl update skips setup for already up-to-date repositories" {
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
@@ -438,15 +447,15 @@ EOF
             base_update_source_git_library() { :; }
             git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
             base_update_head_revision() { printf "%s\n" abc1234; }
-            base_update_run_setup() { printf "setup ran\n"; }
+            base_update_run_setup() { printf "setup should not run\n"; return 99; }
             base_update_subcommand_main
         '
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Updating project 'base' repository at '$BASE_REPO_ROOT'."* ]]
     [[ "$output" == *"Project 'base' repository is already up to date on 'master' at 'abc1234'."* ]]
-    [[ "$output" == *"Running basectl setup base after update."* ]]
-    [[ "$output" == *"setup ran"* ]]
+    [[ "$output" == *"Skipping basectl setup base because the repository did not change."* ]]
+    [[ "$output" != *"setup should not run"* ]]
     [[ "$output" == *"Project 'base' update is complete."* ]]
 }
 


### PR DESCRIPTION
## Summary

- Skip basectl setup <project> when the Git/source update path leaves the checkout at the same revision.
- Keep setup execution for changed Git revisions and leave the Homebrew-managed update path unchanged.
- Update help, dry-run messaging, README docs, and focused update tests to describe the conditional Git setup behavior.

## Root Cause

basectl update already compared the checked-out revision before and after git_update_repo, but the setup step lived after that comparison and therefore ran for both changed and unchanged checkouts.

## Validation

- bats cli/bash/commands/basectl/tests/update.bats
- bash -n cli/bash/commands/basectl/subcommands/update.sh
- shellcheck --severity=error cli/bash/commands/basectl/subcommands/update.sh
- git diff --check

Closes #1736
