### PR TITLE
Reject control line breaks in test manifests

### DIFF
--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -191,6 +191,10 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
         raise ManifestError(f"{path}: test.command must be a non-empty string when provided.")
     if mise is not None and (not isinstance(mise, str) or not mise.strip()):
         raise ManifestError(f"{path}: test.mise must be a non-empty string when provided.")
+    if command is not None and has_control_line_break(command):
+        raise ManifestError(f"{path}: test.command must not contain control line breaks.")
+    if mise is not None and has_control_line_break(mise):
+        raise ManifestError(f"{path}: test.mise must not contain control line breaks.")
     if command is not None and mise is not None:
         raise ManifestError(f"{path}: test must declare only one of command or mise.")
     if command is None and mise is None:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -1059,6 +1059,32 @@ class ManifestParsingTests(unittest.TestCase):
                 read_manifest(manifest_path)
 
 
+    def test_rejects_control_line_breaks_in_manifest_test_command_or_mise(self) -> None:
+        for field_name in ("command", "mise"):
+            for escaped_control_break in (r"\0", r"\n", r"\r"):
+                with self.subTest(field_name=field_name, escaped_control_break=escaped_control_break):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        manifest_path = Path(tmpdir) / "base_manifest.yaml"
+                        manifest_path.write_text(
+                            "\n".join(
+                                [
+                                    "project:",
+                                    "  name: demo",
+                                    "test:",
+                                    f'  {field_name}: "test{escaped_control_break}command"',
+                                    "artifacts: []",
+                                ]
+                            ),
+                            encoding="utf-8",
+                        )
+
+                        with self.assertRaisesRegex(
+                            ManifestError,
+                            rf"test\.{field_name} must not contain control line breaks",
+                        ):
+                            read_manifest(manifest_path)
+
+
     def test_rejects_invalid_manifest_test_runner(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = Path(tmpdir) / "base_manifest.yaml"


### PR DESCRIPTION
## Summary

Reject embedded NUL, LF, and CR characters in both `test.command` and `test.mise`, matching the validation already applied to other manifest command surfaces.

## Issue

Fixes #1890

## Validation

- New six-case regression test covering `test.command` and `test.mise` with NUL, LF, and CR values
- `PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m unittest cli/python/base_setup/tests/test_manifest.py` (52 passed)
- `PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/pylint --rcfile=.pylintrc cli/python/base_setup/manifest.py cli/python/base_setup/tests/test_manifest.py`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-v180-small-fixes ./bin/base-test`

## Demo Impact

None.

## Notes

`.ai-context/` is unchanged because this is a narrow manifest input-validation hardening, not a product-shape or workflow change.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue.
- [x] PR body explains what changed and how it was validated.
- [x] Relevant Python tests and lint pass.
- [x] Bug fix includes regression proof.
- [x] Documentation changes are not needed.
- [x] AI context is not applicable.
- [x] PR includes `Fixes #1890`.
- [x] Demo impact is explicitly stated.
