### PR TITLE
fix(check): preserve diagnostics when record persistence fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Preserved `basectl check` diagnostics and exit status when the optional
+  latest-check record cannot be written, with stable JSON and text warnings.
+
 - Separated `basectl workspace check`'s readiness renderer from
   `basectl workspace doctor`'s actionable finding renderer while preserving the
   shared read-only workspace checks and JSON diagnostic shape.

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -101,6 +101,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl check --format json` and `basectl doctor --format json` preserve
   valid structured output even when no usable Python diagnostics renderer is
   available; the result still carries the blocking finding and recovery hint.
+- If a project check cannot save its optional latest-check record, text output
+  continues with a concise warning and JSON adds a `record.status: "warn"`
+  persistence warning without changing the diagnostic result or exit status.
 - `basectl doctor explain <finding-id>` prints local, deterministic guidance
   for selected stable finding IDs, with optional JSON output.
 - Base's extracted adapters require a `base-cli` provider that exports

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -748,11 +748,15 @@ setup_record_project_check_result() {
     # Keep external date -u here so persisted JSON records carry explicit UTC
     # without mutating shell TZ; Bash printf time formatting follows local time.
     checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 0
-    setup_run_diagnostics_json record-check \
+    if ! setup_run_diagnostics_json record-check \
         --project "$project" \
         --status "$status" \
         --checked-at "$checked_at" \
-        --output-path "$path" >/dev/null || return 0
+        --output-path "$path" >/dev/null; then
+        base_std_log_warn \
+            "Unable to persist latest check record at '$path'. Ensure the Base state directory is writable and rerun the check."
+    fi
+    return 0
 }
 
 setup_user_config_path() {

--- a/cli/bash/commands/basectl/subcommands/setup_diagnostics_fallback.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_diagnostics_fallback.sh
@@ -65,6 +65,18 @@ setup_diagnostics_fallback_append_item() {
     fi
 }
 
+setup_diagnostics_fallback_record_warning() {
+    local path="$1"
+
+    printf '{"status":"warn","message":'
+    base_inspection_json_string "Latest check record could not be saved."
+    printf ',"fix":'
+    base_inspection_json_string "Ensure the Base state directory is writable, then rerun the check."
+    printf ',"path":'
+    base_inspection_json_string "$path"
+    printf '}'
+}
+
 setup_diagnostics_fallback_record_check() {
     local checked_at="" path="" project="" status="" tmp_path
 
@@ -99,9 +111,9 @@ setup_diagnostics_fallback_record_check() {
     [[ -n "$project" && -n "$checked_at" && -n "$path" ]] ||
         base_std_fatal_error "Diagnostics record fallback requires project, status, checked-at, and output-path."
 
-    mkdir -p -- "$(dirname -- "$path")" || return 1
+    mkdir -p -- "$(dirname -- "$path")" 2>/dev/null || return 1
     tmp_path="${path}.tmp.$$"
-    {
+    if ! {
         printf '{\n  "schema_version": 1,\n  "project": '
         base_inspection_json_string "$project"
         printf ',\n  "command": "basectl check",\n  "status": '
@@ -109,7 +121,14 @@ setup_diagnostics_fallback_record_check() {
         printf ',\n  "checked_at": '
         base_inspection_json_string "$checked_at"
         printf '\n}\n'
-    } >"$tmp_path" && mv -- "$tmp_path" "$path"
+    } >"$tmp_path" 2>/dev/null; then
+        rm -f -- "$tmp_path"
+        return 1
+    fi
+    if ! mv -- "$tmp_path" "$path" 2>/dev/null; then
+        rm -f -- "$tmp_path"
+        return 1
+    fi
 }
 
 setup_diagnostics_fallback_json() {
@@ -246,15 +265,17 @@ setup_diagnostics_fallback_json() {
                 base_inspection_json_string "$embedded_key"
                 printf ': %s' "$embedded_payload"
             done
-            printf '}\n'
-
             if [[ -n "$record_path" && -n "$project" && -n "$checked_at" && "$command" == check-json ]]; then
-                setup_diagnostics_fallback_record_check \
+                if ! setup_diagnostics_fallback_record_check \
                     --project "$project" \
                     --status "$status" \
                     --checked-at "$checked_at" \
-                    --output-path "$record_path" || return 1
+                    --output-path "$record_path" 2>/dev/null; then
+                    printf ', "record": '
+                    setup_diagnostics_fallback_record_warning "$record_path"
+                fi
             fi
+            printf '}\n'
             [[ "$status" != error ]]
             return $?
             ;;

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -443,6 +443,31 @@ EOF
     grep -Eq '"checked_at": "20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"' "$record_path"
 }
 
+@test "basectl check continues with a warning when last check record cannot be saved" {
+    local venv_dir="$TEST_HOME/.base.d/base/.venv"
+    local workspace="$TEST_TMPDIR/workspace"
+    local record_parent="$TEST_HOME/.base.d/demo/checks"
+
+    create_brew_stub
+    create_xcode_stubs
+    touch "$TEST_STATE_DIR/xcode-installed"
+    mkdir -p "$TEST_TMPDIR/CommandLineTools" "$workspace/demo" "$TEST_HOME/.base.d/demo"
+    touch "$TEST_STATE_DIR/python-installed"
+    touch "$TEST_STATE_DIR/pyyaml-installed"
+    touch "$TEST_STATE_DIR/click-installed"
+    printf 'project:\n  name: demo\nartifacts: []\n' > "$workspace/demo/base_manifest.yaml"
+    printf 'not-a-directory\n' > "$record_parent"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
+    BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$workspace/demo/.venv"
+
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"*"Unable to persist latest check record"* ]]
+    [[ "$output" == *"Base CLI environment and project 'demo' check passed."* ]]
+    [[ "$output" != *"Traceback"* ]]
+}
+
 @test "basectl check persists warnings from Base, profile, and project checks in text and JSON modes" {
     local args record_path="$TEST_HOME/.base.d/demo/checks/last.json"
     local source

--- a/cli/bash/commands/basectl/tests/diagnostics_module_fixture.bash
+++ b/cli/bash/commands/basectl/tests/diagnostics_module_fixture.bash
@@ -135,9 +135,9 @@ base_test_diagnostics_record_check() {
             *) return 2 ;;
         esac
     done
-    mkdir -p -- "$(dirname -- "$path")" || return 1
+    mkdir -p -- "$(dirname -- "$path")" 2>/dev/null || return 1
     tmp_path="${path}.tmp.$$"
-    {
+    if ! {
         printf '{"schema_version":1,"project":'
         base_test_diagnostics_json_string "$project"
         printf ',"command":"basectl check","status":'
@@ -145,7 +145,26 @@ base_test_diagnostics_record_check() {
         printf ',"checked_at":'
         base_test_diagnostics_json_string "$checked_at"
         printf '}\n'
-    } >"$tmp_path" && mv -- "$tmp_path" "$path"
+    } >"$tmp_path" 2>/dev/null; then
+        rm -f -- "$tmp_path"
+        return 1
+    fi
+    if ! mv -- "$tmp_path" "$path" 2>/dev/null; then
+        rm -f -- "$tmp_path"
+        return 1
+    fi
+}
+
+base_test_diagnostics_record_warning() {
+    local path="$1"
+
+    printf '{"status":"warn","message":'
+    base_test_diagnostics_json_string "Latest check record could not be saved."
+    printf ',"fix":'
+    base_test_diagnostics_json_string "Ensure the Base state directory is writable, then rerun the check."
+    printf ',"path":'
+    base_test_diagnostics_json_string "$path"
+    printf '}'
 }
 
 base_test_diagnostics_module() {
@@ -262,11 +281,14 @@ base_test_diagnostics_module() {
                 base_test_diagnostics_json_string "${embedded_keys[$i]}"
                 printf ': %s' "${embedded_values[$i]}"
             done
-            printf '}\n'
             if [[ -n "$record_path" && -n "$project" && -n "$checked_at" && "$command" == check-json ]]; then
-                base_test_diagnostics_record_check \
-                    --project "$project" --status "$status" --checked-at "$checked_at" --output-path "$record_path" || return 1
+                if ! base_test_diagnostics_record_check \
+                    --project "$project" --status "$status" --checked-at "$checked_at" --output-path "$record_path"; then
+                    printf ', "record": '
+                    base_test_diagnostics_record_warning "$record_path"
+                fi
             fi
+            printf '}\n'
             [[ "$status" != error ]]
             return $?
             ;;

--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -24,6 +24,8 @@ from .checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 
 
 VALID_STATUSES = {"ok", "warn", "error"}
+CHECK_RECORD_WARNING_MESSAGE = "Latest check record could not be saved."
+CHECK_RECORD_WARNING_FIX = "Ensure the Base state directory is writable, then rerun the check."
 BASE_CHECK_FINDING_IDS = {
     "homebrew": "BASE-D001",
     "xcode_command_line_tools": "BASE-D002",
@@ -271,27 +273,44 @@ def write_check_record(
     checked_at: str,
     *,
     command: str = "basectl check",
-) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if command == "basectl check":
-        record = render_check_record(project, status, checked_at)
-    else:
-        record = render_check_record(project, status, checked_at, command=command)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as temp_file:
-        temp_file.write(record)
-        temp_path = Path(temp_file.name)
-
+) -> bool:
+    temp_path: Path | None = None
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if command == "basectl check":
+            record = render_check_record(project, status, checked_at)
+        else:
+            record = render_check_record(project, status, checked_at, command=command)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(record)
+        assert temp_path is not None
         temp_path.replace(path)
+    except OSError:
+        return False
     finally:
-        temp_path.unlink(missing_ok=True)
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+    return True
+
+
+def check_record_warning(path: Path) -> dict[str, str]:
+    return {
+        "status": "warn",
+        "message": CHECK_RECORD_WARNING_MESSAGE,
+        "fix": CHECK_RECORD_WARNING_FIX,
+        "path": str(path),
+    }
 
 
 def diagnostic_check(name: str, status: str, message: str, fix: str = "") -> DiagnosticCheck:
@@ -408,10 +427,14 @@ def main(argv: list[str] | None = None) -> int:
         checks = load_diagnostic_checks(args.check, args.check_result_file)
         embedded_payloads = tuple((key, payload) for key, payload in args.embedded_payload)
         payload = render_base_check_payload(checks, project=args.project, embedded_payloads=embedded_payloads)
-        print(payload, end="")
-        status = payload_status(json.loads(payload))
+        payload_object = json.loads(payload)
+        status = payload_status(payload_object)
         if args.record_path and args.project and args.checked_at:
-            write_check_record(Path(args.record_path), args.project, status, args.checked_at)
+            record_path = Path(args.record_path)
+            if not write_check_record(record_path, args.project, status, args.checked_at):
+                payload_object["record"] = check_record_warning(record_path)
+                payload = render_top_level_payload(payload_object)
+        print(payload, end="")
         exit_code = base_cli.ExitCode.SUCCESS if status != "error" else base_cli.ExitCode.FAILURE
     elif args.command == "doctor-json":
         checks = load_diagnostic_checks(args.finding, args.finding_result_file)
@@ -421,7 +444,8 @@ def main(argv: list[str] | None = None) -> int:
         status = payload_status(json.loads(payload))
         exit_code = base_cli.ExitCode.SUCCESS if status != "error" else base_cli.ExitCode.FAILURE
     elif args.command == "record-check":
-        write_check_record(Path(args.output_path), args.project, args.status, args.checked_at)
+        if not write_check_record(Path(args.output_path), args.project, args.status, args.checked_at):
+            exit_code = base_cli.ExitCode.FAILURE
     elif args.command == "base-check-metadata":
         print(render_base_check_metadata(args.name), end="")
     elif args.command == "project-venv-check-json":

--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -291,7 +291,8 @@ def write_check_record(
         ) as temp_file:
             temp_path = Path(temp_file.name)
             temp_file.write(record)
-        assert temp_path is not None
+        if temp_path is None:
+            return False
         temp_path.replace(path)
     except OSError:
         return False

--- a/cli/python/base_setup/tests/test_diagnostics_payloads.py
+++ b/cli/python/base_setup/tests/test_diagnostics_payloads.py
@@ -113,6 +113,94 @@ class DiagnosticsPayloadTests(unittest.TestCase):
             self.assertEqual(payload["status"], "ok")
             self.assertFalse(list(Path(tmpdir).glob(".last.json.*.tmp")))
 
+    def test_write_check_record_returns_false_when_parent_is_unwritable(self) -> None:
+        path = Path("/unwritable-base-state/checks/last.json")
+
+        with mock.patch.object(Path, "mkdir", side_effect=PermissionError("read-only")):
+            written = diagnostics.write_check_record(
+                path,
+                project="demo",
+                status="ok",
+                checked_at="2026-06-28T12:00:00Z",
+            )
+
+        self.assertFalse(written)
+
+    def test_write_check_record_cleans_temp_file_when_replace_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "last.json"
+            with mock.patch.object(Path, "replace", side_effect=OSError("read-only")):
+                written = diagnostics.write_check_record(
+                    path,
+                    project="demo",
+                    status="ok",
+                    checked_at="2026-06-28T12:00:00Z",
+                )
+
+            self.assertFalse(written)
+            self.assertFalse(list(Path(tmpdir).glob(".last.json.*.tmp")))
+
+    def test_check_json_preserves_payload_when_record_persistence_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            record_path = Path(tmpdir) / "last.json"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with mock.patch.object(diagnostics, "write_check_record", return_value=False):
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    status = diagnostics.main(
+                        [
+                            "check-json",
+                            "--project",
+                            "demo",
+                            "--check",
+                            "homebrew",
+                            "ok",
+                            "Homebrew is installed.",
+                            "",
+                            "--record-path",
+                            str(record_path),
+                            "--checked-at",
+                            "2026-06-28T12:00:00Z",
+                        ]
+                    )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(status, 0)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["checks"][0]["status"], "ok")
+            self.assertEqual(payload["record"]["status"], "warn")
+            self.assertEqual(payload["record"]["path"], str(record_path))
+            self.assertIn("could not be saved", payload["record"]["message"])
+            self.assertIn("writable", payload["record"]["fix"])
+            self.assertEqual(stderr.getvalue(), "")
+
+    def test_check_json_preserves_error_exit_when_record_persistence_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stdout = io.StringIO()
+            with mock.patch.object(diagnostics, "write_check_record", return_value=False):
+                with redirect_stdout(stdout):
+                    status = diagnostics.main(
+                        [
+                            "check-json",
+                            "--project",
+                            "demo",
+                            "--check",
+                            "homebrew",
+                            "error",
+                            "Homebrew is missing.",
+                            "Install Homebrew.",
+                            "--record-path",
+                            str(Path(tmpdir) / "last.json"),
+                            "--checked-at",
+                            "2026-06-28T12:00:00Z",
+                        ]
+                    )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(status, 1)
+            self.assertEqual(payload["status"], "error")
+            self.assertEqual(payload["record"]["status"], "warn")
+
     def test_render_base_check_payload_merges_embedded_statuses(self) -> None:
         payload_text = render_base_check_payload(
             checks=(

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -84,6 +84,12 @@ results as nested diagnostic payload objects under `project_checks` and
 object shape and use the same diagnostic item fields inside each project's
 `checks` array.
 
+When a project check cannot persist its optional latest-check record, the check
+payload may also include a top-level `record` object with `status: "warn"`, a
+stable `message`, a suggested `fix`, and the attempted `path`. This warning
+does not change the aggregate diagnostic `status` or exit code; workspace
+status explicitly treats the missing record as unavailable state.
+
 Doctor commands use the same diagnostic item fields. The top-level
 `basectl doctor --format json` wrapper includes `schema_version` and aggregate
 `status`, and keeps doctor-specific arrays named `findings`,

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -65,6 +65,11 @@ check date in the `LAST CHECK` column, while JSON output includes the full
 timestamp and check status. Projects without a recorded check show `-` in text
 output and `null` in JSON output.
 
+The latest-check record is optional persistence state. If a check succeeds but
+cannot save that record, the check result remains authoritative and workspace
+status reports the missing record as `-` or `null` until a later check can save
+one.
+
 With `--manifest <path>`, the same commands also report expected repositories,
 missing required and optional repositories, and discovered Base-managed
 projects outside the manifest.


### PR DESCRIPTION
## Summary

- Preserve valid check JSON and the original diagnostic exit status when optional last-check persistence fails.
- Add stable JSON and concise text warnings for the persistence failure.
- Harden fallback record writes and temporary-file cleanup, with focused regression coverage and contract documentation.

## Root cause

check-json emitted its diagnostic payload before an unguarded last-check write. A write failure therefore surfaced after valid output as a traceback, while text-mode persistence failures were silently ignored.

## Validation

- 19 focused Python diagnostics payload tests passed.
- All 42 check BATS tests passed.
- Full gate passed: 957 Python tests passed, 1 skipped, and 857 BATS tests passed.
- ShellCheck error-level validation passed.

Fixes #1916

## AI context

No AI-context update was needed; this is a contained diagnostics contract and persistence fix documented in the command and diagnostic contract docs.