### PR TITLE
ci: promote base-bash-libs v2.0.0 GA pin

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: c134fb8a3397e2cfee1d90845cec44f56dacae7b
+          ref: b4243765726c133499feeabdc50154f99c0fec12
           path: .base/base-bash-libs
 
       - name: Checkout base-cli source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: c134fb8a3397e2cfee1d90845cec44f56dacae7b
+          ref: b4243765726c133499feeabdc50154f99c0fec12
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -628,7 +628,7 @@ def test_reusable_base_check_workflow_contract() -> None:
     assert "args=(check --ci \"$BASE_CHECK_PROJECT\" --format \"$BASE_CHECK_OUTPUT_FORMAT\")" in run_commands
     assert "BASE_BASH_LIBS_DIR" in run_commands
     assert "basefoundry/base-bash-libs" in str(steps)
-    assert "c134fb8a3397e2cfee1d90845cec44f56dacae7b" in str(steps)
+    assert "b4243765726c133499feeabdc50154f99c0fec12" in str(steps)
     assert "${{ inputs.base-ref || github.workflow_sha }}" in str(steps)
     assert "uses: basefoundry/base/.github/workflows/base-check.yml@<base-ref-or-sha>" in ci_docs
     assert "| `setup-mode` | `source-checkout` |" in ci_docs


### PR DESCRIPTION
## Summary
- promote Base CI and source-checkout validation from the v2.0.0-rc.1 commit to the immutable v2.0.0 GA commit `b4243765726c133499feeabdc50154f99c0fec12`
- update the workflow contract assertion to prevent RC drift

The Base v2 API/runtime migration is already merged in #1934; this is the GA promotion required by base-bash-libs #240.

Validation: full local Base harness reached 958 passed / 1 skipped with one pre-existing host-timezone failure in `base_history`; the changed workflow contract passed within that run.