### PR TITLE
Report package details for uv environment drift

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -264,7 +265,12 @@ class WorkspaceCheckTests(unittest.TestCase):
 
             with (
                 mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
-                mock.patch("base_setup.uv.process.run_check", return_value=True),
+                mock.patch(
+                    "base_setup.uv.process.run_capture",
+                    return_value=subprocess.CompletedProcess(
+                        ["uv"], 0, stdout='{"sync": {"changes": []}}', stderr=""
+                    ),
+                ),
             ):
                 status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
 
@@ -288,7 +294,12 @@ class WorkspaceCheckTests(unittest.TestCase):
 
             with (
                 mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
-                mock.patch("base_setup.uv.process.run_check", return_value=True),
+                mock.patch(
+                    "base_setup.uv.process.run_capture",
+                    return_value=subprocess.CompletedProcess(
+                        ["uv"], 0, stdout='{"sync": {"changes": []}}', stderr=""
+                    ),
+                ),
             ):
                 status, stdout, stderr = invoke_engine(["doctor", "--workspace", str(workspace)], base_home, home)
 

--- a/cli/python/base_setup/finding_explanations.py
+++ b/cli/python/base_setup/finding_explanations.py
@@ -228,7 +228,7 @@ CATALOG = catalog_by_id(
             title="uv-managed project virtual environment synchronization",
             summary=(
                 "Base found that the uv-managed project environment is not synchronized with its declared "
-                "dependencies."
+                "dependencies; the finding may include the package changes reported by uv."
             ),
             why_it_matters=(
                 "A manually installed, removed, or otherwise stale package can make local commands differ from the "

--- a/cli/python/base_setup/tests/test_uv.py
+++ b/cli/python/base_setup/tests/test_uv.py
@@ -343,7 +343,15 @@ class UvProjectTests(unittest.TestCase):
 
             with (
                 mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
-                mock.patch("base_setup.uv.process.run_check", return_value=True) as run_check,
+                mock.patch(
+                    "base_setup.uv.process.run_capture",
+                    return_value=subprocess.CompletedProcess(
+                        ["uv"],
+                        0,
+                        stdout='{"sync": {"changes": []}}',
+                        stderr="",
+                    ),
+                ) as run_capture,
             ):
                 checks = check_uv(manifest)
 
@@ -351,8 +359,8 @@ class UvProjectTests(unittest.TestCase):
         self.assertEqual(findings["BASE-P154"].status, "")
         self.assertIn(str(root / ".venv"), findings["BASE-P154"].message)
         self.assertEqual(findings["BASE-P155"].status, "")
-        run_check.assert_called_once_with(
-            ["uv", "sync", "--check", "--offline"],
+        run_capture.assert_called_once_with(
+            ["uv", "sync", "--check", "--offline", "--output-format", "json"],
             cwd=root,
             timeout_seconds=10,
         )
@@ -381,7 +389,21 @@ class UvProjectTests(unittest.TestCase):
 
             with (
                 mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
-                mock.patch("base_setup.uv.process.run_check", return_value=False),
+                mock.patch(
+                    "base_setup.uv.process.run_capture",
+                    return_value=subprocess.CompletedProcess(
+                        ["uv"],
+                        1,
+                        stdout=(
+                            '{"sync": {"changes": ['
+                            '{"name": "clicker", "version": "0.2.5", "action": "uninstalled"},'
+                            '{"name": "requests", "version": "2.32.4", "action": "installed"},'
+                            '{"name": "PyYAML", "version": "6.0.3", "action": "reinstalled"}'
+                            ']}}'
+                        ),
+                        stderr="",
+                    ),
+                ),
             ):
                 checks = check_uv(manifest)
 
@@ -389,7 +411,55 @@ class UvProjectTests(unittest.TestCase):
         self.assertFalse(drift.ok)
         self.assertEqual(drift.status, "")
         self.assertIn("not synchronized", drift.message)
+        self.assertIn("unexpected clicker==0.2.5", drift.message)
+        self.assertIn("missing requests==2.32.4", drift.message)
+        self.assertIn("version mismatch PyYAML==6.0.3", drift.message)
         self.assertIn("uv sync", drift.fix)
+        self.assertEqual(
+            drift.details["package_changes"],
+            (
+                {"name": "clicker", "version": "0.2.5", "action": "uninstalled"},
+                {"name": "requests", "version": "2.32.4", "action": "installed"},
+                {"name": "PyYAML", "version": "6.0.3", "action": "reinstalled"},
+            ),
+        )
+
+    def test_check_uv_falls_back_to_generic_message_for_unstructured_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "project"
+            manifest = write_manifest(
+                root,
+                "\n".join(
+                    [
+                        "project:",
+                        "  name: demo",
+                        "python:",
+                        "  manager: uv",
+                        "artifacts: []",
+                    ]
+                ),
+            )
+            (root / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+            (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+            python_bin = root / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+            python_bin.chmod(0o755)
+
+            with (
+                mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
+                mock.patch(
+                    "base_setup.uv.process.run_capture",
+                    return_value=subprocess.CompletedProcess(
+                        ["uv"], 1, stdout="not json", stderr="probe failed"
+                    ),
+                ),
+            ):
+                checks = check_uv(manifest)
+
+        drift = next(check for check in checks if check.finding_id == "BASE-P155")
+        self.assertEqual(drift.message, f"uv project environment is not synchronized with '{root}'.")
+        self.assertEqual(drift.details, {})
 
     def test_check_uv_warns_when_environment_probe_times_out(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -416,8 +486,10 @@ class UvProjectTests(unittest.TestCase):
             with (
                 mock.patch("base_setup.uv.uv_executable", return_value=Path("uv")),
                 mock.patch(
-                    "base_setup.uv.process.run_check",
-                    side_effect=subprocess.TimeoutExpired(["uv", "sync", "--check", "--offline"], 10),
+                    "base_setup.uv.process.run_capture",
+                    side_effect=subprocess.TimeoutExpired(
+                        ["uv", "sync", "--check", "--offline", "--output-format", "json"], 10
+                    ),
                 ),
             ):
                 checks = check_uv(manifest)

--- a/cli/python/base_setup/uv.py
+++ b/cli/python/base_setup/uv.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import base_cli
 
@@ -221,9 +223,9 @@ def uv_project_venv_ready(venv_path: Path) -> bool:
 
 
 def uv_project_environment_check(project_root: Path, uv_bin: Path) -> ArtifactCheck:
-    command = [str(uv_bin), "sync", "--check", "--offline"]
+    command = [str(uv_bin), "sync", "--check", "--offline", "--output-format", "json"]
     try:
-        synchronized = process.run_check(
+        probe = process.run_capture(
             command,
             cwd=project_root,
             timeout_seconds=process.DIAGNOSTIC_TIMEOUT_SECONDS,
@@ -241,7 +243,8 @@ def uv_project_environment_check(project_root: Path, uv_bin: Path) -> ArtifactCh
             status="warn",
         )
 
-    if synchronized:
+    package_changes = uv_sync_package_changes(probe.stdout)
+    if probe.returncode == 0:
         return ArtifactCheck(
             name="uv project environment",
             ok=True,
@@ -249,13 +252,69 @@ def uv_project_environment_check(project_root: Path, uv_bin: Path) -> ArtifactCh
             fix="",
             finding_id="BASE-P155",
         )
+    message = f"uv project environment is not synchronized with '{project_root}'."
+    details: dict[str, Any] = {}
+    if package_changes:
+        message = f"{message} {format_uv_package_changes(package_changes)}"
+        details["package_changes"] = package_changes
     return ArtifactCheck(
         name="uv project environment",
         ok=False,
-        message=f"uv project environment is not synchronized with '{project_root}'.",
+        message=message,
         fix=f"Run 'uv sync' from '{project_root}' to reconcile the environment.",
         finding_id="BASE-P155",
+        details=details,
     )
+
+
+def uv_sync_package_changes(stdout: str) -> tuple[dict[str, str], ...]:
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return ()
+    if not isinstance(payload, dict):
+        return ()
+    sync = payload.get("sync")
+    if not isinstance(sync, dict):
+        return ()
+    changes = sync.get("changes")
+    if not isinstance(changes, list):
+        return ()
+
+    package_changes: list[dict[str, str]] = []
+    for change in changes:
+        if not isinstance(change, dict):
+            continue
+        name = change.get("name")
+        action = change.get("action")
+        if not isinstance(name, str) or not isinstance(action, str):
+            continue
+        normalized = {"name": name, "action": action}
+        version = change.get("version")
+        if isinstance(version, str):
+            normalized["version"] = version
+        package_changes.append(normalized)
+    return tuple(package_changes)
+
+
+def format_uv_package_changes(package_changes: tuple[dict[str, str], ...]) -> str:
+    labels = {
+        "installed": "missing",
+        "reinstalled": "version mismatch",
+        "uninstalled": "unexpected",
+    }
+    descriptions = []
+    for change in package_changes[:5]:
+        label = labels.get(change["action"], change["action"])
+        package = change["name"]
+        if "version" in change:
+            package = f"{package}=={change['version']}"
+        descriptions.append(f"{label} {package}")
+    remaining = len(package_changes) - len(descriptions)
+    if remaining:
+        descriptions.append(f"{remaining} more")
+    count_label = "package change" if len(package_changes) == 1 else "package changes"
+    return f"{count_label}: {', '.join(descriptions)}."
 
 
 def stale_base_venv_check(manifest: BaseManifest) -> ArtifactCheck | None:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -63,6 +63,7 @@ Every diagnostic item emitted by `basectl check --format json` and
 | `name` | Short machine-readable finding subject |
 | `message` | Human-readable diagnostic detail |
 | `fix` | Suggested remediation, or an empty string when no fix is needed |
+| `details` | Optional structured context for findings that can report machine-readable detail |
 
 Check commands that return an object include an aggregate `status` and a
 `checks` array of diagnostic items:
@@ -199,8 +200,10 @@ when uv tooling or expected uv project files are missing, because check/doctor
 should explain readiness without mutating the project. When the project has a
 usable `pyproject.toml`, `uv.lock`, and `.venv`, `BASE-P155` runs uv's offline
 `sync --check` probe and reports an error when the environment is not
-synchronized. Command invocation still fails hard when a command declares
-`runner: uv` and the `uv` executable is unavailable. On Ubuntu/Debian,
+synchronized. When uv provides structured changes, the finding message and
+optional `details.package_changes` identify missing, unexpected, or
+version-mismatched packages. Command invocation still fails hard when a command
+declares `runner: uv` and the `uv` executable is unavailable. On Ubuntu/Debian,
 `BASE-P150` recovery should point users to `basectl setup <project> --dry-run`
 followed by `--yes` when the manifest has explicitly opted into uv.
 For the full uv manifest contract, migration paths, and runner configuration,

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -288,9 +288,12 @@ The file and readiness diagnostics are warning-oriented in `check` and
 `doctor`; they explain readiness without mutating the project or executing
 project command strings.
 When the uv project files and environment are present, `BASE-P155` performs an
-offline `uv sync --check` probe and reports drift as an error. Command linting
-is advisory and does not replace reviewing manifests from unfamiliar
-repositories before running their declared commands.
+offline `uv sync --check` probe and reports drift as an error. When uv provides
+structured changes, the finding identifies missing, unexpected, or
+version-mismatched packages in human-readable output and in the optional
+`details.package_changes` JSON field. Command linting is advisory and does not
+replace reviewing manifests from unfamiliar repositories before running their
+declared commands.
 
 `basectl workspace status --format json` also includes a `python_runtime`
 object for each ready, inspectable project environment. That summary reports


### PR DESCRIPTION
## Summary

- report package-level uv changes in BASE-P155 text diagnostics
- expose full package changes through JSON details.package_changes
- retain a generic fallback when uv output is unavailable or malformed

## Root cause

The existing uv probe only checked the exit status from uv sync --check --offline and discarded uv's structured change report, so users could not see which packages caused the drift.

## Validation

- Focused and workspace regression tests: 381 passed, 196 subtests passed
- Pylint passed on all changed Python files
- Full basectl test: all 1,063 Python tests passed; unrelated BATS fixtures require the sibling base-bash-libs checkout
- git diff --check

.ai-context/ is unchanged.

Fixes #1788