### PR TITLE
Persist warning check status across output formats

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_check_results.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_check_results.sh
@@ -159,3 +159,43 @@ setup_read_check_result_file() {
     setup_add_parsed_check_result
     [[ "$_BASE_SETUP_PARSED_CHECK_STATUS" != error ]]
 }
+
+setup_merge_diagnostic_status() {
+    local current="$1"
+    local next="$2"
+
+    if [[ "$current" == error || "$next" == error ]]; then
+        printf '%s\n' "error"
+    elif [[ "$current" == warn || "$next" == warn ]]; then
+        printf '%s\n' "warn"
+    else
+        printf '%s\n' "ok"
+    fi
+}
+
+setup_check_results_status() {
+    local count i status="ok"
+
+    count="${#_BASE_SETUP_CHECK_NAMES[@]}"
+    for ((i = 0; i < count; i++)); do
+        status="$(setup_merge_diagnostic_status "$status" "$(setup_check_result_status "$i")")"
+    done
+
+    printf '%s\n' "$status"
+}
+
+setup_read_published_check_status() {
+    local path="$1"
+    local status
+
+    [[ -f "$path" ]] || return 1
+    status="$(<"$path")"
+    case "$status" in
+        ok|warn|error)
+            printf '%s\n' "$status"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -50,7 +50,7 @@ setup_ensure_cached_paths() {
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset dry_run DRY_RUN BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_YES
+    unset dry_run DRY_RUN BASE_SETUP_CHECK_STATUS_FILE BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_YES
     setup_refresh_cached_paths
 }
 
@@ -1330,23 +1330,56 @@ setup_write_collected_check_result_files() {
 }
 
 setup_run_check() {
+    local aggregate_status
+    local layer_status
     local missing=0
     local project="${BASE_SETUP_PROJECT_NAME:-}"
+    local profile_status_file
+    local project_status_file
 
     setup_collect_base_check_results fatal || missing=1
     setup_print_check_text_results
+    aggregate_status="$(setup_check_results_status)"
 
     if setup_profiles_enabled; then
-        setup_run_base_dev_layer check || missing=1
+        std_make_temp_file profile_status_file base-profile-check-status ||
+            fatal_error "Unable to create temporary profile check status file."
+        BASE_SETUP_CHECK_STATUS_FILE="$profile_status_file"
+        export BASE_SETUP_CHECK_STATUS_FILE
+        if ! setup_run_base_dev_layer check; then
+            missing=1
+            aggregate_status="error"
+        elif layer_status="$(setup_read_published_check_status "$profile_status_file")"; then
+            aggregate_status="$(setup_merge_diagnostic_status "$aggregate_status" "$layer_status")"
+        else
+            log_error "Python prerequisite profile check layer did not report a valid aggregate status."
+            missing=1
+            aggregate_status="error"
+        fi
+        unset BASE_SETUP_CHECK_STATUS_FILE
     fi
 
     if [[ -n "$project" || -n "${BASE_SETUP_MANIFEST:-}" ]]; then
-        setup_run_project_artifact_check || missing=1
+        std_make_temp_file project_status_file base-project-check-status ||
+            fatal_error "Unable to create temporary project check status file."
+        BASE_SETUP_CHECK_STATUS_FILE="$project_status_file"
+        export BASE_SETUP_CHECK_STATUS_FILE
+        if ! setup_run_project_artifact_check; then
+            missing=1
+            aggregate_status="error"
+        elif layer_status="$(setup_read_published_check_status "$project_status_file")"; then
+            aggregate_status="$(setup_merge_diagnostic_status "$aggregate_status" "$layer_status")"
+        else
+            log_error "Python project check layer did not report a valid aggregate status."
+            missing=1
+            aggregate_status="error"
+        fi
+        unset BASE_SETUP_CHECK_STATUS_FILE
         project="${BASE_SETUP_PROJECT_NAME:-}"
     fi
 
-    if ((missing == 0)); then
-        setup_record_project_check_result "$project" ok
+    if ((missing == 0)) && [[ "$aggregate_status" != error ]]; then
+        setup_record_project_check_result "$project" "$aggregate_status"
         if [[ -n "$project" ]]; then
             log_info "Base CLI environment and project '$project' check passed."
         else

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -419,6 +419,65 @@ EOF
     grep -Eq '"checked_at": "20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"' "$record_path"
 }
 
