### PR TITLE
Pin CI to base-bash-libs v1.4.0

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
+          ref: 2c5ef2c3a9edfbe2cf68d0645be65b920255abff
           path: .base/base-bash-libs
 
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
+          ref: 2c5ef2c3a9edfbe2cf68d0645be65b920255abff
           path: .dependencies/base-bash-libs
 
       - name: Remove flaky hosted-runner apt sources
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
+          ref: 2c5ef2c3a9edfbe2cf68d0645be65b920255abff
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
+          ref: 2c5ef2c3a9edfbe2cf68d0645be65b920255abff
           path: .dependencies/base-bash-libs
 
       - name: Set up Python
@@ -226,7 +226,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: 5e52e79a8d6f61f82e5e95a07c75da256642f92e
+          ref: 2c5ef2c3a9edfbe2cf68d0645be65b920255abff
           path: .dependencies/base-bash-libs
 
       - name: Expose reusable Bash library checkout as sibling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Updated Base CI and source-checkout contract coverage to consume the
+  published `base-bash-libs` v1.4.0 release commit.
 - Refined basectl logs with comma-separated --command filters, the
   --latest path action, and the explicit last-failed report command.
 - Clarified basectl logs action conflicts and help for --latest, --tail, and

--- a/docs/base-bash-libs.md
+++ b/docs/base-bash-libs.md
@@ -171,7 +171,7 @@ The Base contract is external-required:
   bootstrap.
 - Homebrew Base consumes the Homebrew `base-bash-libs` package declared by the
   tap formula.
-- Base CI pins the source checkout to the immutable `base-bash-libs` v1.3.0
+- Base CI pins the source checkout to the immutable `base-bash-libs` v1.4.0
   release commit; runtime compatibility remains a 1.x minimum-version contract.
 - `basectl check` and `basectl doctor` emit `BASE-D007` as ok when the external
   source is explicit, sibling, or Homebrew.

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -101,7 +101,7 @@ EOF
     [[ "$output" == *"BASE_BASH_LIB_DIR=$TEST_BASE_HOME/lib/bash"* ]]
     [[ "$output" == *"BASE_BASH_LIBS_DIR=$expected_bash_libs_dir"* ]]
     [[ "$output" == *"BASE_BASH_LIBS_SOURCE=sibling"* ]]
-    [[ "$output" == *"BASE_BASH_LIBS_VERSION=1.3.0"* ]]
+    [[ "$output" == *"BASE_BASH_LIBS_VERSION=1.4.0"* ]]
     [[ "$output" == *"BASE_SHELL_DIR=$TEST_BASE_HOME/lib/shell"* ]]
 }
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -628,7 +628,7 @@ def test_reusable_base_check_workflow_contract() -> None:
     assert "args=(check --ci \"$BASE_CHECK_PROJECT\" --format \"$BASE_CHECK_OUTPUT_FORMAT\")" in run_commands
     assert "BASE_BASH_LIBS_DIR" in run_commands
     assert "basefoundry/base-bash-libs" in str(steps)
-    assert "5e52e79a8d6f61f82e5e95a07c75da256642f92e" in str(steps)
+    assert "2c5ef2c3a9edfbe2cf68d0645be65b920255abff" in str(steps)
     assert "${{ inputs.base-ref || github.workflow_sha }}" in str(steps)
     assert "uses: basefoundry/base/.github/workflows/base-check.yml@<base-ref-or-sha>" in ci_docs
     assert "| `setup-mode` | `source-checkout` |" in ci_docs


### PR DESCRIPTION
## Summary

- pin all five Base CI checkouts to the peeled base-bash-libs v1.4.0 release commit
- update the workflow contract, sibling fixture, documentation, and changelog
- preserve the runtime compatibility floor at v1.3.0

## Validation

- focused workflow and documentation tests: 44 passed
- `tests/base_init.bats`: 21 passed
- full Python suite: 1,055 passed, 1 skipped
- full BATS suite: 798 passed, 32 failed
- `git diff --check`

The 32 BATS failures are an existing diagnostic-Python fixture problem: the
stub venv/PATH cannot import `base_setup.diagnostics`. The same failures were
reproduced with the exact archived v1.3.0 dependency and an isolated
`BASE_CACHE_DIR`, so they are unrelated to this pin update.

`.ai-context` is unchanged because this dependency pin does not alter repository
topology or contributor process.

Release commit:
`2c5ef2c3a9edfbe2cf68d0645be65b920255abff`

Closes #1752
