### PR TITLE
Make base_cli tests valid for source checkouts and installed distributions

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,7 +57,10 @@ Map each symptom to its likely ownership before changing code:
 Python engine and helper behavior lives under `cli/python/**/tests/` and
 `lib/python/**/tests/`. These tests should cover parsing, manifest merging,
 artifact decisions, JSON output, and error handling without launching public
-shell commands.
+shell commands. Monorepo-wide contract checks that inspect `STANDARDS.md`,
+scan all production packages, or invoke shell files live under the top-level
+`tests/` directory so they are not mistaken for tests of an installed Python
+distribution.
 
 Run them with:
 

--- a/lib/python/base_cli/tests/test_app_run.py
+++ b/lib/python/base_cli/tests/test_app_run.py
@@ -35,7 +35,6 @@ class RunAppTests(unittest.TestCase):
                 {
                     "HOME": str(home),
                     "BASE_CACHE_DIR": str(home / ".cache" / "base"),
-                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
                 },
             ), redirect_stderr(stderr):
                 status = base_cli.run_app(app, [])
@@ -61,7 +60,6 @@ class RunAppTests(unittest.TestCase):
                 {
                     "HOME": str(home),
                     "BASE_CACHE_DIR": str(home / ".cache" / "base"),
-                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
                 },
             ):
                 with self.assertRaisesRegex(RuntimeError, "boom"):
@@ -86,7 +84,6 @@ class RunAppTests(unittest.TestCase):
                 {
                     "HOME": str(home),
                     "BASE_CACHE_DIR": str(home / ".cache" / "base"),
-                    "BASE_HOME": str(Path(__file__).resolve().parents[4]),
                 },
             ), redirect_stderr(stderr):
                 status = base_cli.run_app(app, ["--name=demo"])

--- a/lib/python/base_cli/tests/test_command_protocol.py
+++ b/lib/python/base_cli/tests/test_command_protocol.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import os
-import subprocess
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 from base_cli.command_protocol import CommandProtocolError
@@ -145,67 +142,6 @@ class CommandProtocolTests(unittest.TestCase):
             loads_records(wrong_type)
         with self.assertRaisesRegex(CommandProtocolError, "invalid lowercase hexadecimal"):
             loads_records(malformed_hex)
