### PR TITLE
Polish AI context for bootstrap ensure-bash behavior

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -19,6 +19,13 @@ reusable-layer DEBUG diagnostics.
 
 ## Current Public Commands
 
+- `bootstrap.sh` - first-mile installer/repair script used before `basectl`
+  may be available. `bootstrap.sh --ensure-bash --dry-run` previews the
+  supported Bash 4.2+ repair path, and `bootstrap.sh --ensure-bash --yes`
+  applies only that Bash prerequisite: Homebrew `bash` on macOS, or
+  `sudo apt-get update` plus `sudo apt-get install -y bash` on Ubuntu/Debian.
+  It does not clone Base, install Python, create virtualenvs, install developer
+  tools, or run project setup.
 - `basectl activate <project>` - start an interactive Base Bash runtime shell
   for a project.
 - `basectl setup [project]` - install and bootstrap the local Base CLI

--- a/.ai-context/DECISIONS.md
+++ b/.ai-context/DECISIONS.md
@@ -61,6 +61,11 @@ architecture discussion.
   overrides require paired URL/SHA-256 values and execute the verified bytes.
   First-mile Homebrew installers stay independent of Python and are aligned by
   contract tests.
+- Supported Bash installation is first-mile Base bootstrap behavior, not a
+  reusable `base-bash-libs` responsibility. `bootstrap.sh --ensure-bash`
+  repairs only the Bash 4.2+ prerequisite, using Homebrew on macOS and apt on
+  Ubuntu/Debian, while `base-bash-libs` remains passive with version checks and
+  recovery guidance only.
 
 ## Activation And Environment
 

--- a/.ai-context/INDEX.md
+++ b/.ai-context/INDEX.md
@@ -23,6 +23,8 @@ below when precise detail matters:
 - `docs/product-assessment.md` - maintained evidence-backed product review.
 - `docs/product-requirements.md` - accepted product intent, target users,
   durable requirements, non-goals, and PRD maintenance rules.
+- `docs/bootstrap.md` - first-mile bootstrap behavior, including the targeted
+  supported-Bash repair path.
 - `docs/architecture.md` - product direction, command model, environment model,
   and repository conventions.
 - `docs/execution-model.md` - `basectl` runtime and dispatch contract.

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -10,6 +10,8 @@ only during release-prep PRs, not on every ordinary PR.
 The current command surface covers:
 
 - setup and first-mile bootstrap
+- targeted first-mile Bash 4.2+ repair through `bootstrap.sh --ensure-bash`
+  without cloning Base or running full setup
 - checks and doctor diagnostics
 - project discovery
 - project activation
@@ -72,6 +74,8 @@ Recent released work includes:
   apt-backed setup behind explicit `--dry-run` / `--yes` confirmation, and
   policy-governed uv/mise CLI bootstrap with explicit consent and optional
   managed checksum verification
+- targeted `bootstrap.sh --ensure-bash` support for Mac and Ubuntu/Debian Bash
+  4.2+ repair before the normal `basectl setup` path can run
 - `basectl docs` for opening the GitHub README documentation entrypoint
 - standardized `basectl` help, option, logging, and usage-error behavior
 - Python-backed CI setup JSON rendering and Project issue-default handling


### PR DESCRIPTION
## Summary

- document `bootstrap.sh --ensure-bash` in the AI command surface
- capture the Base vs. `base-bash-libs` ownership decision for supported Bash installation
- point future AI context readers at `docs/bootstrap.md` for first-mile bootstrap behavior

## Issue

Closes #1865

## Validation

- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest /Users/rameshhp/work/base/tests/test_bootstrap_docs.py -q`
- `git diff --check --cached`