### PR TITLE
Fix Debian GitHub CLI finding ID

### DIFF
--- a/cli/python/base_dev/linux_profile.py
+++ b/cli/python/base_dev/linux_profile.py
@@ -84,7 +84,7 @@ def check_linux_debian_github_cli_artifact(
             ok=True,
             message="GitHub CLI 'gh' is installed; authentication remains user-owned.",
             fix="",
-            finding_id="BASE-D107",
+            finding_id="BASE-D011",
         )
     return DevCheck(
         name=artifact.name,
@@ -94,7 +94,7 @@ def check_linux_debian_github_cli_artifact(
             "Debian/Ubuntu apt repository."
         ),
         fix=profile_setup_fix(profile),
-        finding_id="BASE-D107",
+        finding_id="BASE-D011",
     )
 
 

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -555,7 +555,7 @@ class DevManifestTests(unittest.TestCase):
         )
         self.assertIn(
             {
-                "id": "BASE-D107",
+                "id": "BASE-D011",
                 "status": "error",
                 "name": "gh",
                 "message": (

--- a/cli/python/base_setup/tests/test_finding_explanations.py
+++ b/cli/python/base_setup/tests/test_finding_explanations.py
@@ -49,6 +49,16 @@ class FindingExplanationTests(unittest.TestCase):
         self.assertGreaterEqual(len(payload["related_commands"]), 1)
         self.assertEqual(payload["docs"][0]["path"], "docs/doctor-findings.md#base-runtime-findings")
 
+    def test_linux_github_cli_id_renders_its_matching_explanation(self) -> None:
+        status, stdout, stderr = invoke(["BASE-D011", "--format", "json"])
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertTrue(payload["found"])
+        self.assertEqual(payload["id"], "BASE-D011")
+        self.assertEqual(payload["title"], "GitHub CLI availability on Ubuntu/Debian")
+
     def test_unknown_id_fails_with_clear_text_guidance(self) -> None:
         status, stdout, stderr = invoke(["BASE-X999"])
 


### PR DESCRIPTION
## Summary

Correct the Ubuntu/Debian GitHub CLI diagnostic to emit `BASE-D011`, the finding ID whose explanation describes that condition. The unrelated AI developer-tool diagnostic remains `BASE-D107`.

## Issue

Fixes #1889

## Validation

- `PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_dev/tests/test_engine.py cli/python/base_setup/tests/test_finding_explanations.py` (63 passed)
- `PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc cli/python/base_dev/linux_profile.py cli/python/base_dev/tests/test_engine.py cli/python/base_setup/tests/test_finding_explanations.py`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-v180-small-fixes ./bin/base-test` (945 passed, 1 skipped)
- `basectl doctor explain BASE-D011 --format json` smoke test

## Demo Impact

None.

## Notes

`.ai-context/` is unchanged because this is a narrow correction to an existing stable diagnostic mapping, not a product-shape or workflow change.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Relevant Python tests and lint pass.
- [x] Bug fix includes regression proof.
- [x] Documentation changes are not needed.
- [x] AI context is not applicable.
- [x] PR includes `Fixes #1889`.
- [x] Demo impact is explicitly stated.