-
-    def test_python_project_list_framing_is_consumed_by_standalone_completion_reader(self) -> None:
-        payload = dumps_records(
-            "project-list-entry",
-            [
-                {"project_name": "base", "project_root": "/tmp/base"},
-                {"project_name": "demo", "project_root": "/tmp/work space/λ demo"},
-            ],
-        )
-        repo_root = Path(__file__).resolve().parents[4]
-        completion_script = repo_root / "lib" / "shell" / "completions" / "basectl_completion.sh"
-        result = subprocess.run(
-            [
-                "/bin/bash",
-                "-c",
-                'source "$COMPLETION_SCRIPT"; '
-                '_base_basectl_completion_project_names_from_protocol "$PAYLOAD" || exit; '
-                'printf "%s\\n" "$_BASE_BASECTL_COMPLETION_PROJECT_NAMES_DECODED"',
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            env={**os.environ, "COMPLETION_SCRIPT": str(completion_script), "PAYLOAD": payload},
-        )
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout, "base\ndemo\n")
-
-    def test_python_command_framing_is_consumed_by_runtime_bash_decoder(self) -> None:
-        command = "printf 'tab=\t unicode=λ newline=\n control=\x01'"
-        payload = dumps_record(
-            "project-command",
-            project_command_record(command=command),
-        )
-        repo_root = Path(__file__).resolve().parents[4]
-        decoder_script = repo_root / "lib" / "bash" / "runtime" / "command_protocol.sh"
-        result = subprocess.run(
-            [
-                "bash",
-                "-c",
-                'source "$DECODER_SCRIPT"; '
-                'base_command_protocol_decode_one project-command "$PAYLOAD" || exit; '
-                '[[ "${BASE_COMMAND_PROTOCOL_FIELDS[command]}" == "$EXPECTED_COMMAND" ]] || exit 2; '
-                '[[ "${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}" == "/tmp/work space/demo" ]] || exit 3; '
-                '[[ "${BASE_COMMAND_PROTOCOL_NULL_FIELDS[runner]:-}" == 1 ]] || exit 4; '
-                'printf "decoded\\n"',
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            env={
-                **os.environ,
-                "DECODER_SCRIPT": str(decoder_script),
-                "EXPECTED_COMMAND": command,
-                "PAYLOAD": payload,
-            },
-        )
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout, "decoded\n")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_base_cli_command_protocol_bash.py
+++ b/tests/test_base_cli_command_protocol_bash.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+from base_cli.command_protocol import dumps_record
+from base_cli.command_protocol import dumps_records
+
+
+def project_command_record(**overrides: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "project_name": "demo",
+        "project_root": "/tmp/work space/demo",
+        "manifest_path": "/tmp/work space/demo/base_manifest.yaml",
+        "project_venv_dir": "/tmp/work space/demo/.venv",
+        "uses_uv_manager": False,
+        "manifest_command_trust_required": True,
+        "command": "printf 'tab=\t unicode=λ newline=\n control=\x01'",
+        "runner": None,
+    }
+    record.update(overrides)
+    return record
+
+
+class BaseCliCommandProtocolBashTests(unittest.TestCase):
+    def test_python_project_list_framing_is_consumed_by_standalone_completion_reader(self) -> None:
+        payload = dumps_records(
+            "project-list-entry",
+            [
+                {"project_name": "base", "project_root": "/tmp/base"},
+                {"project_name": "demo", "project_root": "/tmp/work space/λ demo"},
+            ],
+        )
+        repo_root = Path(__file__).resolve().parents[1]
+        completion_script = repo_root / "lib" / "shell" / "completions" / "basectl_completion.sh"
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                "-c",
+                'source "$COMPLETION_SCRIPT"; '
+                '_base_basectl_completion_project_names_from_protocol "$PAYLOAD" || exit; '
+                'printf "%s\\n" "$_BASE_BASECTL_COMPLETION_PROJECT_NAMES_DECODED"',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "COMPLETION_SCRIPT": str(completion_script), "PAYLOAD": payload},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "base\ndemo\n")
+
+    def test_python_command_framing_is_consumed_by_runtime_bash_decoder(self) -> None:
+        command = "printf 'tab=\t unicode=λ newline=\n control=\x01'"
+        payload = dumps_record(
+            "project-command",
+            project_command_record(command=command),
+        )
+        repo_root = Path(__file__).resolve().parents[1]
+        decoder_script = repo_root / "lib" / "bash" / "runtime" / "command_protocol.sh"
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$DECODER_SCRIPT"; '
+                'base_command_protocol_decode_one project-command "$PAYLOAD" || exit; '
+                '[[ "${BASE_COMMAND_PROTOCOL_FIELDS[command]}" == "$EXPECTED_COMMAND" ]] || exit 2; '
+                '[[ "${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}" == "/tmp/work space/demo" ]] || exit 3; '
+                '[[ "${BASE_COMMAND_PROTOCOL_NULL_FIELDS[runner]:-}" == 1 ]] || exit 4; '
+                'printf "decoded\\n"',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "DECODER_SCRIPT": str(decoder_script),
+                "EXPECTED_COMMAND": command,
+                "PAYLOAD": payload,
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "decoded\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_base_cli_exit_code_adoption.py
+++ b/tests/test_base_cli_exit_code_adoption.py
@@ -13,7 +13,7 @@ NON_EXIT_STATUS_RETURN_FUNCTIONS = {
 
 
 def repository_root() -> Path:
-    return Path(__file__).resolve().parents[4]
+    return Path(__file__).resolve().parents[1]
 
 
 def iter_production_python_files() -> list[Path]:

--- a/tests/test_base_cli_public_command_lifecycle.py
+++ b/tests/test_base_cli_public_command_lifecycle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
+REPO_ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_COMMAND_ROOT = REPO_ROOT / "cli" / "python"
 
 

--- a/tests/test_base_cli_python_standards.py
+++ b/tests/test_base_cli_python_standards.py
@@ -4,7 +4,7 @@ import ast
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
+REPO_ROOT = Path(__file__).resolve().parents[1]
 STANDARDS_DOC = REPO_ROOT / "STANDARDS.md"
 PYTHON_ROOTS = (
     REPO_ROOT / "cli" / "python",


### PR DESCRIPTION
## Summary

- Move monorepo-only Python standards, public-command lifecycle, and exit-code adoption checks to the top-level `tests/` suite.
- Move Bash completion and runtime protocol integration checks out of the installable `base_cli` test package.
- Remove checkout-derived `BASE_HOME` values from package tests.
- Document the boundary between package tests and monorepo-wide contract tests.

## Root Cause

Several tests under `lib/python/base_cli/tests` used `Path(__file__).resolve().parents[4]` to reach the Base checkout and then read repository files or invoke shell scripts. An installed distribution does not contain those paths, so the tests could fail or become misleading outside the monorepo.

## Validation

- Focused package and checkout-contract tests: 21 passed, 4 subtests passed.
- Full Python suite: 1047 passed, 1 skipped, 251 subtests passed.
- `git diff --check`.

Fixes #1743