### PR TITLE
ci: align Base with merged base-cli consumer policy

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: beb99953e5df66dea207a31cea3c00332aaadcad
           path: .dependencies/base-cli
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: beb99953e5df66dea207a31cea3c00332aaadcad
           path: .dependencies/base-cli
 
       - name: Set up Python
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: beb99953e5df66dea207a31cea3c00332aaadcad
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -248,7 +248,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: beb99953e5df66dea207a31cea3c00332aaadcad
           path: .dependencies/base-cli
 
       - name: Expose reusable Bash library checkout as sibling

--- a/bin/base-test
+++ b/bin/base-test
@@ -103,8 +103,8 @@ base_test_preflight_source_checkout() {
 base_test_run_python_suite() {
     local base_cli_path
 
-    base_cli_path="$(base_cli_runtime_source_root)" || return 1
-    base_cli_runtime_prepare || return 1
+    base_cli_path="$(base_cli_runtime_source_root "$base_test_home")" || return 1
+    base_cli_runtime_prepare "$base_test_home" || return 1
     if [[ -n "$base_cli_path" ]]; then
         base_test_pythonpath="$base_cli_path:$base_test_home/cli/python"
     else

--- a/cli/python/base_cli_profile.py
+++ b/cli/python/base_cli_profile.py
@@ -12,7 +12,6 @@ from base_cli.config import load_yaml_file
 from base_cli.config import read_user_config
 from base_cli.history import HISTORY_SCOPE_INTERNAL
 from base_cli.history import write_finished_record
-from base_history.display import display_command as history_display_command
 from base_cli.paths import base_cache_root
 from base_cli.paths import discover_manifest
 from base_cli.paths import make_run_id
@@ -20,6 +19,7 @@ from base_cli.paths import normalize_runtime_owner
 from base_cli.paths import resolve_base_home
 from base_cli.paths import runtime_project_name
 from base_cli.paths import runtime_project_root
+from base_history.display import display_command as history_display_command
 from base_setup.ide_schema import SUPPORTED_IDES
 
 

--- a/cli/python/base_cli_profile.py
+++ b/cli/python/base_cli_profile.py
@@ -12,6 +12,7 @@ from base_cli.config import load_yaml_file
 from base_cli.config import read_user_config
 from base_cli.history import HISTORY_SCOPE_INTERNAL
 from base_cli.history import write_finished_record
+from base_history.display import display_command as history_display_command
 from base_cli.paths import base_cache_root
 from base_cli.paths import discover_manifest
 from base_cli.paths import make_run_id
@@ -19,6 +20,7 @@ from base_cli.paths import normalize_runtime_owner
 from base_cli.paths import resolve_base_home
 from base_cli.paths import runtime_project_name
 from base_cli.paths import runtime_project_root
+from base_setup.ide_schema import SUPPORTED_IDES
 
 
 # Keep the legacy patch point available while Base supports released base-cli
@@ -103,7 +105,7 @@ def base_cli_profile() -> base_cli.CliProfile:
 
     return base_cli.CliProfile(
         discover_project=discover,
-        load_user_config=read_user_config,
+        load_user_config=_read_user_config,
         load_config=lambda project, explicit: load_config(
             project.root if project is not None else None,
             explicit,
@@ -111,7 +113,12 @@ def base_cli_profile() -> base_cli.CliProfile:
         resolve_runtime=resolve_runtime,
         history_writer=_write_finished_record,
         display_command=_display_command,
+        history_display_command=history_display_command,
     )
+
+
+def _read_user_config() -> base_cli.UserConfig:
+    return read_user_config(supported_ides=SUPPORTED_IDES)
 
 
 def _write_finished_record(*args: Any) -> None:

--- a/cli/python/base_config/engine.py
+++ b/cli/python/base_config/engine.py
@@ -9,6 +9,7 @@ import base_cli
 from base_cli_profile import base_cli_app
 from base_cli.config import UserConfig, load_user_config, read_user_config, user_config_path
 from base_cli.redaction import REDACTED, is_secret_key, redact_text_value
+from base_setup.ide_schema import SUPPORTED_IDES
 
 
 app = base_cli_app(
@@ -109,7 +110,7 @@ def doctor_config_command() -> int:
     print_finding("ok", "yaml", "Config YAML is valid.")
     print_finding("ok", "mapping", f"Config contains {len(config)} top-level key(s).")
     try:
-        user_config = read_user_config()
+        user_config = read_user_config(supported_ides=SUPPORTED_IDES)
     except (RuntimeError, ValueError) as exc:
         print_finding("error", "schema", str(exc))
         return base_cli.ExitCode.FAILURE

--- a/cli/python/base_history/display.py
+++ b/cli/python/base_history/display.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+
+_BASE_DISPLAY_COMMANDS = frozenset(
+    {
+        "base_activate",
+        "base_build",
+        "base_check",
+        "base_ci",
+        "base_clean",
+        "base_config",
+        "base_demo",
+        "base_dev",
+        "base_devcontainer",
+        "base_devenv",
+        "base_devenv_report",
+        "base_docs",
+        "base_export_context",
+        "base_gh",
+        "base_github_projects",
+        "base_history",
+        "base_logs",
+        "base_onboard",
+        "base_pr_policy",
+        "base_projects",
+        "base_prompt",
+        "base_release",
+        "base_repo",
+        "base_run",
+        "base_setup",
+        "base_test",
+        "base_trust",
+        "base_update",
+        "base_update_profile",
+        "base_workspace",
+    }
+)
+
+
+def display_command(cli_name: str, argv: list[str]) -> str:
+    if cli_name == "base_setup":
+        return base_setup_action(argv) or "setup"
+    if cli_name in _BASE_DISPLAY_COMMANDS:
+        return cli_name.removeprefix("base_").replace("_", "-")
+    return cli_name.replace("_", "-")
+
+
+def base_setup_action(argv: list[str]) -> str | None:
+    for index, arg in enumerate(argv):
+        if arg == "--action" and index + 1 < len(argv):
+            return argv[index + 1]
+        if arg.startswith("--action="):
+            return arg.partition("=")[2]
+    return None

--- a/cli/python/base_history/tests/test_display.py
+++ b/cli/python/base_history/tests/test_display.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import unittest
+
+from base_history.display import display_command
+
+
+class BaseHistoryDisplayTests(unittest.TestCase):
+    def test_base_commands_use_user_facing_aliases(self) -> None:
+        self.assertEqual(display_command("base_history", []), "history")
+        self.assertEqual(display_command("base_setup", ["--action", "check"]), "check")
+
+    def test_non_base_names_keep_generic_formatting(self) -> None:
+        self.assertEqual(display_command("base_something", []), "base-something")
+        self.assertEqual(display_command("my_tool", []), "my-tool")

--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -19,7 +19,6 @@ from base_cli.command_filters import command_matches
 from base_cli.command_filters import normalize_command_filters
 from base_cli.history import HISTORY_PATH
 from base_cli.history import compact_path
-from base_cli.history import display_command
 from base_cli.history import optional_int
 from base_cli.history import optional_string
 from base_cli.history import parse_finished_history_record_line
@@ -29,6 +28,7 @@ from base_cli.history import redact_history_text
 from base_cli.paths import base_cache_root
 from base_cli.redaction import REDACTED
 from base_cli.redaction import redact_text_value
+from base_history.display import display_command
 
 
 RUN_ID_RE = re.compile(r"^(?P<stamp>\d{8}T\d{6})_[A-Za-z0-9]+(?:__.*)?$")

--- a/cli/python/base_setup/ide.py
+++ b/cli/python/base_setup/ide.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import base_cli
 from base_cli.config import UserConfig
-from base_cli.ide_schema import IDE_DEFINITIONS
-from base_cli.ide_schema import IdeDefinition
+from .ide_schema import IDE_DEFINITIONS
+from .ide_schema import IdeDefinition
 
 from .checks import ArtifactCheck
 from .ide_diagnostics import IdeDiagnosticSnapshot

--- a/cli/python/base_setup/ide_diagnostics.py
+++ b/cli/python/base_setup/ide_diagnostics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from base_cli.ide_schema import IdeDefinition
+from .ide_schema import IdeDefinition
 
 from . import process
 from .errors import ArtifactError

--- a/cli/python/base_setup/ide_extensions.py
+++ b/cli/python/base_setup/ide_extensions.py
@@ -4,8 +4,8 @@ import subprocess
 from typing import TYPE_CHECKING
 
 import base_cli
-from base_cli.ide_schema import IDE_DEFINITIONS
-from base_cli.ide_schema import IdeDefinition
+from .ide_schema import IDE_DEFINITIONS
+from .ide_schema import IdeDefinition
 
 from . import process
 from .checks import ArtifactCheck

--- a/cli/python/base_setup/ide_installs.py
+++ b/cli/python/base_setup/ide_installs.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import subprocess
 
 import base_cli
-from base_cli.ide_schema import IDE_DEFINITIONS
-from base_cli.ide_schema import IdeDefinition
+from .ide_schema import IDE_DEFINITIONS
+from .ide_schema import IdeDefinition
 
 from . import process
 from .checks import ArtifactCheck

--- a/cli/python/base_setup/ide_schema.py
+++ b/cli/python/base_setup/ide_schema.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from base_cli.ide_schema import parse_ide_extensions
+from base_cli.ide_schema import parse_ide_settings
+
+
+@dataclass(frozen=True)
+class IdeDefinition:
+    name: str
+    label: str
+    cli: str
+    cask: str
+    settings_app_dir: str
+
+
+IDE_DEFINITIONS = {
+    "vscode": IdeDefinition(
+        name="vscode",
+        label="VS Code",
+        cli="code",
+        cask="visual-studio-code",
+        settings_app_dir="Code",
+    ),
+    "cursor": IdeDefinition(
+        name="cursor",
+        label="Cursor",
+        cli="cursor",
+        cask="cursor",
+        settings_app_dir="Cursor",
+    ),
+}
+
+SUPPORTED_IDES = frozenset(IDE_DEFINITIONS)
+PROJECT_AUTO_SETTING_KEYS = frozenset({"python.defaultInterpreterPath"})
+
+__all__ = [
+    "IDE_DEFINITIONS",
+    "IdeDefinition",
+    "PROJECT_AUTO_SETTING_KEYS",
+    "SUPPORTED_IDES",
+    "parse_ide_extensions",
+    "parse_ide_settings",
+]

--- a/cli/python/base_setup/ide_settings.py
+++ b/cli/python/base_setup/ide_settings.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import base_cli
-from base_cli.ide_schema import IDE_DEFINITIONS
-from base_cli.ide_schema import IdeDefinition
+from .ide_schema import IDE_DEFINITIONS
+from .ide_schema import IdeDefinition
 
 from .checks import ArtifactCheck
 from .errors import ArtifactError

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from base_cli.ide_schema import PROJECT_AUTO_SETTING_KEYS
-from base_cli.ide_schema import SUPPORTED_IDES
 from base_cli.ide_schema import parse_ide_extensions
 from base_cli.ide_schema import parse_ide_settings
 from base_setup.github_manifest import GithubConfig
@@ -40,6 +38,9 @@ from base_setup.manifest_schema import SUPPORTED_PYTHON_MANAGERS
 from base_setup.manifest_schema import SUPPORTED_PYTHON_VENV_LOCATIONS
 from base_setup.manifest_schema import has_control_line_break
 from base_setup.manifest_schema import normalize_project_language
+
+from .ide_schema import PROJECT_AUTO_SETTING_KEYS
+from .ide_schema import SUPPORTED_IDES
 
 
 def read_manifest(path: Path) -> BaseManifest:

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -153,6 +153,7 @@ ctx.temp_dir       # run_root/tmp/<cli-name>/<run-id>
 ctx.log_file       # run_root/logs/primary.log, or None when disabled
 ctx.config         # dict
 ctx.user_config    # typed user config from ~/.base.d/config.yaml
+ctx.history_display_command  # consumer policy for persisted command labels
 ctx.environment    # str
 ctx.debug          # bool
 ctx.dry_run        # bool

--- a/lib/base/base_cli_runtime.sh
+++ b/lib/base/base_cli_runtime.sh
@@ -6,10 +6,13 @@
 #   1. BASE_CLI_SOURCE_DIR, when explicitly supplied;
 #   2. a sibling base-cli checkout;
 #   3. an installed base-cli distribution in the selected Python environment.
+# The resolver functions accept an optional Base root for callers that need to
+# locate a sibling checkout while BASE_HOME is intentionally unset.
 #
 base_cli_runtime_source_root() {
+    local base_home="${1:-${BASE_HOME:-}}"
     local explicit_root="${BASE_CLI_SOURCE_DIR:-}"
-    local sibling_repo="${BASE_HOME:-}/../base-cli"
+    local sibling_repo="${base_home:+$base_home/../base-cli}"
     local sibling_root="$sibling_repo/lib/python"
 
     if [[ -n "$explicit_root" ]]; then
@@ -36,8 +39,9 @@ base_cli_runtime_source_root() {
 }
 
 base_cli_runtime_source_kind() {
+    local base_home="${1:-${BASE_HOME:-}}"
     local explicit_root="${BASE_CLI_SOURCE_DIR:-}"
-    local sibling_repo="${BASE_HOME:-}/../base-cli"
+    local sibling_repo="${base_home:+$base_home/../base-cli}"
     local sibling_root="$sibling_repo/lib/python"
 
     if [[ -n "$explicit_root" ]]; then
@@ -54,6 +58,6 @@ base_cli_runtime_source_kind() {
 base_cli_runtime_prepare() {
     local source_kind
 
-    source_kind="$(base_cli_runtime_source_kind)" || return 1
+    source_kind="$(base_cli_runtime_source_kind "$@")" || return 1
     export BASE_CLI_SOURCE="$source_kind"
 }

--- a/tests/base_cli_runtime.bats
+++ b/tests/base_cli_runtime.bats
@@ -24,6 +24,24 @@ setup() {
     [ "$output" = "sibling $TEST_RUNTIME_HOME/../base-cli/lib/python" ]
 }
 
+@test "base_cli runtime accepts an explicit Base root when BASE_HOME is unset" {
+    mkdir -p "$TEST_TMPDIR/base-cli/lib/python/base_cli"
+    touch "$TEST_TMPDIR/base-cli/lib/python/base_cli/__init__.py"
+
+    run env \
+        BASE_HOME="$TEST_RUNTIME_HOME" \
+        bash -c '
+            base_home="$BASE_HOME"
+            source "$base_home/lib/base/base_cli_runtime.sh"
+            unset BASE_HOME
+            base_cli_runtime_prepare "$base_home"
+            printf "%s %s\n" "${BASE_CLI_SOURCE}" "$(base_cli_runtime_source_root "$base_home")"
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "sibling $TEST_RUNTIME_HOME/../base-cli/lib/python" ]
+}
+
 @test "base_cli runtime uses an explicit source directory before sibling checkout" {
     mkdir -p "$TEST_TMPDIR/base-cli/lib/python/base_cli" "$TEST_TMPDIR/explicit/base_cli"
     touch "$TEST_TMPDIR/base-cli/lib/python/base_cli/__init__.py" "$TEST_TMPDIR/explicit/base_cli/__init__.py"

--- a/tests/test_base_cli_profile.py
+++ b/tests/test_base_cli_profile.py
@@ -38,3 +38,4 @@ def test_base_profile_owns_base_runtime_and_history_policies(tmp_path: Path, mon
     assert binding.layout.owner_root == cache_root.resolve() / "base"
     assert profile.history_writer is not None
     assert profile.display_command() is None
+    assert profile.history_display_command("base_setup", ["--action", "check"]) == "check"


### PR DESCRIPTION
Fixes #1823 and supersedes #1822.\n\nBase CI was checking out base-cli commit 59471fa, which predates merged base-cli PR #18. The consumer-policy code therefore failed during collection with CliProfile.__init__() got an unexpected keyword argument 'history_display_command' and related pylint errors.\n\nThis PR pins all Base source-checkout and pylint workflows to merged base-cli commit beb9995, uses an issue-backed branch so Issue Branch Policy can validate it, and preserves the Base IDE/history consumer extraction from #1822.\n\nValidation: full local Base suite — 932 passed; git diff --check passed. Package renaming remains out of scope.: