### PR TITLE
docs: align Python test commands with CI source paths

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -153,7 +153,9 @@ basectl test base
 Python tests run with:
 
 ```bash
-PYTHONPATH=cli/python python -m pytest
+BASE_CLI_SOURCE_DIR=../base-cli/lib/python \
+PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
+python -m pytest
 ```
 
 The shared `base_cli` framework is maintained in the standalone `base-cli`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,8 +32,9 @@ patterns over new one-off conventions.
 Use the narrowest relevant validation first:
 
 - documentation-only changes: `git diff --check`;
-- Python changes: install the pinned `base-cli` development dependency and run
-  the focused pytest target with `PYTHONPATH=cli/python`;
+- Python changes: use the standalone `base-cli` source checkout and run the
+  focused pytest target with `BASE_CLI_SOURCE_DIR=../base-cli/lib/python` and
+  `PYTHONPATH=../base-cli/lib/python:lib/python:cli/python`;
 - Bash command changes: run the focused BATS tests;
 - general Base changes: run `env -u BASE_HOME ./bin/base-test` when practical.
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Run Python tests
         env:
+          BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python
           PYTHONPATH: .dependencies/base-cli/lib/python:lib/python:cli/python
         run: |
           python -m pytest \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,10 +112,17 @@ Before opening the PR:
 4. Run the narrowest validation command that proves the change.
 
 For documentation-only starter issues, `git diff --check` is usually enough.
-For Python-only changes, run the focused pytest target with
-`PYTHONPATH=lib/python:cli/python python -m pytest`. For shell command or
-runtime changes, run the focused BATS test when one exists and broaden only
-when the change crosses command boundaries.
+For Python-only changes, run the focused pytest target with the standalone
+`base-cli` source path used by CI:
+
+```bash
+BASE_CLI_SOURCE_DIR=../base-cli/lib/python \
+PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
+python -m pytest
+```
+
+For shell command or runtime changes, run the focused BATS test when one exists
+and broaden only when the change crosses command boundaries.
 
 When the full source-checkout suite is needed from a linked worktree under
 `~/work/base-worktrees`, export the reusable Bash library path first:

--- a/docs/ci-supply-chain-policy.md
+++ b/docs/ci-supply-chain-policy.md
@@ -37,7 +37,9 @@ this policy if the rule changes.
 3. Run:
 
    ```bash
-   PYTHONPATH=cli/python python -m pytest cli/python/base_setup/tests/test_ci_supply_chain_policy.py -q
+   BASE_CLI_SOURCE_DIR=../base-cli/lib/python \
+   PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
+   python -m pytest cli/python/base_setup/tests/test_ci_supply_chain_policy.py -q
    ```
 
 4. Let pull request CI run the pinned workflows before merging.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,17 +62,30 @@ scan all production packages, or invoke shell files live under the top-level
 `tests/` directory so they are not mistaken for tests of an installed Python
 distribution.
 
-Run them with:
+From a Base source checkout with the standalone `base-cli` checkout next to it,
+run the Python suite with the same source roots used by CI:
 
 ```bash
-PYTHONPATH=cli/python python -m pytest
+BASE_CLI_SOURCE_DIR=../base-cli/lib/python \
+PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
+python -m pytest
 ```
