### PR TITLE
Clarify inactive project diagnostics

### DIFF
--- a/cli/python/base_setup/health.py
+++ b/cli/python/base_setup/health.py
@@ -12,7 +12,8 @@ def check_required_env(manifest: BaseManifest) -> list[ArtifactCheck]:
     activation_hint = ""
     if manifest.activate.source:
         activation_hint = (
-            f", or run 'basectl activate {manifest.project_name}' if the project activation provides it"
+            f"Project '{manifest.project_name}' is not activated in this shell; "
+            f"run 'basectl activate {manifest.project_name}' if its activation provides this variable"
         )
     return [
         check_required_env_var(env_name, activation_hint=activation_hint)
@@ -33,11 +34,17 @@ def check_required_env_var(env_name: str, *, activation_hint: str = "") -> Artif
             fix="",
             finding_id="BASE-H001",
         )
+    if activation_hint:
+        fix = (
+            f"{activation_hint}; otherwise, set {env_name} in your shell, .env, or secrets manager."
+        )
+    else:
+        fix = f"Set {env_name} in your shell, .env, or secrets manager."
     return ArtifactCheck(
         name=env_name,
         ok=False,
         message=f"Environment variable '{env_name}' is not set or is empty.",
-        fix=f"Set {env_name} in your shell, .env, or secrets manager{activation_hint}.",
+        fix=fix,
         finding_id="BASE-H001",
     )
 

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -369,8 +369,9 @@ class ProjectCheckTests(unittest.TestCase):
             self.assertEqual(activation_status, 1)
             self.assertEqual(
                 activation_payload["checks"][0]["fix"],
-                "Set BASE_TEST_ACTIVATION_ENV in your shell, .env, or secrets manager, "
-                "or run 'basectl activate demo' if the project activation provides it.",
+                "Project 'demo' is not activated in this shell; run 'basectl activate demo' "
+                "if its activation provides this variable; otherwise, set "
+                "BASE_TEST_ACTIVATION_ENV in your shell, .env, or secrets manager.",
             )
 
 


### PR DESCRIPTION
## Summary

- Make missing required-environment diagnostics explicitly identify an inactive project shell.
- Point users to `basectl activate <project>` while preserving direct environment-variable guidance.
- Keep check and doctor read-only; activation scripts are never sourced implicitly.

## Issue

Closes #1784

## Validation

- Focused diagnostics tests: 22 passed, 1 subtest passed.
- Full `base_setup` test package: 367 passed, 193 subtests passed.
- Pylint passed for `cli/python/base_setup/health.py`.
- `python3 -m compileall -q cli/python/base_setup` passed.
- `git diff --check` passed.

## Demo Impact

The first-run `base-demo` check now gives a clearer activation hint when `BASE_DEMO_ENV` is missing. No demo behavior or activation semantics changed.

## Notes

- `.ai-context/` is unchanged because this is a focused diagnostic wording and regression-test change.
- CI-oriented commands continue to inspect the supplied environment and do not source project activation scripts.

## Checklist

- [x] Tests added or updated
- [x] No unrelated changes
