### PR TITLE
refactor: make Base's base-cli profile explicit

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -34,10 +34,11 @@ Base keeps clear layer ownership:
 - Bash owns runtime bootstrap, shell startup, setup/check/doctor orchestration,
   and command dispatch.
 - Python owns manifest parsing, structured project discovery, artifact
-  decisions, JSON output, and Base's CLI integration. The reusable `base_cli`
-  framework is maintained in the standalone `basefoundry/base-cli` repository;
-  Base resolves it from an explicit source root, a sibling checkout, or the
-  installed `base-cli` distribution.
+  decisions, JSON output, and Base's CLI integration. Base supplies its
+  consumer policy through `cli/python/base_cli_profile.py`; the reusable
+  `base_cli` lifecycle framework is maintained in the standalone
+  `basefoundry/base-cli` repository. Base resolves it from an explicit source
+  root, a sibling checkout, or the installed `base-cli` distribution.
 - Project repositories own application code, tests, service definitions,
   project-specific setup, and product onboarding.
 - Persistent local state lives under `~/.base.d`.

--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -169,9 +169,12 @@ to Python packages under `cli/python/`.
 
 ## Python CLI Pattern
 
-Base Python commands use `base_cli.App`. The framework adds standard options,
-logging, config loading, project discovery, temp/cache directories, cleanup
-hooks, and a command context.
+Base Python commands use the Base-owned `base_cli_app()` adapter. It passes
+`base_cli_profile()` to newer `base_cli.App` releases and preserves the
+historical constructor path for older installed releases. The generic framework
+adds standard options, logging, temp/cache directories, cleanup hooks, and a
+command context; the adapter supplies Base configuration, manifest discovery,
+runtime placement, and history policies.
 
 Important Python packages include:
 

--- a/.ai-context/DECISIONS.md
+++ b/.ai-context/DECISIONS.md
@@ -41,6 +41,11 @@ architecture discussion.
   `basefoundry/base-cli` repository. Base owns provider selection and command
   integration, resolving an explicit source root, a sibling checkout, or the
   installed `base-cli` distribution; it does not carry an in-tree copy.
+- Base Python command engines use the Base-owned `base_cli_app()` adapter,
+  which passes an explicit `base_cli_profile()` to newer `base_cli.App`
+  releases and preserves compatibility with older installed releases. Base-specific
+  discovery, configuration, runtime, and history policies do not belong to the
+  reusable framework.
 - Python CLIs run through `base-wrapper` so venv and `PYTHONPATH` behavior is
   consistent.
 - Python-to-Bash command metadata uses the strict versioned

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-cli
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          path: .dependencies/base-cli
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -34,6 +40,6 @@ jobs:
 
       - name: Run Pylint
         env:
-          PYTHONPATH: lib/python:cli/python
+          PYTHONPATH: .dependencies/base-cli/lib/python:lib/python:cli/python
         run: |
           git ls-files -z '*.py' | xargs -0 pylint --rcfile=.pylintrc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-cli
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          path: .dependencies/base-cli
+
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -40,7 +46,7 @@ jobs:
 
       - name: Run Python tests
         env:
-          PYTHONPATH: lib/python:cli/python
+          PYTHONPATH: .dependencies/base-cli/lib/python:lib/python:cli/python
         run: |
           python -m pytest
 
@@ -63,7 +69,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 047c5873834529c2895c76500a6502769b75ea8f
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling

