### PR TITLE
Keep Base Bash prompts shell-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Kept helper-backed Bash defaults and runtime prompts shell-local so child
+  shells no longer report missing prompt helper functions.
 - Corrected Bash startup's readonly `BASE_HOME` detection to inspect only
   variable attributes, allowing refreshed profile snippets to replace writable
   Homebrew paths while keeping genuine mismatch recovery diagnostics specific.

--- a/cli/bash/commands/basectl/tests/update-profile.bats
+++ b/cli/bash/commands/basectl/tests/update-profile.bats
@@ -808,6 +808,44 @@ EOF
     fi
 }
 
+@test "basectl update-profile --defaults keeps the Bash prompt shell-local" {
+    run_base_command update-profile --defaults
+    [ "$status" -eq 0 ]
+
+    run env -u BASE_HOST -u BASE_HOST_ENV -u BASE_OS -u BASE_PLATFORM \
+        HOME="$TEST_HOME" \
+        BASE_HOME="/usr/local/opt/base/libexec" \
+        BASE_SHELL=1 \
+        PS1="inherited prompt: " \
+        LC_ALL=C \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        /bin/bash --rcfile "$TEST_HOME/.bashrc" -i -c '
+            declaration="$(declare -p PS1)"
+            attributes="${declaration#declare -}"
+            attributes="${attributes%% *}"
+            if [[ "$attributes" == *x* ]]; then
+                printf "ps1_exported=1\n"
+            else
+                printf "ps1_exported=0\n"
+            fi
+            printf "prompt_helper=%s\n" "$(type -t _base_bash_defaults_git_prompt)"
+            child_stderr="$HOME/default-child.stderr"
+            "$BASH" --noprofile --norc -i </dev/null \
+                >/dev/null 2>"$child_stderr"
+            if grep -F "_base_bash_defaults_git_prompt" "$child_stderr" >/dev/null; then
+                cat "$child_stderr"
+                exit 9
+            fi
+            printf "child_prompt=clean\n"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ps1_exported=0"* ]]
+    [[ "$output" == *"prompt_helper=function"* ]]
+    [[ "$output" == *"child_prompt=clean"* ]]
+    [[ "$output" != *"_base_bash_defaults_git_prompt: command not found"* ]]
+}
+
 @test "Base shell defaults abbreviate detached HEAD without command substitution" {
     run grep -F 'branch="$(printf' "$BASE_REPO_ROOT/lib/shell/bash_defaults.sh" "$BASE_REPO_ROOT/lib/shell/zsh_defaults.sh"
     [ "$status" -eq 1 ]

--- a/lib/bash/runtime/bashrc
+++ b/lib/bash/runtime/bashrc
@@ -204,9 +204,10 @@ _base_runtime_git_prompt() {
 _base_runtime_set_prompt() {
     # Base owns this runtime shell prompt, so disable prompt mutation by Python
     # virtualenv activation and render the active venv dynamically instead.
+    # Its helper functions are shell-local, so the prompt must be shell-local too.
     export VIRTUAL_ENV_DISABLE_PROMPT=1
     _BASE_RUNTIME_HOST_PROMPT="$(_base_runtime_host_prompt)"
-    PS1='\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '
+    export -n PS1='\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '
 }
 
 _base_runtime_main() {

--- a/lib/bash/runtime/tests/runtime_bashrc.bats
+++ b/lib/bash/runtime/tests/runtime_bashrc.bats
@@ -103,6 +103,47 @@ EOF
     [[ "$output" == *'PS1=\T ${_BASE_RUNTIME_HOST_PROMPT:-unknown} ${BASE_PROJECT:+[$BASE_PROJECT] }$(_base_runtime_venv_prompt)$(_base_runtime_git_prompt)\w: '* ]]
 }
 
+@test "runtime bashrc keeps the helper-backed prompt shell-local" {
+    cat > "$TEST_HOME/.bashrc" <<'EOF'
+export PS1='user prompt: '
+set -a
+EOF
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASH" --rcfile "$BASE_REPO_ROOT/lib/bash/runtime/bashrc" -i -c '
+            declaration="$(declare -p PS1)"
+            attributes="${declaration#declare -}"
+            attributes="${attributes%% *}"
+            if [[ "$attributes" == *x* ]]; then
+                printf "ps1_exported=1\n"
+            else
+                printf "ps1_exported=0\n"
+            fi
+            printf "venv_prompt_helper=%s\n" "$(type -t _base_runtime_venv_prompt)"
+            printf "git_prompt_helper=%s\n" "$(type -t _base_runtime_git_prompt)"
+            child_stderr="$HOME/runtime-child.stderr"
+            "$BASH" --noprofile --norc -i </dev/null \
+                >/dev/null 2>"$child_stderr"
+            if grep -F "_base_runtime_venv_prompt" "$child_stderr" >/dev/null ||
+                grep -F "_base_runtime_git_prompt" "$child_stderr" >/dev/null; then
+                cat "$child_stderr"
+                exit 9
+            fi
+            printf "child_prompt=clean\n"
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ps1_exported=0"* ]]
+    [[ "$output" == *"venv_prompt_helper=function"* ]]
+    [[ "$output" == *"git_prompt_helper=function"* ]]
+    [[ "$output" == *"child_prompt=clean"* ]]
+    [[ "$output" != *"_base_runtime_venv_prompt: command not found"* ]]
+    [[ "$output" != *"_base_runtime_git_prompt: command not found"* ]]
+}
+
 @test "runtime bashrc can source user bashrc with Base-managed snippet after readonly BASE_HOME" {
     cat > "$TEST_HOME/.bashrc" <<EOF
 source "$BASE_REPO_ROOT/lib/shell/bashrc"

--- a/lib/shell/bash_defaults.sh
+++ b/lib/shell/bash_defaults.sh
@@ -96,7 +96,8 @@ _base_bash_defaults_git_prompt() {
     printf '(%s) ' "$branch"
 }
 
-export PS1='\[\033[0;35m\]\T \h\[\033[0;33m\] $(_base_bash_defaults_git_prompt)\w\[\033[00m\]: '
+# The prompt depends on shell-local helpers and must not reach child shells.
+export -n PS1='\[\033[0;35m\]\T \h\[\033[0;33m\] $(_base_bash_defaults_git_prompt)\w\[\033[00m\]: '
 
 _base_bash_defaults_bind_set() {
     bind "set $1" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Make the helper-backed Bash defaults and activated-runtime prompts
  shell-local by atomically assigning `PS1` without its export attribute.
- Preserve both prompt literals and keep their helper functions private to the
  owning shell.
- Add real interactive-child regressions, including macOS Bash 3.2, inherited
  exported `PS1`, and `set -a`.

## Issue

Closes #1767
Refs #1768

## Validation

- Regression proof before the fix: both new tests reported `ps1_exported=1`
  and reproduced the missing prompt-helper errors in child shells.
- `bats cli/bash/commands/basectl/tests/update-profile.bats lib/bash/runtime/tests/runtime_bashrc.bats` (51 passed)
- Runtime dispatch, runtime shell, and source-guard BATS suites (54 passed)
- Focused regressions under both native and Intel Homebrew Bash (2 passed in
  each environment); the defaults regression explicitly uses macOS Bash 3.2.
- Full Python suite (1056 passed, 1 skipped)
- Bash 3.2 and Bash 5.3 syntax checks
- `shellcheck --severity=warning lib/shell/bash_defaults.sh lib/bash/runtime/bashrc`
- `git diff --check`
- GitHub Actions: Python and Pylint matrices, BATS, Ubuntu source-checkout,
  macOS smoke, integration, security, and branch-policy checks passed.
- The local macOS broad BATS gate has pre-existing JSON-diagnostic fixture
  failures because those fixtures expose only Apple Python 3.9; the
  authoritative Ubuntu CI gate provides the exhaustive BATS result above.

## Demo Impact

None.

## Notes

- #1768 is merged, and this branch is rebased directly onto its merge commit;
  this PR now contains only the shell-local prompt change.
- `VERSION` is unchanged; the fix is recorded under the existing Unreleased
  changelog section.
- `.ai-context/` is unchanged because this fixes an implementation leak while
  preserving the existing prompt design and command surfaces.
- Project V2 status/priority fields could not be updated because the current
  GitHub credential lacks the `project` scope.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
