### PR TITLE
ci: add Python coverage reporting and floor (#1831)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source =
+    cli/python
+omit =
+    cli/python/**/tests/*
+    cli/python/**/__main__.py
+    cli/python/**/__init__.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,10 @@ jobs:
         env:
           PYTHONPATH: .dependencies/base-cli/lib/python:lib/python:cli/python
         run: |
-          python -m pytest
+          python -m pytest \
+            --cov=cli/python \
+            --cov-report=term-missing \
+            --cov-fail-under=85
 
   bats:
     name: BATS tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,6 +68,23 @@ Run them with:
 PYTHONPATH=cli/python python -m pytest
 ```
 
+The Python CI job also measures coverage for production code under
+`cli/python`:
+
+```bash
+PYTHONPATH=cli/python python -m pytest \
+  --cov=cli/python \
+  --cov-report=term-missing \
+  --cov-fail-under=85
+```
+
+The shared [coverage configuration](../.coveragerc) excludes Python test
+modules, package initializers, and `__main__.py` entrypoints from the measured
+source set. The initial floor is 85%, based on an 87% baseline from the full
+Python suite across 11,428 production statements. This is a regression guard,
+not a claim that every module has ideal behavioral coverage; ratchet it upward
+as lower-covered areas gain focused tests.
+
 ## Bash Command And Runtime Tests
 
 BATS tests next to Bash commands and Base runtime helpers cover shell parsing,
@@ -112,6 +129,11 @@ resolves to a source checkout. In a packaged install such as Homebrew,
 `basectl test base` is package-aware: it runs the packaged Python test layer and
 skips source-checkout-only BATS and integration tests with a message pointing
 back to the source checkout command above.
+
+There is not yet an equivalent Bash/BATS line-coverage floor. The BATS suite
+continues to provide behavior and contract coverage, while a lightweight Bash
+coverage tool (such as `kcov` or `bashcov`) is evaluated separately so it can
+be introduced without making the shell test job platform-dependent.
 
 ## Integration Tests
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ click==8.4.1
 base-cli==0.1.0
 PyYAML==6.0.3
 pytest==9.0.3
+pytest-cov==7.1.0
 tomli==2.4.1
 bandit==1.9.4
 pip-audit==2.10.1

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -12,6 +12,11 @@ ACTIVE_WORKFLOW_GUIDANCE_FILES = (
     REPO_ROOT / "CONTRIBUTING.md",
 )
 GITHUB_WORKFLOW_DOC = REPO_ROOT / "docs" / "github-workflow.md"
+COVERAGE_CONFIG = REPO_ROOT / ".coveragerc"
+DEV_REQUIREMENTS = REPO_ROOT / "requirements-dev.txt"
+TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+TESTING_DOC = REPO_ROOT / "docs" / "testing.md"
+PYTHON_COVERAGE_FLOOR = 85
 CANONICAL_POSITIONING_DOCS = tuple(
     REPO_ROOT / relative_path
     for relative_path in (
@@ -83,6 +88,23 @@ def test_default_pytest_discovery_includes_top_level_contract_tests() -> None:
 
 def test_default_pytest_pythonpath_includes_base_package_roots() -> None:
     assert pytest_config_list("pythonpath") == ["lib/python", "cli/python"]
+
+
+def test_python_coverage_policy_is_wired_and_documented() -> None:
+    requirements = DEV_REQUIREMENTS.read_text(encoding="utf-8")
+    workflow = TESTS_WORKFLOW.read_text(encoding="utf-8")
+    coverage_config = COVERAGE_CONFIG.read_text(encoding="utf-8")
+    testing_doc = TESTING_DOC.read_text(encoding="utf-8")
+
+    assert "pytest-cov==7.1.0" in requirements
+    assert "--cov=cli/python" in workflow
+    assert "--cov-report=term-missing" in workflow
+    assert f"--cov-fail-under={PYTHON_COVERAGE_FLOOR}" in workflow
+    assert "source =\n    cli/python" in coverage_config
+    assert "cli/python/**/tests/*" in coverage_config
+    assert f"--cov-fail-under={PYTHON_COVERAGE_FLOOR}" in testing_doc
+    assert f"{PYTHON_COVERAGE_FLOOR}%" in testing_doc
+    assert "Bash/BATS" in testing_doc
 
 
 def test_active_project_guidance_uses_repo_named_project_language() -> None:


### PR DESCRIPTION
## Summary

- add pinned pytest-cov and a production-source .coveragerc
- report Python coverage in CI and fail below the documented 85% floor
- document the baseline, exclusions, rationale, and Bash/BATS follow-up
- add a contract test so the coverage policy cannot silently drift

Measured locally: 937 passed, 1 skipped, 87.30% coverage.

Closes #1831