### PR TITLE
refactor: move command protocol schemas into Base

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 8c3854fc69564a264bf66e27a4c046f28ebfcfc5
+          ref: d8c703fd805523607f76ba8702edc22b85b083d5
           path: .dependencies/base-cli
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 8c3854fc69564a264bf66e27a4c046f28ebfcfc5
+          ref: d8c703fd805523607f76ba8702edc22b85b083d5
           path: .dependencies/base-cli
 
       - name: Set up Python
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 8c3854fc69564a264bf66e27a4c046f28ebfcfc5
+          ref: d8c703fd805523607f76ba8702edc22b85b083d5
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 8c3854fc69564a264bf66e27a4c046f28ebfcfc5
+          ref: d8c703fd805523607f76ba8702edc22b85b083d5
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 8c3854fc69564a264bf66e27a4c046f28ebfcfc5
+          ref: d8c703fd805523607f76ba8702edc22b85b083d5
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -275,7 +275,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 8c3854fc69564a264bf66e27a4c046f28ebfcfc5
+          ref: d8c703fd805523607f76ba8702edc22b85b083d5
           path: .dependencies/base-cli
 
       - name: Expose reusable Bash library checkout as sibling

--- a/cli/python/base_cli_adapters/protocol.py
+++ b/cli/python/base_cli_adapters/protocol.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from base_cli.command_protocol import BOOLEAN
+from base_cli.command_protocol import CommandProtocolError
+from base_cli.command_protocol import FieldSpec
+from base_cli.command_protocol import NULLABLE_STRING
+from base_cli.command_protocol import STRING
+from base_cli.command_protocol import dumps_record as _dumps_record
+from base_cli.command_protocol import dumps_records as _dumps_records
+from base_cli.command_protocol import loads_records as _loads_records
+from base_cli.command_protocol import register_record_schema
+from base_cli.command_protocol import RECORD_SCHEMAS as _registered_schemas
+
+
+BASE_PROTOCOL_HEADER = "BASE_COMMAND_PROTOCOL_V1"
+RecordValue = str | bool | None
+Record = Mapping[str, RecordValue]
+
+PROJECT_REFERENCE_FIELDS = {
+    "project_name": STRING,
+    "project_root": STRING,
+    "manifest_path": STRING,
+}
+PROJECT_ROUTE_FIELDS = {
+    **PROJECT_REFERENCE_FIELDS,
+    "project_venv_dir": STRING,
+    "uses_uv_manager": BOOLEAN,
+    "manifest_command_trust_required": BOOLEAN,
+}
+PROJECT_SETUP_ROUTE_FIELDS = {
+    **PROJECT_ROUTE_FIELDS,
+    "requires_project_python": BOOLEAN,
+}
+
+BASE_RECORD_SCHEMAS: dict[str, dict[str, FieldSpec]] = {
+    "project-list-entry": {
+        "project_name": STRING,
+        "project_root": STRING,
+    },
+    "project-reference": PROJECT_REFERENCE_FIELDS,
+    "project-route": PROJECT_ROUTE_FIELDS,
+    "project-setup-route": PROJECT_SETUP_ROUTE_FIELDS,
+    "project-command": {
+        **PROJECT_ROUTE_FIELDS,
+        "command": STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "named-command": {
+        **PROJECT_REFERENCE_FIELDS,
+        "command_name": STRING,
+        "command": STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "build-target": {
+        **PROJECT_ROUTE_FIELDS,
+        "target_name": STRING,
+        "working_dir": STRING,
+        "command": STRING,
+        "description": NULLABLE_STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "demo": {
+        **PROJECT_ROUTE_FIELDS,
+        "demo_script": STRING,
+        "runner": NULLABLE_STRING,
+    },
+    "activation-source": {
+        "source_path": STRING,
+    },
+}
+
+
+def register_base_record_schemas() -> None:
+    """Register Base's record schemas with the generic protocol runtime."""
+
+    for record_type, fields in BASE_RECORD_SCHEMAS.items():
+        if record_type not in _registered_schemas:
+            register_record_schema(record_type, fields)
+
+
+def dumps_record(record_type: str, record: Record) -> str:
+    register_base_record_schemas()
+    return _dumps_record(record_type, record, protocol_header=BASE_PROTOCOL_HEADER)
+
+
+def dumps_records(record_type: str, records: tuple[Record, ...] | list[Record]) -> str:
+    register_base_record_schemas()
+    return _dumps_records(record_type, records, protocol_header=BASE_PROTOCOL_HEADER)
+
+
+def loads_records(
+    payload: str,
+    expected_record_type: str | None = None,
+) -> tuple[str, tuple[dict[str, RecordValue], ...]]:
+    register_base_record_schemas()
+    return _loads_records(
+        payload,
+        expected_record_type=expected_record_type,
+        protocol_header=BASE_PROTOCOL_HEADER,
+    )
+
+
+__all__ = [
+    "BASE_PROTOCOL_HEADER",
+    "BASE_RECORD_SCHEMAS",
+    "CommandProtocolError",
+    "dumps_record",
+    "dumps_records",
+    "loads_records",
+    "register_base_record_schemas",
+]
+
+
+register_base_record_schemas()

--- a/cli/python/base_projects/build_targets.py
+++ b/cli/python/base_projects/build_targets.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Protocol
 
 import base_cli
-from base_cli.command_protocol import dumps_records
+from base_cli_adapters.protocol import dumps_records
 from base_projects.project_commands import route_metadata_record
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import base_cli
 from base_cli_profile import base_cli_app
-from base_cli.command_protocol import dumps_record
-from base_cli.command_protocol import dumps_records
+from base_cli_adapters.protocol import dumps_record
+from base_cli_adapters.protocol import dumps_records
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
 from base_projects.command_helpers import ProjectUsageError

--- a/cli/python/base_projects/tests/test_build_targets.py
+++ b/cli/python/base_projects/tests/test_build_targets.py
@@ -9,7 +9,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_cli.command_protocol import loads_records
+from base_cli_adapters.protocol import loads_records
 from base_projects import engine
 
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -11,8 +11,8 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_cli.command_protocol import loads_records
 from base_cli_adapters.history import build_finished_record
+from base_cli_adapters.protocol import loads_records
 from base_projects import engine, project_discovery
 
 

--- a/cli/python/base_setup/project_routing.py
+++ b/cli/python/base_setup/project_routing.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from base_cli.command_protocol import dumps_record
+from base_cli_adapters.protocol import dumps_record
 
 from .manifest import BaseManifest
 from .project_environment import project_venv_dir_override

--- a/cli/python/base_setup/tests/test_project_routing.py
+++ b/cli/python/base_setup/tests/test_project_routing.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from base_cli.command_protocol import loads_records
+from base_cli_adapters.protocol import loads_records
 from base_setup.manifest import read_manifest
 from base_setup.project_routing import manifest_requires_project_python
 from base_setup.tests.helpers import run_engine

--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -49,7 +49,10 @@ Treat the package boundary as a design constraint for new Base work:
 
 The standalone repository owns package metadata, versioning, licensing, public
 API tests, and release workflow. Base owns provider selection and compatibility
-tests for its own command integration.
+tests for its own command integration. Base-specific command-protocol schemas
+and the `BASE_COMMAND_PROTOCOL_V1` Bash compatibility header live in
+`cli/python/base_cli_adapters/protocol.py`; the standalone package owns only
+generic protocol framing and schema registration.
 
 ## Standalone Provider Resolution
 

--- a/tests/test_base_cli_command_protocol_bash.py
+++ b/tests/test_base_cli_command_protocol_bash.py
@@ -5,8 +5,8 @@ import subprocess
 import unittest
 from pathlib import Path
 
-from base_cli.command_protocol import dumps_record
-from base_cli.command_protocol import dumps_records
+from base_cli_adapters.protocol import dumps_record
+from base_cli_adapters.protocol import dumps_records
 
 
 def project_command_record(**overrides: object) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- add a Base-owned command protocol adapter with all Base record schemas
- preserve `BASE_COMMAND_PROTOCOL_V1` for the Bash peer while generic base-cli uses its neutral protocol header
- route Base Python producers and decoders through the consumer adapter
- document the ownership boundary and update the cross-language protocol test

## Validation

- `PYTHONPATH=/Users/rameshhp/work/base-cli-worktrees/27-protocol-schemas/lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q`
- `931 passed, 1 skipped, 248 subtests passed`
- full pylint suite passes
- focused command-protocol BATS suite: 9 passed
- `git diff --check`

Depends on basefoundry/base-cli#29.

Fixes #1843
