### PR TITLE
fix(repo): honor Base self-check validation contract

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -103,6 +103,8 @@ reusable-layer DEBUG diagnostics.
   repositories to the configured workspace root; use `--path .` for the current
   checkout. Plain `repo init` writes local baseline files without committing or
   pushing them; `repo init --agent-ready` also seeds `AGENTS.md` and `skills.md`;
+  `repo check` follows the manifest-declared `./bin/base-test` validation path
+  for Base itself while generated repositories retain `tests/validate.sh`;
   `repo check --agent-ready` verifies that baseline-integrated agent guidance
   contract; `repo init --pr --issue <number>` commits baseline changes on a
   canonical issue-backed branch, pushes to `origin`, and opens a PR. Offline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Aligned Base's self-repository baseline checks and workspace agent brief with
+  `base_manifest.yaml`'s `./bin/base-test` validation contract while retaining
+  `tests/validate.sh` for generated repositories.
+
 - Preserved `basectl check` diagnostics and exit status when the optional
   latest-check record cannot be written, with stable JSON and text warnings.
 

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -1984,18 +1984,23 @@ base_repo_check_baseline() {
     local path="$1"
     local rel
     local repo_name
-    local required_count="${#BASE_REPO_BASELINE_FILES[@]}"
+    local required_files=()
+    local required_count
+    local validation_file
     local not_executable_files=()
     local command=()
 
-    for rel in "${BASE_REPO_BASELINE_FILES[@]}"; do
+    validation_file="$(base_repo_baseline_validation_file "$path")"
+    mapfile -t required_files < <(base_repo_required_baseline_files "$path")
+    required_count="${#required_files[@]}"
+    for rel in "${required_files[@]}"; do
         if [[ ! -f "$path/$rel" ]]; then
             missing_files+=("$rel")
         fi
     done
 
-    if [[ -f "$path/tests/validate.sh" && ! -x "$path/tests/validate.sh" ]]; then
-        not_executable_files+=(tests/validate.sh)
+    if [[ -f "$path/$validation_file" && ! -x "$path/$validation_file" ]]; then
+        not_executable_files+=("$validation_file")
     fi
 
     if ((${#missing_files[@]} || ${#not_executable_files[@]})); then
@@ -2020,7 +2025,18 @@ base_repo_check_baseline() {
             fi
             printf "  Fix: chmod +x %s\n" "$(base_repo_pretty_arg "$fix_path")"
         done
-        if ((${#missing_files[@]})); then
+        if ((${#missing_files[@]})) && [[ "$validation_file" != 'tests/validate.sh' ]]; then
+            for rel in "${missing_files[@]}"; do
+                if [[ "$rel" == "$validation_file" ]]; then
+                    printf "  Fix: create executable %s as declared by base_manifest.yaml.\n" "$rel"
+                fi
+            done
+        fi
+        if ((${#missing_files[@]})) && {
+            [[ "$validation_file" == 'tests/validate.sh' ]] ||
+                ((${#missing_files[@]} > 1)) ||
+                [[ "${missing_files[0]}" != "$validation_file" ]]
+        }; then
             repo_name="$(basename -- "$path")"
             command=(basectl repo init "$repo_name" --path "$path")
             printf "Run '"
@@ -2789,6 +2805,44 @@ base_repo_check_missing_files() {
     done
 }
 
+base_repo_manifest_uses_base_test() {
+    local manifest_path="$1"
+
+    [[ -f "$manifest_path" ]] || return 1
+    awk '
+        $0 ~ /^test:[[:space:]]*$/ { in_test=1; next }
+        in_test && $0 ~ /^[^[:space:]]/ { in_test=0 }
+        in_test && $0 ~ /^[[:space:]]+command:[[:space:]]*\.\/bin\/base-test[[:space:]]*$/ {
+            found=1
+            exit
+        }
+        END { exit !found }
+    ' "$manifest_path"
+}
+
+base_repo_baseline_validation_file() {
+    local path="$1"
+
+    if base_repo_manifest_uses_base_test "$path/base_manifest.yaml"; then
+        printf '%s\n' 'bin/base-test'
+    else
+        printf '%s\n' 'tests/validate.sh'
+    fi
+}
+
+base_repo_required_baseline_files() {
+    local path="$1"
+    local rel
+    local validation_file
+
+    validation_file="$(base_repo_baseline_validation_file "$path")"
+    for rel in "${BASE_REPO_BASELINE_FILES[@]}"; do
+        [[ "$rel" == 'tests/validate.sh' ]] && continue
+        printf '%s\n' "$rel"
+    done
+    printf '%s\n' "$validation_file"
+}
+
 base_repo_check_json() {
     local path="$1"
     local release_contract="$2"
@@ -2800,13 +2854,15 @@ base_repo_check_json() {
     local check_count=1 failed_count=0 passed_count=0
     local manifest_declared=false process_present=false
     local missing_files=() not_executable_files=() agent_missing_files=() checks_json=()
-    local required_count present_count
+    local required_files=() required_count present_count validation_file
 
-    mapfile -t missing_files < <(base_repo_check_missing_files "$path" "${BASE_REPO_BASELINE_FILES[@]}")
-    if [[ -f "$path/tests/validate.sh" && ! -x "$path/tests/validate.sh" ]]; then
-        not_executable_files+=(tests/validate.sh)
+    validation_file="$(base_repo_baseline_validation_file "$path")"
+    mapfile -t required_files < <(base_repo_required_baseline_files "$path")
+    mapfile -t missing_files < <(base_repo_check_missing_files "$path" "${required_files[@]}")
+    if [[ -f "$path/$validation_file" && ! -x "$path/$validation_file" ]]; then
+        not_executable_files+=("$validation_file")
     fi
-    required_count="${#BASE_REPO_BASELINE_FILES[@]}"
+    required_count="${#required_files[@]}"
     present_count=$((required_count - ${#missing_files[@]}))
     baseline_status=ok
     if ((${#missing_files[@]} || ${#not_executable_files[@]})); then

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -1644,6 +1644,23 @@ EOF
     [[ "$output" == *"Repository baseline: all 13 required files present."* ]]
 }
 
+@test "basectl repo check uses the Base manifest validation command" {
+    run_basectl repo check "$BASE_REPO_ROOT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Repository baseline: all 13 required files present."* ]]
+    [[ "$output" != *"tests/validate.sh"* ]]
+}
+
+@test "basectl repo check JSON uses the Base manifest validation command" {
+    run_basectl repo check "$BASE_REPO_ROOT" --format json
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status":"ok"'* ]]
+    [[ "$output" == *'"missing_files":[]'* ]]
+    [[ "$output" != *"tests/validate.sh"* ]]
+}
+
 @test "basectl repo check reports missing baseline files" {
     local repo_dir="$TEST_TMPDIR/incomplete"
 

--- a/cli/python/base_projects/tests/test_workspace_agent_brief.py
+++ b/cli/python/base_projects/tests/test_workspace_agent_brief.py
@@ -50,15 +50,29 @@ def write_project_manifest(project_root: Path, name: str, test_command: str | No
     (project_root / "base_manifest.yaml").write_text("\n".join(lines), encoding="utf-8")
 
 
-def write_repo_contract(project_root: Path, name: str, *, context: bool = True) -> None:
-    write_project_manifest(project_root, name)
+def write_repo_contract(
+    project_root: Path,
+    name: str,
+    *,
+    context: bool = True,
+    test_command: str | None = None,
+) -> None:
+    write_project_manifest(project_root, name, test_command)
     for relative_path in REPO_BASELINE_FILES:
+        if test_command == "./bin/base-test" and relative_path == "tests/validate.sh":
+            continue
         path = project_root / relative_path
         path.parent.mkdir(parents=True, exist_ok=True)
         if relative_path == "base_manifest.yaml":
             continue
         path.write_text(f"fixture for {relative_path}\n", encoding="utf-8")
-    validation_script = project_root / "tests" / "validate.sh"
+    validation_script = (
+        project_root / "bin" / "base-test"
+        if test_command == "./bin/base-test"
+        else project_root / "tests" / "validate.sh"
+    )
+    validation_script.parent.mkdir(parents=True, exist_ok=True)
+    validation_script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
     validation_script.chmod(0o755)
 
     for relative_path in REPO_AGENT_GUIDANCE_FILES:
@@ -574,6 +588,47 @@ class WorkspaceAgentBriefTests(unittest.TestCase):
         self.assertIn(".ai-context is reported but is not required", stdout)
         self.assertIn(f"basectl repo check {(workspace / 'ready').resolve()} --agent-ready", stdout)
         self.assertIn(f"cd {(workspace / 'ready').resolve()} && ./tests/validate.sh", stdout)
+
+    def test_base_self_repository_uses_manifest_validation_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_workspace_manifest(manifest_path)
+            write_repo_contract(workspace / "ready", "base", test_command="./bin/base-test")
+            write_ready_python(workspace / "ready", home, "base")
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "agent-brief",
+                    "--workspace",
+                    str(workspace),
+                    "--manifest",
+                    str(manifest_path),
+                    "--format",
+                    "json",
+                ],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        ready = next(item for item in payload["repositories"] if item["repository"] == "ready")
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(ready["handoff_status"], "ready")
+        self.assertEqual(ready["signals"]["baseline"]["status"], "complete")
+        self.assertEqual(ready["signals"]["baseline"]["missing_files"], [])
+        self.assertEqual(ready["signals"]["baseline"]["not_executable_files"], [])
+        self.assertEqual(ready["signals"]["validation"]["source"], "manifest_test")
+        self.assertEqual(
+            ready["signals"]["validation"]["command"],
+            f"cd {(workspace / 'ready').resolve()} && basectl test",
+        )
 
     def test_python_readiness_file_contract_matches_shell_repo_check(self) -> None:
         repo_source = (REPO_ROOT / "cli/bash/commands/basectl/subcommands/repo.sh").read_text(encoding="utf-8")

--- a/cli/python/base_projects/workspace_agent_brief.py
+++ b/cli/python/base_projects/workspace_agent_brief.py
@@ -16,6 +16,8 @@ from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_onboarding import test_command_for_status
 from base_projects.workspace_statuses import WorkspaceProjectStatus
 from base_projects.workspace_statuses import workspace_manifest_project_statuses
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError
 
 
 # Keep these tuples in parity with the shell-owned repo check contract. The
@@ -123,7 +125,13 @@ def agent_brief_repository_from_status(status: WorkspaceProjectStatus) -> Worksp
         baseline = not_applicable_file_signal()
         agent_guidance = unmanaged_agent_guidance_signal(status.root)
     else:
-        baseline = repository_file_signal(status.root, REPO_BASELINE_FILES, check_executable=True)
+        validation_file = repository_baseline_validation_file(status)
+        baseline = repository_file_signal(
+            status.root,
+            repository_baseline_files(validation_file),
+            check_executable=True,
+            executable_files=(validation_file,),
+        )
         agent_guidance = repository_file_signal(status.root, REPO_AGENT_GUIDANCE_FILES)
     ai_context_status = repository_ai_context_status(status.root) if present else "unavailable"
     validation = repository_validation_signal(status) if present else RepositoryValidationSignal(status="unavailable")
@@ -160,18 +168,44 @@ def not_applicable_file_signal() -> RepositoryFileSignal:
     return RepositoryFileSignal(status="not_applicable")
 
 
+def repository_baseline_validation_file(status: WorkspaceProjectStatus) -> str:
+    """Return the validation file required by the repository baseline contract."""
+    if status.name != "base" or status.manifest != "valid" or status.manifest_path is None:
+        return "tests/validate.sh"
+    try:
+        manifest = read_manifest(status.manifest_path)
+    except ManifestError:
+        return "tests/validate.sh"
+    if manifest.test is not None and manifest.test.command == "./bin/base-test":
+        return "bin/base-test"
+    return "tests/validate.sh"
+
+
+def repository_baseline_files(validation_file: str) -> tuple[str, ...]:
+    if validation_file == "tests/validate.sh":
+        return REPO_BASELINE_FILES
+    return tuple(
+        validation_file if relative_path == "tests/validate.sh" else relative_path
+        for relative_path in REPO_BASELINE_FILES
+    )
+
+
 def repository_file_signal(
     root: Path,
     required_files: tuple[str, ...],
     *,
     check_executable: bool = False,
+    executable_files: tuple[str, ...] = (),
 ) -> RepositoryFileSignal:
     missing_files = tuple(relative_path for relative_path in required_files if not (root / relative_path).is_file())
     not_executable_files: tuple[str, ...] = ()
     if check_executable:
-        validation_script = root / "tests" / "validate.sh"
-        if validation_script.is_file() and not executable_file(validation_script):
-            not_executable_files = ("tests/validate.sh",)
+        executable_paths = executable_files or ("tests/validate.sh",)
+        not_executable_files = tuple(
+            relative_path
+            for relative_path in executable_paths
+            if (root / relative_path).is_file() and not executable_file(root / relative_path)
+        )
 
     status = "complete" if not missing_files and not not_executable_files else "incomplete"
     return RepositoryFileSignal(

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -245,6 +245,13 @@ Existing files are left unchanged. This makes `repo init` useful both for a
 fresh directory and for bringing a small existing repository up to Base's
 minimum expectations.
 
+The generated repositories use `tests/validate.sh` as their baseline
+validation file. Base's own repository is the documented exception: when
+`base_manifest.yaml` declares `test.command: ./bin/base-test`, `repo check`
+requires the manifest-declared `bin/base-test` path instead of
+`tests/validate.sh`. This keeps the self-check aligned with Base's actual
+validation contract without changing the generated-repository default.
+
 The generated `base_manifest.yaml` declares the project name and a test command.
 When language profiles are selected, it also records the normalized languages
 and applies the Python uv profile:

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -103,8 +103,10 @@ basectl workspace agent-brief --manifest ~/work/base-workspace/workspace.yaml --
 
 The brief reports the Base repository baseline and agent-guidance file
 contracts, `.ai-context` Markdown availability, project environment state, and
-an inferred validation path. An executable `tests/validate.sh` is preferred;
-when only a manifest-declared test is available, its execution stays behind a
+an inferred validation path. The generated repository baseline uses an
+executable `tests/validate.sh`; Base's own manifest-declared
+`test.command: ./bin/base-test` is used for the Base repository instead. When
+only a manifest-declared test is available, its execution stays behind a
 recommended `basectl test` so Base retains runner, trust, and environment
 ownership. The brief never executes those commands. It does not use GitHub,
 generate guidance or context files, clone repositories, or change setup state.


### PR DESCRIPTION
## Summary

- Make `repo check` derive the required validation file from the repository manifest for Base itself.
- Keep `tests/validate.sh` as the default baseline for generated repositories.
- Align `workspace agent-brief` readiness signals with the same self-repository contract.

## Issue

Closes #1915

## Validation

- Focused repo BATS: 129 passed.
- Focused workspace agent-brief tests: 10 passed, 6 subtests.
- Full local harness: 958 Python tests passed, 1 skipped; 859 BATS tests passed.
- Pylint and ShellCheck passed for touched files.
- `git diff --check` passed.

## Notes

- Updated repository baseline and workspace-manifest documentation, changelog, and `.ai-context/COMMANDS.md`.