+@test "basectl check persists warnings from Base, profile, and project checks in text and JSON modes" {
+    local args record_path="$TEST_HOME/.base.d/demo/checks/last.json"
+    local source
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf 'ok\n' > "$TEST_STATE_DIR/profile-check-status"
+    printf 'ok\n' > "$TEST_STATE_DIR/project-check-status"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$workspace/demo/.venv"
+
+    for source in profile project base; do
+        printf 'ok\n' > "$TEST_STATE_DIR/profile-check-status"
+        printf 'ok\n' > "$TEST_STATE_DIR/project-check-status"
+        args=(check demo)
+        case "$source" in
+            profile)
+                printf 'warn\n' > "$TEST_STATE_DIR/profile-check-status"
+                args+=(--profile dev)
+                ;;
+            project)
+                printf 'warn\n' > "$TEST_STATE_DIR/project-check-status"
+                ;;
+            base)
+                touch "$TEST_STATE_DIR/xcode-outdated"
+                ;;
+        esac
+
+        run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" "${args[@]}"
+
+        [ "$status" -eq 0 ]
+        grep -Fq '"status": "warn"' "$record_path" || {
+            printf 'text mode did not persist %s warning\n' "$source" >&3
+            false
+        }
+
+        run_base_command_separate_stderr \
+            BASE_SETUP_TEST_WORKSPACE="$workspace" \
+            "${args[@]}" \
+            --format json
+
+        [ "$status" -eq 0 ]
+        [[ "$output" == *'"status": "warn"'* ]]
+        grep -Fq '"status": "warn"' "$record_path" || {
+            printf 'JSON mode did not persist %s warning\n' "$source" >&3
+            false
+        }
+        [ "${stderr:-}" = "" ]
+    done
+}
+
 @test "basectl check project records failed checks with error status" {
     local record_path="$TEST_HOME/.base.d/demo/checks/last.json"
     local venv_dir="$TEST_HOME/.base.d/base/.venv"

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -899,6 +899,13 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     printf '%s\n' "${BASE_SETUP_YES:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-yes"
     printf '%s\n' "${BASE_PLATFORM:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-setup-platform"
     touch "$BASE_SETUP_TEST_STATE_DIR/project-setup-ran"
+    check_status="ok"
+    if [[ -f "$BASE_SETUP_TEST_STATE_DIR/project-check-status" ]]; then
+        check_status="$(cat "$BASE_SETUP_TEST_STATE_DIR/project-check-status")"
+    fi
+    if [[ "$action" == "check" && -n "${BASE_SETUP_CHECK_STATUS_FILE:-}" ]]; then
+        printf '%s\n' "$check_status" > "$BASE_SETUP_CHECK_STATUS_FILE"
+    fi
     if [[ "$action" == "bootstrap" ]]; then
         printf '%s\n' "${BASE_SETUP_RECREATE_PROJECT_VENV:-}" > "$BASE_SETUP_TEST_STATE_DIR/project-bootstrap-recreate-venv"
     fi
@@ -925,9 +932,14 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
     elif [[ "$action" == "predoctor" ]]; then
         printf 'ok     BASE-P080  git_repository            Project is inside a Git repository.\n'
     elif [[ "$action" == "check" && "$output_format" == "json" ]]; then
-        printf '{"schema_version":1,"status":"ok","project":"demo","checks":[{"id":"BASE-P040","status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""}]}\n'
+        printf '{"schema_version":1,"status":"%s","project":"demo","checks":[{"id":"BASE-P040","status":"%s","name":"demo-artifact","message":"Project artifact check passed.","fix":""}]}\n' \
+            "$check_status" "$check_status"
     elif [[ "$action" == "check" ]]; then
-        printf 'Project artifact check passed.\n' >&2
+        if [[ "$check_status" == "warn" ]]; then
+            printf 'Optional project artifact requires attention.\n' >&2
+        else
+            printf 'Project artifact check passed.\n' >&2
+        fi
     elif [[ "$action" == "doctor" && "$output_format" == "json" ]]; then
         printf '[{"id":"BASE-P040","status":"ok","name":"demo-artifact","message":"Project artifact check passed.","fix":""}]\n'
     elif [[ "$action" == "doctor" ]]; then
@@ -937,6 +949,42 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then
         cat "$BASE_SETUP_TEST_STATE_DIR/project-setup-stderr" >&2
     fi
     exit "$(cat "$BASE_SETUP_TEST_STATE_DIR/project-setup-exit-code")"
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_dev" ]]; then
+    shift 2
+    printf '%s\n' "$@" > "${BASE_SETUP_TEST_STATE_DIR:?}/dev-args"
+    action="${1:-}"
+    output_format="text"
+    while (($#)); do
+        if [[ "$1" == "--format" ]]; then
+            shift
+            output_format="${1:-}"
+        fi
+        shift || true
+    done
+    if [[ "$action" == "check" ]]; then
+        check_status="ok"
+        if [[ -f "$BASE_SETUP_TEST_STATE_DIR/profile-check-status" ]]; then
+            check_status="$(cat "$BASE_SETUP_TEST_STATE_DIR/profile-check-status")"
+        fi
+        if [[ -n "${BASE_SETUP_CHECK_STATUS_FILE:-}" ]]; then
+            printf '%s\n' "$check_status" > "$BASE_SETUP_CHECK_STATUS_FILE"
+        fi
+        if [[ "$output_format" == "json" ]]; then
+            printf '{"schema_version":1,"status":"%s","profiles":["dev"],"checks":[{"id":"BASE-D104","status":"%s","name":"optional-tool","message":"Developer profile check completed.","fix":""}]}\n' \
+                "$check_status" "$check_status"
+        elif [[ "$check_status" == "warn" ]]; then
+            printf 'Optional developer profile tool requires attention.\n' >&2
+        else
+            printf 'Developer profile check passed.\n'
+        fi
+        if [[ "$check_status" == "error" ]]; then
+            exit 1
+        fi
+        exit 0
+    fi
+    printf 'unexpected base_dev args: %s\n' "$*" >&2
+    exit 1
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" ]]; then
     project="${4:-}"

--- a/cli/python/base_dev/profile_output.py
+++ b/cli/python/base_dev/profile_output.py
@@ -5,6 +5,7 @@ import sys
 
 import base_cli
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
+from base_setup.checks import publish_check_status
 
 from .checks import DevCheck
 from .checks import check_to_doctor_json
@@ -45,6 +46,7 @@ def print_check_results(
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
         return base_cli.ExitCode.USAGE_ERROR
 
+    publish_check_status(checks_status(checks))
     if all(doctor_status(check) != "error" for check in checks):
         return base_cli.ExitCode.SUCCESS
     return base_cli.ExitCode.FAILURE

--- a/cli/python/base_dev/tests/test_profile_output.py
+++ b/cli/python/base_dev/tests/test_profile_output.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from base_dev import profile_output
@@ -8,6 +11,32 @@ from base_dev.checks import DevCheck
 
 
 class ProfileCheckOutputTests(unittest.TestCase):
+    def test_text_output_publishes_warning_status_without_changing_exit_status(self) -> None:
+        warning_check = DevCheck(
+            name="optional-tool",
+            ok=False,
+            message="Optional developer tool is not installed.",
+            fix="Install the optional developer tool.",
+            status="warn",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            status_path = Path(temp_dir) / "profile-check.status"
+            with mock.patch.dict(
+                os.environ,
+                {"BASE_SETUP_CHECK_STATUS_FILE": str(status_path)},
+                clear=False,
+            ):
+                status = profile_output.print_check_results(
+                    mock.Mock(),
+                    (warning_check,),
+                    output_format="text",
+                    profiles=("dev",),
+                )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(status_path.read_text(encoding="utf-8"), "warn\n")
+
     def test_text_output_routes_findings_by_status_and_preserves_exit_status(self) -> None:
         warning_check = DevCheck(
             name="optional-tool",

--- a/cli/python/base_setup/checks.py
+++ b/cli/python/base_setup/checks.py
@@ -6,10 +6,12 @@ from collections.abc import Iterable
 from collections.abc import Mapping
 from dataclasses import dataclass
 from dataclasses import field
+from pathlib import Path
 from typing import Any
 
 
 DIAGNOSTIC_JSON_SCHEMA_VERSION = 1
+CHECK_STATUS_FILE_ENVIRONMENT_VARIABLE = "BASE_SETUP_CHECK_STATUS_FILE"
 
 
 @dataclass(frozen=True)
@@ -43,6 +45,15 @@ def checks_status(checks: Iterable[ArtifactCheck]) -> str:
     if "warn" in statuses:
         return "warn"
     return "ok"
+
+
+def publish_check_status(status: str) -> None:
+    if status not in {"ok", "warn", "error"}:
+        raise ValueError(f"Unsupported check status '{status}'.")
+
+    status_file = os.environ.get(CHECK_STATUS_FILE_ENVIRONMENT_VARIABLE)
+    if status_file:
+        Path(status_file).write_text(f"{status}\n", encoding="utf-8")
 
 
 def checks_payload_to_json(checks: Iterable[ArtifactCheck], **metadata: Any) -> dict[str, Any]:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -20,8 +20,10 @@ from base_devenv.report import print_devenv_report_text
 from .checks import ArtifactCheck
 from .checks import check_to_json
 from .checks import checks_payload_to_json
+from .checks import checks_status
 from .checks import doctor_status
 from .checks import print_doctor_finding
+from .checks import publish_check_status
 from .errors import ArtifactError
 from .manifest import BaseManifest, ManifestError, read_manifest
 from .manifest_checks import empty_user_config  # pylint: disable=unused-import
@@ -285,6 +287,7 @@ def check_manifest(
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
         return base_cli.ExitCode.USAGE_ERROR
+    publish_check_status(checks_status(checks))
     if all(check.ok or doctor_status(check) == "warn" for check in checks):
         return base_cli.ExitCode.SUCCESS
     return base_cli.ExitCode.FAILURE
@@ -305,6 +308,7 @@ def check_pre_venv_manifest(
     else:
         ctx.log.error("Unsupported check output format '%s'. Expected text or json.", output_format)
         return base_cli.ExitCode.USAGE_ERROR
+    publish_check_status(checks_status(checks))
     if all(check.ok or doctor_status(check) == "warn" for check in checks):
         return base_cli.ExitCode.SUCCESS
     return base_cli.ExitCode.FAILURE

--- a/cli/python/base_setup/tests/test_check_text_output.py
+++ b/cli/python/base_setup/tests/test_check_text_output.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import os
 import re
+import tempfile
 import unittest
 from contextlib import redirect_stderr
 from contextlib import redirect_stdout
@@ -16,6 +17,89 @@ from base_setup.tests.helpers import fake_context
 
 
 class ProjectCheckTextOutputTests(unittest.TestCase):
+    def test_check_manifest_publishes_warning_status_without_changing_exit_status(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+        warning_check = setup_checks.ArtifactCheck(
+            name="optional-artifact",
+            ok=False,
+            message="Optional project artifact is not installed.",
+            fix="Review the optional project artifact.",
+            finding_id="BASE-P033",
+            status="warn",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            status_path = Path(temp_dir) / "project-check.status"
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"BASE_SETUP_CHECK_STATUS_FILE": str(status_path)},
+                    clear=False,
+                ),
+                mock.patch(
+                    "base_setup.engine.manifest_checks",
+                    return_value=(warning_check,),
+                ),
+            ):
+                status = engine.check_manifest(
+                    fake_context(),
+                    default_manifest,
+                    manifest,
+                    output_format="text",
+                )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(status_path.read_text(encoding="utf-8"), "warn\n")
+
+    def test_check_pre_venv_publishes_warning_status_without_changing_exit_status(self) -> None:
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+        )
+        warning_check = setup_checks.ArtifactCheck(
+            name="git-remote",
+            ok=False,
+            message="The Git remote could not be checked.",
+            fix="Review the Git remote manually.",
+            finding_id="BASE-P083",
+            status="warn",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            status_path = Path(temp_dir) / "project-precheck.status"
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"BASE_SETUP_CHECK_STATUS_FILE": str(status_path)},
+                    clear=False,
+                ),
+                mock.patch(
+                    "base_setup.engine.pre_venv_manifest_checks",
+                    return_value=(warning_check,),
+                ),
+            ):
+                status = engine.check_pre_venv_manifest(
+                    fake_context(),
+                    manifest,
+                    output_format="text",
+                )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(status_path.read_text(encoding="utf-8"), "warn\n")
+
     def test_doctor_finding_uses_shared_visual_status_format_on_tty(self) -> None:
         class TtyBuffer(io.StringIO):
             def isatty(self) -> bool:


### PR DESCRIPTION
## Summary

- Aggregate warning state consistently across the Base, prerequisite-profile, and project check layers.
- Publish each reusable Python layer's aggregate status through a validated internal status file, while preserving warning-only exit code 0.
- Persist `warn` rather than `ok` for warning-only text runs so text and JSON modes record the same result; fail closed if a layer does not publish a valid status.

## Issue

Fixes #1790

## Validation

- Focused `check.bats` selector and warning-persistence cases: 10 passed.
- `PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q cli/python/base_setup/tests cli/python/base_dev/tests`: 432 passed, 1 skipped, 204 subtests passed.
- `bash -n`, ShellCheck (error severity), and Pylint passed for the changed files.
- `git diff --check`
- Final stacked `./bin/base-test`: 1,064 Python tests passed, 1 skipped; 829 of 835 BATS tests passed. The six failures are pre-existing diagnostic JSON fixture failures reproduced on `origin/main`.

## Demo Impact

None.

## Notes

- This is PR 2 of 3 and targets `bug/1789-20260728-check-project-selectors`. Retarget it to `main` after #1789 merges.
- `.ai-context/` is unchanged because this PR corrects internal status propagation without changing the documented command inventory; the final UX PR documents the warning result contract explicitly.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the issue worktree and the final stacked worktree.
- [x] Relevant BATS and Python tests pass; broader baseline failures are documented above.
- [x] The bug fix includes regression coverage for Base, profile, and project warnings in text and JSON modes.
- [x] User-facing documentation is covered by the final PR in this train.
- [x] AI-context applicability is explained above.
- [x] PR includes `Fixes #1790`.
- [x] `Demo Impact` is explicitly stated.
