### PR TITLE
Report issue numbers during Project backfill

### DIFF
--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -343,19 +343,19 @@ def fetch_issue_id(owner: str, name: str, number: int) -> str:
     return issue["id"]
 
 
-def fetch_repository_issue_ids(repo: str) -> tuple[str, ...]:
+def fetch_repository_issues(repo: str) -> tuple[tuple[str, int], ...]:
     owner, name = split_repo(repo)
-    issue_ids: list[str] = []
+    issues_found: list[tuple[str, int]] = []
     cursor: str | None = None
     while True:
-        payload = run_graphql(queries.FETCH_REPOSITORY_ISSUE_IDS, {"owner": owner, "name": name, "cursor": cursor})
+        payload = run_graphql(queries.FETCH_REPOSITORY_ISSUES, {"owner": owner, "name": name, "cursor": cursor})
         repository = payload["data"].get("repository")
         if repository is None:
             raise ProjectError(f"Repository '{repo}' was not found.")
         issues = repository["issues"]
-        issue_ids.extend(node["id"] for node in issues["nodes"])
+        issues_found.extend((node["id"], node["number"]) for node in issues["nodes"])
         if not issues["pageInfo"]["hasNextPage"]:
-            return tuple(issue_ids)
+            return tuple(issues_found)
         cursor = issues["pageInfo"]["endCursor"]
 
 
@@ -377,16 +377,16 @@ def fetch_project_issue_content_ids(project_id: str) -> set[str]:
         cursor = items["pageInfo"]["endCursor"]
 
 
-def backfill_repository_issues(project_id: str, repo: str) -> int:
+def backfill_repository_issues(project_id: str, repo: str) -> tuple[int, ...]:
     existing = fetch_project_issue_content_ids(project_id)
-    added = 0
-    for issue_id in fetch_repository_issue_ids(repo):
+    added: list[int] = []
+    for issue_id, issue_number in fetch_repository_issues(repo):
         if issue_id in existing:
             continue
         add_project_item(project_id, issue_id)
         existing.add(issue_id)
-        added += 1
-    return added
+        added.append(issue_number)
+    return tuple(sorted(added))
 
 
 def find_project_item_id(project_id: str, issue_id: str) -> str | None:

