### PR TITLE
Report missing project venv without a fatal trace

### DIFF
--- a/cli/bash/commands/basectl/subcommands/activate.sh
+++ b/cli/bash/commands/basectl/subcommands/activate.sh
@@ -127,9 +127,10 @@ base_activate_subcommand_main() {
 
     venv_dir="$(base_activate_project_venv_dir "$resolved_name" "$project_root" "$route_venv_dir")"
     venv_fix="$(base_project_venv_fix "$resolved_name" "$project_root" "$venv_dir" "$uses_uv_manager")"
-    [[ -x "$venv_dir/bin/python" ]] || {
-        base_std_fatal_error "Project virtual environment Python was not found at '$venv_dir/bin/python'. $venv_fix"
-    }
+    if [[ ! -x "$venv_dir/bin/python" ]]; then
+        base_std_log_error "Project virtual environment Python was not found at '$venv_dir/bin/python'. $venv_fix"
+        return 1
+    fi
 
     shell_rc="$BASE_HOME/lib/bash/runtime/bashrc"
     [[ -f "$shell_rc" ]] || base_std_fatal_error "Base runtime shell rcfile '$shell_rc' was not found."

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -388,6 +388,8 @@ EOF
     [[ "$output" == *"Project virtual environment Python was not found at '$workspace/demo/.venv/bin/python'."* ]]
     [[ "$output" == *"Run 'uv sync' in '$workspace/demo' first."* ]]
     [[ "$output" != *"Run 'basectl setup demo' first."* ]]
+    [[ "$output" != *"FATAL"* ]]
+    [[ "$output" != *"Encountered a fatal error"* ]]
 }
 
 @test "basectl default runtime shell preserves caller working directory" {


### PR DESCRIPTION
Fixes #1884

## What changed

- Report a missing project virtual environment through the normal error logger during activation.
- Preserve the nonzero exit status and uv-specific remediation.
- Add regression assertions that the expected missing-venv path emits no fatal marker or stack-trace header.

## Root cause

Activation used the shared fatal helper for a user-actionable first-run prerequisite. That helper intentionally emits a Bash stack trace, making a missing uv environment look like an internal failure.

## Validation

- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/activate.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/project-command-helpers.bats`
- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash ./bin/base-test` (944 passed, 1 skipped; 852 BATS passed)
- Real missing-venv activation repro