### PR TITLE
Report incompatible base-cli providers clearly

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -100,6 +100,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   provided, project manifest artifacts with suggested fixes.
 - `basectl doctor explain <finding-id>` prints local, deterministic guidance
   for selected stable finding IDs, with optional JSON output.
+- Base's extracted adapters require a `base-cli` provider that exports
+  `base_cli.command_protocol.register_record_schema`. If setup reports an
+  incompatible provider, upgrade `base-cli` or set `BASE_CLI_SOURCE_DIR` to a
+  compatible source checkout before retrying the command.
 - `basectl gh` manages GitHub authentication, issues, pull requests, branch naming, repository
   hygiene, and GitHub Project metadata using Base's opinionated workflow. It
   uses standard GitHub-style issue categories such as `bug`, `enhancement`,

--- a/cli/python/base_cli_adapters/protocol.py
+++ b/cli/python/base_cli_adapters/protocol.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from base_cli.command_protocol import BOOLEAN
-from base_cli.command_protocol import CommandProtocolError
-from base_cli.command_protocol import FieldSpec
-from base_cli.command_protocol import NULLABLE_STRING
-from base_cli.command_protocol import STRING
-from base_cli.command_protocol import dumps_record as _dumps_record
-from base_cli.command_protocol import dumps_records as _dumps_records
-from base_cli.command_protocol import loads_records as _loads_records
-from base_cli.command_protocol import register_record_schema
-from base_cli.command_protocol import RECORD_SCHEMAS as _registered_schemas
+from .provider import load_command_protocol
+
+
+_command_protocol = load_command_protocol()
+BOOLEAN = _command_protocol.BOOLEAN
+CommandProtocolError = _command_protocol.CommandProtocolError
+FieldSpec = _command_protocol.FieldSpec
+NULLABLE_STRING = _command_protocol.NULLABLE_STRING
+STRING = _command_protocol.STRING
+_dumps_record = _command_protocol.dumps_record
+_dumps_records = _command_protocol.dumps_records
+_loads_records = _command_protocol.loads_records
+register_record_schema = _command_protocol.register_record_schema
+_registered_schemas = _command_protocol.RECORD_SCHEMAS
 
 
 BASE_PROTOCOL_HEADER = "BASE_COMMAND_PROTOCOL_V1"

--- a/cli/python/base_cli_adapters/provider.py
+++ b/cli/python/base_cli_adapters/provider.py
@@ -1,0 +1,59 @@
+"""Compatibility checks for the extracted Base CLI provider."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+
+REQUIRED_COMMAND_PROTOCOL_SYMBOLS = (
+    "BOOLEAN",
+    "CommandProtocolError",
+    "FieldSpec",
+    "NULLABLE_STRING",
+    "STRING",
+    "dumps_record",
+    "dumps_records",
+    "loads_records",
+    "register_record_schema",
+    "RECORD_SCHEMAS",
+)
+
+
+class BaseCliCompatibilityError(ImportError):
+    """Raised when the installed base-cli provider cannot serve Base."""
+
+
+def load_command_protocol() -> ModuleType:
+    """Load the provider protocol or explain how to repair an incompatible one."""
+
+    try:
+        command_protocol = import_module("base_cli.command_protocol")
+    except ImportError as exc:
+        raise BaseCliCompatibilityError(
+            "Base requires a compatible base-cli provider with "
+            "base_cli.command_protocol. Install or upgrade base-cli, or set "
+            "BASE_CLI_SOURCE_DIR to a compatible source checkout."
+        ) from exc
+
+    missing = [
+        name
+        for name in REQUIRED_COMMAND_PROTOCOL_SYMBOLS
+        if not hasattr(command_protocol, name)
+    ]
+    if missing:
+        names = ", ".join(missing)
+        raise BaseCliCompatibilityError(
+            "The installed base-cli provider is incompatible with Base: "
+            f"base_cli.command_protocol is missing {names}. Install or upgrade "
+            "base-cli, or set BASE_CLI_SOURCE_DIR to a compatible source checkout."
+        )
+
+    return command_protocol
+
+
+__all__ = [
+    "BaseCliCompatibilityError",
+    "REQUIRED_COMMAND_PROTOCOL_SYMBOLS",
+    "load_command_protocol",
+]

--- a/cli/python/base_cli_adapters/tests/test_provider.py
+++ b/cli/python/base_cli_adapters/tests/test_provider.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import patch
+
+from base_cli_adapters.provider import BaseCliCompatibilityError
+from base_cli_adapters.provider import load_command_protocol
+
+
+class BaseCliProviderTests(TestCase):
+    def test_compatible_provider_loads(self) -> None:
+        command_protocol = load_command_protocol()
+
+        self.assertTrue(hasattr(command_protocol, "register_record_schema"))
+
+    def test_missing_provider_has_actionable_error(self) -> None:
+        with patch(
+            "base_cli_adapters.provider.import_module",
+            side_effect=ModuleNotFoundError("No module named 'base_cli'"),
+        ):
+            with self.assertRaisesRegex(
+                BaseCliCompatibilityError,
+                "Install or upgrade base-cli.*BASE_CLI_SOURCE_DIR",
+            ):
+                load_command_protocol()
+
+    def test_missing_protocol_capability_has_actionable_error(self) -> None:
+        command_protocol = ModuleType("base_cli.command_protocol")
+
+        with patch(
+            "base_cli_adapters.provider.import_module",
+            return_value=command_protocol,
+        ):
+            with self.assertRaisesRegex(
+                BaseCliCompatibilityError,
+                "missing .*register_record_schema",
+            ):
+                load_command_protocol()


### PR DESCRIPTION
## What changed

- add a shared Base CLI provider capability loader
- report missing command-protocol symbols with upgrade/source-checkout guidance
- cover compatible, missing, and incompatible provider cases
- document the extracted provider contract

## Why

Base previously surfaced a raw import error when an installed base-cli distribution was stale. Setup and command failures now identify the missing capability and the supported remediation.

## Validation

- PYTHONPATH=<base-cli source>:<Base source> python -m pytest cli/python/base_cli_adapters/tests/test_provider.py -q
- git diff --check
- full-suite collection with the ambient stale provider reproduces the incompatibility; the controlled source provider removes it

Fixes #1853