### PR TITLE
Honor manifest selectors in check and doctor

### DIFF
--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -17,8 +17,8 @@ Options:
   --ci                  Run checks with CI-safe defaults.
   --profile <list>      Include named prerequisite profiles. Known profiles: dev, sre, ai, linux-lab.
   --format <text|json>  Select output format. Defaults to text.
-  --manifest <path>     Use a specific base_manifest.yaml path for project checks.
-  --remote-network      Opt in to bounded project Git origin reachability checks.
+  --manifest <path>     Use this base_manifest.yaml; infer an omitted project.
+  --remote-network      Check project Git origin; requires project or --manifest.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
 
@@ -126,6 +126,10 @@ base_check_subcommand_main() {
         shift
     done
 
+    if [[ "$remote_network" == true && -z "$project" && -z "${BASE_SETUP_MANIFEST:-}" ]]; then
+        base_check_usage_error "Option '--remote-network' requires a project or '--manifest <path>'."
+        return $?
+    fi
     BASE_SETUP_PROJECT_NAME="$project"
     BASE_SETUP_REMOTE_NETWORK="$remote_network"
     export BASE_SETUP_PROJECT_NAME

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -18,8 +18,8 @@ Options:
   --ci                  Run diagnostics with CI-safe defaults.
   --profile <list>      Include named prerequisite profiles. Known profiles: dev, sre, ai, linux-lab.
   --format <text|json>  Select output format. Defaults to text.
-  --manifest <path>     Use a specific base_manifest.yaml path for project diagnostics.
-  --remote-network      Opt in to bounded project Git origin reachability diagnostics.
+  --manifest <path>     Use this base_manifest.yaml; infer an omitted project.
+  --remote-network      Check project Git origin; requires project or --manifest.
   --no-color            Disable doctor status colors and symbols in text output.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
@@ -221,9 +221,10 @@ base_doctor_run_ci_runtime_text() {
         profile_errors=$?
         errors=$((errors + profile_errors))
     fi
-    if [[ -n "$project" ]]; then
+    if [[ -n "$project" || -n "${BASE_SETUP_MANIFEST:-}" ]]; then
         setup_run_project_artifact_doctor
         errors=$((errors + $?))
+        project="${BASE_SETUP_PROJECT_NAME:-}"
     fi
 
     if ((errors == 0)); then
@@ -249,9 +250,12 @@ base_doctor_run_json() {
     local profile_json="[]"
     local project="$1"
     local project_json="[]"
+    local project_json_file project_status=0 requested_project="$1"
     local remote_network="${2:-${BASE_SETUP_REMOTE_NETWORK:-}}"
 
     BASE_SETUP_XCODE_HOMEBREW_DIAGNOSTICS=true setup_collect_base_check_results warn || true
+    std_make_temp_dir check_result_dir base-doctor-json ||
+        fatal_error "Unable to create temporary Base doctor JSON result directory."
 
     if setup_profiles_enabled; then
         if ! profile_json="$(setup_run_base_dev_layer doctor --format json)"; then
@@ -259,18 +263,24 @@ base_doctor_run_json() {
         fi
     fi
 
-    if [[ -n "$project" ]]; then
-        if ! project_json="$(setup_run_project_artifact_doctor_json "$remote_network")"; then
-            [[ -n "$project_json" ]] || project_json="[]"
+    if [[ -n "$project" || -n "${BASE_SETUP_MANIFEST:-}" ]]; then
+        project_json_file="$check_result_dir/project.json"
+        setup_run_project_artifact_doctor_json "$remote_network" > "$project_json_file"
+        project_status=$?
+        project_json="$(<"$project_json_file")"
+        if ((project_status)) && [[ -z "$project_json" ]]; then
+            if [[ -z "$requested_project" && -n "${BASE_SETUP_MANIFEST:-}" ]]; then
+                return 1
+            fi
+            project_json="[]"
         fi
+        project="${BASE_SETUP_PROJECT_NAME:-$project}"
     fi
 
     args+=(doctor-json)
     if [[ -n "$project" ]]; then
         args+=(--project "$project")
     fi
-    std_make_temp_dir check_result_dir base-doctor-json ||
-        fatal_error "Unable to create temporary Base doctor JSON result directory."
     check_result_paths="$(setup_write_collected_check_result_files "$check_result_dir")" || return 1
     if [[ -n "$check_result_paths" ]]; then
         while IFS= read -r check_result_file; do
@@ -368,6 +378,10 @@ base_doctor_subcommand_main() {
         shift
     done
 
+    if [[ "$remote_network" == true && -z "$project" && -z "${BASE_SETUP_MANIFEST:-}" ]]; then
+        base_doctor_usage_error "Option '--remote-network' requires a project or '--manifest <path>'."
+        return $?
+    fi
     BASE_SETUP_PROJECT_NAME="$project"
     BASE_SETUP_REMOTE_NETWORK="$remote_network"
     export BASE_SETUP_PROJECT_NAME
@@ -397,9 +411,10 @@ base_doctor_subcommand_main() {
         profile_errors=$?
         errors=$((errors + profile_errors))
     fi
-    if [[ -n "$project" ]]; then
+    if [[ -n "$project" || -n "${BASE_SETUP_MANIFEST:-}" ]]; then
         setup_run_project_artifact_doctor
         errors=$((errors + $?))
+        project="${BASE_SETUP_PROJECT_NAME:-}"
     fi
 
     if ((errors == 0)); then

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -1007,7 +1007,7 @@ setup_run_project_bootstrap_layer() {
 setup_run_project_artifact_layer() {
     local action="$1"
     local output_format="$2"
-    local exit_code manifest_path platform precheck_json project project_requires_python project_uses_uv_manager project_venv_dir python_bin remote_network resolved_root route_output venv_dir
+    local exit_code manifest_path platform precheck_json project project_requires_python project_uses_uv_manager project_venv_dir python_bin remote_network requested_project resolved_root route_output venv_dir
     local args=()
     local project_env_args=()
 
@@ -1017,12 +1017,17 @@ setup_run_project_artifact_layer() {
     fi
 
     project="${BASE_SETUP_PROJECT_NAME:-}"
+    requested_project="$project"
     setup_ensure_cached_paths
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
     setup_resolve_project_manifest "$project" "$python_bin" project resolved_root manifest_path || {
-        log_error "Unable to resolve Base project '$project'."
-        log_error "Run 'basectl projects list' to see projects Base can discover."
+        if [[ -z "$requested_project" && -n "${BASE_SETUP_MANIFEST:-}" ]]; then
+            log_error "Unable to resolve a project from manifest '$BASE_SETUP_MANIFEST'."
+        else
+            log_error "Unable to resolve Base project '$project'."
+            log_error "Run 'basectl projects list' to see projects Base can discover."
+        fi
         return 1
     }
     if [[ "$project" != base ]]; then
@@ -1055,6 +1060,8 @@ setup_run_project_artifact_layer() {
         log_error "Python project routing returned incomplete metadata for '$project'."
         return 1
     fi
+    BASE_SETUP_PROJECT_NAME="$project"
+    export BASE_SETUP_PROJECT_NAME
     if [[ "$project_uses_uv_manager" != true && "$project_uses_uv_manager" != false ]]; then
         log_error "Python project routing returned invalid uv-manager metadata for '$project'."
         return 1
@@ -1333,8 +1340,9 @@ setup_run_check() {
         setup_run_base_dev_layer check || missing=1
     fi
 
-    if [[ -n "$project" ]]; then
+    if [[ -n "$project" || -n "${BASE_SETUP_MANIFEST:-}" ]]; then
         setup_run_project_artifact_check || missing=1
+        project="${BASE_SETUP_PROJECT_NAME:-}"
     fi
 
     if ((missing == 0)); then
@@ -1373,9 +1381,12 @@ setup_run_check_json() {
     local profile_json=""
     local project="${BASE_SETUP_PROJECT_NAME:-}"
     local project_json=""
+    local project_json_file project_status=0
     local remote_network="${1:-${BASE_SETUP_REMOTE_NETWORK:-}}"
 
     setup_collect_base_check_results warn || true
+    std_make_temp_dir check_result_dir base-check-json ||
+        fatal_error "Unable to create temporary Base check JSON result directory."
 
     if setup_profiles_enabled; then
         if ! profile_json="$(setup_run_base_dev_layer check --format json)"; then
@@ -1385,12 +1396,15 @@ setup_run_check_json() {
         fi
     fi
 
-    if [[ -n "$project" ]]; then
-        if ! project_json="$(setup_run_project_artifact_check_json "$remote_network")"; then
-            if [[ -z "$project_json" ]]; then
-                return 1
-            fi
+    if [[ -n "$project" || -n "${BASE_SETUP_MANIFEST:-}" ]]; then
+        project_json_file="$check_result_dir/project.json"
+        setup_run_project_artifact_check_json "$remote_network" > "$project_json_file"
+        project_status=$?
+        project_json="$(<"$project_json_file")"
+        if ((project_status)) && [[ -z "$project_json" ]]; then
+            return 1
         fi
+        project="${BASE_SETUP_PROJECT_NAME:-}"
         # Keep external date -u here so persisted JSON records carry explicit UTC
         # without mutating shell TZ; Bash printf time formatting follows local time.
         checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 1
@@ -1400,8 +1414,6 @@ setup_run_check_json() {
     if [[ -n "$project" ]]; then
         args+=(--project "$project")
     fi
-    std_make_temp_dir check_result_dir base-check-json ||
-        fatal_error "Unable to create temporary Base check JSON result directory."
     check_result_paths="$(setup_write_collected_check_result_files "$check_result_dir")" || return 1
     if [[ -n "$check_result_paths" ]]; then
         while IFS= read -r check_result_file; do

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -16,7 +16,8 @@ load ./setup_helpers.bash
     [[ "$output" == *"sre       - production/SRE prerequisite tooling."* ]]
     [[ "$output" == *"ai        - AI coding assistant tooling."* ]]
     [[ "$output" == *"linux-lab - Multipass tooling for local Ubuntu lab VMs on macOS hosts."* ]]
-    [[ "$output" == *"--remote-network"* ]]
+    [[ "$output" == *"infer an omitted project"* ]]
+    [[ "$output" == *"requires project or --manifest"* ]]
     [[ "$output" == *"Verify the local Base CLI environment and, when provided, project artifacts on supported platforms without making changes."* ]]
     [[ "$output" == *"Use check for a quick pass/fail result; use doctor for finding IDs and fix hints."* ]]
     [[ "$output" == *"See also:"* ]]
@@ -551,6 +552,13 @@ EOF
 
     [ "$status" -eq 0 ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format text --remote-network demo)" ]
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" \
+        check --manifest "$workspace/demo/base_manifest.yaml" --remote-network
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base CLI environment and project 'demo' check passed."* ]]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format text --remote-network demo)" ]
 }
 
 @test "basectl check --format json writes successful check results to stdout" {
@@ -805,6 +813,27 @@ EOF
     [[ "$output" == *'"schema_version":1,"status":"ok","project":"demo","checks"'* ]]
     [[ "$output" == *'"id":"BASE-P040","status":"ok","name":"demo-artifact"'* ]]
     [[ "$output" != *'"ok":'* ]]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format json --remote-network demo)" ]
+    [ "${stderr:-}" = "" ]
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        OSTYPE="darwin24" \
+        BASE_SETUP_BREW_BIN="$TEST_MOCKBIN/brew" \
+        BASE_SETUP_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        BASE_SETUP_TEST_MOCKBIN="$TEST_MOCKBIN" \
+        BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
+        BASE_SETUP_TEST_WORKSPACE="$workspace" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
+        "$BASE_REPO_ROOT/bin/basectl" check \
+            --manifest "$workspace/demo/base_manifest.yaml" \
+            --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"project_checks":'* ]]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --manifest "$workspace/demo/base_manifest.yaml" --action check --format json demo)" ]
     [ "${stderr:-}" = "" ]
 }
 
@@ -1031,4 +1060,31 @@ EOF
 
     [ "$status" -eq 2 ]
     [[ "$output" == *"Unsupported check output format 'xml'."* ]]
+}
+
+@test "basectl check rejects remote network checks without a project selector" {
+    run_base_command check --remote-network
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Option '--remote-network' requires a project or '--manifest <path>'."* ]]
+}
+
+@test "basectl check reports an invalid manifest instead of ignoring it" {
+    local manifest_path="$TEST_TMPDIR/missing/base_manifest.yaml"
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_project_setup_venv_stub "$venv_dir"
+
+    run_base_command check --manifest "$manifest_path"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Manifest not found: $manifest_path"* ]]
+    [[ "$output" == *"Unable to resolve a project from manifest '$manifest_path'."* ]]
+    [ ! -e "$TEST_STATE_DIR/project-setup-ran" ]
+
+    run_base_command check --manifest "$manifest_path" --format json
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Manifest not found: $manifest_path"* ]]
+    [[ "$output" == *"Unable to resolve a project from manifest '$manifest_path'."* ]]
 }

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -181,7 +181,8 @@ EOF
     [[ "$output" == *"sre       - production/SRE prerequisite tooling."* ]]
     [[ "$output" == *"ai        - AI coding assistant tooling."* ]]
     [[ "$output" == *"linux-lab - Multipass tooling for local Ubuntu lab VMs on macOS hosts."* ]]
-    [[ "$output" == *"--remote-network"* ]]
+    [[ "$output" == *"infer an omitted project"* ]]
+    [[ "$output" == *"requires project or --manifest"* ]]
     [[ "$output" == *"--no-color"* ]]
     [[ "$output" != *"--dev"* ]]
     [[ "$output" == *"Diagnose the local Base CLI environment"* ]]
@@ -1093,6 +1094,11 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" &
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "manifest" ]]; then
+    base_test_protocol_project_reference demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     if [[ "$*" == *"--action route"* ]]; then
         base_test_protocol_project_setup_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -1124,6 +1130,22 @@ EOF
         "$BASE_REPO_ROOT/bin/basectl" doctor demo --remote-network
 
     [ "$status" -eq 0 ]
+    [ "$(cat "$TEST_TMPDIR/project-args")" = "$(printf '%s\n' -m base_setup --manifest "$workspace/demo/base_manifest.yaml" --action doctor --format text --remote-network demo)" ]
+
+    run env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ARGS="$TEST_TMPDIR/project-args" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor \
+            --manifest "$workspace/demo/base_manifest.yaml" \
+            --remote-network
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Base doctor found no blocking issues for project 'demo'."* ]]
     [ "$(cat "$TEST_TMPDIR/project-args")" = "$(printf '%s\n' -m base_setup --manifest "$workspace/demo/base_manifest.yaml" --action doctor --format text --remote-network demo)" ]
 }
 
@@ -1171,6 +1193,9 @@ if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
 fi
+if [[ "${1:-}" == "-c" && "${2:-}" == "import base_setup.diagnostics" ]]; then
+    exit 0
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     case "${4:-}" in
         PyYAML|click) exit 0 ;;
@@ -1179,6 +1204,36 @@ fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "manifest" ]]; then
+    base_test_protocol_project_reference demo "${BASE_TEST_PROJECT_ROOT:?}" \
+        "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup.diagnostics" && "${3:-}" == "doctor-json" ]]; then
+    shift 3
+    project=""
+    project_findings="[]"
+    while (($#)); do
+        case "$1" in
+            --project)
+                shift
+                project="${1:-}"
+                ;;
+            --embedded-payload)
+                shift
+                if [[ "${1:-}" == "project_findings" ]]; then
+                    shift
+                    project_findings="${1:-[]}"
+                fi
+                ;;
+        esac
+        shift || true
+    done
+    [[ -n "$project" ]] || exit 1
+    printf '{"schema_version": 1, "status": "warn", "project": "%s", "project_findings": %s}\n' \
+        "$project" "$project_findings"
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
@@ -1218,6 +1273,62 @@ EOF
     [[ "$output" == *'"id":"BASE-P033","status":"warn","name":"demo-artifact","message":"Optional project artifact is not installed.","fix":"basectl setup demo"'* ]]
     [[ "$output" != *"Running Python project doctor layer."* ]]
     [ "${stderr:-}" = "" ]
+
+    run --separate-stderr env \
+        HOME="$TEST_HOME" \
+        OSTYPE="darwin24" \
+        PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
+        "$BASE_REPO_ROOT/bin/basectl" doctor \
+            --manifest "$workspace/demo/base_manifest.yaml" \
+            --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"project": "demo"'* ]]
+    [[ "$output" == *'"project_findings":'* ]]
+    [ "${stderr:-}" = "" ]
+}
+
+@test "basectl doctor rejects remote network diagnostics without a project selector" {
+    run_basectl doctor --remote-network
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Option '--remote-network' requires a project or '--manifest <path>'."* ]]
+}
+
+@test "basectl doctor reports an invalid manifest instead of ignoring it" {
+    local manifest_path="$TEST_TMPDIR/missing/base_manifest.yaml"
+    local venv_python="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$venv_python")"
+    cat > "$venv_python" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    printf 'Python 3.13.test\n'
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "manifest" ]]; then
+    printf 'Manifest not found: %s\n' "${4:-}" >&2
+    exit 1
+fi
+printf 'unexpected invalid-manifest Python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$venv_python"
+
+    run_basectl doctor --manifest "$manifest_path"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Manifest not found: $manifest_path"* ]]
+    [[ "$output" == *"Unable to resolve a project from manifest '$manifest_path'."* ]]
+
+    run_basectl doctor --manifest "$manifest_path" --format json
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Manifest not found: $manifest_path"* ]]
+    [[ "$output" == *"Unable to resolve a project from manifest '$manifest_path'."* ]]
 }
 
 @test "basectl doctor project --format json reports broken project virtualenv integrity" {


### PR DESCRIPTION
## Summary

- Treat `--manifest` as an effective project selector for both `basectl check` and `basectl doctor`, even when no positional project name is supplied.
- Preserve the manifest-inferred project name through text output, JSON output, history metadata, and persisted project check records.
- Reject `--remote-network` as a usage error unless a project or manifest selector is present, and report invalid manifest selectors instead of silently falling back to Base-only checks.

## Issue

Fixes #1789

## Validation

- Focused `check.bats` and `doctor.bats` selector, remote-network, JSON, and invalid-manifest cases: 9 passed.
- `bash -n` and ShellCheck (error severity) passed for the changed shell and BATS files.
- `git diff --check`
- Final stacked `./bin/base-test`: 1,064 Python tests passed, 1 skipped; 829 of 835 BATS tests passed. The six failures are pre-existing diagnostic JSON fixture failures reproduced on `origin/main`.

## Demo Impact

None.

## Notes

- This is PR 1 of 3 in the `basectl check` UX train. #1790 stacks on this branch, and #1791 carries the consolidated user-facing help, command-reference, and AI-context updates.
- `.ai-context/` is unchanged in this PR because its existing command summary already describes optional project checks; the more precise selector contract is documented in the final UX PR.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the issue worktree and the final stacked worktree.
- [x] Relevant BATS tests pass; broader baseline failures are documented above.
- [x] The bug fix includes regression coverage.
- [x] User-facing documentation is covered by the final PR in this train.
- [x] AI-context applicability is explained above.
- [x] PR includes `Fixes #1789`.
- [x] `Demo Impact` is explicitly stated.