+
+If `base-cli` is not at `../base-cli`, replace that path in both assignments
+with the absolute path to its `lib/python` directory. `BASE_CLI_SOURCE_DIR`
+must point at a directory containing `base_cli/__init__.py`. The pinned
+`base-cli` package installed from `requirements-dev.txt` is useful for package
+metadata and tooling, but it is not a substitute for this source checkout:
+the documented suite imports source-level APIs that the package does not
+provide.
 
 The Python CI job also measures coverage for production code under
 `cli/python`:
 
 ```bash
-PYTHONPATH=cli/python python -m pytest \
+BASE_CLI_SOURCE_DIR=../base-cli/lib/python \
+PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
+python -m pytest \
   --cov=cli/python \
   --cov-report=term-missing \
   --cov-fail-under=85

--- a/skills.md
+++ b/skills.md
@@ -178,13 +178,15 @@ Use this workflow when adding or changing Python-backed Base behavior.
 - Command execution wrapper: `bin/base-wrapper`
 - Keep Base-owned tests under `cli/python/**/tests/`; framework tests live in
   the standalone `base-cli` repository.
-- Run Base Python commands with `PYTHONPATH=cli/python` and an installed
-  `base-cli` development dependency, or set `BASE_CLI_SOURCE_DIR` for a source
-  checkout.
+- Run Base Python commands with the standalone `base-cli` source checkout:
+  `BASE_CLI_SOURCE_DIR=../base-cli/lib/python` and
+  `PYTHONPATH=../base-cli/lib/python:lib/python:cli/python`.
 - Validate with:
 
 ```bash
-env PYTHONPATH=cli/python python -m pytest
+BASE_CLI_SOURCE_DIR=../base-cli/lib/python \
+PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
+python -m pytest
 ```
 
 ## Add or change artifact setup

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -107,6 +107,49 @@ def test_python_coverage_policy_is_wired_and_documented() -> None:
     assert "Bash/BATS" in testing_doc
 
 
+def test_python_test_docs_and_ci_use_the_standalone_base_cli_source_contract() -> None:
+    workflow = TESTS_WORKFLOW.read_text(encoding="utf-8")
+    testing_doc = TESTING_DOC.read_text(encoding="utf-8")
+    contributor_doc = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    workflow_guidance = (REPO_ROOT / ".ai-context" / "WORKFLOWS.md").read_text(
+        encoding="utf-8"
+    )
+    skills_doc = (REPO_ROOT / "skills.md").read_text(encoding="utf-8")
+    supply_chain_doc = (REPO_ROOT / "docs" / "ci-supply-chain-policy.md").read_text(
+        encoding="utf-8"
+    )
+
+    source_path = "../base-cli/lib/python"
+    pythonpath = f"{source_path}:lib/python:cli/python"
+
+    assert (
+        "BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python"
+        in workflow
+    )
+    assert (
+        "PYTHONPATH: .dependencies/base-cli/lib/python:lib/python:cli/python"
+        in workflow
+    )
+    for text in (
+        testing_doc,
+        contributor_doc,
+        workflow_guidance,
+        skills_doc,
+        supply_chain_doc,
+    ):
+        assert f"BASE_CLI_SOURCE_DIR={source_path}" in text
+        assert f"PYTHONPATH={pythonpath}" in text
+
+    for text in (
+        testing_doc,
+        contributor_doc,
+        workflow_guidance,
+        skills_doc,
+        supply_chain_doc,
+    ):
+        assert "PYTHONPATH=cli/python" not in text
+
+
 def test_active_project_guidance_uses_repo_named_project_language() -> None:
     for path in ACTIVE_WORKFLOW_GUIDANCE_FILES:
         text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Align the documented Python and coverage commands with CI's standalone `base-cli` source checkout.
- Document sibling checkout resolution, `BASE_CLI_SOURCE_DIR` overrides, and why the packaged dependency is insufficient for source-level APIs.
- Update contributor, skills, Copilot, AI workflow, and supply-chain guidance to the same contract.
- Add a contract regression test covering the documentation and workflow source paths.

## Issue

Closes #1914

## Validation

- `git diff --check`
- `BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python python -m pytest --cov=cli/python --cov-report=term-missing --cov-fail-under=85` (959 passed, 1 skipped, 87.49% coverage)
- `tests/contracts/run.sh` (all steps passed)
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python ./bin/base-test` (Python: 959 passed, 1 skipped; BATS: 858/859 passed on first run; the one transient ordering test passed on isolated rerun)

## AI Context

- Updated `.ai-context/WORKFLOWS.md` and the active contributor/agent guidance because this changes the documented validation workflow.
