### PR TITLE
fix(logs): preserve complete log paths

### DIFF
--- a/cli/python/base_logs/engine.py
+++ b/cli/python/base_logs/engine.py
@@ -681,12 +681,31 @@ def print_log_table(entries: list[LogEntry]) -> None:
         ("STATUS", "status"),
         ("PATH", "path"),
     )
+    output_records = log_output_records(entries)
+    minimum_widths = (19, 12, 24, 6)
     base_cli.render_records(
-        log_output_records(entries),
+        output_records,
         requested_format="text",
         columns=columns,
-        minimum_widths=(19, 12, 24, 6),
+        minimum_widths=minimum_widths,
+        max_cell_width=None,
+        terminal_width=logs_table_width(output_records, columns, minimum_widths),
     )
+
+
+def logs_table_width(
+    records: list[dict[str, Any]],
+    columns: tuple[tuple[str, str], ...],
+    minimum_widths: tuple[int, ...],
+) -> int:
+    """Return enough width for the logs table without truncating log paths."""
+
+    widths = []
+    for index, (header, key) in enumerate(columns):
+        values = [str(record.get(key, "")) for record in records]
+        minimum_width = minimum_widths[index] if index < len(minimum_widths) else 0
+        widths.append(max(len(header), minimum_width, *(len(value) for value in values)))
+    return sum(widths) + 2 * (len(columns) - 1)
 
 
 def log_output_columns() -> tuple[tuple[str, str], ...]:

--- a/cli/python/base_logs/tests/test_engine.py
+++ b/cli/python/base_logs/tests/test_engine.py
@@ -282,14 +282,18 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
         self.assertIn("clean", stdout)
         self.assertIn("20260601T010000_aaaaaaaa", stdout)
 
-    def test_table_expands_columns_for_long_command_and_run_id(self) -> None:
+    def test_table_expands_columns_for_long_values_without_truncating_path(self) -> None:
         stdout = TerminalStringIO()
+        long_path = (
+            Path.home()
+            / "Library/Caches/base/base/runs/20260811T132141_20742_18289__workspace/logs/primary.log"
+        )
         entries = [
             engine.LogEntry(
                 command="export-context",
                 raw_command="base_export_context",
                 run_id="20260718T192921_abcdefghijkl",
-                path=Path("/tmp/short.log"),
+                path=long_path,
                 timestamp=engine.datetime(2026, 7, 18, 19, 29, 21, tzinfo=engine.timezone.utc),
                 status="ok",
             ),
@@ -308,9 +312,11 @@ class BaseLogsTests(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
         lines = stdout.getvalue().splitlines()
         path_column = lines[0].index("PATH")
-        self.assertEqual(lines[1].index(engine.compact_path(entries[0].path)), path_column)
+        compact_long_path = engine.compact_path(entries[0].path)
+        self.assertEqual(lines[1].index(compact_long_path), path_column)
         self.assertEqual(lines[2].index(engine.compact_path(entries[1].path)), path_column)
         self.assertIn("TIME", lines[0])
+        self.assertNotIn("…", stdout.getvalue())
 
     def test_path_prints_most_recent_matching_log(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- preserve complete compact log paths in interactive `basectl logs` tables
- calculate a consumer-specific table width and disable shared cell truncation
- add regression coverage for a long cache-run path

Fixes #1925

## Root cause

The shared `base-cli` renderer defaults to `max_cell_width=80`. The history consumer already overrides that limit, but the logs consumer did not, so long cache paths were rendered with an ellipsis.

## Validation

- focused Python suite: 26 passed
- repository Python suite: 949 passed, 1 skipped
- focused logs Bats suite: 6 passed
- repository Bats suite: 856 passed
- touched-file Pylint
- `git diff --check`

## AI context

No `.ai-context` update needed; this is a focused terminal-rendering fix.
