### PR TITLE
workspace: add deterministic setup planning

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -64,7 +64,7 @@ Daily project loop:
     Inspect trust across projects, or manage one project's local approval.
 
 Workspace and repositories:
-  workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]
+  workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure|setup> [options]
     Show workspace status, onboarding, agent readiness, checks, or explicit workspace mutations.
   repo <init|clone|check|configure|agent-guidance|installer-template> [options]
     Create, clone, check, and configure repository baselines and guidance.

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -130,6 +130,23 @@ Apply or repair Base-managed GitHub repo configuration across workspace reposito
 EOF
 }
 
+base_workspace_setup_usage() {
+    cat <<'EOF'
+Usage:
+  basectl workspace setup [options]
+
+Options:
+  --workspace <path>  Workspace directory to prepare. Defaults to workspace.root, then BASE_HOME's parent.
+  --manifest <path>   Local workspace manifest describing expected repositories.
+                      Overrides workspace.manifest from ~/.base.d/config.yaml.
+  --dry-run           Show the ordered workspace setup plan without writing.
+  -v                  Enable DEBUG logging for this subcommand.
+  -h, --help          Show this help text.
+
+Plan setup across eligible repositories in a workspace manifest.
+EOF
+}
+
 base_workspace_subcommand_usage() {
     case "${1:-}" in
         status|check|doctor)
@@ -153,10 +170,13 @@ base_workspace_subcommand_usage() {
         configure)
             base_workspace_configure_usage
             ;;
+        setup)
+            base_workspace_setup_usage
+            ;;
         *)
             cat <<'EOF'
 Usage:
-  basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]
+  basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure|setup> [options]
 
 Commands:
   status     Show workspace status. Supports --format text|csv|tsv|yaml|json.
@@ -168,6 +188,7 @@ Commands:
   pull       Fetch and validate a canonical workspace manifest source.
   init       Initialize a workspace from a workspace configuration repository.
   configure  Apply repo configure across workspace repositories.
+  setup      Plan setup across eligible workspace repositories.
 
 Run `basectl workspace <command> --help` for command-specific options.
 EOF
@@ -191,7 +212,7 @@ base_workspace_subcommand_main() {
             base_workspace_subcommand_usage
             return 0
             ;;
-        status|check|doctor|onboarding|agent-brief|clone|pull|init|configure)
+        status|check|doctor|onboarding|agent-brief|clone|pull|init|configure|setup)
             shift
             ;;
         *)

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -165,6 +165,10 @@ EOF
             COMP_CWORD=3; \
             _base_basectl_completion; \
             printf "workspace_configure_options=%s\n" "${COMPREPLY[*]}"; \
+            COMP_WORDS=(basectl workspace setup --); \
+            COMP_CWORD=3; \
+            _base_basectl_completion; \
+            printf "workspace_setup_options=%s\n" "${COMPREPLY[*]}"; \
             COMP_WORDS=(basectl onboard --); \
             COMP_CWORD=2; \
             _base_basectl_completion; \
@@ -294,13 +298,14 @@ EOF
     [[ "$output" == *"devenv_report_projects=base demo"* ]]
     [[ "$output" == *"devenv_report_options=--workspace --format"* ]]
     [[ "$output" == *"projects_options=--workspace --format"* ]]
-    [[ "$output" == *"workspace_commands=status check doctor onboarding agent-brief clone pull init configure"* ]]
+    [[ "$output" == *"workspace_commands=status check doctor onboarding agent-brief clone pull init configure setup"* ]]
     [[ "$output" == *"workspace_status_options=--workspace --manifest --format"* ]]
     [[ "$output" == *"workspace_agent_brief_options=--workspace --manifest --format"* ]]
     [[ "$output" == *"workspace_clone_options=--workspace --manifest --include-optional --dry-run"* ]]
     [[ "$output" == *"workspace_pull_options=--source --manifest --dry-run"* ]]
     [[ "$output" == *"workspace_init_options=--owner --path --workspace --manifest --include-optional --dry-run"* ]]
     [[ "$output" == *"workspace_configure_options=--workspace --manifest --dry-run"* ]]
