### PR TITLE
ci: add external base-demo end-to-end workflow

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -163,6 +163,12 @@ repository. Source-checkout tests resolve it from `BASE_CLI_SOURCE_DIR`, a
 sibling `../base-cli/lib/python` checkout, or the installed `base-cli`
 development dependency; Base no longer provides an in-tree copy.
 
+The scheduled/manual `Base Demo E2E` workflow runs the macOS setup, check, test,
+and non-interactive demo loop against the external `basefoundry/base-demo`
+repository. Keep its failure ownership visible: `Base bug` covers Base
+dispatch/runtime failures, while `base-demo manifest needs updating` covers
+manifest, artifact, or declared-command drift.
+
 Integration tests live under `tests/integration/` and run against temporary
 homes, workspaces, and fake projects. Add integration coverage for
 cross-command workflows, setup/check/doctor interactions, shell profile

--- a/.github/workflows/base-demo-e2e.yml
+++ b/.github/workflows/base-demo-e2e.yml
@@ -1,0 +1,150 @@
+name: Base Demo E2E
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      base_demo_ref:
+        description: "base-demo branch, tag, or commit to validate"
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  base-demo-e2e:
+    name: Base demo end-to-end loop
+    runs-on: macos-14
+    timeout-minutes: 45
+    env:
+      BASE_CACHE_DIR: ${{ github.workspace }}/.base-cache
+      BASE_BASH_LIBS_DIR: ${{ github.workspace }}/.dependencies/base-bash-libs/lib/bash
+      BASE_CLI_SOURCE_DIR: ${{ github.workspace }}/.dependencies/base-cli/lib/python
+      BASE_SETUP_NOTIFY: "false"
+      BASE_DEMO_ENV: baseline
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      - name: Check out Base
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Check out base-cli
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-cli
+          ref: v0.4.2
+          path: .dependencies/base-cli
+
+      - name: Check out base-bash-libs
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-bash-libs
+          ref: b4243765726c133499feeabdc50154f99c0fec12
+          path: .dependencies/base-bash-libs
+
+      - name: Expose dependency checkouts as Base siblings
+        run: |
+          ln -s "$GITHUB_WORKSPACE/.dependencies/base-cli" "$GITHUB_WORKSPACE/../base-cli"
+          ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"
+
+      - name: Check out base-demo
+        env:
+          BASE_DEMO_REF: ${{ inputs.base_demo_ref || 'main' }}
+        run: |
+          if [[ ! "$BASE_DEMO_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::base_demo_ref contains unsupported characters."
+            exit 2
+          fi
+          git init "$GITHUB_WORKSPACE/../base-demo"
+          git -C "$GITHUB_WORKSPACE/../base-demo" remote add origin \
+            https://github.com/basefoundry/base-demo.git
+          git -C "$GITHUB_WORKSPACE/../base-demo" fetch --depth 1 origin "$BASE_DEMO_REF"
+          git -C "$GITHUB_WORKSPACE/../base-demo" checkout --detach FETCH_HEAD
+          git -C "$GITHUB_WORKSPACE/../base-demo" log -1 --oneline
+
+      - name: Install Bash and BATS
+        run: brew install bash bats-core
+
+      - name: Set up Base
+        run: ./bin/basectl setup --ci base --format json
+
+      - name: Disable IDE setup in CI
+        run: |
+          mkdir -p "$HOME/.base.d"
+          {
+            printf '\nide:\n'
+            printf '  enabled: false\n'
+          } >> "$HOME/.base.d/config.yaml"
+
+      - name: Run Base demo end-to-end loop
+        env:
+          BASE_DEMO_ROOT: ${{ github.workspace }}/../base-demo
+          BASE_DEMO_WORKSPACE: ${{ github.workspace }}/..
+        run: |
+          set -o pipefail
+          log_dir="$RUNNER_TEMP/base-demo-e2e"
+          mkdir -p "$log_dir"
+
+          run_base_demo_command() {
+            local label="$1"
+            shift
+            local log_path="$log_dir/${label// /-}.log"
+            local status
+            local owner
+
+            printf '::group::%s\n' "$label"
+            if "$@" 2>&1 | tee "$log_path"; then
+              status=0
+            else
+              status="${PIPESTATUS[0]}"
+            fi
+            printf '::endgroup::\n'
+
+            if ((status == 0)); then
+              return 0
+            fi
+
+            if grep -Eiq 'base_manifest\.yaml|manifest|artifact|test\.command|demo\.script|BASE-[A-Z0-9-]+' "$log_path"; then
+              owner="base-demo manifest needs updating"
+            else
+              owner="Base bug"
+            fi
+            printf '::error title=Base demo E2E failure::%s failed with exit %s. Owner triage: %s. Full output: %s\n' \
+              "$label" "$status" "$owner" "$log_path"
+            return "$status"
+          }
+
+          run_base_demo_command \
+            "basectl setup base-demo" \
+            ./bin/basectl setup --ci base-demo \
+              --manifest "$BASE_DEMO_ROOT/base_manifest.yaml" \
+              --format json --no-notify
+
+          run_base_demo_command \
+            "basectl check base-demo" \
+            ./bin/basectl check --ci base-demo \
+              --manifest "$BASE_DEMO_ROOT/base_manifest.yaml" \
+              --format json
+
+          run_base_demo_command \
+            "uv sync base-demo" \
+            bash -c 'cd "$BASE_DEMO_ROOT" && uv sync --locked'
+
+          run_base_demo_command \
+            "basectl trust allow base-demo" \
+            ./bin/basectl trust allow base-demo --workspace "$BASE_DEMO_WORKSPACE"
+
+          run_base_demo_command \
+            "basectl test base-demo" \
+            ./bin/basectl test base-demo --workspace "$BASE_DEMO_WORKSPACE"
+
+          run_base_demo_command \
+            "basectl demo base-demo" \
+            ./bin/basectl demo base-demo --workspace "$BASE_DEMO_WORKSPACE" -- --non-interactive

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -168,6 +168,21 @@ The default integration suite should not install real Homebrew packages, edit
 real shell startup files, depend on network access, or mutate repositories
 outside the temporary BATS workspace.
 
+## External Base Demo E2E
+
+The [Base Demo E2E workflow](../.github/workflows/base-demo-e2e.yml) runs the
+macOS product loop against the real `basefoundry/base-demo` repository on a
+nightly schedule and through `workflow_dispatch`. It sets up and checks the
+demo, approves its reviewed manifest, then runs the declared test and
+non-interactive demo commands. Use the workflow input to validate a specific
+`base-demo` branch, tag, or commit.
+
+This job is intentionally separate from Base's own test matrix because it
+validates an external manifest and project contract. Its grouped CI output
+labels the likely owner as either `Base bug` or `base-demo manifest needs
+updating`, while keeping a per-command temporary log path available during the
+runner for triage.
+
 Run only integration tests with:
 
 ```bash

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -18,6 +18,7 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 COPILOT_INSTRUCTIONS = REPO_ROOT / ".github" / "copilot-instructions.md"
 COPILOT_SETUP_WORKFLOW = WORKFLOW_DIR / "copilot-setup-steps.yml"
 BASE_CHECK_WORKFLOW = WORKFLOW_DIR / "base-check.yml"
+BASE_DEMO_E2E_WORKFLOW = WORKFLOW_DIR / "base-demo-e2e.yml"
 BASE_PROJECT_CONFIG = REPO_ROOT / ".github" / "base-project.yml"
 ISSUE_BRANCH_POLICY_WORKFLOW = WORKFLOW_DIR / "issue-branch-policy.yml"
 ISSUE_BRANCH_POLICY_TEMPLATE = REPO_ROOT / "templates" / "issue-branch-policy.yml"
@@ -632,6 +633,50 @@ def test_reusable_base_check_workflow_contract() -> None:
     assert "${{ inputs.base-ref || github.workflow_sha }}" in str(steps)
     assert "uses: basefoundry/base/.github/workflows/base-check.yml@<base-ref-or-sha>" in ci_docs
     assert "| `setup-mode` | `source-checkout` |" in ci_docs
+
+
+def test_base_demo_e2e_workflow_covers_the_external_project_loop() -> None:
+    workflow = load_workflow(BASE_DEMO_E2E_WORKFLOW)
+    triggers = workflow.get("on") or workflow.get(True)
+    job = workflow["jobs"]["base-demo-e2e"]
+    steps = job["steps"]
+    run_commands = "\n".join(step.get("run", "") for step in steps if isinstance(step, dict))
+
+    assert workflow["name"] == "Base Demo E2E"
+    assert triggers["schedule"] == [{"cron": "17 3 * * *"}]
+    assert "workflow_dispatch" in triggers
+    assert workflow["permissions"] == {"contents": "read"}
+    assert "concurrency" in workflow
+    assert job["runs-on"] == "macos-14"
+    assert job["timeout-minutes"] == 45
+    assert job["env"]["BASE_DEMO_ENV"] == "baseline"
+    assert job["env"]["BASE_CLI_SOURCE_DIR"].endswith(".dependencies/base-cli/lib/python")
+
+    checkout_repositories = [
+        step.get("with", {}).get("repository")
+        for step in steps
+        if isinstance(step, dict) and step.get("uses", "").startswith("actions/checkout@")
+        and step.get("with", {}).get("repository")
+    ]
+    assert checkout_repositories == [
+        "basefoundry/base-cli",
+        "basefoundry/base-bash-libs",
+    ]
+    assert "b4243765726c133499feeabdc50154f99c0fec12" in str(steps)
+    assert "v0.4.2" in str(steps)
+
+    for command in (
+        "basectl setup --ci base-demo",
+        "basectl check --ci base-demo",
+        "basectl test base-demo",
+        "basectl demo base-demo",
+    ):
+        assert command in run_commands
+    assert "basefoundry/base-demo.git" in run_commands
+    assert "base-demo manifest needs updating" in run_commands
+    assert "owner=\"Base bug\"" in run_commands
+    assert "BASE_DEMO_ROOT/base_manifest.yaml" in run_commands
+    assert "--non-interactive" in run_commands
 
 
 def test_copilot_repository_instructions_stay_anchored_to_base_guidance() -> None:


### PR DESCRIPTION
## Summary

- add a scheduled and manually dispatched macOS Base Demo E2E workflow
- exercise setup, check, trust, test, and non-interactive demo against the real external base-demo repository
- pin the workflow to the verified base-bash-libs v2.0.0 GA commit and document failure ownership

## Issue

Closes #1913

## Validation

- `git diff --check`
- reviewed workflow contract and pinned dependency refs locally
- hosted CI validates the workflow contract and repository test suite

## Demo Impact

None.
