### PR TITLE
Persist workspace check timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,17 +653,19 @@ Project list output is tab-separated as `<project-name><TAB><path>`.
 In a source checkout, `basectl projects list` can run before `basectl setup`
 when the ambient `python3` has Base's bootstrap Python dependencies available;
 otherwise it reports a targeted setup diagnostic.
-`basectl projects list` and the read-only workspace status, check, doctor,
-onboarding, and agent-brief commands support `--format json` for
+`basectl projects list` and the read-only workspace status, doctor, onboarding,
+and agent-brief commands support `--format json` for
 machine-readable output.
 Workspace clone, pull, init, configure, and setup use text output only. Status reports
 each discovered project's manifest validity, whether the Base-managed project
 virtual environment is present, and the latest recorded `basectl check
-<project>` date when one exists. Check records live under
-`~/.base.d/<project>/checks/last.json`; status JSON includes the full timestamp
-and recorded check status.
+<project>` or `basectl workspace check` date when one exists. Check records live
+under `~/.base.d/<project>/checks/last.json`; status JSON includes the full
+timestamp and recorded check status.
 Check and doctor run project diagnostics across discovered projects and keep
-invalid project manifests visible as per-project findings.
+invalid project manifests visible as per-project findings. Workspace check also
+refreshes each checked project's last-check record after rendering its report;
+record-write failures are logged without changing the diagnostic result.
 
 `basectl workspace onboarding` is also shipped. It summarizes first-day
 workspace onboarding from a workspace manifest without cloning repositories or

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -235,14 +235,15 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl workspace status` reports a read-only workspace summary across
   discovered projects, or across expected repositories when
   `workspace.manifest` is configured or `--manifest <path>` is supplied. When
-  `basectl check <project>` has run, status reports the latest recorded project
-  check date from `~/.base.d/<project>/checks/last.json`.
+  `basectl check <project>` or `basectl workspace check` has run, status reports
+  the latest recorded project check date from
+  `~/.base.d/<project>/checks/last.json`.
 - `basectl workspace check` renders check-oriented readiness state across
-  discovered projects. `basectl workspace doctor` renders actionable findings
-  with stable finding IDs and fix guidance. Both commands are read-only and,
-  with a configured workspace manifest or `--manifest <path>`, report missing
-  expected repositories and discovered Base-managed projects outside the
-  manifest.
+  discovered projects and records each result for later status reporting.
+  `basectl workspace doctor` renders actionable findings with stable finding
+  IDs and fix guidance and remains read-only. With a configured
+  workspace manifest or `--manifest <path>`, they also report missing expected
+  repositories and discovered Base-managed projects outside the manifest.
 - `basectl workspace onboarding` reports expected-repository first-day state
   and next actions without cloning or setup.
 - `basectl workspace agent-brief` reports expected and extra Base-managed

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -42,6 +42,9 @@ from base_projects.workspace_clone_command import require_workspace_clone_manife
 from base_projects.workspace_clone_command import should_skip_optional_clone  # pylint: disable=unused-import
 from base_projects.workspace_clone_command import workspace_clone_command
 from base_projects.workspace_clone_command import workspace_clone_repo_spec  # pylint: disable=unused-import
+from base_projects.workspace_checks import persist_workspace_check_records
+from base_projects.workspace_checks import workspace_error_count
+from base_projects.workspace_checks import workspace_project_check_results
 from base_projects.workspace_configure import workspace_configure_from_options
 from base_projects.workspace_context import effective_workspace_manifest
 from base_projects.workspace_context import resolve_workspace_manifest
@@ -62,8 +65,6 @@ from base_projects.workspace_report_text import print_workspace_agent_brief
 from base_projects.workspace_report_text import print_workspace_onboarding
 from base_projects.workspace_report_text import print_workspace_status
 from base_projects.workspace_scanner import ProjectDiscoveryError
-from base_projects.workspace_checks import workspace_error_count
-from base_projects.workspace_checks import workspace_project_check_results
 from base_projects.workspace_statuses import workspace_project_statuses
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
@@ -324,6 +325,9 @@ def workspace_check_command(
         text_renderer=lambda: print_workspace_check(workspace_root, results, manifest),
     ):
         return base_cli.ExitCode.USAGE_ERROR
+
+    for project_name, exc in persist_workspace_check_records(results):
+        ctx.log.warning("Could not record workspace check for project '%s': %s", project_name, exc)
 
     if any(result.status == "error" for result in results):
         return base_cli.ExitCode.FAILURE

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -85,6 +85,10 @@ def write_default_manifest(base_home: Path) -> None:
     )
 
 
+def read_last_check(home: Path, project: str) -> dict[str, str]:
+    return json.loads((home / ".base.d" / project / "checks" / "last.json").read_text(encoding="utf-8"))
+
+
 class TerminalStringIO(io.StringIO):
     def isatty(self) -> bool:
         return True
@@ -106,6 +110,65 @@ def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, st
 
 
 class WorkspaceCheckTests(unittest.TestCase):