--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.paths import base_cache_root
 
 
-app = base_cli.App(name="base_clean")
+app = base_cli_app(name="base_clean")
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_cli_profile.py
+++ b/cli/python/base_cli_profile.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import base_cli
+import base_cli.app as base_cli_app_module
+from base_cli._runtime import runtime_layout
+from base_cli.config import load_config
+from base_cli.config import load_yaml_file
+from base_cli.config import read_user_config
+from base_cli.history import HISTORY_SCOPE_INTERNAL
+from base_cli.history import write_finished_record
+from base_cli.paths import base_cache_root
+from base_cli.paths import discover_manifest
+from base_cli.paths import make_run_id
+from base_cli.paths import normalize_runtime_owner
+from base_cli.paths import resolve_base_home
+from base_cli.paths import runtime_project_name
+from base_cli.paths import runtime_project_root
+
+
+# Keep the legacy patch point available while Base supports released base-cli
+# versions that still own this callback in base_cli.app.
+base_cli_app_module.write_finished_record = write_finished_record
+
+
+def base_cli_app(*args: Any, **kwargs: Any) -> Any:
+    """Construct a Base CLI app with compatibility for older base-cli releases."""
+    if hasattr(base_cli, "CliProfile"):
+        kwargs["profile"] = base_cli_profile()
+    return base_cli.App(*args, **kwargs)
+
+
+def base_cli_profile() -> base_cli.CliProfile:
+    """Return Base's explicit consumer policy for the shared CLI lifecycle."""
+
+    def discover(cwd: Path) -> base_cli.ProjectInfo | None:
+        manifest_override = os.environ.get("BASE_CLI_PROJECT_MANIFEST")
+        manifest = (
+            Path(manifest_override).expanduser().resolve()
+            if manifest_override
+            else discover_manifest(cwd)
+        )
+        if manifest is None:
+            return None
+
+        name: str | None = None
+        try:
+            project = load_yaml_file(manifest).get("project")
+            if isinstance(project, dict) and isinstance(project.get("name"), str):
+                name = project["name"]
+        except (OSError, RuntimeError, ValueError):
+            pass
+        return base_cli.ProjectInfo(root=manifest.parent, manifest=manifest, name=name)
+
+    def resolve_runtime(
+        cli_name: str,
+        project: base_cli.ProjectInfo | None,
+    ) -> base_cli.RuntimeBinding:
+        runtime_owner = normalize_runtime_owner()
+        selected_project_root = runtime_project_root() or (project.root if project else None)
+        selected_project_name = runtime_project_name() or (
+            project.name if project else (selected_project_root.name if selected_project_root else None)
+        )
+        inherited_run_root = os.environ.get("BASE_CLI_RUN_ROOT") if runtime_owner == "base" else None
+        inherited_path = Path(inherited_run_root).expanduser().resolve() if inherited_run_root else None
+        inherited_run_id = os.environ.get("BASE_CLI_RUN_ID") if inherited_path is not None else None
+        run_id = inherited_run_id or (
+            inherited_path.name if inherited_path is not None else make_run_id()
+        )
+        cache_root = base_cache_root()
+        return base_cli.RuntimeBinding(
+            cache_root=cache_root,
+            layout=runtime_layout(
+                cache_root,
+                cli_name,
+                run_id,
+                owner=runtime_owner,
+                project_name=selected_project_name,
+                project_root=selected_project_root,
+                inherited_run_root=inherited_path,
+            ),
+            application_home=resolve_base_home(),
+            runtime_owner=runtime_owner,
+            project_root=selected_project_root,
+            project_name=selected_project_name,
+            inherited_path=inherited_path,
+            history_parent_run_id=os.environ.get("BASE_CLI_HISTORY_PARENT_RUN_ID") or None,
+            run_id=run_id,
+            primary_log_file=(
+                Path(os.environ["BASE_CLI_PRIMARY_LOG"]).expanduser()
+                if inherited_path is not None and os.environ.get("BASE_CLI_PRIMARY_LOG")
+                else None
+            ),
+            history_scope=os.environ.get(
+                "BASE_CLI_HISTORY_SCOPE",
+                HISTORY_SCOPE_INTERNAL if inherited_path is not None else "primary",
+            ),
+            write_identity=runtime_owner == "project",
+        )
+
+    return base_cli.CliProfile(
+        discover_project=discover,
+        load_user_config=read_user_config,
+        load_config=lambda project, explicit: load_config(
+            project.root if project is not None else None,
+            explicit,
+        ),
+        resolve_runtime=resolve_runtime,
+        history_writer=_write_finished_record,
+        display_command=_display_command,
+    )
+
+
+def _write_finished_record(*args: Any) -> None:
+    base_cli_app_module.write_finished_record(*args)
+
+
+def _display_command() -> str | None:
+    value = os.environ.get("BASE_CLI_DISPLAY_COMMAND", "").strip()
+    return value or None

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from typing import Any
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.config import UserConfig, load_user_config, read_user_config, user_config_path
 from base_cli.redaction import REDACTED, is_secret_key, redact_text_value
 
 
