### PR TITLE
Make workspace init missing-source errors actionable

### DIFF
--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -288,6 +288,41 @@ EOF
     [ "$output" = "ARGS=base-workspace --owner codeforester --path $config_repo --workspace $workspace --manifest workspace.yaml --include-optional --dry-run" ]
 }
 
+@test "basectl workspace init propagates actionable missing-source usage errors" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" &&
+      "${2:-}" == "base_projects" &&
+      "${3:-}" == "init" &&
+      "${4:-}" == "--workspace" &&
+      "${5:-}" == "${BASE_TEST_WORKSPACE_ROOT:?}" &&
+      "${6:-}" == "--dry-run" &&
+      "$#" -eq 6 ]]; then
+    printf "ERROR: The 'basectl workspace init' command requires the positional argument <workspace-source>. Option '--workspace' selects the local directory for member repositories, not the workspace source.\n" >&2
+    exit 2
+fi
+printf 'unexpected workspace init python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_TEST_WORKSPACE_ROOT="$workspace" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace init --workspace "$workspace" --dry-run
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"The 'basectl workspace init' command requires the positional argument <workspace-source>."* ]]
+    [[ "$output" == *"Option '--workspace' selects the local directory for member repositories, not the workspace source."* ]]
+    [[ "$output" != *"Project command 'init' requires at least"* ]]
+}
+
 @test "basectl workspace commands print help without requiring the Base Python venv" {
     run_basectl workspace status --help
 

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -171,6 +171,12 @@ def _handle_init(
     options: WorkspaceCommandOptions,
     actions: ProjectCommandActions,
 ) -> int:
+    if not arguments:
+        raise ProjectUsageError(
+            "The 'basectl workspace init' command requires the positional argument <workspace-source>. "
+            "Option '--workspace' selects the local directory for member repositories, "
+            "not the workspace source."
+        )
     require_argument_count("init", arguments, 1, 1)
     return actions.workspace_init(ctx, arguments[0], options)
 

--- a/cli/python/base_projects/tests/test_workspace_init.py
+++ b/cli/python/base_projects/tests/test_workspace_init.py
@@ -104,6 +104,39 @@ class WorkspaceInitTests(unittest.TestCase):
             workspace_init.workspace_init_command,
         )
 
+    def test_workspace_init_missing_source_reports_public_command_usage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "init",
+                    "--owner",
+                    "basefoundry",
+                    "--path",
+                    str(root),
+                    "--workspace",
+                    "basefoundry/base-workspace",
+                    "--dry-run",
+                ],
+                base_home,
+                home,
+            )
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn(
+            "The 'basectl workspace init' command requires the positional argument <workspace-source>. "
+            "Option '--workspace' selects the local directory for member repositories, "
+            "not the workspace source.",
+            stderr,
+        )
+        self.assertNotIn("Project command 'init' requires at least", stderr)
+
     def test_workspace_init_dry_run_uses_local_source_without_writing_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -265,7 +298,6 @@ class WorkspaceInitTests(unittest.TestCase):
             status, stdout, stderr = invoke_engine(
                 [
                     "init",
-                    "base-workspace",
                     "--owner",
                     "codeforester",
                     "--path",
@@ -273,6 +305,7 @@ class WorkspaceInitTests(unittest.TestCase):
                     "--workspace",
                     str(workspace),
                     "--dry-run",
+                    "base-workspace",
                 ],
                 base_home,
                 home,


### PR DESCRIPTION
## Summary

- replace the internal `Project command 'init'...` message with a
  `basectl workspace init` diagnostic that names the required positional
  `<workspace-source>`
- explain that `--workspace` selects the local directory for member
  repositories rather than the workspace source
- cover the reported option/value mix-up, source placement after options, and
  public wrapper propagation

## Issue

Fixes #1798

## Validation

- `PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_projects/tests/test_workspace_init.py -q`
  — 7 passed
- `PYTHONPATH=lib/python:cli/python python -m pytest cli/python/base_projects/tests -q`
  — 179 passed, 18 subtests passed
- `bats cli/bash/commands/basectl/tests/workspace.bats` — 13 passed
- Pylint on the touched Python module and test
- `git diff --check`
- public reproduction of the reported command returned status 2 with the new
  actionable diagnostic
- GitHub Actions — all checks passed
- `./bin/base-test` — Python: 1,066 passed, 1 skipped; BATS: 837 of 843
  passed, including both workspace-init cases. The six unrelated JSON
  check/doctor fixture failures reproduce on clean `main` with the same local
  base-bash-libs checkout.

## Demo Impact

None.

## Notes

Click parsing and option ordering are unchanged. A valid source remains
accepted before or after options.

Documentation and `.ai-context/` are unchanged because the public command,
argument semantics, and help contract are unchanged; this patch only makes an
existing usage error specific and actionable.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the
  prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the issue worktree.
- [x] Relevant BATS and Python tests pass.
- [x] The bug fix includes regression proof.
- [x] Documentation is updated when behavior or user-facing commands change,
  or the PR explains why it is not needed.
- [x] AI context is updated in `.ai-context/`, or the PR explains why it is
  not applicable.
- [x] PR includes `Fixes #1798`.
- [x] Demo Impact is explicit.