+    [[ "$output" == *"workspace_setup_options=--workspace --manifest --dry-run"* ]]
     [[ "$output" == *"onboard_options=--profile --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"onboard_projects=base demo"* ]]
     [[ "$output" == *"onboard_profiles=dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab"* ]]
@@ -441,6 +446,6 @@ EOF
             printf "options=%s\n" "${COMPREPLY[*]}"'
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"commands=status check doctor onboarding agent-brief clone pull init configure"* ]]
+    [[ "$output" == *"commands=status check doctor onboarding agent-brief clone pull init configure setup"* ]]
     [[ "$output" == *"options=--workspace --manifest --dry-run"* ]]
 }

--- a/cli/bash/commands/basectl/tests/help.bats
+++ b/cli/bash/commands/basectl/tests/help.bats
@@ -32,7 +32,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"demo [project] [options]"* ]]
     [[ "$output" == *"update [project] [options]"* ]]
     [[ "$output" == *"projects list [options]"* ]]
-    [[ "$output" == *"workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]"* ]]
+    [[ "$output" == *"workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure|setup> [options]"* ]]
     [[ "$output" == *"Invoking \`basectl\` with no command starts a Base runtime shell"* ]]
     [[ "$output" == *"--version"* ]]
     [[ "$output" == *"Wrapper options:"* ]]
@@ -103,7 +103,7 @@ load ./basectl_helpers.bash
     grep -Fqx '  docs [options]' <<<"$output"
     grep -Fqx '  logs [options]' <<<"$output"
     grep -Fqx '  history [options]' <<<"$output"
-    grep -Fqx '  workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]' <<<"$output"
+    grep -Fqx '  workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure|setup> [options]' <<<"$output"
     grep -Fqx '  trust <status|allow|revoke> [project] [options]' <<<"$output"
     [[ "$output" != *"-b DIR"* ]]
     [[ "$output" != *"Force install"* ]]
@@ -122,7 +122,7 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure|setup> [options]"* ]]
     [[ "$output" != *"Usage: basectl [options] <command> [args...]"* ]]
 
     run_basectl help release

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -258,6 +258,34 @@ EOF
     [ "$output" = "ARGS=--workspace $workspace --manifest $manifest --dry-run" ]
 }
 
+@test "basectl workspace setup delegates to the Python projects layer" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local manifest="$TEST_TMPDIR/workspace.yaml"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/base"
+    touch "$manifest"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "setup" ]]; then
+    printf 'ARGS=%s\n' "${*:4}"
+    exit 0
+fi
+printf 'unexpected workspace setup python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$BASE_REPO_ROOT/bin/basectl" workspace setup --workspace "$workspace" --manifest "$manifest" --dry-run
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ARGS=--workspace $workspace --manifest $manifest --dry-run" ]
+}
+
 @test "basectl workspace init delegates to the Python projects layer" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
@@ -393,6 +421,16 @@ EOF
     [[ "$output" == *"--dry-run"* ]]
     [[ "$output" != *"--format"* ]]
 
+    run_basectl workspace setup --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl workspace setup [options]"* ]]
+    [[ "$output" == *"--workspace <path>"* ]]
+    [[ "$output" == *"--manifest <path>"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"ordered workspace setup plan"* ]]
+    [[ "$output" != *"--format"* ]]
+
     run_basectl workspace init --help
 
     [ "$status" -eq 0 ]
@@ -408,7 +446,7 @@ EOF
     run_basectl workspace help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure> [options]"* ]]
+    [[ "$output" == *"basectl workspace <status|check|doctor|onboarding|agent-brief|clone|pull|init|configure|setup> [options]"* ]]
     [[ "$output" != *"Project virtual environment Python was not found"* ]]
 }
 

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -47,6 +47,7 @@ from base_projects.workspace_context import resolve_workspace_manifest
 from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_init import workspace_init_command
 from base_projects.workspace_pull_command import workspace_pull_command
