### PR TITLE
Align prune help and summaries

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -545,12 +545,9 @@ Note:
   Runs in dry-run mode by default. Pass --yes to apply changes.
 
 Options:
-  --days <days>  Minimum age for stale branch reporting. Defaults to 30.
-  --format <text|json>
-                 Select human text or stable inspection JSON for stale reporting.
-  --dry-run      Preview branches that would be deleted (default).
-  --yes          Delete merged branches after preview.
-  --remote       Also prune merged GitHub remote branches and stale origin/* refs.
+  stale: --days <days>, --format <text|json>
+  prune: --dry-run, --yes, --remote
+  -h, --help     Show this help text.
 EOF
 }
 
@@ -607,6 +604,7 @@ Note:
 Options:
   --dry-run      Preview worktrees that would be removed (default).
   --yes          Remove safe merged worktrees after preview.
+  -h, --help     Show this help text.
 EOF
 }
 

--- a/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
@@ -234,14 +234,19 @@ base_gh_branch_prune_local() {
     local dry_run="$1"
     local default_branch="$2"
     local branch current_branch merge_source merge_status worktree_path upstream
-    local deleted=0 skipped_worktree=0 skipped_upstream=0 failed=0 candidates=0
+    local deleted=0 skipped_current=0 skipped_worktree=0 skipped_upstream=0 failed=0 candidates=0
 
     current_branch="$(git branch --show-current)"
     printf 'Local branches\n'
     while read -r branch; do
         branch="${branch#\* }"
         branch="${branch## }"
-        [[ -z "$branch" || "$branch" == "$default_branch" || "$branch" == "$current_branch" ]] && continue
+        [[ -n "$branch" ]] || continue
+        if [[ "$branch" == "$default_branch" || "$branch" == "$current_branch" ]]; then
+            printf 'SKIP   %s  current/default branch protected\n' "$branch"
+            skipped_current=$((skipped_current + 1))
+            continue
+        fi
 
         merge_source=""
         if base_gh_branch_cleanup_merged "$branch" "$default_branch" merge_source; then
@@ -297,9 +302,9 @@ base_gh_branch_prune_local() {
     if ((skipped_worktree > 0)); then
         printf 'Hint: run `basectl gh worktree prune` to inspect stale worktrees.\n'
     fi
-    printf 'Summary: %s %s, %s skipped worktree, %s skipped upstream, %s failed.\n' \
+    printf 'Summary: %s %s, %s skipped current/default, %s skipped worktree, %s skipped upstream, %s failed.\n' \
         "$deleted" "$([[ "$dry_run" -eq 1 ]] && printf 'would delete' || printf 'deleted')" \
-        "$skipped_worktree" "$skipped_upstream" "$failed"
+        "$skipped_current" "$skipped_worktree" "$skipped_upstream" "$failed"
     if ((failed > 0)); then
         return 1
     fi
@@ -310,13 +315,13 @@ base_gh_branch_prune_github_branches() {
     local dry_run="$1"
     local default_branch="$2"
     local branch current_branch merge_status worktree_path remote_branches
-    local deleted=0 skipped_worktree=0 skipped_unmerged=0 failed=0 candidates=0 found=0
+    local deleted=0 skipped_current=0 skipped_worktree=0 skipped_unmerged=0 failed=0 candidates=0 found=0
 
     printf 'GitHub branches\n'
     if ! base_gh_prune_github_ready; then
         base_gh_error "GitHub merge verification requires the GitHub CLI 'gh' on PATH."
         printf 'SKIP   GitHub merge verification unavailable; remote branches retained\n'
-        printf 'Summary: 0 %s, 0 skipped worktree, 0 skipped unmerged, 1 failed.\n' \
+        printf 'Summary: 0 %s, 0 skipped current/default, 0 skipped worktree, 0 skipped unmerged, 1 failed.\n' \
             "$([[ "$dry_run" -eq 1 ]] && printf 'would delete remotely' || printf 'deleted remotely')"
         return 1
     fi
@@ -329,7 +334,11 @@ base_gh_branch_prune_github_branches() {
     while read -r branch; do
         [[ -n "$branch" ]] || continue
         found=1
-        [[ "$branch" == "$default_branch" || "$branch" == "$current_branch" ]] && continue
+        if [[ "$branch" == "$default_branch" || "$branch" == "$current_branch" ]]; then
+            printf 'SKIP   origin/%s  current/default branch protected\n' "$branch"
+            skipped_current=$((skipped_current + 1))
+            continue
+        fi
 
         if base_gh_branch_github_merged "$branch"; then
             merge_status=0
@@ -373,9 +382,9 @@ base_gh_branch_prune_github_branches() {
     elif ((candidates == 0 && failed == 0)); then
         printf 'No merged GitHub remote branches found.\n'
     fi
-    printf 'Summary: %s %s, %s skipped worktree, %s skipped unmerged, %s failed.\n' \
+    printf 'Summary: %s %s, %s skipped current/default, %s skipped worktree, %s skipped unmerged, %s failed.\n' \
         "$deleted" "$([[ "$dry_run" -eq 1 ]] && printf 'would delete remotely' || printf 'deleted remotely')" \
-        "$skipped_worktree" "$skipped_unmerged" "$failed"
+        "$skipped_current" "$skipped_worktree" "$skipped_unmerged" "$failed"
     if ((failed > 0)); then
         return 1
     fi

--- a/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
+++ b/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
@@ -48,7 +48,9 @@ load ./basectl_helpers.bash
     [[ "$output" == *"basectl gh branch stale [--days <days>]"* ]]
     [[ "$output" == *"basectl gh branch prune [--dry-run] [--yes] [--remote]"* ]]
     [[ "$output" == *"Runs in dry-run mode by default. Pass --yes to apply changes."* ]]
-    [[ "$output" == *"--dry-run      Preview branches that would be deleted (default)."* ]]
+    [[ "$output" == *"stale: --days <days>, --format <text|json>"* ]]
+    [[ "$output" == *"prune: --dry-run, --yes, --remote"* ]]
+    [[ "$output" == *"-h, --help     Show this help text."* ]]
     [[ "$output" != *"basectl gh issue create"* ]]
     [[ "$output" != *"basectl gh worktree prune"* ]]
 }
@@ -61,6 +63,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Prune safe, merged Git worktrees and their local branches."* ]]
     [[ "$output" == *"Runs in dry-run mode by default. Pass --yes to apply changes."* ]]
     [[ "$output" == *"--dry-run      Preview worktrees that would be removed (default)."* ]]
+    [[ "$output" == *"-h, --help     Show this help text."* ]]
     [[ "$output" != *"basectl gh branch prune"* ]]
     [[ "$output" != *"basectl gh issue create"* ]]
 }
@@ -166,7 +169,8 @@ load ./basectl_helpers.bash
     [[ "$output" == *"[DRY-RUN] Branch prune preview for default branch master."* ]]
     [[ "$output" == *"Local branches"* ]]
     [[ "$output" == *"[DRY-RUN] DELETE merged-work"* ]]
-    [[ "$output" == *"Summary: 1 would delete, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
+    [[ "$output" == *"SKIP   master  current/default branch protected"* ]]
+    [[ "$output" == *"Summary: 1 would delete, 1 skipped current/default, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
     [[ "$output" == *"Run with --yes to apply these changes."* ]]
     git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
 }
@@ -192,7 +196,7 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"DELETE merged-work"* ]]
-    [[ "$output" == *"Summary: 1 deleted, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
+    [[ "$output" == *"Summary: 1 deleted, 1 skipped current/default, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
     ! git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
 }
 
@@ -220,7 +224,7 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" == *"SKIP   merged-work  attached to worktree "*"/merged-worktree"* ]]
     [[ "$output" == *'Hint: run `basectl gh worktree prune` to inspect stale worktrees.'* ]]
-    [[ "$output" == *"Summary: 0 deleted, 1 skipped worktree, 0 skipped upstream, 0 failed."* ]]
+    [[ "$output" == *"Summary: 0 deleted, 1 skipped current/default, 1 skipped worktree, 0 skipped upstream, 0 failed."* ]]
     git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
 }
 
@@ -249,7 +253,7 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"SKIP   merged-work  not fully merged to upstream origin/merged-work"* ]]
-    [[ "$output" == *"Summary: 0 deleted, 0 skipped worktree, 1 skipped upstream, 0 failed."* ]]
+    [[ "$output" == *"Summary: 0 deleted, 1 skipped current/default, 0 skipped worktree, 1 skipped upstream, 0 failed."* ]]
     git -C "$repo" show-ref --verify --quiet refs/heads/merged-work
 }
 
@@ -293,7 +297,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"SKIP   unmerged-work  not confirmed merged into master or through a merged GitHub PR; local branch retained"* ]]
     [[ "$output" == *"SKIP   origin/unmerged-work  no merged GitHub PR found for this branch; remote branch retained"* ]]
-    [[ "$output" == *"Summary: 0 deleted remotely, 0 skipped worktree, 1 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Summary: 0 deleted remotely, 1 skipped current/default, 0 skipped worktree, 1 skipped unmerged, 0 failed."* ]]
     git -C "$repo" show-ref --verify --quiet refs/heads/unmerged-work
     git -C "$repo" ls-remote --exit-code --heads origin unmerged-work >/dev/null
 }
@@ -437,7 +441,7 @@ EOF
     [[ "$output" == *"[DRY-RUN] Branch prune preview for default branch master."* ]]
     [[ "$output" == *"GitHub branches"* ]]
     [[ "$output" == *"[DRY-RUN] DELETE-REMOTE origin/squash-remote  merged GitHub PR"* ]]
-    [[ "$output" == *"Summary: 1 would delete remotely, 0 skipped worktree, 0 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Summary: 1 would delete remotely, 1 skipped current/default, 0 skipped worktree, 0 skipped unmerged, 0 failed."* ]]
     [[ "$output" == *"Run with --yes to apply these changes."* ]]
     git -C "$repo" ls-remote --exit-code --heads origin squash-remote >/dev/null
 }
@@ -483,7 +487,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"GitHub branches"* ]]
     [[ "$output" == *"DELETE-REMOTE origin/squash-remote"* ]]
-    [[ "$output" == *"Summary: 1 deleted remotely, 0 skipped worktree, 0 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Summary: 1 deleted remotely, 1 skipped current/default, 0 skipped worktree, 0 skipped unmerged, 0 failed."* ]]
     ! git -C "$repo" ls-remote --exit-code --heads origin squash-remote >/dev/null
 }
 
@@ -528,7 +532,7 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"failed to connect to api.github.com"* ]]
     [[ "$output" == *"SKIP   origin/lookup-failure  GitHub merge verification unavailable; remote branch retained"* ]]
-    [[ "$output" == *"Summary: 0 would delete remotely, 0 skipped worktree, 0 skipped unmerged, 1 failed."* ]]
+    [[ "$output" == *"Summary: 0 would delete remotely, 1 skipped current/default, 0 skipped worktree, 0 skipped unmerged, 1 failed."* ]]
     [[ "$output" == *"Resolve the reported failures and rerun before using --yes."* ]]
     git -C "$repo" ls-remote --exit-code --heads origin lookup-failure >/dev/null
 }
@@ -561,7 +565,7 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"ERROR: GitHub merge verification requires the GitHub CLI 'gh' on PATH."* ]]
     [[ "$output" == *"SKIP   GitHub merge verification unavailable; remote branches retained"* ]]
-    [[ "$output" == *"Summary: 0 would delete remotely, 0 skipped worktree, 0 skipped unmerged, 1 failed."* ]]
+    [[ "$output" == *"Summary: 0 would delete remotely, 0 skipped current/default, 0 skipped worktree, 0 skipped unmerged, 1 failed."* ]]
     [[ "$output" == *"Resolve the reported failures and rerun before using --yes."* ]]
     git -C "$repo" ls-remote --exit-code --heads origin unverified-remote >/dev/null
 }
@@ -608,7 +612,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"SKIP   squash-work  attached to worktree "*"/squash-worktree"* ]]
     [[ "$output" == *"SKIP   origin/squash-work  attached to worktree "*"/squash-worktree"* ]]
-    [[ "$output" == *"Summary: 0 deleted remotely, 1 skipped worktree, 0 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Summary: 0 deleted remotely, 1 skipped current/default, 1 skipped worktree, 0 skipped unmerged, 0 failed."* ]]
     git -C "$repo" ls-remote --exit-code --heads origin squash-work >/dev/null
 }
 
@@ -651,7 +655,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"DELETE squash-work"* ]]
-    [[ "$output" == *"Summary: 1 deleted, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
+    [[ "$output" == *"Summary: 1 deleted, 1 skipped current/default, 0 skipped worktree, 0 skipped upstream, 0 failed."* ]]
     ! git -C "$repo" show-ref --verify --quiet refs/heads/squash-work
 }
 
@@ -695,7 +699,7 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"failed to connect to api.github.com"* ]]
     [[ "$output" == *"SKIP   lookup-failure  GitHub merge verification unavailable; local branch retained"* ]]
-    [[ "$output" == *"Summary: 0 would delete, 0 skipped worktree, 0 skipped upstream, 1 failed."* ]]
+    [[ "$output" == *"Summary: 0 would delete, 1 skipped current/default, 0 skipped worktree, 0 skipped upstream, 1 failed."* ]]
     [[ "$output" == *"Resolve the reported failures and rerun before using --yes."* ]]
     git -C "$repo" show-ref --verify --quiet refs/heads/lookup-failure
 }


### PR DESCRIPTION
## Summary

Align prune help with accepted options and make branch-prune summaries explicitly report protected current/default branches.

## Issue

Fixes #1775

## Validation

- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh-branch-worktree.bats` (28 passed)
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/gh.bats` (60 passed)
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats lib/shell/completions/tests/completions.bats` (29 passed)
- `git diff --check`

## Demo Impact

None.

## Notes

Worktree help now documents `-h/--help`, and branch-area help separates stale and prune options.