+    def test_workspace_check_records_ok_and_warning_results_for_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_workspace_manifest(manifest_path, repos="  - name: demo")
+            write_shell_manifest(workspace / "demo", "demo")
+            write_shell_manifest(workspace / "extra", "extra")
+
+            status, stdout, stderr = invoke_engine(
+                ["check", "--workspace", str(workspace), "--manifest", str(manifest_path)],
+                base_home,
+                home,
+            )
+            demo_record = read_last_check(home, "demo")
+            extra_record = read_last_check(home, "extra")
+            status_status, status_stdout, status_stderr = invoke_engine(
+                ["status", "--workspace", str(workspace), "--manifest", str(manifest_path)],
+                base_home,
+                home,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertIn("extra", stdout + stderr)
+        self.assertEqual(demo_record["command"], "basectl workspace check")
+        self.assertEqual(demo_record["status"], "ok")
+        self.assertEqual(extra_record["command"], "basectl workspace check")
+        self.assertEqual(extra_record["status"], "warn")
+        self.assertRegex(demo_record["checked_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+        self.assertEqual(status_status, 0)
+        self.assertEqual(status_stderr, "")
+        self.assertIn(demo_record["checked_at"][:10], status_stdout)
+        self.assertIn(extra_record["checked_at"][:10], status_stdout)
+
+    def test_workspace_check_records_error_results_before_returning_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_manifest(workspace / "demo", "demo")
+
+            status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
+            record = read_last_check(home, "demo")
+
+        self.assertEqual(status, 1)
+        self.assertIn("Project: demo [error]", stdout)
+        self.assertIn("demo", stdout + stderr)
+        self.assertEqual(record["command"], "basectl workspace check")
+        self.assertEqual(record["status"], "error")
+
     def test_workspace_check_manifest_reports_expected_missing_and_extra_repositories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import replace
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 
 import base_cli
+from base_cli_adapters.paths import base_state_root
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_report_common import missing_repo_fix
@@ -17,6 +20,7 @@ from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import checks_status
 from base_setup.checks import doctor_status
+from base_setup.diagnostics import write_check_record
 from base_setup.engine import manifest_checks
 from base_setup.engine import pre_venv_manifest_checks
 from base_setup.engine import read_default_manifest
@@ -25,6 +29,9 @@ from base_setup.manifest_loader import ManifestError
 from base_setup.manifest_model import BaseManifest
 from base_setup.project_routing import manifest_requires_project_python
 from base_setup.uv import manifest_uses_uv_project_manager
+
+
+WORKSPACE_CHECK_COMMAND = "basectl workspace check"
 
 
 @dataclass(frozen=True)
@@ -41,6 +48,30 @@ class WorkspaceProjectCheckResult:
     repository: str | None = None
     url: str | None = None
     default_branch: str | None = None
+
+
+def workspace_check_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def persist_workspace_check_records(
+    results: tuple[WorkspaceProjectCheckResult, ...],
+) -> tuple[tuple[str, OSError], ...]:
+    checked_at = workspace_check_timestamp()
+    failures: list[tuple[str, OSError]] = []
+    for result in results:
+        record_path = base_state_root() / result.name / "checks" / "last.json"
+        try:
+            write_check_record(
+                record_path,
+                result.name,
+                result.status,
+                checked_at,
+                command=WORKSPACE_CHECK_COMMAND,
+            )
+        except OSError as exc:
+            failures.append((result.name, exc))
+    return tuple(failures)
 
 
 def workspace_project_check_results(

--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -253,20 +253,30 @@ def render_project_venv_doctor_payload(
     return compact_json([*checks, project_venv_check_item(status, message, fix)]) + "\n"
 
 
-def render_check_record(project: str, status: str, checked_at: str) -> str:
+def render_check_record(project: str, status: str, checked_at: str, *, command: str = "basectl check") -> str:
     payload = {
         "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
         "project": project,
-        "command": "basectl check",
+        "command": command,
         "status": validate_status(status),
         "checked_at": checked_at,
     }
     return json.dumps(payload, ensure_ascii=True, indent=2) + "\n"
 
 
-def write_check_record(path: Path, project: str, status: str, checked_at: str) -> None:
+def write_check_record(
+    path: Path,
+    project: str,
+    status: str,
+    checked_at: str,
+    *,
+    command: str = "basectl check",
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    record = render_check_record(project, status, checked_at)
+    if command == "basectl check":
+        record = render_check_record(project, status, checked_at)
+    else:
+        record = render_check_record(project, status, checked_at, command=command)
     with tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -59,7 +59,8 @@ basectl workspace doctor
 ```
 
 `basectl workspace status` reads the latest project check record from
-`~/.base.d/<project>/checks/last.json` when it exists. Text output shows the
+`~/.base.d/<project>/checks/last.json` when it exists. Records are written by
+`basectl check <project>` and `basectl workspace check`. Text output shows the
 check date in the `LAST CHECK` column, while JSON output includes the full
 timestamp and check status. Projects without a recorded check show `-` in text
 output and `null` in JSON output.
@@ -309,7 +310,7 @@ Warnings should not fail automation by default.
 
 ## Relationship To Workspace Commands
 
-The first read-only workspace commands should continue to work without a
+The first workspace inspection commands should continue to work without a
 workspace manifest:
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes #1927.

`basectl workspace status` reads per-project check records from `~/.base.d/<project>/checks/last.json`, but `basectl workspace check` previously only rendered results and returned an exit code. That left `LAST CHECK` stale or unset after a workspace check.

## Changes

- Persist one UTC check record per workspace-check result after report rendering.
- Preserve `ok`, `warn`, and `error` statuses and existing exit-code behavior.
- Record `basectl workspace check` as the command source while preserving the existing record schema and single-project writer compatibility.
- Keep record-write failures as warnings rather than changing diagnostic outcomes.
- Document the updated status/check relationship.

## Validation

- Focused workspace/status/diagnostics tests: 34 passed.
- Full local Base gate before rebase: 951 Python passed, 1 skipped; 856 BATS passed.
- Rebased onto current `origin/main` including #1926.
- `git diff --check` passed.
