### PR TITLE
Reuse parsed manifests in workspace trust status

### DIFF
--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -14,6 +14,7 @@ from base_projects.project_discovery import discover_projects_cached
 from base_projects.project_discovery import read_project
 from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 from .trust_store import ALLOWED_COMMANDS  # pylint: disable=unused-import
 from .trust_store import SCHEMA_VERSION
@@ -22,12 +23,14 @@ from .trust_store import ManifestCommandTrustIdentity
 from .trust_store import ManifestCommandTrustStore
 from .trust_store import TrustStatus
 from .trust_store import compute_identity_key  # pylint: disable=unused-import
+from .trust_store import compute_trust_identity
 from .trust_store import compute_trust_identity_for_manifest
 from .trust_store import git_head  # pylint: disable=unused-import
 from .trust_store import git_origin  # pylint: disable=unused-import
 from .trust_store import git_repository_root  # pylint: disable=unused-import
 from .trust_store import identity_key_from_record  # pylint: disable=unused-import
 from .trust_store import manifest_command_surfaces
+from .trust_store import manifest_command_surfaces_from_manifest
 from .trust_store import sha256_file  # pylint: disable=unused-import
 from .trust_store import write_json_atomic  # pylint: disable=unused-import
 
@@ -173,10 +176,11 @@ def workspace_status_command(ctx: base_cli.Context, workspace: str | None, outpu
         store = ManifestCommandTrustStore()
         statuses = []
         for project in projects:
-            surfaces = manifest_command_surfaces(project.manifest_path)
+            manifest = read_manifest(project.manifest_path)
+            surfaces = manifest_command_surfaces_from_manifest(manifest)
             if not surfaces:
                 continue
-            identity = compute_trust_identity_for_manifest(project.manifest_path)
+            identity = compute_trust_identity(manifest)
             statuses.append((store.status(identity), surfaces))
     except (ProjectDiscoveryError, ManifestError, TrustError) as exc:
         ctx.log.error(str(exc))

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -270,12 +270,13 @@ class ManifestCommandTrustTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            result = invoke(
-                engine.app,
-                ["status", "--workspace", str(workspace), "--format", "json"],
-                home=home,
-                env={"BASE_HOME": str(workspace / "base")},
-            )
+            with mock.patch("base_trust.engine.read_manifest", wraps=engine.read_manifest) as read_manifest:
+                result = invoke(
+                    engine.app,
+                    ["status", "--workspace", str(workspace), "--format", "json"],
+                    home=home,
+                    env={"BASE_HOME": str(workspace / "base")},
+                )
             text_result = invoke(
                 engine.app,
                 ["status", "--workspace", str(workspace)],
@@ -296,6 +297,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             "manifest_changed",
         )
         self.assertNotIn("metadata-only", result.stdout)
+        self.assertEqual(read_manifest.call_count, 4)
         self.assertEqual(text_result.exit_code, 0, text_result.output)
         self.assertIn("allowed\tallowed\tallowed", text_result.stdout)
         self.assertIn("changed\tblocked\tmanifest_changed", text_result.stdout)

--- a/cli/python/base_trust/trust_store.py
+++ b/cli/python/base_trust/trust_store.py
@@ -11,6 +11,7 @@ from base_cli_adapters.history import format_timestamp, utc_now
 from base_cli_adapters.paths import base_state_root
 from base_setup.git_commands import run_git
 from base_setup.git_remote_parse import parse_origin_remote
+from base_setup.manifest import BaseManifest
 from base_setup.manifest import read_manifest
 
 SCHEMA_VERSION = 1
@@ -149,6 +150,10 @@ class ManifestCommandTrustStore:
 
 def manifest_command_surfaces(manifest_path: Path) -> tuple[str, ...]:
     manifest = read_manifest(manifest_path.expanduser().resolve())
+    return manifest_command_surfaces_from_manifest(manifest)
+
+
+def manifest_command_surfaces_from_manifest(manifest: BaseManifest) -> tuple[str, ...]:
     surfaces = []
     if manifest.test is not None:
         surfaces.append("test")
@@ -165,6 +170,10 @@ def manifest_command_surfaces(manifest_path: Path) -> tuple[str, ...]:
 
 def compute_trust_identity_for_manifest(manifest_path: Path) -> ManifestCommandTrustIdentity:
     manifest = read_manifest(manifest_path.expanduser().resolve())
+    return compute_trust_identity(manifest)
+
+
+def compute_trust_identity(manifest: BaseManifest) -> ManifestCommandTrustIdentity:
     canonical_manifest = manifest.path.resolve()
     project_root = canonical_manifest.parent.resolve()
     manifest_sha256 = sha256_file(canonical_manifest)


### PR DESCRIPTION
## Summary

- Parse each workspace project's manifest once during `basectl trust status`.
- Derive both command surfaces and the trust identity from that shared manifest.
- Add a regression assertion covering the one-parse-per-project contract.

## Validation

- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_trust/tests/test_engine.py -q`
- `env -u BASE_HOME PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_trust/engine.py cli/python/base_trust/trust_store.py cli/python/base_trust/tests/test_engine.py`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python ./bin/base-test`
- `git diff --check`

## AI Context

Unchanged: this is an internal performance cleanup with no product, workflow, or architectural change.

Fixes #1893
