### PR TITLE
docs: broaden Base positioning for single repositories

### DIFF
--- a/.ai-context/DECISIONS.md
+++ b/.ai-context/DECISIONS.md
@@ -6,14 +6,16 @@ architecture discussion.
 ## Product And Scope
 
 - Base is a local operating contract for deterministic readiness and handoff
-  across independent Git repositories; macOS remains the primary platform.
+  within a project, including across independent Git repositories when the
+  project spans more than one; macOS remains the primary platform.
 - Ubuntu/Debian runtime support, source-checkout CI validation, and apt-backed
   setup for conservative Base prerequisites are implemented. Broader Linux
   distribution and WSL support remain outside the current contract; keep
   platform details in `docs/linux-support.md`.
 - Windows support is not currently in scope.
-- Base should solve the author's real multi-repo workflow elegantly before
-  trying to be a broad general-purpose platform.
+- Base should solve the author's real multi-repo workflow elegantly while
+  keeping single-repository project adoption low-friction; it should not become
+  a broad general-purpose platform.
 - Base should strengthen the loop
   `inventory -> prepare -> verify -> trust -> onboard -> hand off`.
 - Repository discovery, clone or synchronization, status, and command fan-out

--- a/.ai-context/PROJECT.md
+++ b/.ai-context/PROJECT.md
@@ -12,17 +12,17 @@
 - Windows support is not currently in scope.
 
 Base is a local operating contract for developers and platform engineers who
-work across multiple independent Git repositories. Its core outcome is
-deterministic local readiness and handoff without turning the repo set into a
-monorepo.
+need deterministic local readiness and handoff within a project, whether that
+project is one repository or multiple independent Git repositories. Its core
+outcome does not require turning the repo set into a monorepo.
 
 ## Why It Exists
 
-Real engineering work often spans several peer repositories, while readiness
-rules and handoff context are scattered across docs, shell state, and maintainer
-memory. Base makes participation, local state, trusted execution, onboarding,
-and next actions inspectable while each repository keeps ownership of its code,
-tests, services, and project-specific setup.
+Real engineering work can involve one repository or several peer repositories,
+while readiness rules and handoff context are scattered across docs, shell
+state, and maintainer memory. Base makes local state, trusted execution,
+onboarding, and next actions inspectable while each repository keeps ownership
+of its code, tests, services, and project-specific setup.
 
 Deterministic is a narrow claim: declared inputs and inspectable local state
 should produce explicit ordering, stable findings or machine-readable
@@ -51,6 +51,9 @@ Participating projects declare `base_manifest.yaml`. Base discovers projects
 under a shared workspace root, reads manifests, and orchestrates setup, checks,
 activation, declared test commands, build targets, run commands, demos, and
 workspace reports.
+
+The same project contract is useful for a single repository; a multi-repository
+workspace adds shared inventory and workspace-level onboarding on top.
 
 Repository discovery, clone or synchronization, status, and command fan-out are
 shared ecosystem primitives rather than Base's differentiation. Base adds

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -53,7 +53,8 @@ broader prompt ergonomics, broader Linux distribution support, and broader
 setup policy work remaining outside the 1.7 release contract.
 
 The accepted product position is now a local operating contract for
-deterministic readiness and handoff. `workspace agent-brief` summarizes local
+deterministic readiness and handoff within a project, from a single repository
+to a multi-repository workspace. `workspace agent-brief` summarizes local
 repository readiness, while onboarding, diagnostics, history reports, and
 context exports provide deeper handoff evidence. The issue-oriented artifact in
 #1562 remains planned.

--- a/FAQ.md
+++ b/FAQ.md
@@ -13,6 +13,14 @@ Base makes a participating repo set understandable and locally ready while
 projects keep ownership of their application behavior, services, and
 project-specific setup.
 
+### Can Base help if my team has only one repository?
+
+Yes. Base can standardize the project's environment setup, readiness checks,
+trusted commands, tests, builds, onboarding, and handoff even when there is
+only one repository. Multiple repositories amplify the need for shared
+inventory and workspace coordination, but they are not required for Base's
+project contract to be useful.
+
 ## First-Time Installation
 
 ### What should I run on a blank macOS machine?
@@ -162,7 +170,8 @@ while `base_cli` answers "how should a Base Python CLI behave?" See the
 Base's reusable Bash helpers live in the standalone
 `basefoundry/base-bash-libs` repository so other scripts can reuse the logging,
 command execution, filesystem, and Git conventions without depending on Base's
