### PR TITLE
ci: pin Base to published base-cli v0.4.0

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .base/base-cli
 
       - name: Set up Python

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Set up Python

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Set up Python
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -281,7 +281,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Expose reusable Bash library checkout as sibling
@@ -343,7 +343,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: 9f3ed25fc0991e3aa9de8411878805c122f90a11
+          ref: v0.4.0
           path: .dependencies/base-cli
 
       - name: Set up Python


### PR DESCRIPTION
Closes #1877.\n\nNow that base-cli 0.4.0 is published on PyPI, replace the temporary release-candidate commit in every Base CI source checkout with the immutable v0.4.0 tag.\n\nValidation: targeted workflow-policy tests pass locally; the full Base CI matrix will run against the published tag.