### PR TITLE
Fix user-local uv and mise command runners

### DIFF
--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -167,6 +167,13 @@ base_project_run_shell_command() {
         # A project command gets its own owner-scoped bundle. Keep the parent
         # history ID, but do not let it write raw logs into Base's bundle.
         unset BASE_CLI_RUN_ROOT BASE_CLI_RUN_ID BASE_CLI_PRIMARY_LOG
+        # setup and diagnostics also recognize user-local tool installs. Keep
+        # the project environment first, then make $HOME/.local/bin available
+        # for runners such as uv and mise.
+        if [[ -n "${HOME:-}" ]]; then
+            PATH="${PATH:+$PATH:}$HOME/.local/bin"
+            export PATH
+        fi
         cd "$working_dir" && bash -c "$command_to_run" "$command_name" "$@"
     )
 }
@@ -179,9 +186,10 @@ base_validate_command_runner() {
             return 0
             ;;
         uv)
-            command -v uv >/dev/null 2>&1 || {
-                fatal_error "Command runner 'uv' is not available. Install uv or remove runner: uv from the project manifest."
-            }
+            if command -v uv >/dev/null 2>&1 || [[ -n "${HOME:-}" && -x "$HOME/.local/bin/uv" ]]; then
+                return 0
+            fi
+            fatal_error "Command runner 'uv' is not available. Install uv or remove runner: uv from the project manifest."
             ;;
         *)
             fatal_error "Unsupported command runner '$runner'."

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -41,12 +41,12 @@ EOF
     [[ "$(cat "$state_file")" == *"path=$workspace/demo/.venv/bin:"* ]]
 }
 
-@test "basectl run routes uv runner commands through uv" {
+@test "basectl run routes uv runner commands through user-local uv" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
     local state_file="$TEST_TMPDIR/run-state"
 
-    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin" "$TEST_HOME/.local/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "audit" ]]; then
@@ -58,7 +58,7 @@ fi
 printf 'unexpected run python args: %s\n' "$*" >&2
 exit 1
 EOF
-    cat > "$workspace/demo/.venv/bin/uv" <<'EOF'
+    cat > "$TEST_HOME/.local/bin/uv" <<'EOF'
 #!/usr/bin/env bash
 {
     printf 'pwd=%s\n' "$PWD"
@@ -67,7 +67,7 @@ EOF
     printf '\n'
 } > "${BASE_TEST_RUN_STATE:?}"
 EOF
-    chmod +x "$python_bin" "$workspace/demo/.venv/bin/uv"
+    chmod +x "$python_bin" "$TEST_HOME/.local/bin/uv"
     printf 'project:\n  name: demo\ncommands:\n  audit:\n    command: pytest tests/audit\n    runner: uv\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     workspace="$(cd "$workspace" && pwd -P)"
 
@@ -235,11 +235,12 @@ fi
 printf 'unexpected run python args: %s\n' "$*" >&2
 exit 1
 EOF
-    cat > "$workspace/demo/.venv/bin/mise" <<'EOF'
+    mkdir -p "$TEST_HOME/.local/bin"
+    cat > "$TEST_HOME/.local/bin/mise" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "${BASE_TEST_RUN_STATE:?}"
 EOF
-    chmod +x "$python_bin" "$workspace/demo/.venv/bin/mise"
+    chmod +x "$python_bin" "$TEST_HOME/.local/bin/mise"
     printf 'project:\n  name: demo\ncommands:\n  dev: mise run dev\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
     workspace="$(cd "$workspace" && pwd -P)"
 


### PR DESCRIPTION
Fixes #1867

## What changed

- Make project command subshells include `$HOME/.local/bin` after the activated project environment.
- Let the `uv` runner validator recognize an executable installed only in that user-local directory.
- Add BATS coverage for user-local-only `uv` and `mise` installations.

## Why

Setup and diagnostics already support user-local `uv` and `mise` installs, but project command validation and execution depended on the inherited `PATH`. That made supported installations appear unavailable.

## Impact

The project virtual environment remains first in `PATH`; user-local tools are available as a fallback. No command syntax or manifest format changes.

## Checks

- `env -u BASE_HOME ... ./bin/base-test`
- 943 Python tests passed, 1 skipped
- 851 BATS tests passed
- ShellCheck and `git diff --check` passed