### PR TITLE
fix(security): verify AI installer downloads

### DIFF
--- a/cli/python/base_dev/ai_tools.py
+++ b/cli/python/base_dev/ai_tools.py
@@ -6,11 +6,12 @@ from dataclasses import dataclass
 
 import base_cli
 from base_setup.errors import ArtifactError
-from base_setup.process import DIAGNOSTIC_TIMEOUT_SECONDS, dry_run_command, run_command
+from base_setup.process import DIAGNOSTIC_TIMEOUT_SECONDS
 from base_setup.remote_installers import CLAUDE_REMOTE_INSTALLER
 from base_setup.remote_installers import CODEX_REMOTE_INSTALLER
 from base_setup.remote_installers import RemoteInstallerSpec
 from base_setup.remote_installers import require_registered_remote_installer
+from base_setup.remote_installers import run_remote_installer
 
 from .checks import DevCheck
 
@@ -56,13 +57,10 @@ def setup_ai_tools(ctx: base_cli.Context, dry_run: bool) -> int:
             if check.ok:
                 ctx.log.info("%s", check.message)
                 continue
-            installer_command = ai_tool_installer_command(tool)
+            validate_ai_remote_installer(tool)
             log_ai_remote_installer_policy(ctx, tool)
             ctx.log.info("Installing %s.", tool.display_name)
-            if dry_run:
-                dry_run_command(ctx, list(installer_command))
-            else:
-                run_command(ctx, list(installer_command))
+            run_remote_installer(ctx, tool.installer, dry_run=dry_run)
     except ArtifactError as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
@@ -90,24 +88,10 @@ def validate_ai_remote_installer(tool: AITool) -> None:
         )
 
 
-def ai_tool_installer_command(tool: AITool) -> tuple[str, ...]:
-    validate_ai_remote_installer(tool)
-    return (
-        "sh",
-        "-c",
-        'curl -fsSL "$1" | "$2"',
-        "--",
-        tool.installer.default_url,
-        tool.installer.interpreter,
-    )
-
-
 def log_ai_remote_installer_policy(ctx: base_cli.Context, tool: AITool) -> None:
     ctx.log.info(
-        "Remote installer policy: %s uses allowlisted official mutable installer %s without checksum verification; "
-        "execution requires explicit --profile ai.",
+        "Remote installer policy: %s execution requires explicit --profile ai.",
         tool.display_name,
-        tool.installer.default_url,
     )
 
 

--- a/cli/python/base_dev/tests/test_engine.py
+++ b/cli/python/base_dev/tests/test_engine.py
@@ -21,6 +21,7 @@ from base_dev import engine
 from base_dev import profile_output
 from base_dev.engine import main
 from base_setup import remote_installers
+from base_setup.errors import ArtifactError
 from base_setup.prerequisites import PrerequisiteCheck
 
 
@@ -141,32 +142,21 @@ class DevManifestTests(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            [ai_tools.ai_tool_installer_command(tool) for tool in ai_tools.AI_TOOLS],
+            [
+                (tool.installer.url_env, tool.installer.sha256_env)
+                for tool in ai_tools.AI_TOOLS
+            ],
             [
                 (
-                    "sh",
-                    "-c",
-                    'curl -fsSL "$1" | "$2"',
-                    "--",
-                    "https://chatgpt.com/codex/install.sh",
-                    "sh",
+                    "BASE_SETUP_CODEX_INSTALLER_URL",
+                    "BASE_SETUP_CODEX_INSTALLER_SHA256",
                 ),
                 (
-                    "sh",
-                    "-c",
-                    'curl -fsSL "$1" | "$2"',
-                    "--",
-                    "https://claude.ai/install.sh",
-                    "bash",
+                    "BASE_SETUP_CLAUDE_INSTALLER_URL",
+                    "BASE_SETUP_CLAUDE_INSTALLER_SHA256",
                 ),
             ],
         )
-
-    def test_ai_installer_command_does_not_interpolate_url_into_shell_source(self) -> None:
-        command = ai_tools.ai_tool_installer_command(ai_tools.AI_TOOLS[0])
-
-        self.assertNotIn(ai_tools.AI_TOOLS[0].installer_url, command[2])
-        self.assertEqual(command[3:], ("--", ai_tools.AI_TOOLS[0].installer_url, "sh"))
 
     @unittest.skipUnless(importlib.util.find_spec("click"), "Click is not installed")
     def test_setup_profile_sre_uses_sre_manifest(self) -> None:
