### PR TITLE
Skip setup on unchanged Homebrew Base version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,7 +1432,8 @@ brew upgrade --no-ask basefoundry/base/base
 Homebrew installs the Base files. `basectl setup` still prepares the local Base
 runtime under `~/.base.d/base/.venv`, and `basectl update-profile` adds Base to
 your shell startup path. When installed through Homebrew, `basectl update` for
-Base hands off to Homebrew and runs setup afterward. This is equivalent to:
+Base hands off to Homebrew and runs setup only when the installed Base version
+changes. The Homebrew handoff is equivalent to:
 
 ```bash
 brew upgrade --no-ask basefoundry/base/base
@@ -1620,9 +1621,10 @@ them.
 
 In a Homebrew-managed install, the Base update path remains Base-only:
 `basectl update` runs the Base package upgrade,
-`brew upgrade basefoundry/base/base`, and then runs `basectl setup base` with
-inherited Base environment variables cleared. `basectl update --dry-run` prints
-the Git or Homebrew handoff it would perform without changing files or packages.
+`brew upgrade basefoundry/base/base`, and runs `basectl setup base` with
+inherited Base environment variables cleared only when the installed Base version
+changes. `basectl update --dry-run` prints the Git or Homebrew handoff it would
+perform without changing files or packages.
 For manual Homebrew upgrades outside `basectl update`, prefer
 `brew upgrade --no-ask basefoundry/base/base` so Homebrew skips the preview
 prompt path on already-current installs. If Homebrew refuses to load

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -31,7 +31,8 @@ Options:
 
 Purpose:
   Update a Base-managed project from Git, or update Base through Homebrew for
-  Homebrew installs. Git updates run setup when the selected project changes.
+  Homebrew installs. Git updates run setup when the selected project changes;
+  Homebrew updates run setup when Base's installed version changes.
 
 Notes:
   - When project is omitted, Base updates project 'base'.
@@ -145,6 +146,64 @@ base_update_run_homebrew_upgrade() {
     local package="$1"
 
     brew upgrade "$package"
+}
+
+base_update_homebrew_installed_version_from_json() {
+    local info_json="$1"
+    local package="$2"
+    local python_bin
+
+    python_bin="$(base_update_json_python_bin)" || return 1
+    INFO_JSON="$info_json" INFO_PACKAGE="$package" "$python_bin" - <<'PY'
+import json
+import os
+import sys
+
+package = os.environ.get("INFO_PACKAGE", "")
+short_name = package.rsplit("/", 1)[-1] if package else ""
+
+try:
+    data = json.loads(os.environ["INFO_JSON"])
+except (KeyError, json.JSONDecodeError):
+    sys.exit(1)
+
+formulae = data.get("formulae", [])
+if not isinstance(formulae, list):
+    sys.exit(1)
+
+for formula in formulae:
+    if not isinstance(formula, dict):
+        continue
+    names = {name for name in (formula.get("name"), formula.get("full_name")) if isinstance(name, str)}
+    if package not in names and short_name not in names:
+        continue
+
+    linked_keg = formula.get("linked_keg")
+    if isinstance(linked_keg, str) and linked_keg:
+        print(linked_keg)
+        sys.exit(0)
+
+    installed_versions = [
+        entry.get("version")
+        for entry in formula.get("installed", [])
+        if isinstance(entry, dict) and isinstance(entry.get("version"), str) and entry.get("version")
+    ]
+    if installed_versions:
+        print(installed_versions[-1])
+        sys.exit(0)
+
+    sys.exit(1)
+
+sys.exit(1)
+PY
+}
+
+base_update_homebrew_installed_version() {
+    local package="$1"
+    local info_json
+
+    info_json="$(brew info --json=v2 --installed "$package" 2>/dev/null)" || return 1
+    base_update_homebrew_installed_version_from_json "$info_json" "$package"
 }
 
 base_update_homebrew_requires_tap_trust() {
@@ -282,6 +341,8 @@ base_update_run_homebrew_setup() {
 base_update_homebrew_install() {
     local base_home="$1"
     local dry_run="$2"
+    local after_version
+    local before_version
     local exit_code
     local package
 
@@ -290,7 +351,7 @@ base_update_homebrew_install() {
 
     if ((dry_run)); then
         log_info "[DRY-RUN] Would run: brew upgrade $package"
-        log_info "[DRY-RUN] Would run 'basectl setup' after the Homebrew upgrade with inherited Base environment cleared."
+        log_info "[DRY-RUN] Would run 'basectl setup' if the Homebrew upgrade changes Base's installed version, with inherited Base environment cleared."
         return 0
     fi
 
@@ -304,6 +365,11 @@ base_update_homebrew_install() {
         return 1
     fi
 
+    before_version="$(base_update_homebrew_installed_version "$package")" || {
+        log_error "Unable to determine installed Homebrew version for $package before upgrade."
+        return 1
+    }
+
     log_info "Running Homebrew upgrade for $package."
     base_update_run_homebrew_upgrade "$package"
     exit_code=$?
@@ -312,8 +378,19 @@ base_update_homebrew_install() {
         return "$exit_code"
     fi
 
-    log_info "Running basectl setup after Homebrew upgrade."
-    base_update_run_homebrew_setup "$base_home" "$package" || return $?
+    after_version="$(base_update_homebrew_installed_version "$package")" || {
+        log_error "Unable to determine installed Homebrew version for $package after upgrade."
+        return 1
+    }
+
+    if [[ "$before_version" == "$after_version" ]]; then
+        log_info "Homebrew Base version is unchanged at '$after_version' after upgrade."
+        log_info "Skipping basectl setup because the Homebrew Base version did not change."
+    else
+        log_info "Homebrew Base version changed from '$before_version' to '$after_version'."
+        log_info "Running basectl setup after Homebrew upgrade."
+        base_update_run_homebrew_setup "$base_home" "$package" || return $?
+    fi
 
     log_info "Base update is complete."
 }

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -20,7 +20,8 @@ assert_status() {
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" == *"basectl update [project] [options]"* ]]
     [[ "$output" == *"Update a Base-managed project from Git, or update Base through Homebrew"* ]]
-    [[ "$output" == *"Git updates run setup when the selected project changes."* ]]
+    [[ "$output" == *"Git updates run setup when the selected project changes;"* ]]
+    [[ "$output" == *"Homebrew updates run setup when Base's installed version changes."* ]]
     [[ "$output" == *"When project is omitted, Base updates project 'base'."* ]]
     [[ "$output" == *"Tracked project files must be clean"* ]]
     [[ "$output" == *"brew upgrade basefoundry/base/base"* ]]
@@ -144,7 +145,7 @@ assert_status() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Detected Homebrew-managed Base install at '$fake_base'."* ]]
     [[ "$output" == *"[DRY-RUN] Would run: brew upgrade basefoundry/base/base"* ]]
-    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup' after the Homebrew upgrade with inherited Base environment cleared."* ]]
+    [[ "$output" == *"[DRY-RUN] Would run 'basectl setup' if the Homebrew upgrade changes Base's installed version, with inherited Base environment cleared."* ]]
     [[ "$output" != *"brew should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
 }
@@ -219,6 +220,27 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "base_update_homebrew_installed_version_from_json reads structured Homebrew versions" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+
+            linked_json="{\"formulae\":[{\"name\":\"base\",\"full_name\":\"basefoundry/base/base\",\"linked_keg\":\"1.8.0\",\"installed\":[{\"version\":\"1.7.0\"}]},{\"name\":\"base-bash-libs\",\"full_name\":\"basefoundry/base/base-bash-libs\",\"linked_keg\":\"1.3.0\",\"installed\":[{\"version\":\"1.3.0\"}]}],\"casks\":[]}"
+            fallback_json="{\"formulae\":[{\"name\":\"base\",\"full_name\":\"basefoundry/base/base\",\"linked_keg\":null,\"installed\":[{\"version\":\"1.7.0\"},{\"version\":\"1.8.0\"}]}],\"casks\":[]}"
+
+            [ "$(base_update_homebrew_installed_version_from_json "$linked_json" "basefoundry/base/base")" = "1.8.0" ]
+            [ "$(base_update_homebrew_installed_version_from_json "$fallback_json" "basefoundry/base/base")" = "1.8.0" ]
+            if base_update_homebrew_installed_version_from_json "{\"formulae\":[]}" "basefoundry/base/base"; then
+                exit 10
+            fi
+        '
+
+    [ "$status" -eq 0 ]
+}
+
 @test "base_update_homebrew_prefix does not repeat identical base prefix probes" {
     local fake_bin="$TEST_TMPDIR/bin"
     local brew_log="$TEST_TMPDIR/brew.log"
@@ -250,10 +272,11 @@ EOF
     [ "$(cat "$brew_log")" = "--prefix base" ]
 }
 
-@test "basectl update runs exact Homebrew package upgrade and clears Base env for setup" {
+@test "basectl update runs Homebrew setup when Base version changes" {
     local fake_bin="$TEST_TMPDIR/bin"
     local fake_base="$TEST_TMPDIR/homebrew/opt/base/libexec"
     local brew_log="$TEST_TMPDIR/brew.log"
+    local brew_state="$TEST_TMPDIR/brew-state"
     local setup_log="$TEST_TMPDIR/setup.log"
 
     mkdir -p "$fake_bin" "$fake_base/bin"
@@ -261,6 +284,18 @@ EOF
 #!/usr/bin/env bash
 if [[ "\$1" == "config" ]]; then
     exit 0
+fi
+if [[ "\$1" == "info" && "\$2" == "--json=v2" && "\$3" == "--installed" ]]; then
+    printf '%s\n' "\$*" >> "$brew_log"
+    if [[ -f "$brew_state" ]]; then
+        printf '%s\n' '{"formulae":[{"name":"base","full_name":"basefoundry/base/base","linked_keg":"1.8.0","installed":[{"version":"1.8.0"}]}],"casks":[]}'
+    else
+        printf '%s\n' '{"formulae":[{"name":"base","full_name":"basefoundry/base/base","linked_keg":"1.7.0","installed":[{"version":"1.7.0"}]}],"casks":[]}'
+    fi
+    exit 0
+fi
+if [[ "\$1" == "upgrade" ]]; then
+    touch "$brew_state"
 fi
 printf '%s\n' "\$*" >> "$brew_log"
 exit 0
@@ -291,13 +326,61 @@ EOF
         '
 
     [ "$status" -eq 0 ]
-    [ "$(cat "$brew_log")" = "upgrade basefoundry/base/base" ]
+    [ "$(cat "$brew_log")" = $'info --json=v2 --installed basefoundry/base/base\nupgrade basefoundry/base/base\ninfo --json=v2 --installed basefoundry/base/base' ]
     [[ "$(cat "$setup_log")" == *"args=setup"* ]]
     [[ "$(cat "$setup_log")" == *"BASE_HOME=unset"* ]]
     [[ "$(cat "$setup_log")" == *"BASE_PROJECT=unset"* ]]
     [[ "$output" == *"Detected Homebrew-managed Base install at '$fake_base'."* ]]
     [[ "$output" == *"Running Homebrew upgrade for basefoundry/base/base."* ]]
+    [[ "$output" == *"Homebrew Base version changed from '1.7.0' to '1.8.0'."* ]]
     [[ "$output" == *"Running basectl setup after Homebrew upgrade."* ]]
+    [[ "$output" == *"Base update is complete."* ]]
+}
+
+@test "basectl update skips Homebrew setup when Base version is unchanged" {
+    local fake_bin="$TEST_TMPDIR/bin"
+    local fake_base="$TEST_TMPDIR/homebrew/opt/base/libexec"
+    local brew_log="$TEST_TMPDIR/brew.log"
+
+    mkdir -p "$fake_bin" "$fake_base/bin"
+    cat > "$fake_bin/brew" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "config" ]]; then
+    exit 0
+fi
+if [[ "\$1" == "info" && "\$2" == "--json=v2" && "\$3" == "--installed" ]]; then
+    printf '%s\n' "\$*" >> "$brew_log"
+    printf '%s\n' '{"formulae":[{"name":"base","full_name":"basefoundry/base/base","linked_keg":"1.7.0","installed":[{"version":"1.7.0"}]}],"casks":[]}'
+    exit 0
+fi
+printf '%s\n' "\$*" >> "$brew_log"
+exit 0
+EOF
+    chmod +x "$fake_bin/brew"
+    touch "$fake_base/bin/basectl"
+    chmod +x "$fake_base/bin/basectl"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$fake_base" \
+        BASE_REPO_ROOT="$BASE_REPO_ROOT" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -c '
+            log_debug() { :; }
+            log_error() { printf "ERROR: %s\n" "$*"; }
+            log_info() { printf "INFO: %s\n" "$*"; }
+            log_warn() { printf "WARN: %s\n" "$*"; }
+            print_error() { printf "ERROR: %s\n" "$*"; }
+            source "$BASE_REPO_ROOT/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_run_homebrew_setup() { printf "setup should not run\n"; return 99; }
+            base_update_subcommand_main
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$brew_log")" = $'info --json=v2 --installed basefoundry/base/base\nupgrade basefoundry/base/base\ninfo --json=v2 --installed basefoundry/base/base' ]
+    [[ "$output" == *"Homebrew Base version is unchanged at '1.7.0' after upgrade."* ]]
+    [[ "$output" == *"Skipping basectl setup because the Homebrew Base version did not change."* ]]
+    [[ "$output" != *"setup should not run"* ]]
     [[ "$output" == *"Base update is complete."* ]]
 }
 
@@ -307,6 +390,7 @@ EOF
     local cellar_base="$homebrew/Cellar/base/0.4.0/libexec"
     local opt_prefix="$homebrew/opt/base"
     local opt_base="$opt_prefix/libexec"
+    local brew_state="$TEST_TMPDIR/brew-state"
     local setup_log="$TEST_TMPDIR/setup.log"
 
     mkdir -p "$fake_bin" "$cellar_base/bin" "$opt_base/bin"
@@ -314,6 +398,21 @@ EOF
     chmod +x "$cellar_base/bin/basectl"
     cat > "$fake_bin/brew" <<EOF
 #!/usr/bin/env bash
+if [[ "\$1" == "config" ]]; then
+    exit 0
+fi
+if [[ "\$1" == "info" && "\$2" == "--json=v2" && "\$3" == "--installed" ]]; then
+    if [[ -f "$brew_state" ]]; then
+        printf '%s\n' '{"formulae":[{"name":"base","full_name":"basefoundry/base/base","linked_keg":"0.5.0","installed":[{"version":"0.5.0"}]}],"casks":[]}'
+    else
+        printf '%s\n' '{"formulae":[{"name":"base","full_name":"basefoundry/base/base","linked_keg":"0.4.0","installed":[{"version":"0.4.0"}]}],"casks":[]}'
+    fi
+    exit 0
+fi
+if [[ "\$1" == "upgrade" ]]; then
+    touch "$brew_state"
+    exit 0
+fi
 if [[ "\$1" == "--prefix" ]]; then
     printf '%s\n' "$opt_prefix"
     exit 0


### PR DESCRIPTION
## Summary

- Read the installed Homebrew Base version from structured `brew info --json=v2 --installed` output before and after `brew upgrade basefoundry/base/base`.
- Run `basectl setup` only when the installed Base version changes.
- Skip setup with an explicit log when Homebrew leaves Base at the same version.
- Update help, dry-run messaging, README docs, and focused update tests for the conditional Homebrew setup behavior.

## Root Cause

The Homebrew update path treated any successful `brew upgrade` as a real Base update. Homebrew can also return success when the formula is already current, so `basectl update` was still running setup for no-op Homebrew upgrades.

## Validation

- `bats cli/bash/commands/basectl/tests/update.bats`
- `bash -n cli/bash/commands/basectl/subcommands/update.sh`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/update.sh`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_base_cli_docs.py tests/test_docs_version.py`
- `git diff --check`
- live read-only probe: `base_update_homebrew_installed_version basefoundry/base/base` returned `1.7.0`

Closes #1739
