### PR TITLE
fix(onboard): continue after Doctor findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Continue `basectl onboard` through project discovery and manifest trust
+  status when `basectl doctor` reports remaining findings.
 - Kept helper-backed Bash defaults and runtime prompts shell-local so child
   shells no longer report missing prompt helper functions.
 - Corrected Bash startup's readonly `BASE_HOME` detection to inspect only

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -151,6 +151,7 @@ base_onboard_subcommand_main() {
     local verbose=0
     local yes=0
     local check_status=0
+    local doctor_status=0
     local profile_status=0
     local projects_status=0
     local setup_status=0
@@ -288,7 +289,11 @@ base_onboard_subcommand_main() {
     fi
 
     base_onboard_print_heading "Doctor"
-    base_onboard_execute "$dry_run" "${doctor_args[@]}" || return $?
+    base_onboard_execute "$dry_run" "${doctor_args[@]}"
+    doctor_status=$?
+    if ((doctor_status != 0)); then
+        printf '%s\n' "Some doctor findings remain. Project discovery and trust status will still run."
+    fi
 
     base_onboard_print_heading "Projects"
     if ((dry_run)); then

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -200,6 +200,29 @@ load ./basectl_helpers.bash
     [[ "$output" != *"RUN:trust allow"* ]]
 }
 
+@test "basectl onboard continues to projects and trust when doctor reports findings" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() {
+                printf "RUN:%s\\n" "$*"
+                [[ "$1" == doctor ]] && return 1
+                return 0
+            }
+            base_onboard_subcommand_main --yes --no-profile
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RUN:doctor base"* ]]
+    [[ "$output" == *"Some doctor findings remain. Project discovery and trust status will still run."* ]]
+    [[ "$output" == *"RUN:projects list"* ]]
+    [[ "$output" == *"RUN:trust status"* ]]
+    [[ "$output" == *"Next Steps"* ]]
+}
+
 @test "basectl onboard --yes accepts setup and profile prompts" {
     run env \
         HOME="$TEST_HOME" \

--- a/docs/basectl-onboard.md
+++ b/docs/basectl-onboard.md
@@ -194,6 +194,9 @@ Failures are recoverable and specific:
   profile updates.
 - If `basectl update-profile` fails, leave setup success intact and explain how
   to rerun that step.
+- If `basectl doctor` reports remaining findings, preserve its output and
+  continue to project discovery and manifest trust status. The findings remain
+  actionable, but do not prevent the rest of the read-only onboarding summary.
 - If project discovery or trust status fails after setup, stop before activation
   guidance, preserve the failing status, and tell the user to retry
   `basectl projects list` followed by `basectl trust status`. Earlier setup or


### PR DESCRIPTION
## Summary

- Treat nonzero `basectl doctor` findings as advisory within the guided onboarding checklist.
- Continue into project discovery and manifest trust status, while preserving existing hard stops for setup, discovery, and trust failures.
- Add regression coverage, document the recovery behavior, and record the release note.

## Issue

Fixes #1887

## Validation

- `env BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/onboard.bats` (16 passed)
- `bash -n cli/bash/commands/basectl/subcommands/onboard.sh`
- `shellcheck -S error cli/bash/commands/basectl/subcommands/onboard.sh`
- `git diff origin/main...HEAD --check`
- Isolated real-project smoke: `basectl onboard base-demo --dry-run --no-profile`
- Full Python suite: 944 passed, 1 skipped, 248 subtests passed.

## Demo Impact

None. The safe Base-demo dry-run verifies its onboarding checklist without changing the demo project or host state.

## Notes

- `.ai-context/` is unchanged: the user-facing onboarding behavior is documented in `docs/basectl-onboard.md`.
- The dedicated onboarding BATS suite passed; GitHub Actions will run the required broader BATS and integration checks.
