### PR TITLE
Detect uv environment drift in check and doctor

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -262,7 +262,10 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_default_manifest(base_home)
             write_uv_manifest(workspace / "bankbuddy", "bankbuddy")
 
-            with mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")):
+            with (
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
+                mock.patch("base_setup.uv.process.run_check", return_value=True),
+            ):
                 status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
 
         self.assertEqual(status, 0)
@@ -283,7 +286,10 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_default_manifest(base_home)
             write_uv_manifest(workspace / "bankbuddy", "bankbuddy")
 
-            with mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")):
+            with (
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
+                mock.patch("base_setup.uv.process.run_check", return_value=True),
+            ):
                 status, stdout, stderr = invoke_engine(["doctor", "--workspace", str(workspace)], base_home, home)
 
         self.assertEqual(status, 0)

--- a/cli/python/base_setup/finding_explanations.py
+++ b/cli/python/base_setup/finding_explanations.py
@@ -224,6 +224,31 @@ CATALOG = catalog_by_id(
             docs=(RelatedDoc("Python Manifest - Command Runners", "docs/python-manifest.md#command-runners"),),
         ),
         FindingExplanation(
+            finding_id="BASE-P155",
+            title="uv-managed project virtual environment synchronization",
+            summary=(
+                "Base found that the uv-managed project environment is not synchronized with its declared "
+                "dependencies."
+            ),
+            why_it_matters=(
+                "A manually installed, removed, or otherwise stale package can make local commands differ from the "
+                "locked project contract. uv is the owner of this environment, so its read-only synchronization "
+                "check is the authoritative drift signal."
+            ),
+            likely_causes=(
+                "A package was installed or removed directly with pip inside the uv virtual environment.",
+                "The project dependencies or uv.lock changed without synchronizing the environment.",
+                "The environment was created by a different Python or dependency-management workflow.",
+            ),
+            fix_steps=(
+                "Run `uv sync` from the project root to reconcile the environment.",
+                "Review the resulting lockfile and package changes before rerunning project commands.",
+                "Run `basectl doctor <project>` again and confirm `BASE-P155` reports `ok`.",
+            ),
+            related_commands=("uv sync --check", "uv sync", "basectl check <project>", "basectl doctor <project>"),
+            docs=(RelatedDoc("Python Manifest", "docs/python-manifest.md#diagnostics"),),
+        ),
+        FindingExplanation(
             finding_id="BASE-P160",
             title="Manifest command executable availability",
             summary="Base found an obvious missing executable in a manifest-declared command.",

--- a/cli/python/base_setup/tests/test_uv.py
+++ b/cli/python/base_setup/tests/test_uv.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -302,13 +303,15 @@ class UvProjectTests(unittest.TestCase):
             )
             (root / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
 
-            with mock.patch.dict("os.environ", {"HOME": str(home)}), mock.patch(
-                "base_setup.uv.uv_executable",
-                return_value=Path("uv"),
+            with (
+                mock.patch.dict("os.environ", {"HOME": str(home)}),
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
+                mock.patch("base_setup.uv.process.run_check") as run_check,
             ):
                 checks = check_uv(manifest)
 
         findings = {check.finding_id: check for check in checks}
+        run_check.assert_not_called()
         self.assertEqual(findings["BASE-P151"].status, "")
         self.assertEqual(findings["BASE-P152"].status, "warn")
         self.assertEqual(findings["BASE-P153"].status, "warn")
@@ -338,12 +341,91 @@ class UvProjectTests(unittest.TestCase):
             python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
             python_bin.chmod(0o755)
 
-            with mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")):
+            with (
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
+                mock.patch("base_setup.uv.process.run_check", return_value=True) as run_check,
+            ):
                 checks = check_uv(manifest)
 
         findings = {check.finding_id: check for check in checks}
         self.assertEqual(findings["BASE-P154"].status, "")
         self.assertIn(str(root / ".venv"), findings["BASE-P154"].message)
+        self.assertEqual(findings["BASE-P155"].status, "")
+        run_check.assert_called_once_with(
+            ["uv", "sync", "--check", "--offline"],
+            cwd=root,
+            timeout_seconds=10,
+        )
+
+    def test_check_uv_reports_environment_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "project"
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            (root / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+            (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+            python_bin = root / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            python_bin.chmod(0o755)
+
+            with (
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
+                mock.patch("base_setup.uv.process.run_check", return_value=False),
+            ):
+                checks = check_uv(manifest)
+
+        drift = next(check for check in checks if check.finding_id == "BASE-P155")
+        self.assertFalse(drift.ok)
+        self.assertEqual(drift.status, "")
+        self.assertIn("not synchronized", drift.message)
+        self.assertIn("uv sync", drift.fix)
+
+    def test_check_uv_warns_when_environment_probe_times_out(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "project"
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            (root / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+            (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+            python_bin = root / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            python_bin.chmod(0o755)
+
+            with (
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
+                mock.patch(
+                    "base_setup.uv.process.run_check",
+                    side_effect=subprocess.TimeoutExpired(["uv", "sync", "--check", "--offline"], 10),
+                ),
+            ):
+                checks = check_uv(manifest)
+
+        timeout = next(check for check in checks if check.finding_id == "BASE-P155")
+        self.assertEqual(timeout.status, "warn")
+        self.assertIn("timed out", timeout.message)
+        self.assertIn("uv sync --check", timeout.fix)
 
     def test_uv_project_setup_skips_python_package_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/uv.py
+++ b/cli/python/base_setup/uv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 import base_cli
@@ -62,13 +63,25 @@ def check_uv(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
         return ()
 
     checks: list[ArtifactCheck] = []
-    uv_available = uv_executable() is not None
+    uv_bin = uv_executable()
+    uv_available = uv_bin is not None
     checks.append(uv_tool_check(manifest.project_name, uv_available, uses_uv_manager, uses_uv_runner))
 
     if uses_uv_manager:
-        checks.append(pyproject_check(manifest.path.parent / "pyproject.toml"))
-        checks.append(uv_lock_check(manifest.path.parent / "uv.lock"))
-        checks.append(uv_project_venv_check(manifest.path.parent / ".venv"))
+        project_root = manifest.path.parent
+        pyproject_path = project_root / "pyproject.toml"
+        lock_path = project_root / "uv.lock"
+        venv_path = project_root / ".venv"
+        checks.append(pyproject_check(pyproject_path))
+        checks.append(uv_lock_check(lock_path))
+        checks.append(uv_project_venv_check(venv_path))
+        if (
+            uv_bin is not None
+            and pyproject_path.is_file()
+            and lock_path.is_file()
+            and uv_project_venv_ready(venv_path)
+        ):
+            checks.append(uv_project_environment_check(project_root, uv_bin))
         stale_check = stale_base_venv_check(manifest)
         if stale_check is not None:
             checks.append(stale_check)
@@ -184,7 +197,7 @@ def uv_lock_check(lock_path: Path) -> ArtifactCheck:
 
 def uv_project_venv_check(venv_path: Path) -> ArtifactCheck:
     python_path = venv_path / "bin" / "python"
-    if python_path.is_file() and os.access(python_path, os.X_OK):
+    if uv_project_venv_ready(venv_path):
         return ArtifactCheck(
             name="uv project virtualenv",
             ok=True,
@@ -199,6 +212,49 @@ def uv_project_venv_check(venv_path: Path) -> ArtifactCheck:
         fix="Run 'uv sync' from the project root.",
         finding_id="BASE-P154",
         status="warn",
+    )
+
+
+def uv_project_venv_ready(venv_path: Path) -> bool:
+    python_path = venv_path / "bin" / "python"
+    return python_path.is_file() and os.access(python_path, os.X_OK)
+
+
+def uv_project_environment_check(project_root: Path, uv_bin: Path) -> ArtifactCheck:
+    command = [str(uv_bin), "sync", "--check", "--offline"]
+    try:
+        synchronized = process.run_check(
+            command,
+            cwd=project_root,
+            timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return ArtifactCheck(
+            name="uv project environment",
+            ok=False,
+            message=(
+                f"uv environment synchronization check for '{project_root}' timed out after "
+                f"{process.DIAGNOSTIC_TIMEOUT_SECONDS} seconds."
+            ),
+            fix=f"Retry 'uv sync --check' from '{project_root}'.",
+            finding_id="BASE-P155",
+            status="warn",
+        )
+
+    if synchronized:
+        return ArtifactCheck(
+            name="uv project environment",
+            ok=True,
+            message=f"uv project environment is synchronized at '{project_root}'.",
+            fix="",
+            finding_id="BASE-P155",
+        )
+    return ArtifactCheck(
+        name="uv project environment",
+        ok=False,
+        message=f"uv project environment is not synchronized with '{project_root}'.",
+        fix=f"Run 'uv sync' from '{project_root}' to reconcile the environment.",
+        finding_id="BASE-P155",
     )
 
 

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -173,6 +173,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P152` | uv-managed project `uv.lock` presence |
 | `BASE-P153` | Stale Base-managed project virtual environment ignored by a uv-managed project |
 | `BASE-P154` | uv-managed project virtual environment readiness |
+| `BASE-P155` | uv-managed project virtual environment synchronization |
 | `BASE-P160` | Manifest command executable availability |
 | `BASE-P161` | Manifest command project script path readiness |
 | `BASE-P170` | Project Python version requirement support window |
@@ -193,13 +194,15 @@ configuration source and do not cause Base to install Python dependencies.
 Warnings in this range should guide users toward a valid Python project file
 without failing the Base manifest check by themselves.
 
-`BASE-P150` through `BASE-P154` are uv support diagnostics. They are warnings
+`BASE-P150` through `BASE-P155` are uv support diagnostics. They are warnings
 when uv tooling or expected uv project files are missing, because check/doctor
-should explain readiness without performing dependency resolution. Command
-invocation still fails hard when a command declares `runner: uv` and the `uv`
-executable is unavailable. On Ubuntu/Debian, `BASE-P150` recovery should point
-users to `basectl setup <project> --dry-run` followed by `--yes` when the
-manifest has explicitly opted into uv.
+should explain readiness without mutating the project. When the project has a
+usable `pyproject.toml`, `uv.lock`, and `.venv`, `BASE-P155` runs uv's offline
+`sync --check` probe and reports an error when the environment is not
+synchronized. Command invocation still fails hard when a command declares
+`runner: uv` and the `uv` executable is unavailable. On Ubuntu/Debian,
+`BASE-P150` recovery should point users to `basectl setup <project> --dry-run`
+followed by `--yes` when the manifest has explicitly opted into uv.
 For the full uv manifest contract, migration paths, and runner configuration,
 see [Python Manifest](python-manifest.md).
 

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -278,15 +278,19 @@ Python manifest support adds these project diagnostics:
 - `BASE-P153`: stale Base-managed project virtual environment ignored by a
   uv-managed project
 - `BASE-P154`: uv-managed project virtual environment readiness
+- `BASE-P155`: uv-managed project virtual environment synchronization
 - `BASE-P160`: manifest command starts with an executable that is not available
   on PATH or in the project virtual environment
 - `BASE-P161`: manifest command references a project script path that is
   missing, outside the project root, not a file, or not executable
 
-These diagnostics are warning-oriented in `check` and `doctor`; they explain
-readiness without performing dependency resolution or executing project command
-strings. Command linting is advisory and does not replace reviewing manifests
-from unfamiliar repositories before running their declared commands.
+The file and readiness diagnostics are warning-oriented in `check` and
+`doctor`; they explain readiness without mutating the project or executing
+project command strings.
+When the uv project files and environment are present, `BASE-P155` performs an
+offline `uv sync --check` probe and reports drift as an error. Command linting
+is advisory and does not replace reviewing manifests from unfamiliar
+repositories before running their declared commands.
 
 `basectl workspace status --format json` also includes a `python_runtime`
 object for each ready, inspectable project environment. That summary reports


### PR DESCRIPTION
## Summary

- Add `BASE-P155` to `basectl check` and `basectl doctor` for uv-managed project environments.
- Run uv's read-only `sync --check --offline` probe only after uv, `pyproject.toml`, `uv.lock`, and `.venv` are ready.
- Report environment drift as an actionable error and probe timeouts as warnings.
- Document the finding and add local explanation-catalog coverage.

## User-visible behavior

When a user installs or removes packages directly inside a uv-managed project virtual environment, check and doctor now report that the environment is not synchronized and point to `uv sync`. The diagnostic does not run synchronization or modify project files.

## Validation

- `uv run --with pytest --with pyyaml --with click python -m pytest cli/python/base_setup/tests cli/python/base_projects/tests/test_workspace_checks.py -q` — 380 passed, 196 subtests passed
- `uv run --with pylint --with pyyaml pylint --rcfile=.pylintrc cli/python/base_setup/uv.py cli/python/base_setup/finding_explanations.py cli/python/base_setup/tests/test_uv.py cli/python/base_projects/tests/test_workspace_checks.py` — passed
- `git diff --check` — passed

## Scope note

This PR uses uv as the authoritative source for uv-managed environments. It does not attempt to infer a complete allowlist for Base-managed pip environments, where transitive dependencies and packaging tools make naïve undeclared-package detection unsafe; that needs a separate design.

`.ai-context/` is unchanged.

Closes #1786