--- a/cli/python/base_github_projects/graphql_queries.py
+++ b/cli/python/base_github_projects/graphql_queries.py
@@ -108,12 +108,12 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 """
 
-FETCH_REPOSITORY_ISSUE_IDS = """
+FETCH_REPOSITORY_ISSUES = """
 query($owner: String!, $name: String!, $cursor: String) {
   repository(owner: $owner, name: $name) {
     issues(first: 100, after: $cursor, states: [OPEN, CLOSED], orderBy: {field: CREATED_AT, direction: ASC}) {
       pageInfo { hasNextPage endCursor }
-      nodes { id }
+      nodes { id number }
     }
   }
 }

--- a/cli/python/base_github_projects/project_configure_command.py
+++ b/cli/python/base_github_projects/project_configure_command.py
@@ -160,8 +160,12 @@ def link_and_backfill_project(project_id: str, repo: str | None, ops: ProjectOpe
     if not repo:
         return
     ops.link_project_to_repository(project_id, repo)
-    count = ops.backfill_repository_issues(project_id, repo)
-    print(f"✓ Backfilled {count} issue(s) from {repo}")
+    added_issue_numbers = ops.backfill_repository_issues(project_id, repo)
+    if added_issue_numbers:
+        issue_list = ", ".join(f"#{number}" for number in added_issue_numbers)
+        print(f"✓ Backfilled {len(added_issue_numbers)} issue(s) from {repo}: {issue_list}")
+    else:
+        print(f"✓ Backfilled 0 issue(s) from {repo} (already up to date)")
 
 
 def copy_replacement_project_fields(

--- a/cli/python/base_github_projects/project_operations.py
+++ b/cli/python/base_github_projects/project_operations.py
@@ -59,7 +59,7 @@ class ProjectOperations:
     ProjectUsageError: type[Exception]
     add_project_item: Callable[[str, str], str]
     apply_missing_project_item_defaults: Callable[[str, tuple[ProjectField, ...], dict[str, str]], FieldCopySummary]
-    backfill_repository_issues: Callable[[str, str], int]
+    backfill_repository_issues: Callable[[str, str], tuple[int, ...]]
     compare_schema: Callable[[tuple[ProjectField, ...], ProjectSchema], tuple[Finding, ...]]
     configuration_plan: ConfigurationPlan
     copy_missing_project_item_fields: Callable[[str, str], FieldCopySummary]

--- a/cli/python/base_github_projects/tests/test_engine.py
+++ b/cli/python/base_github_projects/tests/test_engine.py
@@ -557,7 +557,7 @@ def test_configure_command_copies_template_for_repo_project_and_backfills_issues
     monkeypatch.setattr(
         engine,
         "backfill_repository_issues",
-        lambda project_id, repo: backfilled.append((project_id, repo)),
+        lambda project_id, repo: backfilled.append((project_id, repo)) or (),
     )
 
     status = engine.configure_command(
@@ -605,7 +605,7 @@ def test_configure_command_copies_missing_project_fields_when_requested(
     monkeypatch.setattr(engine, "update_single_select_field", lambda field, spec: None)
     monkeypatch.setattr(engine, "fetch_project_views", lambda project_id: project_model.STANDARD_TEMPLATE_VIEWS)
     monkeypatch.setattr(engine, "link_project_to_repository", lambda project_id, repo: None)
-    monkeypatch.setattr(engine, "backfill_repository_issues", lambda project_id, repo: 0)
+    monkeypatch.setattr(engine, "backfill_repository_issues", lambda project_id, repo: ())
     monkeypatch.setattr(
         engine,
         "copy_missing_project_item_fields",
@@ -693,7 +693,7 @@ def test_configure_command_applies_issue_defaults_from_project_config(
     monkeypatch.setattr(engine, "create_single_select_field", lambda project_id, spec: None)
     monkeypatch.setattr(engine, "update_single_select_field", lambda field, spec: None)
     monkeypatch.setattr(engine, "link_project_to_repository", lambda project_id, repo: None)
-    monkeypatch.setattr(engine, "backfill_repository_issues", lambda project_id, repo: 0)
+    monkeypatch.setattr(engine, "backfill_repository_issues", lambda project_id, repo: ())
     monkeypatch.setattr(
         engine,
         "apply_missing_project_item_defaults",
@@ -902,7 +902,11 @@ def test_plan_project_item_field_defaults_skips_existing_values_and_missing_opti
 def test_backfill_repository_issues_adds_only_missing_project_items(monkeypatch: pytest.MonkeyPatch) -> None:
     added: list[tuple[str, str]] = []
 
-    monkeypatch.setattr(engine, "fetch_repository_issue_ids", lambda repo: ("issue-1", "issue-2", "issue-3"))
+    monkeypatch.setattr(
+        engine,
+        "fetch_repository_issues",
+        lambda repo: (("issue-1", 3), ("issue-2", 2), ("issue-3", 1)),
+    )
     monkeypatch.setattr(engine, "fetch_project_issue_content_ids", lambda project_id: {"issue-2"})
     monkeypatch.setattr(
         engine,
@@ -910,9 +914,10 @@ def test_backfill_repository_issues_adds_only_missing_project_items(monkeypatch:
         lambda project_id, issue_id: added.append((project_id, issue_id)) or f"item-{issue_id}",
     )
 
-    engine.backfill_repository_issues("project-id", "codeforester/base-demo")
+    issue_numbers = engine.backfill_repository_issues("project-id", "codeforester/base-demo")
 
     assert added == [("project-id", "issue-1"), ("project-id", "issue-3")]
+    assert issue_numbers == (1, 3)
 
 
 def test_link_project_to_repository_skips_existing_link(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/cli/python/base_github_projects/tests/test_project_configure_replacement.py
+++ b/cli/python/base_github_projects/tests/test_project_configure_replacement.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from base_github_projects import engine, project_model
@@ -106,7 +108,7 @@ def test_configure_command_replace_project_skips_replacement_for_standard_views(
     monkeypatch.setattr(
         engine,
         "backfill_repository_issues",
-        lambda project_id, repo: backfilled.append((project_id, repo)) or 3,
+        lambda project_id, repo: backfilled.append((project_id, repo)) or (1, 2, 3),
     )
     monkeypatch.setattr(
         engine,
@@ -247,7 +249,7 @@ def test_configure_command_replace_project_renames_copies_backfills_and_closes_l
     monkeypatch.setattr(
         engine,
         "backfill_repository_issues",
-        lambda project_id, repo: backfilled.append((project_id, repo)) or 7,
+        lambda project_id, repo: backfilled.append((project_id, repo)) or (1, 2, 3),
     )
     monkeypatch.setattr(
         engine,
@@ -278,6 +280,30 @@ def test_configure_command_replace_project_renames_copies_backfills_and_closes_l
     assert field_copies == [("legacy-project", "new-project")]
     output = capsys.readouterr().out
     assert "Renamed existing Project base-demo to base-demo-legacy-20260619-120000" in output
-    assert "Backfilled 7 issue(s) from codeforester/base-demo" in output
+    assert "Backfilled 3 issue(s) from codeforester/base-demo: #1, #2, #3" in output
     assert "Copied 12 Project item field value(s) from base-demo-legacy-20260619-120000" in output
     assert "Closed legacy GitHub Project base-demo-legacy-20260619-120000" in output
+
+
+def test_link_and_backfill_reports_added_issue_numbers(capsys: pytest.CaptureFixture[str]) -> None:
+    linked: list[tuple[str, str]] = []
+    ops = SimpleNamespace(
+        link_project_to_repository=lambda project_id, repo: linked.append((project_id, repo)),
+        backfill_repository_issues=lambda project_id, repo: (1614, 1615),
+    )
+
+    project_configure_command.link_and_backfill_project("project-id", "codeforester/base-demo", ops)
+
+    assert linked == [("project-id", "codeforester/base-demo")]
+    assert capsys.readouterr().out == "✓ Backfilled 2 issue(s) from codeforester/base-demo: #1614, #1615\n"
+
+
+def test_link_and_backfill_reports_up_to_date_project(capsys: pytest.CaptureFixture[str]) -> None:
+    ops = SimpleNamespace(
+        link_project_to_repository=lambda project_id, repo: None,
+        backfill_repository_issues=lambda project_id, repo: (),
+    )
+
+    project_configure_command.link_and_backfill_project("project-id", "codeforester/base-demo", ops)
+
+    assert capsys.readouterr().out == "✓ Backfilled 0 issue(s) from codeforester/base-demo (already up to date)\n"


### PR DESCRIPTION
## Summary

- Return the issue numbers added during repository Project backfill.
- Report deterministic issue-number output from `basectl repo configure`.
- Make the no-op case explicit when the Project is already up to date.
- Add focused coverage for populated and empty backfills.

## Why

The previous output reported only an aggregate count, such as `Backfilled 2 issue(s)`, which made it difficult to reconcile the command with the Project view.

## Validation

- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_github_projects/tests -q` — 61 passed.
- Full Python suite via `bin/base-test` — 1,055 passed, 1 skipped.
- `git diff --check` — passed.
- Source-checkout BATS validation was started but stopped after unrelated environment-dependent `basectl check` failures.

## AI context

No `.ai-context/` update is needed; this changes command observability without changing the product shape or workflow contract.

Closes #1750