### PR TITLE
fix: align source-checkout CI with base-cli provider

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -239,9 +239,19 @@ jobs:
           ref: 2c5ef2c3a9edfbe2cf68d0645be65b920255abff
           path: .dependencies/base-bash-libs
 
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-cli
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          path: .dependencies/base-cli
+
       - name: Expose reusable Bash library checkout as sibling
         run: |
           ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"
+
+      - name: Expose standalone Python package checkout as sibling
+        run: |
+          ln -s "$GITHUB_WORKSPACE/.dependencies/base-cli" "$GITHUB_WORKSPACE/../base-cli"
 
       - name: Remove flaky hosted-runner apt sources
         run: |

--- a/cli/bash/commands/basectl/tests/basectl_helpers.bash
+++ b/cli/bash/commands/basectl/tests/basectl_helpers.bash
@@ -19,3 +19,18 @@ run_basectl() {
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" "$@"
 }
+
+base_cli_test_pythonpath() {
+    local base_cli_path
+
+    # Use the same provider resolver as Base commands so these tests remain
+    # valid with either an installed package or a source checkout.
+    # shellcheck source=lib/base/base_cli_runtime.sh
+    source "$BASE_REPO_ROOT/lib/base/base_cli_runtime.sh"
+    base_cli_path="$(BASE_HOME="$BASE_REPO_ROOT" base_cli_runtime_source_root)" || return 1
+    if [[ -n "$base_cli_path" ]]; then
+        printf '%s:%s\n' "$base_cli_path" "$BASE_REPO_ROOT/cli/python"
+    else
+        printf '%s\n' "$BASE_REPO_ROOT/cli/python"
+    fi
+}

--- a/cli/bash/commands/basectl/tests/projects.bats
+++ b/cli/bash/commands/basectl/tests/projects.bats
@@ -73,6 +73,7 @@ EOF
 @test "basectl projects list falls back to source python before setup" {
     local workspace="$TEST_TMPDIR/workspace"
     local state_file="$TEST_TMPDIR/projects-list-state"
+    local expected_pythonpath
 
     mkdir -p "$workspace/base" "$workspace/demo"
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
@@ -108,7 +109,8 @@ EOF
     [[ "$output" == *$'base\t'"$workspace/base"* ]]
     [[ "$output" == *$'demo\t'"$workspace/demo"* ]]
     grep -Fqx "BASE_PROJECT=base" "$state_file"
-    grep -Fqx "PYTHONPATH=$BASE_REPO_ROOT/cli/python" "$state_file"
+    expected_pythonpath="$(base_cli_test_pythonpath)"
+    grep -Fqx "PYTHONPATH=$expected_pythonpath" "$state_file"
     grep -Fqx "ARGS=-m base_projects list --workspace $workspace" "$state_file"
 }
 

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -459,6 +459,7 @@ EOF
 
 @test "base-wrapper runs package commands in the selected project venv" {
     local python_bin="$TEST_HOME/.base.d/demo/.venv/bin/python"
+    local expected_pythonpath
 
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
@@ -478,7 +479,8 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_HOME=$BASE_REPO_ROOT"* ]]
     [[ "$output" == *"BASE_PROJECT=demo"* ]]
-    [[ "$output" == *"PYTHONPATH=$BASE_REPO_ROOT/cli/python:existing"* ]]
+    expected_pythonpath="$(base_cli_test_pythonpath)"
+    [[ "$output" == *"PYTHONPATH=$expected_pythonpath:existing"* ]]
     [[ "$output" == *"ARGS=-m base_setup --dry-run demo"* ]]
 }
 

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -18,20 +18,35 @@ run_setup_common_script() {
 }
 
 @test "setup_common caches Base virtualenv and Python import paths" {
+    local expected_pythonpath="$BASE_REPO_ROOT/cli/python"
+    local base_cli_path
+
+    base_cli_path="$(base_cli_test_source_dir)"
+    if [[ -n "$base_cli_path" ]]; then
+        expected_pythonpath="$base_cli_path:$expected_pythonpath"
+    fi
+
     run_setup_common_script 'setup_refresh_cached_paths; printf "venv=%s\n" "$(setup_venv_dir)"; printf "pythonpath=%s\n" "$(setup_pythonpath)"'
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"venv=$TEST_HOME/.base.d/base/.venv"* ]]
-    [[ "$output" == *"pythonpath=$BASE_REPO_ROOT/../../base-cli/lib/python:$BASE_REPO_ROOT/cli/python"* || "$output" == *"pythonpath=$BASE_REPO_ROOT/../base-cli/lib/python:$BASE_REPO_ROOT/cli/python"* ]]
+    [[ "$output" == *"pythonpath=$expected_pythonpath"* ]]
 }
 
 @test "setup_common appends an inherited PYTHONPATH after Base paths" {
+    local expected_pythonpath="$BASE_REPO_ROOT/cli/python"
+    local base_cli_path
+
+    base_cli_path="$(base_cli_test_source_dir)"
+    if [[ -n "$base_cli_path" ]]; then
+        expected_pythonpath="$base_cli_path:$expected_pythonpath"
+    fi
+
     BASE_SETUP_TEST_PYTHONPATH="/opt/example/python" \
         run_setup_common_script 'setup_refresh_cached_paths; setup_pythonpath'
 
     [ "$status" -eq 0 ]
-    [ "$output" = "$BASE_REPO_ROOT/../../base-cli/lib/python:$BASE_REPO_ROOT/cli/python:/opt/example/python" ] ||
-        [ "$output" = "$BASE_REPO_ROOT/../base-cli/lib/python:$BASE_REPO_ROOT/cli/python:/opt/example/python" ]
+    [ "$output" = "$expected_pythonpath:/opt/example/python" ]
 }
 
 @test "setup_common parses explicit warning check results" {


### PR DESCRIPTION
## Summary

- pin the Ubuntu source-checkout job to the profile-capable standalone base-cli source and expose it as the expected sibling checkout
- make BATS PYTHONPATH assertions follow the same provider resolver as production code
- keep setup-common expectations valid for both source-provider and installed-package modes

## Issue

Fixes #1819

## Validation

- focused provider-aware BATS tests: 4 passed with an explicit source provider and 4 passed with installed-package fallback
- full CI-equivalent local BATS suite: provider-path regressions pass; 7 Linux/JSON readiness cases remain unavailable on the macOS host
- workflow validation tests: 49 passed
- bash syntax checks and git diff check passed

The baseline main run had the same BATS #327/#512 failures and 59 Ubuntu source-checkout failures. This PR does not modify #1818's implementation; it repairs the CI provider setup and stale assertions.