-app = base_cli.App(
+app = base_cli_app(
     name="base_config",
     help="Inspect Base's machine-local user config.",
 )

--- a/cli/python/base_dev/engine.py
+++ b/cli/python/base_dev/engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_setup.artifacts import reconcile_artifact
 from base_setup.artifacts import resolve_artifact_definitions  # pylint: disable=unused-import
 from base_setup.errors import ArtifactError
@@ -48,7 +49,7 @@ from .profile_output import print_check_results
 from .profile_output import print_doctor_results
 
 
-app = base_cli.App(name="base_dev")
+app = base_cli_app(name="base_dev")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/cli/python/base_export_context/engine.py
+++ b/cli/python/base_export_context/engine.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 import base_cli
+from base_cli_profile import base_cli_app
 
 
-app = base_cli.App(name="base_export_context")
+app = base_cli_app(name="base_export_context")
 
 CONTEXT_DIR_NAME = ".ai-context"
 MARKDOWN_FORMAT = "markdown"

--- a/cli/python/base_github_projects/engine.py
+++ b/cli/python/base_github_projects/engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 
 import base_cli
+from base_cli_profile import base_cli_app
 import click
 from base_projects.command_helpers import ProjectUsageError
 
@@ -53,7 +54,7 @@ from .project_graphql import GITHUB_GRAPHQL_TIMEOUT_SECONDS, is_project_scope_er
 # pylint: enable=unused-import
 
 
-app = base_cli.App(
+app = base_cli_app(
     name="base_github_projects",
     help="Configure GitHub Projects for Base-managed repositories.",
 )

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.command_filters import command_matches
 from base_cli.command_filters import normalize_command_filters
 from base_cli.history import HISTORY_PATH
@@ -25,7 +26,7 @@ from base_cli.history import utc_now
 from base_cli.paths import base_cache_root
 
 
-app = base_cli.App(name="base_history", log_to_file=False)
+app = base_cli_app(name="base_history", log_to_file=False)
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.command_filters import command_matches
 from base_cli.command_filters import normalize_command_filters
 from base_cli.history import HISTORY_PATH
@@ -37,7 +38,7 @@ LOG_SECRET_ASSIGNMENT_RE = re.compile(
 )
 SECRET_KEY_RE = re.compile(r"token|password|secret|api[-_]?key|authorization", re.IGNORECASE)
 
-app = base_cli.App(name="base_logs", log_to_file=False)
+app = base_cli_app(name="base_logs", log_to_file=False)
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_pr_policy/engine.py
+++ b/cli/python/base_pr_policy/engine.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.paths import discover_manifest
 from base_setup.github_manifest import GithubPrConfig
 from base_setup.manifest import read_manifest
@@ -93,7 +94,7 @@ def body_from_manifest(
     )
 
 
-app = base_cli.App(
+app = base_cli_app(
     name="base_pr_policy",
     help="Render Base-managed GitHub pull request policy content.",
 )

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.command_protocol import dumps_record
 from base_cli.command_protocol import dumps_records
 from base_projects.build_targets import build_targets_project_from_args
@@ -69,7 +70,7 @@ from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 
 
-app = base_cli.App(name="base_projects")
+app = base_cli_app(name="base_projects")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/cli/python/base_prompt/engine.py
+++ b/cli/python/base_prompt/engine.py
@@ -6,9 +6,10 @@ from datetime import date
 from pathlib import Path
 
 import base_cli
+from base_cli_profile import base_cli_app
 
 
-app = base_cli.App(name="base_prompt", log_to_file=False)
+app = base_cli_app(name="base_prompt", log_to_file=False)
 
 PROMPTS_DIR = Path(".ai-context") / "prompts"
 

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.inspection import InspectionStatus
 from base_cli.inspection import render_inspection_json
 from base_setup.manifest import read_manifest
@@ -19,7 +20,7 @@ from .release_publish import release_publish_recovery_guidance, require_interact
 from .release_publish import run_release_step, write_temp_release_notes
 from .release_readiness import extract_changelog_section, gh_cli_finding, github_release_finding
 
-app = base_cli.App(name="base_release")
+app = base_cli_app(name="base_release")
 
 
 def release_findings(ctx: ReleaseContext) -> tuple[ReleaseFinding, ...]:

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.config import UserConfig
 from base_cli.paths import discover_manifest
 from base_devcontainer.export import DevcontainerExportError
@@ -39,7 +40,7 @@ from .setup_reconcile import reconcile_bootstrap_artifacts
 from .setup_reconcile import reconcile_manifest
 
 
-app = base_cli.App(name="base_setup")
+app = base_cli_app(name="base_setup")
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import base_cli
+from base_cli_profile import base_cli_app
 from base_cli.history import base_version as read_base_version
 from base_projects import engine as project_engine
 from base_projects.project_discovery import Project
@@ -31,7 +32,7 @@ from .trust_store import sha256_file  # pylint: disable=unused-import
 from .trust_store import write_json_atomic  # pylint: disable=unused-import
 
 
-app = base_cli.App(
+app = base_cli_app(
     name="base_trust",
     help="Manage local approval for manifest-declared project commands.",
 )

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -136,6 +136,7 @@ registration.
 ctx.cli_name       # str
 ctx.run_id         # str
 ctx.base_home      # Path | None
+ctx.application_home  # Path | None; neutral application-home alias
 ctx.project_name   # selected project name, or None
 ctx.project_root   # Path | None
 ctx.manifest_path  # Path | None

--- a/tests/test_base_cli_profile.py
+++ b/tests/test_base_cli_profile.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import base_cli
+import pytest
+
+from base_cli_profile import base_cli_profile
+
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(base_cli, "CliProfile"),
+    reason="explicit consumer profiles require base-cli with profile support",
+)
+
+
+def test_base_profile_discovers_base_manifests_and_projects(tmp_path: Path) -> None:
+    manifest = tmp_path / "base_manifest.yaml"
+    manifest.write_text("project:\n  name: demo\n", encoding="utf-8")
+
+    project = base_cli_profile().discover_project(tmp_path)
+
+    assert project is not None
+    assert project.root == tmp_path
+    assert project.manifest == manifest
+    assert project.name == "demo"
+
+
+def test_base_profile_owns_base_runtime_and_history_policies(tmp_path: Path, monkeypatch) -> None:
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("BASE_CACHE_DIR", str(cache_root))
+    monkeypatch.delenv("BASE_CLI_DISPLAY_COMMAND", raising=False)
+
+    profile = base_cli_profile()
+    binding = profile.resolve_runtime("demo", None)
+
+    assert binding.cache_root == cache_root.resolve()
+    assert binding.layout.owner_root == cache_root.resolve() / "base"
+    assert profile.history_writer is not None
+    assert profile.display_command() is None

--- a/tests/test_base_cli_public_command_lifecycle.py
+++ b/tests/test_base_cli_public_command_lifecycle.py
@@ -7,11 +7,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_COMMAND_ROOT = REPO_ROOT / "cli" / "python"
 
 
-def test_public_python_command_engines_use_base_cli_app_or_declared_exemption() -> None:
+def test_public_python_command_engines_use_base_cli_profile_or_declared_exemption() -> None:
     bypasses = []
     for engine_path in sorted(PUBLIC_COMMAND_ROOT.glob("base_*/engine.py")):
         source = engine_path.read_text(encoding="utf-8")
-        if "base_cli.App(" not in source:
+        if "base_cli_app(" not in source:
             bypasses.append(engine_path.parent.name)
 
     assert not bypasses


### PR DESCRIPTION
## Summary

- Add a Base-owned `base_cli_profile` adapter that supplies Base-specific discovery, configuration, runtime, history, and display policies to newer `base-cli` releases.
- Migrate all 13 public Python command engines to the adapter while preserving compatibility with the released `base-cli==0.1.0` package.
- Exercise the profile-capable source checkout in Python, Pylint, and BATS workflows, and update Base AI context and lifecycle documentation.

## Issue

Fixes #1817

## Validation

- Source-based full Python suite using merged base-cli commit `59471fad8a73c225835b68e8c54eacd532e6baec`: `928 passed`.
- Pylint on the adapter, all migrated engines, and related tests: clean.
- `git diff --check`: clean.
- Released-dependency compatibility run: `925 passed, 3 skipped` in Python.
- The same local `base-test` run reached all 848 BATS tests: 840 passed and 8 platform-sensitive structured-JSON cases failed in this macOS environment; these failures are unrelated to the adapter and are called out for CI verification.

## Demo Impact

None.

## Notes

- The adapter passes `CliProfile` when available and uses the historical constructor path for older installed releases, allowing Base to adopt the refactor before a new base-cli release is published.
- CI source checkouts pin the merged base-cli profile API commit. Package rename/extraction work remains out of scope for this issue.
- Updated `.ai-context/` to document the consumer/framework boundary.