### PR TITLE
workspace: execute setup serially with aggregated results

### DIFF
--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -140,10 +140,11 @@ Options:
   --manifest <path>   Local workspace manifest describing expected repositories.
                       Overrides workspace.manifest from ~/.base.d/config.yaml.
   --dry-run           Show the ordered workspace setup plan without writing.
+  --yes               Apply setup changes that require confirmation.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
-Plan setup across eligible repositories in a workspace manifest.
+Set up eligible repositories in a workspace manifest in manifest order.
 EOF
 }
 
@@ -188,7 +189,7 @@ Commands:
   pull       Fetch and validate a canonical workspace manifest source.
   init       Initialize a workspace from a workspace configuration repository.
   configure  Apply repo configure across workspace repositories.
-  setup      Plan setup across eligible workspace repositories.
+  setup      Set up eligible workspace repositories in manifest order.
 
 Run `basectl workspace <command> --help` for command-specific options.
 EOF

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -305,7 +305,7 @@ EOF
     [[ "$output" == *"workspace_pull_options=--source --manifest --dry-run"* ]]
     [[ "$output" == *"workspace_init_options=--owner --path --workspace --manifest --include-optional --dry-run"* ]]
     [[ "$output" == *"workspace_configure_options=--workspace --manifest --dry-run"* ]]
-    [[ "$output" == *"workspace_setup_options=--workspace --manifest --dry-run"* ]]
+    [[ "$output" == *"workspace_setup_options=--workspace --manifest --dry-run --yes"* ]]
     [[ "$output" == *"onboard_options=--profile --dry-run --yes --no-profile"* ]]
     [[ "$output" == *"onboard_projects=base demo"* ]]
     [[ "$output" == *"onboard_profiles=dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab"* ]]

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -428,6 +428,7 @@ EOF
     [[ "$output" == *"--workspace <path>"* ]]
     [[ "$output" == *"--manifest <path>"* ]]
     [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"--yes"* ]]
     [[ "$output" == *"ordered workspace setup plan"* ]]
     [[ "$output" != *"--format"* ]]
 

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -99,6 +99,7 @@ def main(argv: list[str] | None = None) -> int:
     help="Include optional workspace manifest repositories when cloning.",
 )
 @base_cli.option("--dry-run", is_flag=True, dry_run=True, help="Show planned clone or pull work without writing.")
+@base_cli.option("--yes", is_flag=True, help="Apply workspace setup changes that require confirmation.")
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
@@ -112,6 +113,7 @@ def run(
     workspace_owner: str | None,
     include_optional: bool,
     dry_run: bool,
+    yes: bool,
 ) -> int:
     try:
         return dispatch_projects_command(
@@ -127,6 +129,7 @@ def run(
                 workspace_owner=workspace_owner,
                 include_optional=include_optional,
                 dry_run=dry_run,
+                yes=yes,
             ),
             project_command_actions(),
         )

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -18,6 +18,7 @@ class WorkspaceCommandOptions:
     workspace_owner: str | None = None
     include_optional: bool = False
     dry_run: bool = False
+    yes: bool = False
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_projects/tests/test_workspace_setup.py
+++ b/cli/python/base_projects/tests/test_workspace_setup.py
@@ -214,7 +214,7 @@ repos:
                 encoding="utf-8",
             )
 