+from base_projects.workspace_setup import workspace_setup_from_options
 from base_projects.workspace_onboarding import workspace_onboarding_summary
 from base_projects.workspace_report_json import workspace_check_to_json
 from base_projects.workspace_report_json import workspace_doctor_to_json
@@ -146,6 +147,7 @@ def project_command_actions() -> ProjectCommandActions:
         workspace_pull=workspace_pull_command,
         workspace_init=workspace_init_project_command,
         workspace_configure=workspace_configure_from_options,
+        workspace_setup=workspace_setup_from_options,
         current_project=current_project_command,
         manifest_project=manifest_project_command,
         resolve_project=resolve_project_command,

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -32,6 +32,7 @@ class ProjectCommandActions:
     workspace_pull: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
     workspace_init: Callable[[base_cli.Context, str, WorkspaceCommandOptions], int]
     workspace_configure: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
+    workspace_setup: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
     current_project: Callable[[base_cli.Context, str], int]
     manifest_project: Callable[[base_cli.Context, str | None, str], int]
     resolve_project: Callable[[base_cli.Context, str | None, str | None, str], int]
@@ -191,6 +192,16 @@ def _handle_configure(
     return actions.workspace_configure(ctx, options)
 
 
+def _handle_setup(
+    ctx: base_cli.Context,
+    arguments: tuple[str, ...],
+    options: WorkspaceCommandOptions,
+    actions: ProjectCommandActions,
+) -> int:
+    require_argument_count("setup", arguments, 0, 0)
+    return actions.workspace_setup(ctx, options)
+
+
 def _handle_current(
     ctx: base_cli.Context,
     arguments: tuple[str, ...],
@@ -312,6 +323,7 @@ SUPPORTED_PROJECT_COMMANDS = (
     "agent-brief",
     "clone",
     "configure",
+    "setup",
     "init",
     "test-command",
     "demo-script",
@@ -335,6 +347,7 @@ PROJECT_COMMAND_HANDLERS: dict[str, ProjectCommandHandler] = {
     "pull": _handle_pull,
     "init": _handle_init,
     "configure": _handle_configure,
+    "setup": _handle_setup,
     "current": _handle_current,
     "manifest": _handle_manifest,
     "resolve": _handle_resolve,

--- a/cli/python/base_projects/tests/test_workspace_setup.py
+++ b/cli/python/base_projects/tests/test_workspace_setup.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_projects import engine
+
+
+def write_manifest(project_root: Path, name: str, *, python: bool = False) -> None:
+    project_root.mkdir(parents=True)
+    python_section = "python:\n  manager: uv\n" if python else ""
+    (project_root / "base_manifest.yaml").write_text(
+        f"schema_version: 1\nproject:\n  name: {name}\n{python_section}",
+        encoding="utf-8",
+    )
+
+
+def write_workspace_manifest(path: Path) -> None:
+    path.write_text(
+        """schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: base
+  - name: missing
+    required: false
+  - name: no-manifest
+  - name: invalid
+  - name: shell-only
+  - name: python-project
+""",
+        encoding="utf-8",
+    )
+
+
+class WorkspaceSetupTests(unittest.TestCase):
+    def test_workspace_setup_dry_run_preserves_manifest_order_and_classifies_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_manifest(workspace / "base", "base")
+            (workspace / "no-manifest").mkdir()
+            (workspace / "invalid").mkdir()
+            (workspace / "invalid" / "base_manifest.yaml").write_text(
+                "schema_version: 1\nproject: invalid\n",
+                encoding="utf-8",
+            )
+            write_manifest(workspace / "shell-only", "shell-only")
+            write_manifest(workspace / "python-project", "python-project", python=True)
+            write_workspace_manifest(manifest_path)
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "setup",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(manifest_path),
+                    "--dry-run",
+                ],
+                base_home,
+                home,
+            )
+
+            self.assertEqual(status, 0)
+            self.assertEqual(stderr, "")
+            self.assertIn(f"Workspace setup plan: {workspace.resolve()} (6 manifest repos)", stdout)
+            self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
+            self.assertIn("SKIP repository 'base'", stdout)
+            self.assertIn("active Base control plane is managed from BASE_HOME", stdout)
+            self.assertIn("SKIP repository 'missing'", stdout)
+            self.assertIn("repository is missing", stdout)
+            self.assertIn("SKIP repository 'no-manifest'", stdout)
+            self.assertIn("does not contain base_manifest.yaml", stdout)
+            self.assertIn("SKIP repository 'invalid'", stdout)
+            self.assertIn("base_manifest.yaml is invalid", stdout)
+            self.assertIn("SETUP repository 'shell-only'", stdout)
+            self.assertIn("SETUP repository 'python-project'", stdout)
+            self.assertIn("Workspace setup plan complete: setup=2 skipped=4.", stdout)
+            self.assertIn("[DRY-RUN] No repositories were modified.", stdout)
+            self.assertLess(stdout.index("repository 'base'"), stdout.index("repository 'missing'"))
+            self.assertLess(stdout.index("repository 'missing'"), stdout.index("repository 'no-manifest'"))
+            self.assertLess(stdout.index("repository 'no-manifest'"), stdout.index("repository 'invalid'"))
+            self.assertLess(stdout.index("repository 'invalid'"), stdout.index("repository 'shell-only'"))
+            self.assertLess(stdout.index("repository 'shell-only'"), stdout.index("repository 'python-project'"))
+            self.assertFalse((workspace / "shell-only" / ".venv").exists())
+            self.assertFalse((workspace / "python-project" / ".venv").exists())
+
+    def test_workspace_setup_requires_a_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+
+            status, stdout, stderr = invoke_engine(
+                ["setup", "--workspace", str(workspace), "--dry-run"],
+                base_home,
+                home,
+            )
+
+            self.assertEqual(status, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("requires a configured or explicit workspace manifest", stderr)
+
+    def test_workspace_setup_does_not_mutate_without_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_manifest(workspace / "project", "project")
+            manifest_path.write_text(
+                """schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: project
+""",
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "setup",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(manifest_path),
+                ],
+                base_home,
+                home,
+            )
+
+            self.assertEqual(status, 1)
+            self.assertIn("SETUP repository 'project'", stdout)
+            self.assertIn("execution is not available yet", stderr)
+            self.assertFalse((workspace / "project" / ".venv").exists())
+
+
+def invoke_engine(
+    args: list[str],
+    base_home: Path,
+    home: Path,
+) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    env = {
+        "HOME": str(home),
+        "BASE_HOME": str(base_home),
+        "BASE_PROJECT": "",
+        "BASE_PROJECT_MANIFEST": "",
+    }
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()

--- a/cli/python/base_projects/workspace_setup.py
+++ b/cli/python/base_projects/workspace_setup.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from typing import Any
+
+import base_cli
+from base_projects import workspace_context
+from base_projects.workspace_context import resolve_workspace_manifest
+from base_projects.workspace_manifest import WorkspaceManifest
+from base_projects.workspace_manifest import WorkspaceManifestError
+from base_projects.workspace_manifest import WorkspaceManifestRepo
+from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
+
+
+WorkspaceSetupAction = Literal["setup", "skip"]
+
+
+@dataclass(frozen=True)
+class WorkspaceSetupTarget:
+    name: str
+    root: Path
+    manifest_path: Path | None
+    project_name: str | None
+    action: WorkspaceSetupAction
+    reason: str | None = None
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class WorkspaceSetupCounts:
+    setup: int = 0
+    skipped: int = 0
+
+
+def workspace_setup_from_options(
+    ctx: base_cli.Context,
+    options: Any,
+) -> int:
+    if getattr(options, "output_format", "text") != "text":
+        ctx.log.error("Unsupported output format '%s'. Expected: text.", options.output_format)
+        return base_cli.ExitCode.USAGE_ERROR
+
+    try:
+        workspace_root = workspace_context.resolve_workspace_root(ctx, options.workspace)
+        manifest = resolve_workspace_manifest(
+            workspace_context.effective_workspace_manifest(ctx, options.workspace_manifest)
+        )
+    except (ProjectDiscoveryError, WorkspaceManifestError) as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.FAILURE
+
+    if manifest is None:
+        ctx.log.error(
+            "Workspace setup requires a configured or explicit workspace manifest. "
+            "Pass --manifest <path> or configure workspace.manifest."
+        )
+        return base_cli.ExitCode.FAILURE
+
+    return workspace_setup_command(ctx, workspace_root, manifest, dry_run=options.dry_run)
+
+
+def workspace_setup_command(
+    ctx: base_cli.Context,
+    workspace_root: Path,
+    workspace_manifest: WorkspaceManifest,
+    *,
+    dry_run: bool,
+) -> int:
+    targets = workspace_setup_targets(workspace_root, workspace_manifest)
+    print_workspace_setup_header(workspace_root, workspace_manifest, len(targets))
+
+    counts = WorkspaceSetupCounts()
+    for target in targets:
+        counts = print_workspace_setup_target(target, counts)
+
+    print(
+        "Workspace setup plan complete: "
+        f"setup={counts.setup} skipped={counts.skipped}."
+    )
+    if dry_run:
+        print("[DRY-RUN] No repositories were modified.")
+        return base_cli.ExitCode.SUCCESS
+
+    ctx.log.error(
+        "Workspace setup execution is not available yet. "
+        "Use --dry-run to inspect the setup plan."
+    )
+    return base_cli.ExitCode.FAILURE
+
+
+def workspace_setup_targets(
+    workspace_root: Path,
+    workspace_manifest: WorkspaceManifest,
+) -> tuple[WorkspaceSetupTarget, ...]:
+    return tuple(
+        workspace_setup_manifest_target(workspace_root, repo)
+        for repo in workspace_manifest.repos
+    )
+
+
+def workspace_setup_manifest_target(
+    workspace_root: Path,
+    repo: WorkspaceManifestRepo,
+) -> WorkspaceSetupTarget:
+    root = (workspace_root / repo.name).resolve()
+    manifest_path = root / "base_manifest.yaml"
+
+    if not root.is_dir():
+        return WorkspaceSetupTarget(
+            name=repo.name,
+            root=root,
+            manifest_path=None,
+            project_name=None,
+            action="skip",
+            reason=f"repository is missing at '{root}'",
+            required=repo.required,
+        )
+
+    if repo.name == "base":
+        return WorkspaceSetupTarget(
+            name=repo.name,
+            root=root,
+            manifest_path=manifest_path if manifest_path.is_file() else None,
+            project_name="base",
+            action="skip",
+            reason="active Base control plane is managed from BASE_HOME",
+            required=repo.required,
+        )
+
+    if not manifest_path.is_file():
+        return WorkspaceSetupTarget(
+            name=repo.name,
+            root=root,
+            manifest_path=None,
+            project_name=None,
+            action="skip",
+            reason="repository does not contain base_manifest.yaml",
+            required=repo.required,
+        )
+
+    try:
+        manifest = read_manifest(manifest_path)
+    except ManifestError as exc:
+        return WorkspaceSetupTarget(
+            name=repo.name,
+            root=root,
+            manifest_path=manifest_path.resolve(),
+            project_name=None,
+            action="skip",
+            reason=f"base_manifest.yaml is invalid: {exc}",
+            required=repo.required,
+        )
+
+    return WorkspaceSetupTarget(
+        name=repo.name,
+        root=root,
+        manifest_path=manifest_path.resolve(),
+        project_name=manifest.project_name,
+        action="setup",
+        required=repo.required,
+    )
+
+
+def print_workspace_setup_header(
+    workspace_root: Path,
+    workspace_manifest: WorkspaceManifest,
+    target_count: int,
+) -> None:
+    print(f"Workspace setup plan: {workspace_root} ({target_count} manifest repos)")
+    print(f"Workspace manifest: {workspace_manifest.path} ({workspace_manifest.name})")
+
+
+def print_workspace_setup_target(
+    target: WorkspaceSetupTarget,
+    counts: WorkspaceSetupCounts,
+) -> WorkspaceSetupCounts:
+    if target.action == "skip":
+        print(f"SKIP repository '{target.name}' at '{target.root}': {target.reason}.")
+        return WorkspaceSetupCounts(counts.setup, counts.skipped + 1)
+
+    print(
+        f"SETUP repository '{target.name}' at '{target.root}' "
+        f"using '{target.manifest_path}' for project '{target.project_name}'."
+    )
+    return WorkspaceSetupCounts(counts.setup + 1, counts.skipped)

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -652,7 +652,7 @@ _base_basectl_completion() {
             ;;
         workspace)
             if ((COMP_CWORD == 2)); then
-                _base_basectl_completion_compgen "status check doctor onboarding agent-brief clone pull init configure" "$cur"
+                _base_basectl_completion_compgen "status check doctor onboarding agent-brief clone pull init configure setup" "$cur"
             else
                 case "${COMP_WORDS[2]:-}" in
                     status|check|doctor)
@@ -671,6 +671,9 @@ _base_basectl_completion() {
                         _base_basectl_completion_compgen "--owner --path --workspace --manifest --include-optional --dry-run -v -h --help" "$cur"
                         ;;
                     configure)
+                        _base_basectl_completion_compgen "--workspace --manifest --dry-run -v -h --help" "$cur"
+                        ;;
+                    setup)
                         _base_basectl_completion_compgen "--workspace --manifest --dry-run -v -h --help" "$cur"
                         ;;
                 esac

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -540,14 +540,14 @@ _base_basectl_completion() {
         workspace)
             case "${words[3]:-}" in
                 status|check|doctor|onboarding|agent-brief)