-full local operating contract for multi-repository readiness and handoff.
+full local operating contract for project readiness and handoff across one or
+more repositories.
 
 That separation also keeps the Homebrew packaging path cleaner: `base-bash-libs`
 can mature as its own formula, and a future Homebrew/core Base formula can

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 ![Version](https://img.shields.io/badge/version-1.7.0-blue)
 
 Base is a local operating contract for developers and platform engineers who
-work across multiple independent Git repositories.
+need a repeatable way to prepare, verify, test, build, and hand off a project,
+whether that project lives in one repository or spans multiple independent Git
+repositories.
 
-It makes that repo set easier to inventory, prepare, verify, trust, onboard,
-and hand off without turning it into a monorepo or moving project-specific
-logic into Base.
+It makes that project or repo set easier to inventory, prepare, verify, trust,
+onboard, and hand off without turning it into a monorepo or moving
+project-specific logic into Base.
 
 ```text
 inventory -> prepare -> verify -> trust -> onboard -> hand off
@@ -18,20 +20,21 @@ inventory -> prepare -> verify -> trust -> onboard -> hand off
 
 ## Why Base Exists
 
-Most real engineering environments are not a single repository. Their setup
-steps, readiness rules, trusted commands, and handoff context are often spread
-across READMEs, shell state, and maintainer memory. Base gives participating
-repositories one explicit local contract for answering: what belongs here,
-what is ready, what is missing, what may run, and what the next person or agent
-needs to know.
+Every engineering project accumulates setup steps, readiness rules, trusted
+commands, and handoff context that can become scattered across READMEs, shell
+state, and maintainer memory. That problem exists within a single repository
+and becomes more visible when work spans several repositories. Base gives a
+project or participating repo set one explicit local contract for answering:
+what belongs here, what is ready, what is missing, what may run, and what the
+next person or agent needs to know.
 
 In this product promise, **deterministic** is deliberately narrow. Base makes
 declared inputs, inspection order, findings, and next actions explicit and
 repeatable. It does not promise hermetic builds, byte-for-byte environments, or
 transactional mutation across every repository and external tool.
 
-For a concise evaluator view of where Base fits, what it gives a multi-repo
-workspace, and how it compares with adjacent tools, see
+For a concise evaluator view of where Base fits, what it gives a project or
+multi-repo workspace, and how it compares with adjacent tools, see
 [Why Base](docs/why-base.md).
 For a candid maintained assessment of Base's originality, usefulness, adoption
 potential, and engineering evidence, see
@@ -332,7 +335,7 @@ packs, and adapters that support that outcome.
 ### 1. Core Outcome And Enabling Execution Contract
 
 Base should give the user one entry point for setting up and validating a
-workspace that contains multiple project repositories.
+project or a workspace that contains multiple project repositories.
 
 Current implemented commands include:
 
@@ -1861,10 +1864,13 @@ Base should orchestrate those things, not replace them.
 
 ## Mental Model
 
-Think of Base as the local operating contract beside a set of independent Git
-repositories.
+Think of Base as the local operating contract for a project, whether that
+project is one repository or a set of independent Git repositories.
 
-Each project repo remains independent. Base sits beside those repos and offers:
+A single repository can use Base to make setup, readiness, trusted execution,
+and handoff explicit. When a project spans several repositories, Base extends
+the same contract across the repo set. Each project repo remains independent;
+Base sits beside those repos and offers:
 
 - one declared way to inventory, prepare, and verify local readiness
 - one explicit trust boundary for project-owned commands

--- a/docs/product-assessment.md
+++ b/docs/product-assessment.md
@@ -1,7 +1,7 @@
 # Base Product Assessment
 
 Status: maintained product review artifact
-Last reviewed: 2026-07-25
+Last reviewed: 2026-07-30
 Base era reviewed: 1.7.0 + Unreleased
 
 This document records a candid assessment of Base as a product and engineering
@@ -38,8 +38,9 @@ When revising the assessment, prefer evidence in this order:
 ## Current Product Thesis
 
 Base is a local operating contract for developers and platform engineers who
-work across multiple independent Git repositories. Its core outcome is
-deterministic local readiness and handoff:
+need deterministic local readiness and handoff within a project, whether that
+project is one repository or multiple independent Git repositories. Its core
+outcome is:
 
 ```text
 inventory -> prepare -> verify -> trust -> onboard -> hand off
@@ -76,15 +77,16 @@ bootstrap scripts, environment managers, task runners, manifests, health checks,
 repo templates, release scripts, and dotfile managers.
 
 The original part is the composition and product boundary. Base treats local
-readiness and transferable operating context as the product surface across a
-set of independent repositories without making them a monorepo.
+readiness and transferable operating context as the product surface within a
+project, including a set of independent repositories when the project spans
+more than one, without making them a monorepo.
 
 Adjacent tools already cover project environments, tasks, machine bootstrap,
 containers, dotfiles, and generic multi-repository operations. Base's narrower
 question is:
 
-> What repositories participate, what do they declare, what is ready, what may
-> execute, and what evidence lets the next implementer continue safely?
+> What does this project declare, what is ready, what may execute, and what
+> evidence lets the next implementer continue safely?
 
 That framing is distinctive. Base is not original because every primitive is
 new; it is original because the primitives are assembled into a clear local
@@ -102,12 +104,16 @@ that Base delegates those domains and owns the local readiness/handoff contract.
 
 ## 2. Usefulness
 
-Assessment: high usefulness for the target audience.
-Working rating: 8/10 for multi-repo platform-style developers; lower for the
-general developer population.
+Assessment: high usefulness when a team has recurring setup, readiness,
+onboarding, or handoff friction.
+Working rating: 8/10 for teams with that recurring friction, especially
+multi-repo platform-style developers; lower when a repository is genuinely
+simple and self-explanatory.
 
 Base is especially useful for:
 
+- teams standardizing setup, checks, tests, builds, or handoff within one
+  repository;
 - engineers working across several sibling repositories;
 - platform, SRE, infrastructure, and internal-tooling engineers;
 - teams that need repeatable readiness, onboarding, and handoff without forcing
@@ -123,7 +129,8 @@ Base is especially useful for:
 
 Base is less useful when:
 
-- the developer works in one simple repository;
+- the developer works in one simple repository with no recurring setup,
+  onboarding, or handoff problem;
 - a monorepo is already the right product shape;
 - the main problem is only language version pinning;
 - the main problem is full reproducibility through Nix, Devbox, or Dev
@@ -146,14 +153,16 @@ not yet packaged into the issue-oriented artifact planned in #1562.
 Assessment: medium overall adoption potential, high potential inside a narrow
 wedge.
 
-The strongest wedge is:
+The strongest initial wedge remains:
 
 > A local operating contract for deterministic readiness and handoff across
 > independent Git repositories.
 
 That is a real market of users, especially among platform engineering,
 infrastructure, SRE, internal developer platform, and product engineers who
-work across multiple peer repositories.
+work across multiple peer repositories. A single repository is also a valid,
+lower-friction entry point when its setup and operating conventions need to be
+made explicit; multi-repository support can expand from there.
 
 The blockers to broader adoption are also real:
 
@@ -183,8 +192,17 @@ The best adoption path is evidence-driven:
 
 Base can become much larger, but the larger possibility is not "put every tool
 inside Base." The larger possibility is to make readiness and operating context
-portable across a repo set without absorbing the tools that prepare, build, or
-host those repositories.
+portable within a project, from a single repository to a repo set, without
+absorbing the tools that prepare, build, or host those repositories.
+
+### 2026-07-30 / Single-repository positioning
+
+This documentation update clarifies that Base's project contract is useful
+within a single repository as well as across independent repositories. The
+single-repository case covers recurring setup, readiness, test, build,
+onboarding, and handoff friction; multi-repository work remains the strongest
+initial wedge and an expansion path. This broadens the entry point without
+changing Base's product boundary or serving as evidence of external adoption.
 
 ### 2026-06-17 Product Review Delta
 

--- a/docs/why-base.md
+++ b/docs/why-base.md
@@ -1,12 +1,14 @@
 # Why Base
 
 Status: maintained product entry point
-Last reviewed: 2026-07-25
+Last reviewed: 2026-07-30
 
-Base is a local operating contract for developers and platform engineers whose
-work spans multiple independent Git repositories. It makes a participating repo
-set understandable and locally ready without forcing a monorepo or taking
-project-specific behavior away from the repositories that own it.
+Base is a local operating contract for developers and platform engineers who
+need repeatable project readiness and handoff, whether their work lives in one
+repository or spans multiple independent Git repositories. It makes a project
+or participating repo set understandable and locally ready without forcing a
+monorepo or taking project-specific behavior away from the repositories that
+own it.
 
 The product outcome is:
 
@@ -15,8 +17,12 @@ inventory -> prepare -> verify -> trust -> onboard -> hand off
 ```
 
 Base is most useful when setup rules, readiness state, safe execution, and
-handoff context would otherwise live in several READMEs, shell sessions, and one
-maintainer's memory.
+handoff context would otherwise live in READMEs, shell sessions, and maintainer
+memory. That need does not depend on repository count. A single repository can
+use Base to standardize environment setup, readiness checks, trusted commands,
+tests, builds, and contributor handoff. A multi-repository workspace gets the
+same contract across participating projects, with the additional benefit of
+shared inventory and workspace-level onboarding.
 
 ## What Deterministic Means Here
 
@@ -103,6 +109,8 @@ For the complete shipped command surface, see the
 
 Base is a strong fit when:
 
+- you work in one repository with recurring setup, onboarding, readiness, or
+  handoff friction;
 - your daily work crosses several independent Git repositories;
 - each repository should keep owning its code, tests, services, and setup
   details;
@@ -114,7 +122,8 @@ Base is a strong fit when:
 
 Base is not the first tool to choose when:
 
-- you work in one simple repository with no recurring handoff problem;
+- you work in one simple repository with no recurring setup, onboarding, or
+  handoff problem;
 - a monorepo is the correct source and ownership model;
 - generic multi-repo clone/sync/status is the whole requirement;
 - language version pinning, dotfiles, or task execution is the whole


### PR DESCRIPTION
## Summary

- broaden Base's product entry point from multi-repository work to projects with one or more repositories
- explain single-repository value for setup, readiness, tests, builds, onboarding, and handoff
- retain multi-repository work as the strongest initial wedge and expansion path
- align the product assessment, FAQ, and AI-facing context

## Validation

- `git diff --check`

Fixes #1833
