### PR TITLE
Align Base with base-cli 0.4.2

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .base/base-cli
 
       - name: Set up Python

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Set up Python

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Set up Python
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -281,7 +281,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Expose reusable Bash library checkout as sibling
@@ -343,7 +343,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.0
+          ref: v0.4.2
           path: .dependencies/base-cli
 
       - name: Set up Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Changed
 
+- Align the published Base CLI provider used by development dependencies and
+  CI checkout workflows with `base-cli` `0.4.2`.
+
 - Treat GitHub's unsupported `branch_name_pattern` response as a capability
   warning during `basectl repo configure`, preserving the issue-branch policy
   workflow fallback instead of failing the whole repository configuration.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pylint==3.3.9
 click==8.4.1
-base-cli==0.4.1
+base-cli==0.4.2
 PyYAML==6.0.3
 pytest==9.0.3
 pytest-cov==7.1.0


### PR DESCRIPTION
## Summary

- update Base's development dependency to `base-cli==0.4.2`
- update every Base CI/provider checkout from `base-cli` `v0.4.0` to `v0.4.2`
- document the provider alignment in the unreleased changelog

This keeps the installed, source-checkout, and CI provider paths on the same
released base-cli version after the 0.4.2 release.

## Validation

- `PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python $HOME/.base.d/base/.venv/bin/python -m pytest tests/test_github_workflows.py tests/test_contract_hardening.py -q` (56 passed)
- `git diff --check`\n\nCloses #1909