-                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure setup)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--format[Output format]:format:(text csv tsv yaml json)' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 clone)
-                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure setup)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--include-optional[Include optional manifest repositories when cloning]' \
@@ -555,14 +555,14 @@ _base_basectl_completion() {
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 pull)
-                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure setup)' \
                         '--source[Canonical workspace manifest source]:url-or-path:' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--dry-run[Show planned workspace pull work without writing]' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 init)
-                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure setup)' \
                         '3:workspace source:' \
                         '--owner[GitHub owner for short workspace repository names]:owner:' \
                         '--path[Workspace configuration repository checkout path]:path:_files' \
@@ -573,14 +573,21 @@ _base_basectl_completion() {
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 configure)
-                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)' \
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure setup)' \
                         '--workspace[Workspace directory to configure]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--dry-run[Show planned workspace configuration without applying repo changes]' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
+                setup)
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure setup)' \
+                        '--workspace[Workspace directory to prepare]:path:_files' \
+                        '--manifest[Local workspace manifest]:path:_files' \
+                        '--dry-run[Show the ordered workspace setup plan without writing]' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
                 *)
-                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure)'
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull init configure setup)'
                     ;;
             esac
             ;;


### PR DESCRIPTION
## Summary

Add the `basectl workspace setup` command surface and a manifest-driven, read-only setup planner. The planner preserves manifest order, identifies missing and unmanaged repositories, and explicitly skips the workspace `base` checkout so the active `BASE_HOME` control plane is not confused with the integration workspace.

This is the first slice of the workspace setup train. Execution is intentionally deferred to #1807; this PR supports `--dry-run` only.

## Issue

Closes #1806
Refs #1805

## Validation

- `$HOME/.base.d/base/.venv/bin/python -m pytest -q cli/python/base_projects/tests/test_workspace_setup.py cli/python/base_projects/tests/test_workspace_configure.py cli/python/base_projects/tests/test_engine.py` — 87 passed, 4 subtests passed.
- `bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/help.bats` — 36 passed.
- `$HOME/.base.d/base/.venv/bin/python -m compileall -q cli/python/base_projects/workspace_setup.py cli/python/base_projects/project_dispatch.py cli/python/base_projects/engine.py`
- `git diff --check`

## Demo Impact

None. The mutating workspace setup flow is the next train slice.

## Notes

The follow-up execution PR should delegate to each checkout using its explicit `base_manifest.yaml`, continue after per-repository failures, and keep clone/pull separate.