### PR TITLE
ci: bump base-cli to published 0.2.0 (#1851)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pylint==3.3.9
 click==8.4.1
-base-cli==0.1.0
+base-cli==0.2.0
 PyYAML==6.0.3
 pytest==9.0.3
 pytest-cov==7.1.0


### PR DESCRIPTION
Closes #1851

Update `requirements-dev.txt` from the stale `base-cli==0.1.0` pin to the published `base-cli==0.2.0` release.

Validation:
- Published `base-cli==0.2.0` verified from PyPI
- Clean isolated install exposes `CliProfile`, `register_record_schema`, and `CommandFilterNormalizer`
- Base CI will validate the full installed-provider path