-            status, stdout, stderr = invoke_engine(
+            status, stdout, _ = invoke_engine(
                 [
                     "setup",
                     "--workspace",

--- a/cli/python/base_projects/tests/test_workspace_setup.py
+++ b/cli/python/base_projects/tests/test_workspace_setup.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import os
+import shlex
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr
@@ -118,23 +120,96 @@ class WorkspaceSetupTests(unittest.TestCase):
             self.assertEqual(stdout, "")
             self.assertIn("requires a configured or explicit workspace manifest", stderr)
 
-    def test_workspace_setup_does_not_mutate_without_dry_run(self) -> None:
+    def test_workspace_setup_executes_serially_and_aggregates_failures(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             home = root / "home"
             base_home = root / "base"
             workspace = root / "workspace"
             manifest_path = root / "workspace.yaml"
+            state_path = root / "basectl-state.txt"
             home.mkdir()
             base_home.mkdir()
             workspace.mkdir()
-            write_manifest(workspace / "project", "project")
+            write_manifest(workspace / "base", "base")
+            write_manifest(workspace / "first", "first")
+            write_manifest(workspace / "failing", "failing")
+            write_manifest(workspace / "later", "later")
+            (workspace / "no-manifest").mkdir()
+            write_fake_basectl(base_home, state_path, failing_project="failing")
             manifest_path.write_text(
                 """schema_version: 1
 workspace:
   name: demo-suite
 repos:
-  - name: project
+  - name: base
+  - name: first
+  - name: failing
+  - name: missing
+    required: false
+  - name: later
+  - name: no-manifest
+    required: false
+""",
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "setup",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(manifest_path),
+                    "--yes",
+                ],
+                base_home,
+                home,
+            )
+
+            self.assertEqual(status, 1)
+            self.assertIn("SETUP repository 'first'", stdout)
+            self.assertIn("SETUP repository 'failing'", stdout)
+            self.assertIn("SETUP repository 'later'", stdout)
+            self.assertIn("fake setup first", stdout)
+            self.assertIn("fake setup later", stdout)
+            self.assertIn("simulated setup failure for failing", stderr)
+            self.assertIn("Setup failed for repository 'failing'.", stderr)
+            self.assertIn("Workspace setup completed: setup=2 skipped=3 failed=1.", stdout)
+
+            records = state_path.read_text(encoding="utf-8").splitlines()
+            resolved_workspace = workspace.resolve()
+            resolved_base_home = base_home.resolve()
+            self.assertEqual(
+                records,
+                [
+                    f"setup --manifest {resolved_workspace / 'first' / 'base_manifest.yaml'} --yes first\t"
+                    f"{resolved_workspace / 'first'}\t{resolved_base_home}\t\t\t\t",
+                    f"setup --manifest {resolved_workspace / 'failing' / 'base_manifest.yaml'} --yes failing\t"
+                    f"{resolved_workspace / 'failing'}\t{resolved_base_home}\t\t\t\t",
+                    f"setup --manifest {resolved_workspace / 'later' / 'base_manifest.yaml'} --yes later\t"
+                    f"{resolved_workspace / 'later'}\t{resolved_base_home}\t\t\t\t",
+                ],
+            )
+
+    def test_workspace_setup_fails_for_missing_required_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            manifest_path = root / "workspace.yaml"
+            state_path = root / "basectl-state.txt"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_fake_basectl(base_home, state_path)
+            manifest_path.write_text(
+                """schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: missing
 """,
                 encoding="utf-8",
             )
@@ -152,9 +227,76 @@ repos:
             )
 
             self.assertEqual(status, 1)
-            self.assertIn("SETUP repository 'project'", stdout)
-            self.assertIn("execution is not available yet", stderr)
-            self.assertFalse((workspace / "project" / ".venv").exists())
+            self.assertIn("repository is missing", stdout)
+            self.assertIn("Workspace setup completed: setup=0 skipped=1 failed=1.", stdout)
+            self.assertFalse(state_path.exists())
+
+    def test_workspace_setup_aggregates_timeout_as_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            write_manifest(workspace / "project", "project")
+            write_fake_basectl(base_home, root / "basectl-state.txt")
+            manifest_path.write_text(
+                """schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: project
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch(
+                "base_projects.workspace_setup.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(["basectl", "setup"], 1800),
+            ):
+                status, stdout, stderr = invoke_engine(
+                    [
+                        "setup",
+                        "--workspace",
+                        str(workspace),
+                        "--manifest",
+                        str(manifest_path),
+                    ],
+                    base_home,
+                    home,
+                )
+
+            self.assertEqual(status, 1)
+            self.assertIn("Timed out running basectl setup for repository 'project'", stderr)
+            self.assertIn("Workspace setup completed: setup=0 skipped=0 failed=1.", stdout)
+
+
+def write_fake_basectl(
+    base_home: Path,
+    state_path: Path,
+    *,
+    failing_project: str | None = None,
+) -> None:
+    basectl = base_home / "bin" / "basectl"
+    basectl.parent.mkdir(parents=True)
+    script = """#!/usr/bin/env bash
+set -u
+project="${@: -1}"
+printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' "$*" "$PWD" "${BASE_HOME-}" "${BASE_PROJECT-}" "${BASE_PROJECT_ROOT-}" "${BASE_PROJECT_MANIFEST-}" "${BASE_PROJECT_VENV_DIR-}" >> STATE_PATH
+""".replace("STATE_PATH", shlex.quote(str(state_path)))
+    if failing_project is not None:
+        script += (
+            f"if [[ \"$project\" == {shlex.quote(failing_project)} ]]; then\n"
+            "  printf 'simulated setup failure for %s\\n' \"$project\" >&2\n"
+            "  exit 1\n"
+            "fi\n"
+        )
+    script += "printf 'fake setup %s\\n' \"$project\"\n"
+    basectl.write_text(script, encoding="utf-8")
+    basectl.chmod(0o755)
 
 
 def invoke_engine(
@@ -168,7 +310,9 @@ def invoke_engine(
         "HOME": str(home),
         "BASE_HOME": str(base_home),
         "BASE_PROJECT": "",
+        "BASE_PROJECT_ROOT": "inherited-root",
         "BASE_PROJECT_MANIFEST": "",
+        "BASE_PROJECT_VENV_DIR": "inherited-venv",
     }
     with mock.patch.dict(os.environ, env):
         with redirect_stdout(stdout), redirect_stderr(stderr):

--- a/cli/python/base_projects/workspace_setup.py
+++ b/cli/python/base_projects/workspace_setup.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
-from typing import Any
+from typing import Any, Literal
 
 import base_cli
 from base_projects import workspace_context
@@ -17,6 +19,7 @@ from base_setup.manifest_loader import ManifestError
 
 
 WorkspaceSetupAction = Literal["setup", "skip"]
+WORKSPACE_SETUP_TIMEOUT_SECONDS = 1800
 
 
 @dataclass(frozen=True)
@@ -28,12 +31,14 @@ class WorkspaceSetupTarget:
     action: WorkspaceSetupAction
     reason: str | None = None
     required: bool = True
+    fatal: bool = False
 
 
 @dataclass(frozen=True)
 class WorkspaceSetupCounts:
     setup: int = 0
     skipped: int = 0
+    failed: int = 0
 
 
 def workspace_setup_from_options(
@@ -60,7 +65,7 @@ def workspace_setup_from_options(
         )
         return base_cli.ExitCode.FAILURE
 
-    return workspace_setup_command(ctx, workspace_root, manifest, dry_run=options.dry_run)
+    return workspace_setup_command(ctx, workspace_root, manifest, dry_run=options.dry_run, yes=options.yes)
 
 
 def workspace_setup_command(
@@ -69,27 +74,52 @@ def workspace_setup_command(
     workspace_manifest: WorkspaceManifest,
     *,
     dry_run: bool,
+    yes: bool = False,
 ) -> int:
     targets = workspace_setup_targets(workspace_root, workspace_manifest)
     print_workspace_setup_header(workspace_root, workspace_manifest, len(targets))
 
     counts = WorkspaceSetupCounts()
-    for target in targets:
-        counts = print_workspace_setup_target(target, counts)
+    if not dry_run and ctx.base_home is None:
+        ctx.log.error("BASE_HOME is required to execute workspace setup.")
+        return base_cli.ExitCode.FAILURE
 
-    print(
-        "Workspace setup plan complete: "
-        f"setup={counts.setup} skipped={counts.skipped}."
-    )
+    basectl = ctx.base_home / "bin" / "basectl" if ctx.base_home is not None else None
+    if not dry_run and (basectl is None or not basectl.is_file() or not os.access(basectl, os.X_OK)):
+        ctx.log.error("Base CLI '%s' is missing or is not executable.", basectl)
+        return base_cli.ExitCode.FAILURE
+
+    for target in targets:
+        if target.action == "skip":
+            counts = print_workspace_setup_skip(target, counts)
+            continue
+
+        print_workspace_setup_target(target)
+        if dry_run:
+            counts = WorkspaceSetupCounts(counts.setup + 1, counts.skipped, counts.failed)
+            continue
+        if basectl is None:
+            ctx.log.error("Base CLI is unavailable for workspace setup execution.")
+            return base_cli.ExitCode.FAILURE
+
+        counts = execute_workspace_setup_target(
+            ctx,
+            basectl,
+            target,
+            counts,
+            yes=yes,
+        )
+
     if dry_run:
+        print(f"Workspace setup plan complete: setup={counts.setup} skipped={counts.skipped}.")
         print("[DRY-RUN] No repositories were modified.")
         return base_cli.ExitCode.SUCCESS
 
-    ctx.log.error(
-        "Workspace setup execution is not available yet. "
-        "Use --dry-run to inspect the setup plan."
+    print(
+        "Workspace setup completed: "
+        f"setup={counts.setup} skipped={counts.skipped} failed={counts.failed}."
     )
-    return base_cli.ExitCode.FAILURE
+    return base_cli.ExitCode.FAILURE if counts.failed else base_cli.ExitCode.SUCCESS
 
 
 def workspace_setup_targets(
@@ -118,6 +148,7 @@ def workspace_setup_manifest_target(
             action="skip",
             reason=f"repository is missing at '{root}'",
             required=repo.required,
+            fatal=repo.required,
         )
 
     if repo.name == "base":
@@ -153,6 +184,7 @@ def workspace_setup_manifest_target(
             action="skip",
             reason=f"base_manifest.yaml is invalid: {exc}",
             required=repo.required,
+            fatal=repo.required,
         )
 
     return WorkspaceSetupTarget(
@@ -174,16 +206,71 @@ def print_workspace_setup_header(
     print(f"Workspace manifest: {workspace_manifest.path} ({workspace_manifest.name})")
 
 
-def print_workspace_setup_target(
-    target: WorkspaceSetupTarget,
-    counts: WorkspaceSetupCounts,
-) -> WorkspaceSetupCounts:
-    if target.action == "skip":
-        print(f"SKIP repository '{target.name}' at '{target.root}': {target.reason}.")
-        return WorkspaceSetupCounts(counts.setup, counts.skipped + 1)
-
+def print_workspace_setup_target(target: WorkspaceSetupTarget) -> None:
     print(
         f"SETUP repository '{target.name}' at '{target.root}' "
         f"using '{target.manifest_path}' for project '{target.project_name}'."
     )
-    return WorkspaceSetupCounts(counts.setup + 1, counts.skipped)
+
+
+def print_workspace_setup_skip(
+    target: WorkspaceSetupTarget,
+    counts: WorkspaceSetupCounts,
+) -> WorkspaceSetupCounts:
+    print(f"SKIP repository '{target.name}' at '{target.root}': {target.reason}.")
+    failed = counts.failed + (1 if target.fatal else 0)
+    return WorkspaceSetupCounts(counts.setup, counts.skipped + 1, failed)
+
+
+def execute_workspace_setup_target(
+    ctx: base_cli.Context,
+    basectl: Path,
+    target: WorkspaceSetupTarget,
+    counts: WorkspaceSetupCounts,
+    *,
+    yes: bool,
+) -> WorkspaceSetupCounts:
+    if target.manifest_path is None or target.project_name is None:
+        ctx.log.error("Setup target '%s' is missing manifest routing metadata.", target.name)
+        return WorkspaceSetupCounts(counts.setup, counts.skipped, counts.failed + 1)
+
+    command = [str(basectl), "setup", "--manifest", str(target.manifest_path)]
+    if yes:
+        command.append("--yes")
+    command.append(target.project_name)
+
+    env = os.environ.copy()
+    env["BASE_HOME"] = str(ctx.base_home)
+    for variable in ("BASE_PROJECT", "BASE_PROJECT_ROOT", "BASE_PROJECT_MANIFEST", "BASE_PROJECT_VENV_DIR"):
+        env.pop(variable, None)
+
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=target.root,
+            env=env,
+            timeout=WORKSPACE_SETUP_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        ctx.log.error(
+            "Timed out running basectl setup for repository '%s' after %s seconds.",
+            target.name,
+            WORKSPACE_SETUP_TIMEOUT_SECONDS,
+        )
+        return WorkspaceSetupCounts(counts.setup, counts.skipped, counts.failed + 1)
+    except OSError as exc:
+        ctx.log.error("Could not run basectl setup for repository '%s': %s", target.name, exc)
+        return WorkspaceSetupCounts(counts.setup, counts.skipped, counts.failed + 1)
+
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    if result.returncode == 0:
+        return WorkspaceSetupCounts(counts.setup + 1, counts.skipped, counts.failed)
+
+    ctx.log.error("Setup failed for repository '%s'.", target.name)
+    return WorkspaceSetupCounts(counts.setup, counts.skipped, counts.failed + 1)

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -674,7 +674,7 @@ _base_basectl_completion() {
                         _base_basectl_completion_compgen "--workspace --manifest --dry-run -v -h --help" "$cur"
                         ;;
                     setup)
-                        _base_basectl_completion_compgen "--workspace --manifest --dry-run -v -h --help" "$cur"
+                        _base_basectl_completion_compgen "--workspace --manifest --dry-run --yes -v -h --help" "$cur"
                         ;;
                 esac
             fi

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -584,6 +584,7 @@ _base_basectl_completion() {
                         '--workspace[Workspace directory to prepare]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
                         '--dry-run[Show the ordered workspace setup plan without writing]' \
+                        '--yes[Apply setup changes that require confirmation]' \
                         '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 *)


### PR DESCRIPTION
## Summary

Execute `basectl workspace setup` across eligible workspace repositories in manifest order, delegating each checkout to the existing single-project setup contract.

## Issue

Fixes #1807

## Validation

- `PYTHONPATH=lib/python:cli/python ~/.base.d/base/.venv/bin/python -m pytest -q cli/python/base_projects/tests/test_workspace_setup.py`
- `BASE_BASH_LIBS_DIR=~/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/workspace.bats cli/bash/commands/basectl/tests/completions.bats`
- `shellcheck --severity=error cli/bash/commands/basectl/subcommands/workspace.sh`
- `git diff --check`

The implementation runs serially, preserves the active Base control-plane checkout, forwards explicit manifests, supports `--yes`, continues after failures, and aggregates setup/skip/failure results. Documentation and broader command-contract coverage are tracked in #1808.

## AI Context

The command surface documentation and `.ai-context` inventory are intentionally left for #1808 so the PR train lands in order.