### PR TITLE
fix(history): preserve complete log paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
   rendered final summaries as INFO logs.
 - Made `basectl history --command` accept comma-separated command filters with
   the same normalization and validation as `basectl logs --command`.
+- Preserved complete `basectl history` log paths, including filenames, in
+  interactive terminal tables.
 - Replaced the generic setup-only summary after failed checks with guidance to
   follow each finding's fix and rerun the check; activation-backed environment
   checks now mention project activation.

--- a/cli/python/base_history/engine.py
+++ b/cli/python/base_history/engine.py
@@ -358,11 +358,15 @@ def filter_history(records: list[HistoryRecord], options: HistoryOptions) -> lis
 def print_history_table(records: list[HistoryRecord], *, local_time: bool = False) -> None:
     time_label = "TIME (LOCAL)" if local_time else "TIME (UTC)"
     columns = ((time_label, "time"), *history_output_columns()[1:])
+    output_records = history_output_records(records, local_time=local_time)
+    minimum_widths = (19, 12, 12, 6, 4)
     base_cli.render_records(
-        history_output_records(records, local_time=local_time),
+        output_records,
         requested_format="text",
         columns=columns,
-        minimum_widths=(19, 12, 12, 6, 4),
+        minimum_widths=minimum_widths,
+        max_cell_width=None,
+        terminal_width=history_table_width(output_records, columns, minimum_widths),
     )
 
 
@@ -389,6 +393,21 @@ def history_output_records(records: list[HistoryRecord], *, local_time: bool = F
         }
         for record in records
     ]
+
+
+def history_table_width(
+    records: list[dict[str, Any]],
+    columns: tuple[tuple[str, str], ...],
+    minimum_widths: tuple[int, ...],
+) -> int:
+    """Return enough width for the history table without truncating log paths."""
+
+    widths = []
+    for index, (header, key) in enumerate(columns):
+        values = [str(record.get(key, "")) for record in records]
+        minimum_width = minimum_widths[index] if index < len(minimum_widths) else 0
+        widths.append(max(len(header), minimum_width, *(len(value) for value in values)))
+    return sum(widths) + 2 * (len(columns) - 1)
 
 
 def display_time(record: HistoryRecord, *, local_time: bool = False) -> str:

--- a/cli/python/base_history/tests/test_engine.py
+++ b/cli/python/base_history/tests/test_engine.py
@@ -122,6 +122,10 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertTrue(engine.display_log_path(records[0]).endswith(" (missing)"))
 
     def test_text_table_expands_columns_for_long_command_and_project(self) -> None:
+        long_log_path = (
+            "~/Library/Caches/base/base/runs/20260807T202523_89174_22512__onboard__base-demo/"
+            "logs/primary.log"
+        )
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_root = Path(tmpdir)
             write_history_line(
@@ -131,7 +135,7 @@ class BaseHistoryTests(unittest.TestCase):
                     "export-context",
                     project="base-bash-libs",
                     ended_at="2026-06-10T10:16:00Z",
-                    log_path="~/logs/long.log",
+                    log_path=long_log_path,
                 ),
             )
             write_history_line(
@@ -149,11 +153,13 @@ class BaseHistoryTests(unittest.TestCase):
         self.assertEqual((status, stderr), (0, ""))
         lines = stdout.splitlines()
         log_column = lines[0].index("LOG")
-        self.assertEqual(next(line for line in lines if "~/logs/long.log" in line).index("~/logs/long.log"), log_column)
+        self.assertEqual(next(line for line in lines if long_log_path in line).index(long_log_path), log_column)
         self.assertEqual(
             next(line for line in lines if "~/logs/short.log" in line).index("~/logs/short.log"),
             log_column,
         )
+        self.assertIn(long_log_path, stdout)
+        self.assertNotIn("…", stdout)
 
     def test_local_time_changes_text_label_but_json_remains_canonical(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- preserve complete `LOG` paths, including filenames, in interactive `basectl history` tables
- add regression coverage for a realistic long cache path

## Root cause

The shared terminal renderer applies an 80-column cell cap and fits tables to the detected terminal width. History log paths are actionable output, so that compact presentation hid the filename behind an ellipsis.

## Validation

- `cli/python/base_history/tests/test_engine.py` and `cli/python/base_history/tests/test_display.py`: 22 passed
- touched-file Pylint: passed
- `./bin/base-test`: 944 passed, 1 skipped; 852 Bats passed
- `git diff --check`: passed

## Notes

No `.ai-context` update is needed; this is an internal presentation fix with no command-surface or architecture change.

Closes #1899
