### PR TITLE
fix(runtime): accept prerelease base-bash-libs versions

### DIFF
--- a/base_init.sh
+++ b/base_init.sh
@@ -295,22 +295,31 @@ base_init_source_stdlib() {
     }
 }
 
+base_init_bash_libs_version_is_supported() {
+    local version="${1:-}"
+
+    [[ "$version" =~ ^1[.][0-9]+[.][0-9]+$ ||
+        "$version" =~ ^2[.][0-9]+[.][0-9]+(-(alpha|beta|rc)[.](0|[1-9][0-9]*))?$ ]]
+}
+
 base_init_require_bash_libs_version() {
     local loaded_version="${BASE_BASH_LIBS_VERSION:-}"
 
+    if ! base_init_bash_libs_version_is_supported "$loaded_version"; then
+        base_init_error "Base requires base-bash-libs 1.4.0 or a compatible release with the v2 API; loaded version is '$loaded_version'."
+        return 1
+    fi
+
     case "$loaded_version" in
-        1.*|2.*)
-            # The v2 namespace landed before the coordinated v2 release. Keep
-            # the source checkout usable while the release train is completed;
-            # the final cutover will raise this floor to 2.0.0.
+        1.*)
             if ! base_require_version 1.4.0; then
                 base_init_error "Base requires base-bash-libs 1.4.0 or newer; loaded version is '$loaded_version'."
                 return 1
             fi
             ;;
-        *)
-            base_init_error "Base requires base-bash-libs 1.4.0 or a compatible release with the v2 API; loaded version is '$loaded_version'."
-            return 1
+        2.*)
+            # The v2 API is valid during the coordinated prerelease and GA
+            # window. Do not pass its prerelease form to the v1 numeric helper.
             ;;
     esac
 }

--- a/tests/base_init.bats
+++ b/tests/base_init.bats
@@ -71,9 +71,10 @@ EOF
 }
 
 @test "base_init exports the Base runtime path contract" {
-    local expected_bash_libs_dir
+    local expected_bash_libs_dir expected_bash_libs_version
 
     expected_bash_libs_dir="$(cd "$TEST_TMPDIR/base-bash-libs/lib/bash" && pwd -P)"
+    expected_bash_libs_version="$(<"$TEST_TMPDIR/base-bash-libs/VERSION")"
 
     run_base_init_script '
         base_home="$1"
@@ -101,7 +102,7 @@ EOF
     [[ "$output" == *"BASE_BASH_LIB_DIR=$TEST_BASE_HOME/lib/bash"* ]]
     [[ "$output" == *"BASE_BASH_LIBS_DIR=$expected_bash_libs_dir"* ]]
     [[ "$output" == *"BASE_BASH_LIBS_SOURCE=sibling"* ]]
-    [[ "$output" == *"BASE_BASH_LIBS_VERSION=1.4.0"* ]]
+    [[ "$output" == *"BASE_BASH_LIBS_VERSION=$expected_bash_libs_version"* ]]
     [[ "$output" == *"BASE_SHELL_DIR=$TEST_BASE_HOME/lib/shell"* ]]
 }
 
@@ -118,15 +119,36 @@ EOF
     [[ "$output" == *"loaded version is '1.2.0'"* ]]
 }
 
-@test "base_init accepts the v2 base-bash-libs namespace during the cutover" {
-    printf '2.0.0\n' > "$TEST_TMPDIR/base-bash-libs/VERSION"
+@test "base_init accepts v2 prerelease and GA base-bash-libs versions" {
+    local version
 
-    run_base_init_script '
-        base_home="$1"
-        source "$base_home/base_init.sh"
-    '
+    for version in 2.0.0-alpha.1 2.0.0-beta.2 2.0.0-rc.1 2.0.0; do
+        printf '%s\n' "$version" > "$TEST_TMPDIR/base-bash-libs/VERSION"
 
-    [ "$status" -eq 0 ]
+        run_base_init_script '
+            base_home="$1"
+            source "$base_home/base_init.sh"
+        '
+
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "base_init rejects malformed v2 prerelease versions" {
+    local version
+
+    for version in 2.0.0-rc 2.0.0-gamma.1 3.0.0; do
+        printf '%s\n' "$version" > "$TEST_TMPDIR/base-bash-libs/VERSION"
+
+        run_base_init_script '
+            base_home="$1"
+            source "$base_home/base_init.sh"
+        '
+
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"loaded version is '$version'"* ]]
+        [[ "$output" != *"base_require_version expects dotted numeric versions"* ]]
+    done
 }
 
 @test "base_init preserves explicit symlinked BASE_HOME paths" {


### PR DESCRIPTION
## Summary

- Make Base validate `BASE_BASH_LIBS_VERSION` before invoking the strict v1 dotted-numeric minimum-version helper.
- Accept v2 alpha, beta, RC, and GA forms while preserving the v1.4+ minimum check.
- Add regression coverage for accepted and malformed prerelease versions and make the fixture version assertion follow the active library fixture.

## Issue

Closes #1882

## Validation

- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/base_init.bats` (22 passed)
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python env -u BASE_HOME ./bin/base-test` (944 pytest passed, 1 skipped; 852 Bats passed)
- `BASE_BASH_LIBS_DIR=/private/tmp/base-bash-libs-rc-review.KKiigr/base-bash-libs-2.0.0-rc.1/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python env -u BASE_HOME ./bin/basectl help` (passed)
- `git diff --check` (passed)

## Demo Impact

None. This is a runtime bootstrap compatibility fix with regression coverage.

## Notes

- The fix is Base-local; no compatibility shim or parser change was added to base-bash-libs.
- `.ai-context/` unchanged: this preserves the existing runtime contract and only corrects prerelease parsing.
