### PR TITLE
setup: add explicit pip upgrade option

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -23,6 +23,8 @@ Options:
   --notify           Force a best-effort macOS notification when setup ends.
   --no-notify        Disable the default best-effort macOS completion notification.
   --recreate-venv    Back up and recreate the project virtual environment.
+  --upgrade-pip      Upgrade pip in the selected Base-managed or pip-managed
+                     project virtual environment. uv-managed projects are left unchanged.
   --yes              Apply setup changes that require explicit confirmation.
   -v                 Enable DEBUG logging for this subcommand.
   -h, --help         Show this help text.
@@ -195,6 +197,9 @@ base_setup_subcommand_main() {
                 ;;
             --recreate-venv)
                 setup_enable_recreate_venv
+                ;;
+            --upgrade-pip)
+                setup_enable_upgrade_pip
                 ;;
             -v)
                 setup_enable_debug_logging

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -56,7 +56,7 @@ setup_ensure_cached_paths() {
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset dry_run DRY_RUN BASE_SETUP_CHECK_STATUS_FILE BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_YES
+    unset dry_run DRY_RUN BASE_SETUP_CHECK_STATUS_FILE BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_UPGRADE_PIP BASE_SETUP_YES
     setup_refresh_cached_paths
 }
 
@@ -151,6 +151,14 @@ setup_require_linux_debian_system_consent() {
 
 setup_enable_recreate_venv() {
     export BASE_SETUP_RECREATE_VENV=true
+}
+
+setup_enable_upgrade_pip() {
+    export BASE_SETUP_UPGRADE_PIP=true
+}
+
+setup_upgrade_pip_enabled() {
+    [[ "${BASE_SETUP_UPGRADE_PIP:-false}" == true ]]
 }
 
 setup_enable_notifications() {
@@ -1116,6 +1124,16 @@ setup_run_project_artifact_layer() {
             log_error "$(setup_recovery_project_layer)"
             log_error "Python project $action layer failed."
             return "$exit_code"
+        fi
+    fi
+
+    if [[ "$action" == setup ]] && setup_upgrade_pip_enabled && [[ "$project" != base ]]; then
+        if [[ "$project_uses_uv_manager" == true ]]; then
+            log_warn "Skipping pip upgrade for project '$project': its virtual environment is managed by uv. Run 'uv sync' to reconcile the project environment."
+        elif [[ "$project_requires_python" == true ]]; then
+            setup_upgrade_project_pip "$project" "$project_venv_dir" || return $?
+        else
+            log_warn "Skipping pip upgrade for project '$project': it does not declare a Python runtime."
         fi
     fi
 

--- a/cli/bash/commands/basectl/subcommands/setup_linux_debian.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_linux_debian.sh
@@ -402,6 +402,7 @@ setup_run_linux_debian_install() {
         setup_run_linux_debian_github_cli_prerequisite || return $?
     fi
     setup_create_virtualenv
+    setup_upgrade_base_pip || return $?
     setup_install_pyyaml
     setup_install_click
     if setup_profiles_enabled; then

--- a/cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh
@@ -581,6 +581,7 @@ setup_run_macos_install() {
     setup_install_xcode_tools
     setup_install_python
     setup_create_virtualenv
+    setup_upgrade_base_pip || return $?
     setup_install_pyyaml
     setup_install_click
     if setup_profiles_enabled; then

--- a/cli/bash/commands/basectl/subcommands/setup_venv.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_venv.sh
@@ -258,6 +258,46 @@ setup_create_virtualenv() {
     "$python_bin" -m venv "$venv_dir"
 }
 
+setup_upgrade_pip_in_virtualenv() {
+    local description="$1"
+    local python_bin="$2"
+
+    if setup_is_dry_run; then
+        log_info "[DRY-RUN] Would upgrade pip in the $description virtual environment."
+        return 0
+    fi
+
+    [[ -x "$python_bin" ]] || {
+        log_error "Cannot upgrade pip because the $description virtual environment Python was not found at '$python_bin'."
+        return 1
+    }
+
+    log_info "Upgrading pip in the $description virtual environment."
+    "$python_bin" -m pip install --disable-pip-version-check --upgrade pip || {
+        log_error "Unable to upgrade pip in the $description virtual environment."
+        return 1
+    }
+}
+
+setup_upgrade_base_pip() {
+    local python_bin venv_dir
+
+    setup_upgrade_pip_enabled || return 0
+    [[ -z "${BASE_SETUP_PROJECT_NAME:-}" || "${BASE_SETUP_PROJECT_NAME:-}" == base ]] || return 0
+
+    setup_ensure_cached_paths
+    venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
+    python_bin="$(setup_base_venv_python_bin "$venv_dir" 2>/dev/null || true)"
+    setup_upgrade_pip_in_virtualenv "Base" "$python_bin"
+}
+
+setup_upgrade_project_pip() {
+    local project="$1"
+    local venv_dir="$2"
+
+    setup_upgrade_pip_in_virtualenv "project '$project'" "$venv_dir/bin/python"
+}
+
 setup_base_venv_python_bin() {
     local venv_dir="$1"
     local python_bin="$venv_dir/bin/python"
@@ -425,6 +465,7 @@ setup_collect_ci_runtime_check_results() {
 
 setup_run_ci_runtime_install() {
     setup_create_virtualenv
+    setup_upgrade_base_pip || return $?
     setup_install_pyyaml
     setup_install_click
     if setup_profiles_enabled; then

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -19,6 +19,7 @@ load ./setup_helpers.bash
     [[ "$output" == *"--notify"* ]]
     [[ "$output" == *"--no-notify"* ]]
     [[ "$output" == *"--recreate-venv"* ]]
+    [[ "$output" == *"--upgrade-pip"* ]]
     [[ "$output" == *"--yes"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
     [[ "$output" == *"On Ubuntu/Debian Linux, setup can install apt prerequisites with"* ]]
@@ -108,17 +109,37 @@ load ./setup_helpers.bash
 }
 
 @test "basectl setup --dry-run gives linux-debian apt setup plan" {
-    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --dry-run
+    run_base_command BASE_SETUP_TEST_PLATFORM=linux-debian setup --dry-run --upgrade-pip
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get update"* ]]
     [[ "$output" == *"[DRY-RUN] Would run: sudo apt-get install -y bash git python3 python3-venv python3-pip bats shellcheck jq golang-go"* ]]
     [[ "$output" == *"[DRY-RUN] Would create Python virtual environment at '$TEST_HOME/.base.d/base/.venv'."* ]]
+    [[ "$output" == *"[DRY-RUN] Would upgrade pip in the Base virtual environment."* ]]
     [[ "$output" == *"[DRY-RUN] Would install Python package 'PyYAML' in the Base virtual environment."* ]]
     [[ "$output" == *"[DRY-RUN] Base CLI setup check is complete."* ]]
     [[ "$output" != *"github-cli.list"* ]]
     [[ "$output" != *"Homebrew"* ]]
     [[ "$output" != *"Xcode"* ]]
+}
+
+@test "basectl setup --upgrade-pip upgrades the Base virtual environment" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_project_setup_venv_stub "$venv_dir"
+
+    run_base_command setup --upgrade-pip
+
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_STATE_DIR/pip-upgrade-ran" ]
+    [[ "$output" == *"Upgrading pip in the Base virtual environment."* ]]
 }
 
 @test "basectl setup linux-debian non-interactive requires --yes before apt mutation" {
@@ -797,6 +818,29 @@ EOF
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]
 }
 
+@test "basectl setup --upgrade-pip upgrades a pip-managed project virtualenv" {
+    local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local demo_venv_dir="$TEST_TMPDIR/.venv"
+    local manifest_path="$TEST_TMPDIR/demo_manifest.yaml"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    create_project_setup_venv_stub "$base_venv_dir"
+    create_project_setup_venv_stub "$demo_venv_dir"
+    printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$manifest_path"
+
+    run_base_command setup --upgrade-pip --manifest "$manifest_path" demo
+
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_STATE_DIR/pip-upgrade-ran" ]
+    [[ "$output" == *"Upgrading pip in the project 'demo' virtual environment."* ]]
+}
+
 @test "basectl setup project --recreate-venv targets the project virtualenv" {
     local base_venv_dir="$TEST_HOME/.base.d/base/.venv"
     local demo_venv_dir="$TEST_TMPDIR/.venv"
@@ -865,12 +909,14 @@ EOF
     create_project_setup_venv_stub "$base_venv_dir"
     printf 'project:\n  name: demo\npython:\n  manager: uv\nartifacts: []\n' > "$manifest_path"
 
-    run_base_command setup --dry-run --manifest "$manifest_path"
+    run_base_command setup --dry-run --upgrade-pip --manifest "$manifest_path"
 
     [ "$status" -eq 0 ]
     [[ "$output" != *"Would create project virtual environment at '$TEST_HOME/.base.d/demo/.venv'"* ]]
     [[ "$output" != *"Would run Python project setup layer through base-wrapper"* ]]
     [ ! -e "$TEST_HOME/.base.d/demo/.venv" ]
+    [[ "$output" == *"Skipping pip upgrade for project 'demo': its virtual environment is managed by uv."* ]]
+    [ ! -f "$TEST_STATE_DIR/pip-upgrade-ran" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
 }

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -218,6 +218,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}"
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed"
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "--disable-pip-version-check" && "${5:-}" == "--upgrade" && "${6:-}" == "pip" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pip-upgrade-ran"
+    exit 0
+fi
 printf 'unexpected system venv python args: %s\n' "$*" >&2
 exit 1
 VENVEOF
@@ -432,6 +436,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}"
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed"
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "--disable-pip-version-check" && "${5:-}" == "--upgrade" && "${6:-}" == "pip" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pip-upgrade-ran"
+    exit 0
+fi
 printf 'unexpected venv python args: %s\n' "$*" >&2
 exit 1
 VENVEOF
@@ -600,6 +608,10 @@ fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "--disable-pip-version-check" && "${5:-}" == "$click_package" ]]; then
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-install-ran"
     touch "${BASE_SETUP_TEST_STATE_DIR:?}/click-installed"
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "--disable-pip-version-check" && "${5:-}" == "--upgrade" && "${6:-}" == "pip" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pip-upgrade-ran"
     exit 0
 fi
 printf 'unexpected venv python args: %s\n' "$*" >&2
@@ -799,6 +811,10 @@ if [[ "${1:-}" == "--version" ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-c" && "${2:-}" == "import base_setup.diagnostics" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "install" && "${4:-}" == "--disable-pip-version-check" && "${5:-}" == "--upgrade" && "${6:-}" == "pip" ]]; then
+    touch "${BASE_SETUP_TEST_STATE_DIR:?}/pip-upgrade-ran"
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup" ]]; then

--- a/docs/basectl-ci.md
+++ b/docs/basectl-ci.md
@@ -26,7 +26,10 @@ basectl doctor --ci [project] [--format text|json]
 
 All commands also accept `--manifest <path>` for CI jobs that know the manifest
 path directly, plus `--profile <list>` for opt-in prerequisite profiles.
-`basectl setup --ci` additionally accepts `--recreate-venv`.
+`basectl setup --ci` additionally accepts `--recreate-venv` and
+`--upgrade-pip`. The latter is opt-in and upgrades pip only in the selected
+Base-managed or pip-managed project virtual environment; uv-managed project
+environments are reported and left unchanged.
 
 The default mode is non-interactive. If a required action cannot be performed
 without prompting, the command fails with a clear fix message.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -54,7 +54,7 @@ full compatibility contract.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--ci`, `--format <text\|json>`, `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv`, `--notify`, `--no-notify` |
+| `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--ci`, `--format <text\|json>`, `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv`, `--upgrade-pip`, `--notify`, `--no-notify` |
 | `basectl update-profile` | Create, refresh, or remove Base-managed Bash and Zsh startup snippets, backing up existing dotfiles before changes. | `--defaults`, `--no-defaults`, `--remove`, `--dry-run` |
 | `basectl update [project]` | Update a Base-managed project checkout through Git, or update Base through Homebrew when Base is Homebrew-managed, then run setup for the selected project. | `--dry-run` |
 | `basectl onboard [project]` | Guide first-run setup through check, setup, shell profile, doctor, project discovery, and read-only manifest trust status. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
@@ -111,7 +111,7 @@ manifest trust.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl setup --ci [project]` | Run setup with CI-safe defaults. Does not run tests or create runners/VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv` |
+| `basectl setup --ci [project]` | Run setup with CI-safe defaults. Does not run tests or create runners/VMs. | `--format <text\|json>`, `--manifest <path>`, `--profile <list>`, `--recreate-venv`, `--upgrade-pip` |
 | `basectl check [project]` | Check Base readiness and, when selected by project name or `--manifest`, manifest-declared project requirements. It does not install or repair prerequisites, modify project files, or run tests. Normal runs write local logs/history; project checks also record `~/.base.d/<project>/checks/last.json`. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network` |
 | `basectl doctor [project]` | Explain Base and optional project findings with stable finding IDs and fixes. | `--ci`, `--profile <list>`, `--format <text\|json>`, `--manifest <path>`, `--remote-network`, `--no-color` |
 | `basectl doctor explain <finding-id>` | Print local, deterministic guidance for a stable finding ID. | `--format <text\|json>` |

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -105,6 +105,12 @@ environment as the project virtual environment:
 <project-root>/.venv
 ```
 
+`basectl setup --upgrade-pip <project>` does not mutate a uv-managed project
+environment. Base reports that pip is owned by uv and recommends `uv sync`.
+Use a project-specific uv bootstrap decision only when the project explicitly
+requires pip; do not use the general Base maintenance flag to bypass uv's
+lockfile ownership.
+
 ## Migration Paths
 
 ### Historical External Venv Migration

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -211,6 +211,7 @@ readonly by Base.
 | `BASE_SETUP_NOTIFY` | `basectl setup` | Enables or disables setup completion notifications. |
 | `BASE_SETUP_NOTIFY_MIN_SECONDS` | `basectl setup` | Minimum setup duration before completion notification. |
 | `BASE_SETUP_PYTHON_FORMULA` | `basectl setup` | Overrides the Homebrew Python formula. |
+| `BASE_SETUP_UPGRADE_PIP` | `basectl setup --upgrade-pip` | Internal setup flag requesting an explicit pip upgrade in the selected Base-managed or pip-managed virtual environment. |
 | `BASE_INSTALL_DIR` | `install.sh` | Overrides the default source install directory. |
 | `BASE_BOOTSTRAP_MODE` | `bootstrap.sh` | Selects bootstrap mode when no command-line mode overrides it. |
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -600,7 +600,7 @@ _base_basectl_completion_help() {
 _base_basectl_completion() {
     local command cur
     local commands="activate setup check test export-context devcontainer devenv-report build demo run repo release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
-    local setup_options="--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --yes -v -h --help"
+    local setup_options="--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --upgrade-pip --yes -v -h --help"
     local check_options="--ci --profile --format --manifest --remote-network -v -h --help"
     local doctor_options="--ci --profile --format --manifest --remote-network --no-color -v -h --help"
 

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -593,6 +593,7 @@ _base_basectl_completion() {
                 '--notify[Force a setup completion notification]' \
                 '--no-notify[Disable setup completion notification]' \
                 '--recreate-venv[Recreate the Base venv]' \
+                '--upgrade-pip[Upgrade pip in the selected virtual environment]' \
                 '--yes[Apply setup changes that require explicit confirmation]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '2:Base project:->projects'


### PR DESCRIPTION
## Summary

- Add explicit `basectl setup --upgrade-pip [project]` support.
- Upgrade pip with the selected environment's interpreter for Base-managed and pip-managed environments.
- Report and skip uv-managed project environments, preserving uv lockfile ownership.
- Document the opt-in behavior and add setup coverage for Base, pip-managed, and uv-managed projects.

## Issue

Closes #1802

## Validation

- `bats cli/bash/commands/basectl/tests/setup.bats`
- `bats lib/shell/completions/tests/completions.bats cli/bash/commands/basectl/tests/completions.bats`
- `env BASE_CACHE_DIR=/private/tmp/base-1802-test ./bin/basectl test base`
- `shellcheck -x cli/bash/commands/basectl/subcommands/setup.sh cli/bash/commands/basectl/subcommands/setup_common.sh cli/bash/commands/basectl/subcommands/setup_linux_debian.sh cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh cli/bash/commands/basectl/subcommands/setup_venv.sh cli/bash/commands/basectl/tests/setup_helpers.bash`
- `git diff --check`

## Demo Impact

None.

## Notes

- `--upgrade-pip` is explicit; normal `basectl setup` and activation do not upgrade pip.
- uv-managed environments should be reconciled with `uv sync` instead.
- `.ai-context/` is unchanged because the implementation is fully documented in the command and runtime docs without changing the product architecture.