@@ -189,25 +179,21 @@ class DevManifestTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn(
-            "Remote installer policy: Codex CLI uses allowlisted official mutable installer "
-            "https://chatgpt.com/codex/install.sh without checksum verification; "
-            "execution requires explicit --profile ai.",
+            "Remote installer policy: Codex CLI execution requires explicit --profile ai.",
             stderr,
         )
         self.assertIn(
-            "Remote installer policy: Claude Code uses allowlisted official mutable installer "
-            "https://claude.ai/install.sh without checksum verification; "
-            "execution requires explicit --profile ai.",
+            "Remote installer policy: Claude Code execution requires explicit --profile ai.",
             stderr,
         )
         self.assertIn(
-            "[DRY-RUN] Would run: sh -c 'curl -fsSL \"$1\" | \"$2\"' -- "
-            "https://chatgpt.com/codex/install.sh sh",
+            "[DRY-RUN] Would fetch https://chatgpt.com/codex/install.sh once, execute the same bytes with sh, "
+            "then remove the temporary copy.",
             stderr,
         )
         self.assertIn(
-            "[DRY-RUN] Would run: sh -c 'curl -fsSL \"$1\" | \"$2\"' -- "
-            "https://claude.ai/install.sh bash",
+            "[DRY-RUN] Would fetch https://claude.ai/install.sh once, execute the same bytes with bash, "
+            "then remove the temporary copy.",
             stderr,
         )
 
@@ -257,13 +243,13 @@ class DevManifestTests(unittest.TestCase):
         with (
             mock.patch("base_dev.ai_tools.AI_TOOLS", (tool,)),
             mock.patch("base_dev.ai_tools.check_ai_tool", return_value=engine.DevCheck("bad-ai", False, "missing", "")),
-            mock.patch("base_dev.ai_tools.run_command") as run_command,
+            mock.patch("base_dev.ai_tools.run_remote_installer") as run_installer,
         ):
             status = ai_tools.setup_ai_tools(ctx, dry_run=False)
 
         self.assertEqual(status, 1)
         self.assertIn("Remote installer URL is not allowlisted", ctx.log.error.call_args.args[0])
-        run_command.assert_not_called()
+        run_installer.assert_not_called()
 
     def test_ai_profile_rejects_registered_installer_owned_by_another_setup_surface(self) -> None:
         tool = ai_tools.AITool(
@@ -273,8 +259,8 @@ class DevManifestTests(unittest.TestCase):
             installer=remote_installers.MISE_REMOTE_INSTALLER,
         )
 
-        with self.assertRaisesRegex(RuntimeError, "not allowlisted for Base 'ai' profile"):
-            ai_tools.ai_tool_installer_command(tool)
+        with self.assertRaisesRegex(ArtifactError, "not allowlisted for Base 'ai' profile"):
+            ai_tools.validate_ai_remote_installer(tool)
 
     def test_setup_ai_tools_noninteractive_explicit_profile_runs_allowlisted_installers(self) -> None:
         ctx = mock.Mock()
@@ -282,17 +268,21 @@ class DevManifestTests(unittest.TestCase):
         with (
             mock.patch.dict(os.environ, {"CI": "true"}),
             mock.patch("base_dev.ai_tools.check_ai_tool", return_value=engine.DevCheck("tool", False, "missing", "")),
-            mock.patch("base_dev.ai_tools.run_command") as run_command,
+            mock.patch("base_dev.ai_tools.run_remote_installer") as run_installer,
         ):
             status = ai_tools.setup_ai_tools(ctx, dry_run=False)
 
         self.assertEqual(status, 0)
         self.assertEqual(
-            [call.args[1] for call in run_command.call_args_list],
+            [call.args[1] for call in run_installer.call_args_list],
             [
-                ["sh", "-c", 'curl -fsSL "$1" | "$2"', "--", "https://chatgpt.com/codex/install.sh", "sh"],
-                ["sh", "-c", 'curl -fsSL "$1" | "$2"', "--", "https://claude.ai/install.sh", "bash"],
+                remote_installers.CODEX_REMOTE_INSTALLER,
+                remote_installers.CLAUDE_REMOTE_INSTALLER,
             ],
+        )
+        self.assertEqual(
+            [call.kwargs for call in run_installer.call_args_list],
+            [{"dry_run": False}, {"dry_run": False}],
         )
 
     def test_check_ai_tool_warns_when_version_probe_times_out(self) -> None:

--- a/cli/python/base_setup/remote_installers.py
+++ b/cli/python/base_setup/remote_installers.py
@@ -46,6 +46,8 @@ CODEX_REMOTE_INSTALLER = RemoteInstallerSpec(
     interpreter="sh",
     trigger="Codex CLI is missing from the explicit ai prerequisite profile",
     consent="basectl setup --profile ai",
+    url_env="BASE_SETUP_CODEX_INSTALLER_URL",
+    sha256_env="BASE_SETUP_CODEX_INSTALLER_SHA256",
 )
 CLAUDE_REMOTE_INSTALLER = RemoteInstallerSpec(
     name="claude",
@@ -54,6 +56,8 @@ CLAUDE_REMOTE_INSTALLER = RemoteInstallerSpec(
     interpreter="bash",
     trigger="Claude Code is missing from the explicit ai prerequisite profile",
     consent="basectl setup --profile ai",
+    url_env="BASE_SETUP_CLAUDE_INSTALLER_URL",
+    sha256_env="BASE_SETUP_CLAUDE_INSTALLER_SHA256",
 )
 UV_REMOTE_INSTALLER = RemoteInstallerSpec(
     name="uv",

--- a/cli/python/base_setup/tests/test_remote_installers.py
+++ b/cli/python/base_setup/tests/test_remote_installers.py
@@ -46,6 +46,30 @@ class RemoteInstallerTests(unittest.TestCase):
         self.assertIsNone(source.expected_sha256)
         self.assertFalse(source.managed)
 
+    def test_ai_installers_support_paired_managed_source_and_checksum_overrides(self) -> None:
+        for spec, url_env, sha256_env in (
+            (
+                remote_installers.CODEX_REMOTE_INSTALLER,
+                "BASE_SETUP_CODEX_INSTALLER_URL",
+                "BASE_SETUP_CODEX_INSTALLER_SHA256",
+            ),
+            (
+                remote_installers.CLAUDE_REMOTE_INSTALLER,
+                "BASE_SETUP_CLAUDE_INSTALLER_URL",
+                "BASE_SETUP_CLAUDE_INSTALLER_SHA256",
+            ),
+        ):
+            source = remote_installers.resolve_remote_installer_source(
+                spec,
+                environ={url_env: "/tmp/installer.sh", sha256_env: "a" * 64},
+            )
+
+            self.assertEqual(spec.url_env, url_env)
+            self.assertEqual(spec.sha256_env, sha256_env)
+            self.assertEqual(source.location, "/tmp/installer.sh")
+            self.assertEqual(source.expected_sha256, "a" * 64)
+            self.assertTrue(source.managed)
+
     def test_override_url_and_sha256_must_be_paired(self) -> None:
         spec = remote_installers.UV_REMOTE_INSTALLER
         with self.assertRaisesRegex(ArtifactError, "must be set together"):

--- a/docs/remote-installer-policy.md
+++ b/docs/remote-installer-policy.md
@@ -14,8 +14,8 @@ mutable installer without checksum verification.
 | Installer | URL | Where Base may use it | Opt-in |
 | --- | --- | --- | --- |
 | Homebrew | `https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh` by default; managed environments may provide a pinned installer location with an expected SHA-256 | `bootstrap.sh`, `install.sh`, and `basectl setup` when Homebrew is missing on macOS | First-mile setup path; `bootstrap.sh --no-homebrew-install` can refuse this path |
-| Codex CLI | `https://chatgpt.com/codex/install.sh` | `basectl setup --profile ai` | Explicit `--profile ai` |
-| Claude Code | `https://claude.ai/install.sh` | `basectl setup --profile ai` | Explicit `--profile ai` |
+| Codex CLI | `https://chatgpt.com/codex/install.sh` by default; managed environments may provide a local, mirrored, or pinned installer with an expected SHA-256 | `basectl setup --profile ai` | Explicit `--profile ai` |
+| Claude Code | `https://claude.ai/install.sh` by default; managed environments may provide a local, mirrored, or pinned installer with an expected SHA-256 | `basectl setup --profile ai` | Explicit `--profile ai` |
 | uv | `https://astral.sh/uv/install.sh` by default; managed environments may provide a local, mirrored, or pinned installer with an expected SHA-256 | `basectl setup <project>` on Debian-family Linux when a manifest declares `python.manager: uv` or a `runner: uv` command and uv is missing | Explicit `--yes`; `--dry-run` only previews |
 | mise | `https://mise.run` by default; managed environments may provide a local, mirrored, or pinned installer with an expected SHA-256 | `basectl setup <project>` on Debian-family Linux when a manifest declares mise configuration and mise is missing | Explicit `--yes`; `--dry-run` only previews |
 
@@ -46,8 +46,7 @@ so exporting `BASE_SETUP_YES` does not bypass that boundary.
 Base intentionally follows each tool's official mutable installer entry point
 instead of pinning a reviewed commit by default. When Base uses a default path,
 it identifies the URL as mutable and explicitly says that the script is not
-checksum-verified. The Codex CLI and Claude Code paths do not currently expose
-a Base-managed checksum override.
+checksum-verified.
 
 Teams that require pinned, mirrored, or managed Homebrew installer content can
 opt in by setting both a
@@ -67,14 +66,19 @@ installer location and expected SHA-256. Missing or mismatched values fail
 closed before installer execution. Local file paths, `file://` URLs, and remote
 URLs are accepted as installer locations.
 
-Debian-family Linux setup provides equivalent paired overrides for uv and mise:
+The Python-owned Codex CLI, Claude Code, uv, and mise installers support paired
+overrides:
 
+- Codex CLI: `BASE_SETUP_CODEX_INSTALLER_URL` and
+  `BASE_SETUP_CODEX_INSTALLER_SHA256`
+- Claude Code: `BASE_SETUP_CLAUDE_INSTALLER_URL` and
+  `BASE_SETUP_CLAUDE_INSTALLER_SHA256`
 - uv: `BASE_SETUP_UV_INSTALLER_URL` and
   `BASE_SETUP_UV_INSTALLER_SHA256`
 - mise: `BASE_SETUP_MISE_INSTALLER_URL` and
   `BASE_SETUP_MISE_INSTALLER_SHA256`
 
-For uv and mise, either both variables must be present or neither may be
+For these installers, either both variables must be present or neither may be
 present. The URL may be a local path, a local `file://` URL, or an HTTPS URL;
 HTTP and other schemes fail closed. Base fetches or copies the installer once
 into a user-private temporary directory, verifies the expected SHA-256, runs

--- a/tests/test_remote_installer_policy.py
+++ b/tests/test_remote_installer_policy.py
@@ -67,8 +67,9 @@ def test_standalone_homebrew_entry_points_share_the_documented_default() -> None
         assert urls == {HOMEBREW_INSTALLER_URL}, entry_point
 
 
-def test_uv_and_mise_do_not_embed_remote_shell_pipelines() -> None:
+def test_python_remote_installer_consumers_do_not_embed_remote_shell_pipelines() -> None:
     for relative_path in (
+        "cli/python/base_dev/ai_tools.py",
         "cli/python/base_setup/uv.py",
         "cli/python/base_setup/mise_delegate.py",
     ):


### PR DESCRIPTION
## Summary

Route Codex CLI and Claude Code setup through the existing remote-installer helper. Add paired managed-source URL and SHA-256 overrides, then document the supported trust boundary.

## Issue

Fixes #1886

## Validation

- Focused Python tests: 71 passed, 10 subtests passed
- Touched-file Pylint and `git diff --check`
- `basectl setup --profile ai --dry-run` smoke test
- Full Base gate: 944 passed, 1 skipped; 852/852 BATS

## Demo Impact

None.

## Security Notes

The AI profile no longer builds a curl-to-shell pipeline. Base fetches or copies each installer once into a user-private temporary file and executes those same bytes. Paired managed source and SHA-256 overrides fail closed before execution when configured.

## Notes

No .ai-context update: this aligns the AI profile with the existing remote-installer contract, while docs/remote-installer-policy.md remains the canonical user-facing policy.