### PR TITLE
ci: expand macOS BATS coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,16 @@ jobs:
           ref: 2c5ef2c3a9edfbe2cf68d0645be65b920255abff
           path: .dependencies/base-bash-libs
 
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-cli
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          path: .dependencies/base-cli
+
+      - name: Expose standalone Python package checkout as sibling
+        run: |
+          ln -s "$GITHUB_WORKSPACE/.dependencies/base-cli" "$GITHUB_WORKSPACE/../base-cli"
+
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: beb99953e5df66dea207a31cea3c00332aaadcad
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,10 +169,15 @@ jobs:
             PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
             "$brew_bash" --rcfile "$test_home/.bashrc" -i -c 'command -v basectl >/dev/null && basectl --version'
 
-      - name: Run focused macOS BATS tests
+      - name: Run prioritized macOS BATS tests
         run: |
           bats \
+            cli/bash/commands/basectl/tests/gh.bats \
+            cli/bash/commands/basectl/tests/repo.bats \
+            cli/bash/commands/basectl/tests/setup-common.bats \
+            cli/bash/commands/basectl/tests/setup.bats \
             cli/bash/commands/basectl/tests/update-profile.bats \
+            cli/bash/commands/basectl/tests/workspace.bats \
             lib/bash/version/tests/lib_version.bats \
             lib/shell/completions/tests/completions.bats \
             tests/base_init.bats \

--- a/cli/bash/commands/basectl/tests/basectl_helpers.bash
+++ b/cli/bash/commands/basectl/tests/basectl_helpers.bash
@@ -9,6 +9,7 @@ setup() {
     TEST_HOME="$TEST_TMPDIR/home"
     TEST_MOCKBIN="$TEST_TMPDIR/mockbin"
     TEST_STATE_DIR="$TEST_TMPDIR/state"
+    TEST_BASH_BIN_DIR="$(dirname "$(command -v bash)")"
     mkdir -p "$TEST_HOME" "$TEST_MOCKBIN" "$TEST_STATE_DIR"
     export BASH_ENV="$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash"
 }
@@ -16,7 +17,7 @@ setup() {
 run_basectl() {
     run env \
         HOME="$TEST_HOME" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" "$@"
 }
 

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -2126,7 +2126,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         BASE_REPO_PROJECT_WRAPPER="$TEST_MOCKBIN/project-wrapper" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo
 
     [ "$status" -eq 0 ]
@@ -2259,7 +2259,7 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
@@ -2325,7 +2325,7 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
@@ -2394,7 +2394,7 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
@@ -2440,7 +2440,7 @@ EOF
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         EPOCHSECONDS=0 \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
@@ -2487,7 +2487,7 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
@@ -2538,7 +2538,7 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 0 ]
@@ -2585,7 +2585,7 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo configure "$repo_dir" --repo codeforester/base-demo --no-project
 
     [ "$status" -eq 1 ]

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -124,7 +124,7 @@ run_repo_command_with_mocks() {
         BASE_REPO_TEST_STATE_DIR="$TEST_STATE_DIR" \
         BASE_REPO_TEST_REPO_VIEW_MISSING="${BASE_REPO_TEST_REPO_VIEW_MISSING:-}" \
         BASE_REPO_PROJECT_WRAPPER="${BASE_REPO_PROJECT_WRAPPER:-}" \
-        PATH="$TEST_MOCKBIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         "$BASE_REPO_ROOT/bin/basectl" repo "$@"
 }
 


### PR DESCRIPTION
## What changed

- expand the macOS BATS job beyond the five-file smoke subset
- add the `gh`, `repo`, `setup-common`, `setup`, and `workspace` command suites
- keep the existing version, completion, initialization, and install coverage

## Why

The macOS job was exercising only a narrow slice of the command surface. The added suites cover the largest Bash command modules and the platform-sensitive setup/workspace paths on the host platform where Base is primarily developed.

## Validation

- `git diff --check`
- local macOS BATS run: 399 tests passed

Fixes #1828
