### PR TITLE
Remove duplicate import library declaration

### DIFF
--- a/base_init.sh
+++ b/base_init.sh
@@ -339,7 +339,6 @@ base_init_source_command_protocol() {
 import_base_lib() {
     local relative_path="${1:-}"
     local lib_path
-    local lib_path
 
     [[ -n "$relative_path" ]] || base_std_fatal_error "import_base_lib: no library path provided."
     [[ "$relative_path" != /* ]] || base_std_fatal_error "import_base_lib: expected a path relative to '$BASE_BASH_LIBS_DIR', got '$relative_path'."


### PR DESCRIPTION
## Summary

- Remove the duplicate `local lib_path` declaration from `import_base_lib`.

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats tests/base_init.bats`
- `shellcheck --severity=error base_init.sh`
- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python ./bin/base-test`
- `git diff --check`

## AI Context

Unchanged: this is a no-behavior-change bootstrap cleanup.

Fixes #1894
