### PR TITLE
Remove unused uncached project discovery path

### DIFF
--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -32,12 +32,6 @@ def current_project() -> Project:
     return read_project(manifest_path)
 
 
-def discover_projects(workspace_root: Path) -> tuple[Project, ...]:
-    entries = workspace_manifest_entries(workspace_root)
-    projects = tuple(read_project(entry.path) for entry in entries)
-    return validate_unique_project_names(tuple(sorted(projects)))
-
-
 def discover_projects_cached(ctx: base_cli.Context, workspace_root: Path) -> tuple[Project, ...]:
     start = time.perf_counter()
     entries = workspace_manifest_entries(workspace_root)
@@ -63,11 +57,6 @@ def discover_projects_cached(ctx: base_cli.Context, workspace_root: Path) -> tup
         elapsed_ms,
     )
     return projects
-
-
-def find_project(workspace_root: Path, project_name: str) -> Project:
-    projects = discover_projects(workspace_root)
-    return find_project_in_projects(projects, workspace_root, project_name)
 
 
 def find_project_in_projects(projects: tuple[Project, ...], workspace_root: Path, project_name: str) -> Project:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -387,14 +387,16 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertIn("workspace must be a mapping", stderr)
         self.assertNotIn("Traceback", stderr)
 
-    def test_discovers_projects_under_workspace_root(self) -> None:
+    def test_cached_project_discovery_sorts_projects(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
             write_manifest(workspace / "zeta", "zeta")
             write_manifest(workspace / "alpha", "alpha")
             (workspace / "notes").mkdir()
 
-            projects = project_discovery.discover_projects(workspace)
+            ctx = mock.Mock()
+            ctx.dry_run = True
+            projects = project_discovery.discover_projects_cached(ctx, workspace)
 
         self.assertEqual([project.name for project in projects], ["alpha", "zeta"])
 
@@ -1842,14 +1844,16 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn("project must be a mapping", stderr)
 
-    def test_projects_list_rejects_duplicate_project_names(self) -> None:
+    def test_cached_project_discovery_rejects_duplicate_project_names(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
             write_manifest(workspace / "one", "demo")
             write_manifest(workspace / "two", "demo")
 
             with self.assertRaisesRegex(engine.ProjectDiscoveryError, "Duplicate project names"):
-                project_discovery.discover_projects(workspace)
+                ctx = mock.Mock()
+                ctx.dry_run = True
+                project_discovery.discover_projects_cached(ctx, workspace)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Remove the unused uncached project-discovery and lookup helpers.
- Keep sorting and duplicate-name coverage on the production cached discovery path.

## Validation

- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_engine.py -q`
- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_projects/project_discovery.py cli/python/base_projects/tests/test_engine.py`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python ./bin/base-test`
- `git diff --check`

`basectl test base` was also checked in dry-run mode; the normal command requires local manifest trust, so the same declared `./bin/base-test` command was run directly.

## AI Context

Unchanged: this is an internal dead-code removal with no product, workflow, or architectural change.

Fixes #1892
