### PR TITLE
ci: restore normal base-cli workflow pin

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,8 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          # Keep the consumer validation paired with base-cli #25 until it merges.
-          ref: 03c50fb65cb0a52d5e2f58e208d2fd8c4dee5130
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
           path: .dependencies/base-cli
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: 5828f2d829dd9eb7e392455e454768cff7db7aa6
           path: .dependencies/base-cli
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: 5828f2d829dd9eb7e392455e454768cff7db7aa6
           path: .dependencies/base-cli
 
       - name: Set up Python
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: 5828f2d829dd9eb7e392455e454768cff7db7aa6
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: 5828f2d829dd9eb7e392455e454768cff7db7aa6
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: 5828f2d829dd9eb7e392455e454768cff7db7aa6
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -273,7 +273,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
+          ref: 5828f2d829dd9eb7e392455e454768cff7db7aa6
           path: .dependencies/base-cli
 
       - name: Expose reusable Bash library checkout as sibling

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,6 +199,7 @@ jobs:
     timeout-minutes: 25
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
+      BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -260,6 +261,7 @@ jobs:
     timeout-minutes: 35
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
+      BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          # Keep consumer validation paired with base-cli #25 until it merges.
-          ref: 03c50fb65cb0a52d5e2f58e208d2fd8c4dee5130
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
           path: .dependencies/base-cli
 
       - name: Set up Python
@@ -57,7 +56,6 @@ jobs:
     timeout-minutes: 20
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
-      BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -71,8 +69,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          # Keep consumer validation paired with base-cli #25 until it merges.
-          ref: 03c50fb65cb0a52d5e2f58e208d2fd8c4dee5130
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -124,8 +121,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          # Keep consumer validation paired with base-cli #25 until it merges.
-          ref: 03c50fb65cb0a52d5e2f58e208d2fd8c4dee5130
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -203,7 +199,6 @@ jobs:
     timeout-minutes: 25
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
-      BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -217,8 +212,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          # Keep consumer validation paired with base-cli #25 until it merges.
-          ref: 03c50fb65cb0a52d5e2f58e208d2fd8c4dee5130
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -266,7 +260,6 @@ jobs:
     timeout-minutes: 35
     env:
       BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
-      BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -280,8 +273,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          # Keep consumer validation paired with base-cli #25 until it merges.
-          ref: 03c50fb65cb0a52d5e2f58e208d2fd8c4dee5130
+          ref: 59471fad8a73c225835b68e8c54eacd532e6baec
           path: .dependencies/base-cli
 
       - name: Expose reusable Bash library checkout as sibling


### PR DESCRIPTION
## Summary

Restores Base CI to the compatible post-merge standalone `base-cli` dependency commit now that the paired adapter refactor has merged. It removes the temporary PR-pairing comments and the redundant BATS-job `BASE_CLI_SOURCE_DIR` override while preserving the explicit provider path required by isolated integration and source-checkout fixtures.

## Issue

Closes #1839

## Validation

- `git diff --check`
- Workflow diff audit confirms no temporary `base-cli` PR commit, pairing comment, or `BASE_CLI_SOURCE_DIR` override remains.
- Base source-checkout runner: Python layer passed with `931 passed, 1 skipped`; the macOS BATS portion was attempted but stopped on host-environment-dependent Linux/JSON assertions unrelated to this workflow-only change.
- GitHub Actions will provide the authoritative Pylint, Python, BATS, integration, macOS, security, and Ubuntu source-checkout validation.

## Demo Impact

None.

## Notes

The permanent standalone `base-cli` checkout steps remain in the jobs that need them. This cleanup restores the compatible post-merge `base-cli` main ref to `5828f2d829dd9eb7e392455e454768cff7db7aa6` and retains `BASE_CLI_SOURCE_DIR` where isolated fixture homes require it.

`.ai-context/` was not changed because this is CI housekeeping with no product or architecture change.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current worktree; unavailable checks are explained.
- [ ] Relevant BATS and Python tests pass.
- [x] Documentation is unchanged because behavior is unchanged.
- [x] AI context is unchanged because this is CI housekeeping.
- [x] PR includes `Closes #1839`.
- [x] Demo impact is `None.`
