### PR TITLE
Remove Base-specific assumptions from base_cli standalone behavior

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -685,6 +685,7 @@ basectl_history_record() {
     args+=(--exit-code "$exit_code")
     args+=(--scope "$scope")
     args+=(--owner "${BASE_CLI_RUNTIME_OWNER:-base}")
+    args+=(--raw-command basectl)
     if [[ -n "${BASE_CLI_RUN_ROOT:-}" ]]; then
         args+=(--bundle-path "$BASE_CLI_RUN_ROOT")
     fi

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -685,7 +685,6 @@ basectl_history_record() {
     args+=(--exit-code "$exit_code")
     args+=(--scope "$scope")
     args+=(--owner "${BASE_CLI_RUNTIME_OWNER:-base}")
-    args+=(--raw-command basectl)
     if [[ -n "${BASE_CLI_RUN_ROOT:-}" ]]; then
         args+=(--bundle-path "$BASE_CLI_RUN_ROOT")
     fi

--- a/cli/python/base_history/record.py
+++ b/cli/python/base_history/record.py
@@ -28,6 +28,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--manifest")
     parser.add_argument("--owner", default=os.environ.get("BASE_CLI_RUNTIME_OWNER", "base"))
     parser.add_argument("--bundle-path")
+    parser.add_argument("--raw-command", default="basectl")
     parser.add_argument("argv", nargs=argparse.REMAINDER)
     options = parser.parse_args(argv)
 
@@ -48,6 +49,7 @@ def main(argv: list[str] | None = None) -> int:
         log_path=None,
         owner=options.owner,
         bundle_path=options.bundle_path,
+        raw_command=options.raw_command,
     )
     return base_cli.ExitCode.SUCCESS
 

--- a/lib/python/base_cli/app.py
+++ b/lib/python/base_cli/app.py
@@ -55,7 +55,7 @@ def _require_click():
     try:
         import click
     except ImportError as exc:
-        raise RuntimeError("Click is required for base_cli. Run 'basectl setup' to install it.") from exc
+        raise RuntimeError("Click is required for base_cli. Install it with 'pip install click'.") from exc
     return click
 
 

--- a/lib/python/base_cli/context.py
+++ b/lib/python/base_cli/context.py
@@ -5,7 +5,7 @@ import logging
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from .config import UserConfig, UserIdeConfig
 
@@ -29,7 +29,7 @@ class Context:
     cache_dir: Path
     temp_dir: Path
     log_file: Path | None
-    config: dict
+    config: dict[str, Any]
     environment: str
     debug: bool
     keep_temp: bool

--- a/lib/python/base_cli/history.py
+++ b/lib/python/base_cli/history.py
@@ -23,6 +23,44 @@ HISTORY_PATH = Path("base") / "history" / "runs.jsonl"
 HISTORY_SCOPE_PRIMARY = "primary"
 HISTORY_SCOPE_INTERNAL = "internal"
 
+# Only these names are Base-owned Python entry points. A standalone caller
+# may legitimately choose a name beginning with ``base_`` and should not have
+# that name rewritten by the shared framework.
+_BASE_DISPLAY_COMMANDS = frozenset(
+    {
+        "base_activate",
+        "base_build",
+        "base_check",
+        "base_ci",
+        "base_clean",
+        "base_config",
+        "base_demo",
+        "base_dev",
+        "base_devcontainer",
+        "base_devenv",
+        "base_devenv_report",
+        "base_docs",
+        "base_export_context",
+        "base_gh",
+        "base_github_projects",
+        "base_history",
+        "base_logs",
+        "base_onboard",
+        "base_pr_policy",
+        "base_projects",
+        "base_prompt",
+        "base_release",
+        "base_repo",
+        "base_run",
+        "base_setup",
+        "base_test",
+        "base_trust",
+        "base_update",
+        "base_update_profile",
+        "base_workspace",
+    }
+)
+
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -102,6 +140,8 @@ def write_primary_record(
     log_path: str | None = None,
     owner: str = "base",
     bundle_path: str | None = None,
+    *,
+    raw_command: str = "basectl",
 ) -> None:
     """Write the user-facing record for a Bash-dispatched command."""
     ended_at = utc_now()
@@ -110,7 +150,7 @@ def write_primary_record(
         "run_id": run_id,
         "event": "finished",
         "command": command,
-        "raw_command": "basectl",
+        "raw_command": raw_command,
         "argv": redact_history_argv(argv, sensitive_options=set()),
         "started_at": format_timestamp(started_at),
         "ended_at": format_timestamp(ended_at),
@@ -232,7 +272,7 @@ def duration_ms(started_at: datetime, ended_at: datetime) -> int:
 def display_command(cli_name: str, argv: list[str]) -> str:
     if cli_name == "base_setup":
         return base_setup_action(argv) or "setup"
-    if cli_name.startswith("base_"):
+    if cli_name in _BASE_DISPLAY_COMMANDS:
         return cli_name.removeprefix("base_").replace("_", "-")
     return cli_name.replace("_", "-")
 

--- a/lib/python/base_cli/logging.py
+++ b/lib/python/base_cli/logging.py
@@ -84,7 +84,9 @@ class SecureLogFileHandler(logging.FileHandler):
     def _open(self) -> TextIO:
         fd = os.open(self.baseFilename, _secure_log_file_open_flags(self.mode), 0o600)
         try:
-            os.fchmod(fd, 0o600)
+            fchmod = getattr(os, "fchmod", None)
+            if fchmod is not None:
+                fchmod(fd, 0o600)
             return open(fd, self.mode, encoding=self.encoding, errors=self.errors, closefd=True)
         except BaseException:
             os.close(fd)

--- a/lib/python/base_cli/testing.py
+++ b/lib/python/base_cli/testing.py
@@ -30,7 +30,7 @@ def invoke(
     try:
         from click.testing import CliRunner
     except ImportError as exc:
-        raise RuntimeError("Click is required for base_cli.testing. Run 'basectl setup' to install it.") from exc
+        raise RuntimeError("Click is required for base_cli.testing. Install it with 'pip install click'.") from exc
 
     invoke_env = dict(env or {})
     if home is not None:
@@ -48,7 +48,10 @@ def _write_manifest_fixture(cwd: Path, manifest: Mapping[str, Any]) -> None:
     try:
         import yaml
     except ImportError as exc:
-        raise RuntimeError("PyYAML is required to write base_cli.testing manifest fixtures.") from exc
+        raise RuntimeError(
+            "PyYAML is required to write base_cli.testing manifest fixtures. "
+            "Install it with 'pip install PyYAML'."
+        ) from exc
 
     (cwd / "base_manifest.yaml").write_text(
         yaml.safe_dump(dict(manifest), sort_keys=False),

--- a/lib/python/base_cli/tests/test_app_runtime_errors.py
+++ b/lib/python/base_cli/tests/test_app_runtime_errors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import os
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr
@@ -10,9 +11,26 @@ from pathlib import Path
 from unittest import mock
 
 import base_cli
+from base_cli.testing import invoke
 
 
 class AppRuntimeErrorTests(unittest.TestCase):
+    def test_missing_click_error_recommends_pip_install(self) -> None:
+        with mock.patch.dict(sys.modules, {"click": None}):
+            with self.assertRaisesRegex(RuntimeError, r"Install it with 'pip install click'"):
+                base_cli.app._require_click()
+
+    def test_testing_missing_click_error_recommends_pip_install(self) -> None:
+        app = base_cli.App(name="missing-click")
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+
+        with mock.patch.dict(sys.modules, {"click": None}):
+            with self.assertRaisesRegex(RuntimeError, r"Install it with 'pip install click'"):
+                invoke(app, [])
+
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_run_app_reports_unwritable_cache_root_without_traceback(self) -> None:
         app = base_cli.App(name="cache-failure", version="0.1.0")

--- a/lib/python/base_cli/tests/test_app_runtime_errors.py
+++ b/lib/python/base_cli/tests/test_app_runtime_errors.py
@@ -16,9 +16,15 @@ from base_cli.testing import invoke
 
 class AppRuntimeErrorTests(unittest.TestCase):
     def test_missing_click_error_recommends_pip_install(self) -> None:
+        app = base_cli.App(name="missing-click")
+
+        @app.command()
+        def main(ctx: base_cli.Context) -> None:
+            del ctx
+
         with mock.patch.dict(sys.modules, {"click": None}):
             with self.assertRaisesRegex(RuntimeError, r"Install it with 'pip install click'"):
-                base_cli.app._require_click()
+                _ = app.click_command
 
     def test_testing_missing_click_error_recommends_pip_install(self) -> None:
         app = base_cli.App(name="missing-click")

--- a/lib/python/base_cli/tests/test_history.py
+++ b/lib/python/base_cli/tests/test_history.py
@@ -46,6 +46,9 @@ class BaseCliHistoryTests(unittest.TestCase):
                     )
                 )
                 self.assertEqual(history_helpers.display_command("base_setup", ["--action", "check"]), "check")
+                self.assertEqual(history_helpers.display_command("base_history", []), "history")
+                self.assertEqual(history_helpers.display_command("base_something", []), "base-something")
+                self.assertEqual(history_helpers.display_command("my_tool", []), "my-tool")
                 self.assertEqual(history_helpers.compact_path(inside_home), "~/logs/run.log")
                 self.assertEqual(
                     history_helpers.compact_path(outside_home),
@@ -132,13 +135,14 @@ class BaseCliHistoryTests(unittest.TestCase):
                     project_root=str(project_root),
                     manifest=str(manifest),
                     bundle_path=str(bundle),
+                    raw_command="base-history",
                 )
             record = read_history_records(cache_root)[0]
             metadata = json.loads((bundle / "run.json").read_text(encoding="utf-8"))
             metadata_mode = (bundle / "run.json").stat().st_mode & 0o777
 
         self.assertEqual(record["command"], "test")
-        self.assertEqual(record["raw_command"], "basectl")
+        self.assertEqual(record["raw_command"], "base-history")
         self.assertEqual(record["scope"], "internal")
         self.assertEqual(record["run_id"], "parent-1")
         self.assertEqual(record["project"], "demo")
@@ -148,7 +152,7 @@ class BaseCliHistoryTests(unittest.TestCase):
         self.assertEqual(metadata["project"], "demo")
         self.assertEqual(metadata["project_root"], str(project_root.resolve()))
         self.assertEqual(metadata["manifest"], str(manifest.resolve()))
-        self.assertEqual(metadata["raw_command"], "basectl")
+        self.assertEqual(metadata["raw_command"], "base-history")
         self.assertEqual(metadata["scope"], "internal")
         self.assertEqual(metadata_mode, 0o600)
 

--- a/lib/python/base_cli/tests/test_logging.py
+++ b/lib/python/base_cli/tests/test_logging.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest import mock
 
 import base_cli
+import base_cli.logging as logging_module
 from base_cli.logging import BaseCliFormatter
 
 
@@ -149,3 +150,22 @@ class ConfigureLoggerTests(unittest.TestCase):
 
         self.assertTrue(all(mode == 0o600 for mode in observed_modes), observed_modes)
         self.assertEqual(final_mode, 0o600)
+
+    def test_configure_logger_opens_log_file_without_fchmod(self) -> None:
+        stream = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "portable.log"
+            with mock.patch.object(logging_module.os, "fchmod", None):
+                logger = base_cli.configure_logger(
+                    "portable-log-file",
+                    log_file,
+                    debug=False,
+                    stream=stream,
+                )
+                logger.info("portable log")
+                for handler in logger.handlers:
+                    handler.flush()
+
+            self.assertIn("portable log", log_file.read_text(encoding="utf-8"))
+            self.assertEqual(log_file.stat().st_mode & 0o777, 0o600)


### PR DESCRIPTION
## Summary
- replace basectl-specific missing-dependency guidance with standalone pip installation instructions
- preserve caller-provided raw command names in primary history records and pass basectl explicitly from the Base call site
- restrict Base command display normalization to an explicit command set
- make secure log-file opening portable when os.fchmod is unavailable and tighten Context.config typing
- add focused regression coverage for standalone behavior and portable logging

## Validation
- PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q
- 1050 passed, 1 skipped, 251 subtests passed
- git diff --check

Closes #1746