### PR TITLE
Fix false readonly BASE_HOME detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Corrected Bash startup's readonly `BASE_HOME` detection to inspect only
+  variable attributes, allowing refreshed profile snippets to replace writable
+  Homebrew paths while keeping genuine mismatch recovery diagnostics specific.
 - Prevented `basectl activate` from reusing a virtual environment override owned
   by a different active project.
 - Unified human-readable `basectl doctor` output across Base and project

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -348,6 +348,36 @@ EOF
     [[ "$output" == *"PATH=$opt_base/bin:/usr/bin:/bin:/usr/sbin:/sbin"* ]]
 }
 
+@test "Base-managed Bash startup replaces writable inherited BASE_HOME values" {
+    local inherited_base
+    local source_base="$TEST_TMPDIR/work/base"
+
+    create_fake_shell_base "$source_base"
+
+    for inherited_base in \
+        /usr/local/opt/base/libexec \
+        /opt/homebrew/opt/base/libexec; do
+        run env -u BASE_PLATFORM_TOOLS_HOME -u BASE_PLATFORM_TOOLS_BIN_DIR \
+            HOME="$TEST_HOME" \
+            BASE_HOME="$inherited_base" \
+            BASE_SHELL=1 \
+            PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+            bash --rcfile "$source_base/lib/shell/bashrc" -i -c '\
+                printf "BASE_HOME=%s\n" "$BASE_HOME"; \
+                printf "BASE_BIN=%s\n" "$(command -v basectl)"; \
+                declare -p BASE_HOME'
+
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"BASE_HOME=$source_base"* ]]
+        [[ "$output" == *"BASE_BIN=$source_base/bin/basectl"* ]]
+        [[ "$output" == *"declare -x BASE_HOME=\"$source_base\""* ]]
+        [[ "$output" != *"BASE_HOME is readonly"* ]]
+        [[ "$output" != *"already running Base"* ]]
+        [[ "$output" != *"Start a fresh shell without stale Base runtime variables"* ]]
+        [[ "$output" != *"Run basectl update-profile"* ]]
+    done
+}
+
 @test "Base-managed Bash startup explains stale readonly BASE_HOME recovery" {
     local old_base="$TEST_TMPDIR/homebrew/Cellar/base/0.3.0/libexec"
     local cellar_base="$TEST_TMPDIR/homebrew/Cellar/base/0.4.1/libexec"
@@ -372,6 +402,24 @@ EOF
     [[ "$output" == *"-u BASE_PROJECT_VENV_DIR \\"* ]]
     [[ "$output" == *'"$SHELL" -l'* ]]
     [[ "$output" != *"ERROR:   exec env"* ]]
+    [[ "$output" != *"Unable to determine BASE_HOME from Base bashrc snippet"* ]]
+    [[ "$output" != *"Run basectl update-profile"* ]]
+}
+
+@test "Base-managed Bash startup preserves generic guidance for undiagnosed failures" {
+    local invalid_base="$TEST_TMPDIR/invalid-base"
+
+    create_fake_shell_base "$invalid_base"
+    rm "$invalid_base/base_init.sh"
+
+    run env -u BASE_HOME -u BASE_PLATFORM_TOOLS_HOME -u BASE_PLATFORM_TOOLS_BIN_DIR \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -i -c 'source "$1"' \
+        bash "$invalid_base/lib/shell/bashrc"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile."* ]]
 }
 
 @test "Base-managed Bash startup skips mismatched snippet inside active Base runtime" {

--- a/lib/shell/bashrc
+++ b/lib/shell/bashrc
@@ -44,9 +44,12 @@ base_bashrc_source_baserc_guard() {
 
 base_bashrc_var_is_readonly() {
     local declaration
+    local attributes
 
     declaration="$(declare -p "$1" 2>/dev/null)" || return 1
-    [[ "$declaration" == declare\ -*r* ]]
+    attributes="${declaration#declare -}"
+    attributes="${attributes%% *}"
+    [[ "$attributes" == *r* ]]
 }
 
 base_bashrc_print_stale_base_home_recovery() {
@@ -104,7 +107,8 @@ base_bashrc_set_base_home() {
             fi
             printf "ERROR: BASE_HOME is readonly and points at '%s', not '%s'.\n" "$BASE_HOME" "$base_home" >&2
             base_bashrc_print_stale_base_home_recovery
-            return 1
+            # The mismatch and recovery have already been diagnosed.
+            return 3
         fi
     fi
     export BASE_HOME="$base_home"
@@ -211,7 +215,9 @@ if ((base_bashrc_status == 2)); then
     unset base_bashrc_status
     return 0
 elif ((base_bashrc_status)); then
-    printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
+    if ((base_bashrc_status != 3)); then
+        printf 'ERROR: Unable to determine BASE_HOME from Base bashrc snippet. Run basectl update-profile.\n' >&2
+    fi
     unset -f base_bashrc_debug base_bashrc_snippet_dir base_bashrc_source_baserc_guard base_bashrc_var_is_readonly
     unset -f base_bashrc_print_stale_base_home_recovery base_bashrc_print_active_runtime_skip
     unset -f base_bashrc_source_platform_tools_helper base_bashrc_configure_path base_bashrc_source_defaults


### PR DESCRIPTION
## Summary

- Correct readonly `BASE_HOME` detection by inspecting only the declaration
  attribute token, not the variable value.
- Keep the specific stale-runtime recovery message without appending
  contradictory generic `update-profile` guidance.
- Add regressions for writable Intel and Apple Silicon Homebrew paths, genuine
  readonly mismatches, and undiagnosed startup failures.

## Issue

Closes #1766

## Validation

- `bats cli/bash/commands/basectl/tests/update-profile.bats` (37 passed)
- Forced macOS Bash 3.2 focused regression slice (4 passed)
- `/bin/bash -n lib/shell/bashrc`
- `/usr/local/bin/bash -n lib/shell/bashrc`
- `shellcheck --severity=warning lib/shell/bashrc`
- `git diff --check`
- `./bin/base-test`: Python suite passed (1056 passed, 1 skipped). The local
  macOS BATS gate reaches pre-existing JSON-diagnostic fixture failures because
  those fixtures expose only Apple Python 3.9; the authoritative Ubuntu CI gate
  will provide the broad BATS result.

## Demo Impact

None.

## Notes

- `VERSION` is unchanged; the fix is recorded under the existing Unreleased
  changelog section.
- `.ai-context/` is unchanged because this preserves the existing startup
  contract and does not alter Base architecture or command surfaces.
- Project V2 status/priority fields could not be updated because the current
  GitHub credential lacks the `project` scope.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
