### PR TITLE
Contain workspace clone targets

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_clone.py
+++ b/cli/python/base_projects/tests/test_workspace_clone.py
@@ -242,6 +242,44 @@ repos:
                 [f"repo clone codeforester/api --path {(workspace / 'api').resolve()} --dry-run"],
             )
 
+    def test_workspace_clone_rejects_repository_target_outside_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            outside = root / "outside"
+            base_home = root / "base"
+            state_file = root / "basectl-calls"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            workspace.mkdir()
+            outside.mkdir()
+            base_home.mkdir()
+            (workspace / "api").symlink_to(outside, target_is_directory=True)
+            write_fake_basectl(base_home, state_file)
+            write_workspace_manifest(
+                manifest_path,
+                """
+schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: api
+    url: https://github.com/codeforester/api.git
+""",
+            )
+
+            status, stdout, stderr = invoke_engine(
+                ["clone", "--workspace", str(workspace), "--manifest", str(manifest_path)],
+                base_home,
+                home,
+            )
+
+        self.assertEqual(status, 1)
+        self.assertIn("resolves outside workspace root", stderr)
+        self.assertIn("Workspace clone completed with 1 error(s).", stdout)
+        self.assertFalse(state_file.exists())
+
     def test_workspace_clone_requires_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/workspace_clone_command.py
+++ b/cli/python/base_projects/workspace_clone_command.py
@@ -37,6 +37,8 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCloneOption
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
+    workspace_root = workspace_root.resolve(strict=False)
+
     if ctx.base_home is None:
         ctx.log.error("BASE_HOME is required to clone workspace repositories.")
         return base_cli.ExitCode.FAILURE
@@ -47,7 +49,12 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCloneOption
 
     errors = 0
     for repo in manifest.repos:
-        target = (workspace_root / repo.name).resolve()
+        try:
+            target = resolve_workspace_clone_target(workspace_root, repo.name)
+        except ProjectUsageError as exc:
+            ctx.log.error(str(exc))
+            errors += 1
+            continue
         required_label = "required" if repo.required else "optional"
         if should_skip_optional_clone(repo, target, options.include_optional):
             print_optional_clone_skip(repo, target)
@@ -64,6 +71,17 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCloneOption
 
     print("Workspace clone completed.")
     return base_cli.ExitCode.SUCCESS
+
+
+def resolve_workspace_clone_target(workspace_root: Path, repo_name: str) -> Path:
+    target = (workspace_root / repo_name).resolve(strict=False)
+    try:
+        target.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ProjectUsageError(
+            f"Repository '{repo_name}' resolves outside workspace root '{workspace_root}'."
+        ) from exc
+    return target
 
 
 def require_workspace_clone_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> WorkspaceManifest:


### PR DESCRIPTION
## Summary

- Resolve the workspace root before cloning repositories.
- Reject repository targets whose symlinks resolve outside that root.
- Report the invalid target and continue with the remaining repositories.

## Issue

Closes #1771

## Validation

- Workspace-clone focused tests: 5 passed.
- Full `base_projects` Python suite: 1057 passed, 1 skipped, 251 subtests passed.
- `compileall` and `git diff --check` passed.

## Security Notes

Repository clone destinations are checked after symlink resolution and must remain descendants of the resolved workspace root. A repository entry that escapes the workspace is rejected before invoking the clone operation.

## Demo Impact

None.

## Notes

- `.ai-context/` is unchanged because this is a narrow implementation and regression-test fix.
- `pylint` was not run because it is not installed in the local environment.

## Checklist

- [x] Tests added or updated
- [x] No unrelated changes
