### PR TITLE
Handle unsupported branch naming rulesets gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Treat GitHub's unsupported `branch_name_pattern` response as a capability
+  warning during `basectl repo configure`, preserving the issue-branch policy
+  workflow fallback instead of failing the whole repository configuration.
 - Updated Base CI and source-checkout contract coverage to consume the
   published `base-bash-libs` v1.4.0 release commit.
 - Refined basectl logs with comma-separated --command filters, the

--- a/cli/bash/commands/basectl/subcommands/repo_github_settings.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_github_settings.sh
@@ -100,6 +100,13 @@ base_repo_rulesets_plan_gated_error() {
         [[ "$message" == *"(HTTP 403)"* ]]
 }
 
+base_repo_branch_name_rule_unavailable_error() {
+    local message="$1"
+
+    [[ "$message" == *"Invalid rule 'branch_name_pattern'"* ]] &&
+        [[ "$message" == *"(HTTP 422)"* ]]
+}
+
 base_repo_configure_default_branch_protection() {
     local dry_run="$1"
     local payload
@@ -338,6 +345,11 @@ base_repo_configure_branch_naming() {
                 log_warn "$ruleset_write_output"
                 return 0
             fi
+            if base_repo_branch_name_rule_unavailable_error "$ruleset_write_output"; then
+                log_warn "Branch naming ruleset unavailable for '$repo'; issue branch policy workflow remains the fallback."
+                log_warn "$ruleset_write_output"
+                return 0
+            fi
             [[ -z "$ruleset_write_output" ]] || log_error "$ruleset_write_output"
             log_error "Unable to update Base branch naming ruleset for '$repo'."
             return 1
@@ -347,6 +359,11 @@ base_repo_configure_branch_naming() {
         ruleset_write_output="$(printf '%s\n' "$payload" | gh api "repos/$repo/rulesets" --method POST --input - 2>&1)" || {
             if base_repo_rulesets_plan_gated_error "$ruleset_write_output"; then
                 log_warn "Branch naming enforcement skipped for '$repo'."
+                log_warn "$ruleset_write_output"
+                return 0
+            fi
+            if base_repo_branch_name_rule_unavailable_error "$ruleset_write_output"; then
+                log_warn "Branch naming ruleset unavailable for '$repo'; issue branch policy workflow remains the fallback."
                 log_warn "$ruleset_write_output"
                 return 0
             fi

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -2695,6 +2695,43 @@ EOF
     [[ "$output" == *"make this repository public"* ]]
 }
 
+@test "basectl repo configure warns when branch-name metadata rules are unavailable" {
+    local repo_dir="$TEST_TMPDIR/repo"
+
+    mkdir -p "$repo_dir"
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth status -h github.com" ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/bankbuddy/rulesets" && "$*" != *"--method POST"* ]]; then
+    printf '%s\n' "api-list $*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "repos/codeforester/bankbuddy/rulesets" && "$*" == *"--method POST"* ]]; then
+    payload="$(cat)"
+    [[ "$payload" == *"branch_name_pattern"* ]] || exit 0
+    printf '%s\n' '{"message":"Validation Failed","errors":["Invalid rule '\''branch_name_pattern'\'': "],"status":422}' >&2
+    printf '%s\n' 'gh: Validation Failed (HTTP 422)' >&2
+    exit 1
+fi
+printf '%s\n' "$*" >> "${BASE_REPO_TEST_STATE_DIR:?}/gh-args"
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/bankbuddy --no-project
+
+    [ "$status" -eq 0 ]
+    grep -Fq "api-list api repos/codeforester/bankbuddy/rulesets" "$TEST_STATE_DIR/gh-args"
+    [[ "$output" == *"Branch naming ruleset unavailable for 'codeforester/bankbuddy'; issue branch policy workflow remains the fallback."* ]]
+    [[ "$output" == *"Invalid rule 'branch_name_pattern'"* ]]
+    [[ "$output" != *"Unable to create Base branch naming ruleset"* ]]
+}
+
 @test "basectl repo configure fails for unexpected ruleset lookup errors" {
     local repo_dir="$TEST_TMPDIR/repo"
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -309,12 +309,15 @@ must use the same shape. Prefixes such as `feat/`, `agent/`, `codex/`, and bare
 `<issue>-<slug>` names are invalid. `YYYYMMDD` must be a real calendar date.
 
 `basectl repo configure` creates or updates the active `Base branch naming`
-GitHub ruleset. It targets all non-default branches and uses a branch-name
-regular expression, so an invalid name is rejected when any tool tries to
-create or push the remote branch. The default branch is excluded and remains
-protected by the separate `Base default branch protection` ruleset. On GitHub
-plans where repository rulesets are unavailable, Base reports that enforcement
-was skipped instead of claiming the repository is protected.
+GitHub ruleset when the repository supports branch-name metadata restrictions.
+It targets all non-default branches and uses a branch-name regular expression,
+so an invalid name is rejected when any tool tries to create or push the remote
+branch. The default branch is excluded and remains protected by the separate
+`Base default branch protection` ruleset. When GitHub rejects repository
+rulesets or the branch-name rule for the repository's current plan or ownership
+context, Base reports that enforcement was skipped and keeps the trusted issue
+branch policy workflow as the fallback instead of claiming the repository is
+fully protected.
 
 The regular expression can validate shape but cannot look up the referenced
 issue. `.github/workflows/issue-branch-policy.yml` closes that semantic gap. Its
@@ -343,7 +346,9 @@ workflow therefore aggregates every open pull request sharing a head commit
 and treats any mismatch as a failure for that commit. The branch-name ruleset
 is still the immediate hard boundary for branches created in the repository;
 the status workflow adds asynchronous semantic validation, including for pull
-requests whose branches live in forks that this repository cannot govern.
+requests whose branches live in forks that this repository cannot govern. The
+workflow can block merges once its status is required, but it cannot prevent a
+direct branch create or push when the GitHub branch-name ruleset is unavailable.
 
 Before committing or opening a pull request, verify the active branch is not
 `main` and follows the issue-backed branch convention.

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -429,12 +429,16 @@ approval counts, CODEOWNERS, teams, or repository secrets. Pass
 `--no-protect-default-branch` when a repository intentionally skips this
 Base-managed ruleset.
 
-Branch naming enforcement is tool-independent. `repo configure` creates or
-updates the active `Base branch naming` ruleset for all non-default branches and
-requires `<category>/<issue>-<YYYYMMDD>-<slug>`, using one of the standard Base
-categories. The CLI and semantic workflow also reject impossible calendar
-dates. This rejects nonconforming remote branches whether they come from a
-human, an AI tool, a GitHub Action, or a Base helper.
+Branch naming enforcement is tool-independent. When supported by the
+repository's current GitHub plan and ownership context, `repo configure`
+creates or updates the active `Base branch naming` ruleset for all non-default
+branches and requires `<category>/<issue>-<YYYYMMDD>-<slug>`, using one of the
+standard Base categories. The CLI and semantic workflow also reject impossible
+calendar dates. If GitHub rejects the branch-name rule, Base warns and keeps
+the trusted issue-branch policy workflow as the fallback; once its status is
+required, it blocks nonconforming pull requests at merge time but cannot block
+a direct branch create or push. This keeps enforcement behavior explicit for
+human, AI-tool, GitHub Action, and Base-helper changes.
 
 The generated `.github/workflows/issue-branch-policy.yml` verifies the semantic
 half of the convention: the referenced number must be an issue with exactly one


### PR DESCRIPTION
## Summary

- treat GitHub's `Invalid rule 'branch_name_pattern'` HTTP 422 as a capability warning
- preserve the issue-branch-policy workflow as the fallback instead of failing repository configuration
- document the difference between remote branch blocking and merge-time workflow enforcement

## Root cause

Some user-owned repositories accept ordinary repository rulesets but reject the branch-name metadata rule. Base previously handled only plan-level 403 responses, so `basectl repo configure` returned failure after applying the other settings.

## Validation

- `bats cli/bash/commands/basectl/tests/repo.bats`
- `./bin/base-test`
- `git diff --check`

Fixes #1800
