### PR TITLE
Fix doctor failure summary severity

### DIFF
--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -237,9 +237,9 @@ base_doctor_run_ci_runtime_text() {
     fi
 
     if [[ -n "$project" ]]; then
-        base_std_log_info "Base CI doctor found $errors blocking issue(s) for project '$project'."
+        base_std_log_error "Base CI doctor found $errors blocking issue(s) for project '$project'."
     else
-        base_std_log_info "Base CI doctor found $errors blocking issue(s)."
+        base_std_log_error "Base CI doctor found $errors blocking issue(s)."
     fi
     return 1
 }
@@ -427,9 +427,9 @@ base_doctor_subcommand_main() {
     fi
 
     if [[ -n "$project" ]]; then
-        base_std_log_info "Base doctor found $errors blocking issue(s) for project '$project'."
+        base_std_log_error "Base doctor found $errors blocking issue(s) for project '$project'."
     else
-        base_std_log_info "Base doctor found $errors blocking issue(s)."
+        base_std_log_error "Base doctor found $errors blocking issue(s)."
     fi
     return 1
 }

--- a/cli/bash/commands/basectl/tests/ci.bats
+++ b/cli/bash/commands/basectl/tests/ci.bats
@@ -86,6 +86,17 @@ prepare_ci_runtime() {
     [ "$(cat "$TEST_STATE_DIR/project-setup-ci")" = "true" ]
 }
 
+@test "basectl doctor --ci logs a blocking summary at error level" {
+    create_system_python3_stub
+    create_project_setup_venv_stub "$TEST_HOME/.base.d/base/.venv"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+
+    run_base_command OSTYPE=linux-gnu doctor --ci base
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *" ERROR "*"Base CI doctor found 1 blocking issue(s) for project 'base'."* ]]
+}
+
 @test "basectl setup --ci json output summarizes stderr without embedding log stream" {
     local workspace="$TEST_TMPDIR/workspace"
 

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -665,7 +665,7 @@ EOF
     [[ "$output" == *"error"*"Homebrew"*"Homebrew is not installed."* ]]
     [[ "$output" == *"Fix: Run 'basectl setup' to install Homebrew, or install it manually from https://brew.sh/."* ]]
     [[ "$output" == *$'\n       Fix: Run '\''basectl setup'\'' to install Homebrew, or install it manually from https://brew.sh/.'* ]]
-    [[ "$output" == *" INFO "*"Base doctor found"*"blocking issue(s)."* ]]
+    [[ "$output" == *" ERROR "*"Base doctor found"*"blocking issue(s)."* ]]
     [[ "$output" != *$'\n\n'*"Base doctor found"* ]]
 }
 


### PR DESCRIPTION
## Summary

Raise the final blocking-issue summary from INFO to ERROR when `basectl doctor` fails.

## Why

The command returned a non-zero status while its final count was hidden from warn/error-level log consumers. Both regular and CI-runtime text paths had this behavior.

## Impact

Failed doctor runs now retain their final blocking-issue count in error-level output. Successful summaries remain INFO.

## Root cause

Both failure branches called `base_std_log_info` immediately before returning 1.

## Validation

- `bats cli/bash/commands/basectl/tests/doctor.bats` (29 passed)
- `bats cli/bash/commands/basectl/tests/ci.bats` (7 passed)
- `shellcheck cli/bash/commands/basectl/subcommands/doctor.sh`
- `git diff --check origin/main...HEAD`
- Full local gate with the compatible Base CLI source: 945 passed, 1 skipped Python; 854 BATS

## AI context

`.ai-context/` is unchanged: this is a small diagnostic severity correction with no architecture or command-surface change.

Fixes #1895
