### PR TITLE
Update BATS diagnostics Python stubs

### DIFF
--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -177,6 +177,9 @@ if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
 fi
+if [[ "${1:-}" == "-c" && "${2:-}" == "import base_setup.diagnostics" ]]; then
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
         base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
@@ -380,6 +383,9 @@ if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
 fi
+if [[ "${1:-}" == "-c" && "${2:-}" == "import base_setup.diagnostics" ]]; then
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
         base_test_protocol_project_setup_route base "$BASE_HOME" "$BASE_HOME/base_manifest.yaml" \
@@ -545,6 +551,9 @@ pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-c" && "${2:-}" == "import base_setup.diagnostics" ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
@@ -727,6 +736,9 @@ if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
 fi
+if [[ "${1:-}" == "-c" && "${2:-}" == "import base_setup.diagnostics" ]]; then
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" && "${4:-}" == "$pyyaml_package" ]]; then
     printf '%s\n' "$4" >> "${BASE_SETUP_TEST_STATE_DIR:?}/pip-show.log"
     [[ -f "${BASE_SETUP_TEST_STATE_DIR:?}/pyyaml-installed" ]]
@@ -784,6 +796,9 @@ pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-c" && "${2:-}" == "import base_setup.diagnostics" ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then


### PR DESCRIPTION
## Summary

- Teach the BATS fake Python implementations the diagnostics capability probe used by production setup checks.
- Preserve the existing behavior for the other fake-Python command forms.

## Issue

Closes #1772

## Validation

- Focused project-artifact check: 1 passed.
- Focused setup-common delegation test: 1 passed.
- `bash -n` and `shellcheck --severity=error` passed for `setup_helpers.bash`.

## Demo Impact

None.

## Notes

- `.ai-context/` is unchanged because this is a narrow test-fixture compatibility fix.
- The broader local macOS `check`/`ci`/`doctor` BATS run still has pre-existing JSON-diagnostic fixture failures beyond this capability-probe fix; the focused regression that originally failed now passes.

## Checklist

- [x] Tests added or updated
- [x] No unrelated changes
