### PR TITLE
Align Base with base-cli 0.4.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pylint==3.3.9
 click==8.4.1
-base-cli==0.4.0
+base-cli==0.4.1
 PyYAML==6.0.3
 pytest==9.0.3
 pytest-cov==7.1.0


### PR DESCRIPTION
## Summary

- align Base's development/runtime provider pin with `base-cli==0.4.1`
- keep Base's standalone provider boundary unchanged

## Why

The current Base checkout pins `base-cli==0.4.0`, while the released provider
is `0.4.1`. Updating the pin keeps Base's validation environment aligned with
the provider consumed by downstream projects.

## Validation

- `BASE_CACHE_DIR=/private/tmp/base-cli041-base-cache BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python ./bin/base-test`
- `git diff --check`
- result: `944 passed, 1 skipped`

Related downstream work: basefoundry/base-demo#205

Closes #1896
