### PR TITLE
Make check result writes safe for concurrent checks

### DIFF
--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -265,9 +266,22 @@ def render_check_record(project: str, status: str, checked_at: str) -> str:
 
 def write_check_record(path: Path, project: str, status: str, checked_at: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_name(f"{path.name}.tmp")
-    temp_path.write_text(render_check_record(project, status, checked_at), encoding="utf-8")
-    temp_path.replace(path)
+    record = render_check_record(project, status, checked_at)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temp_file:
+        temp_file.write(record)
+        temp_path = Path(temp_file.name)
+
+    try:
+        temp_path.replace(path)
+    finally:
+        temp_path.unlink(missing_ok=True)
 
 
 def diagnostic_check(name: str, status: str, message: str, fix: str = "") -> DiagnosticCheck:

--- a/cli/python/base_setup/tests/test_diagnostics_payloads.py
+++ b/cli/python/base_setup/tests/test_diagnostics_payloads.py
@@ -4,7 +4,9 @@ import io
 import json
 import os
 import tempfile
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
@@ -85,6 +87,31 @@ class DiagnosticsPayloadTests(unittest.TestCase):
             self.assertEqual(status, 0)
             self.assertTrue(output_path.exists())
             self.assertFalse((cache_root / "cli" / "base_setup.diagnostics").exists())
+
+    def test_write_check_record_is_safe_for_concurrent_writers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "last.json"
+            render = diagnostics.render_check_record
+
+            def slow_render(project: str, status: str, checked_at: str) -> str:
+                time.sleep(0.005)
+                return render(project, status, checked_at)
+
+            def write_record(index: int) -> None:
+                diagnostics.write_check_record(
+                    path,
+                    project=f"demo-{index}",
+                    status="ok",
+                    checked_at="2026-06-28T12:00:00Z",
+                )
+
+            with mock.patch.object(diagnostics, "render_check_record", side_effect=slow_render):
+                with ThreadPoolExecutor(max_workers=8) as executor:
+                    list(executor.map(write_record, range(32)))
+
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "ok")
+            self.assertFalse(list(Path(tmpdir).glob(".last.json.*.tmp")))
 
     def test_render_base_check_payload_merges_embedded_statuses(self) -> None:
         payload_text = render_base_check_payload(


### PR DESCRIPTION
Fixes #1868

## What changed

- Replace the shared `last.json.tmp` path with a unique temporary file in the destination directory.
- Keep the final `replace` atomic and remove temporary files even when replacement fails.
- Add a concurrent-writer regression test.

## Why

Concurrent `check` or `record-check` processes raced on the fixed temporary path, causing intermittent `FileNotFoundError` failures and risking incomplete diagnostic records.

## Impact

The check record format and destination are unchanged. Concurrent writers now safely publish complete records; the last completed writer still determines the final record.

## Checks

- Full Python suite: 944 passed, 1 skipped, 248 subtests passed
- Focused diagnostics regression passed
- ShellCheck and `git diff --check` passed