### PR TITLE
feat: opt into closed unmerged branch cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in `--closed-unmerged` cleanup to `basectl gh branch prune` and
+  `basectl gh worktree prune`, with explicit PR-state classification and
+  retention details for open, closed-unmerged, and no-PR branches.
+
 ## [1.8.0] - 2026-08-15
 
 ### Added

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -31,8 +31,8 @@ Usage:
   basectl gh project configure --project <title> [--owner <login>] [--repo <owner/name>] [--schema base-project] [--config <path>] [--copy-fields-from <title>] [--replace-project] [--initiative-option <name>] [--dry-run]
   basectl gh project issue set-fields <number> --project <title> [--owner <login>] [--repo <owner/name>] [--allow-cross-repo] [field options...]
   basectl gh branch stale [--days <days>] [--format <text|json>]
-  basectl gh branch prune [--dry-run] [--yes] [--remote]
-  basectl gh worktree prune [--dry-run] [--yes]
+  basectl gh branch prune [--dry-run] [--yes] [--remote] [--closed-unmerged]
+  basectl gh worktree prune [--dry-run] [--yes] [--closed-unmerged]
 
 Purpose:
   Manage GitHub issues, pull requests, Project metadata, branch naming, and
@@ -540,7 +540,7 @@ base_gh_branch_usage() {
     cat <<'EOF'
 Usage:
   basectl gh branch stale [--days <days>] [--format <text|json>]
-  basectl gh branch prune [--dry-run] [--yes] [--remote]
+  basectl gh branch prune [--dry-run] [--yes] [--remote] [--closed-unmerged]
 
 Purpose:
   Inspect stale branches and prune merged local or GitHub branches.
@@ -551,7 +551,7 @@ Note:
 
 Options:
   stale: --days <days>, --format <text|json>
-  prune: --dry-run, --yes, --remote
+  prune: --dry-run, --yes, --remote, --closed-unmerged
   -h, --help     Show this help text.
 EOF
 }
@@ -583,10 +583,11 @@ Purpose:
   Preview or remove safely merged local and GitHub branches.
 
 Options:
-  --dry-run   Preview branches that would be deleted (default).
-  --yes       Delete safely merged branches after preview.
-  --remote    Also clean merged GitHub branches and stale origin refs.
-  -h, --help  Show this help text.
+  --dry-run          Preview branches that would be deleted (default).
+  --yes              Delete selected branches after preview.
+  --remote           Also clean selected GitHub branches and stale origin refs.
+  --closed-unmerged  Include branches whose PRs were closed without merging.
+  -h, --help         Show this help text.
 EOF
             ;;
         *)
@@ -598,19 +599,20 @@ EOF
 base_gh_worktree_usage() {
     cat <<'EOF'
 Usage:
-  basectl gh worktree prune [--dry-run] [--yes]
+  basectl gh worktree prune [--dry-run] [--yes] [--closed-unmerged]
 
 Purpose:
-  Prune safe, merged Git worktrees and their local branches.
+  Prune safe merged worktrees and explicitly selected closed-unmerged worktrees.
 
 Note:
   Runs in dry-run mode by default. Pass --yes to apply changes.
   --dry-run and --yes are mutually exclusive; choose one when overriding the default.
 
 Options:
-  --dry-run      Preview worktrees that would be removed (default).
-  --yes          Remove safe merged worktrees after preview.
-  -h, --help     Show this help text.
+  --dry-run          Preview worktrees that would be removed (default).
+  --yes              Remove selected worktrees after preview.
+  --closed-unmerged  Include clean worktrees tied to closed, unmerged PRs.
+  -h, --help         Show this help text.
 EOF
 }
 

--- a/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
@@ -4,6 +4,8 @@
 _base_gh_branch_worktree_sourced=1
 readonly _base_gh_branch_worktree_sourced
 
+declare -gA BASE_GH_BRANCH_PR_STATE_CACHE=()
+
 base_gh_branch_stale() {
     local days=30 now ref name timestamp age
     local output_format="text" requested_format
@@ -152,6 +154,49 @@ base_gh_format_unix_date() {
     printf 'unknown\n'
 }
 
+base_gh_closed_age_days() {
+    local closed_unix="$1"
+    local now age
+
+    [[ "$closed_unix" =~ ^[0-9]+$ ]] || {
+        printf 'unknown\n'
+        return 0
+    }
+    printf -v now '%(%s)T' -1
+    age=$(((now - closed_unix) / 86400))
+    ((age < 0)) && age=0
+    printf '%s\n' "$age"
+}
+
+base_gh_branch_pr_detail() {
+    local state="$1"
+    local pr_numbers="$2"
+    local closed_at="$3"
+    local closed_unix="$4"
+    local age
+
+    case "$state" in
+        open)
+            printf 'open GitHub PR #%s; branch retained' "$pr_numbers"
+            ;;
+        closed_unmerged)
+            age="$(base_gh_closed_age_days "$closed_unix")"
+            if [[ -n "$closed_at" ]]; then
+                printf 'closed GitHub PR #%s without merge (%s days ago, %s); branch retained' \
+                    "$pr_numbers" "$age" "${closed_at%%T*}"
+            else
+                printf 'closed GitHub PR #%s without merge; branch retained' "$pr_numbers"
+            fi
+            ;;
+        no_pr)
+            printf 'no GitHub PR found; branch retained'
+            ;;
+        *)
+            printf 'branch retained'
+            ;;
+    esac
+}
+
 base_gh_worktree_path_for_branch() {
     local branch="$1"
 
@@ -182,39 +227,105 @@ base_gh_prune_github_ready() {
     [[ "$_base_gh_prune_github_ready" == 1 ]]
 }
 
-base_gh_branch_github_merged() {
+base_gh_branch_github_pr_state() {
     local branch="$1"
-    local count
+    local result state pr_numbers closed_at closed_unix
 
+    if [[ ${BASE_GH_BRANCH_PR_STATE_CACHE[$branch]+cached} ]]; then
+        printf '%s\n' "${BASE_GH_BRANCH_PR_STATE_CACHE[$branch]}"
+        return 0
+    fi
     if ! base_gh_prune_github_ready; then
         base_gh_error "GitHub merge verification requires the GitHub CLI 'gh' on PATH."
         return 2
     fi
-    count="$(base_cli_gh_run pr list --head "$branch" --state merged --json number --jq 'length')" || return 2
-    if [[ ! "$count" =~ ^[0-9]+$ ]]; then
-        base_gh_error "GitHub merge verification returned an invalid result for branch '$branch'."
+
+    result="$(base_cli_gh_run pr list --head "$branch" --state all \
+        --json number,state,closedAt,mergedAt \
+        --jq '
+            if any(.[]; .state == "OPEN") then
+                ["open", ([.[] | select(.state == "OPEN") | .number] | map(tostring) | join(",")), "-", 0]
+            elif any(.[]; .state == "MERGED") then
+                ["merged", ([.[] | select(.state == "MERGED") | .number] | map(tostring) | join(",")), "-", 0]
+            elif any(.[]; .state == "CLOSED" and .mergedAt == null) then
+                [
+                    "closed_unmerged",
+                    ([.[] | select(.state == "CLOSED" and .mergedAt == null) | .number] | map(tostring) | join(",")),
+                    ([.[] | select(.state == "CLOSED" and .mergedAt == null and .closedAt != null) | .closedAt] | sort | last // "-"),
+                    (([.[] | select(.state == "CLOSED" and .mergedAt == null and .closedAt != null) | (.closedAt | fromdateiso8601)] | sort | last) // 0)
+                ]
+            else
+                ["no_pr", "-", "-", 0]
+            end | @tsv')" || return 2
+    IFS=$'\t' read -r state pr_numbers closed_at closed_unix <<< "$result"
+    case "$state" in
+        open|merged|closed_unmerged|no_pr)
+            ;;
+        *)
+            base_gh_error "GitHub PR state verification returned an invalid result for branch '$branch'."
+            return 2
+            ;;
+    esac
+    if [[ ! "$closed_unix" =~ ^[0-9]+$ ]]; then
+        base_gh_error "GitHub PR state verification returned an invalid close time for branch '$branch'."
         return 2
     fi
-    ((count > 0))
+
+    BASE_GH_BRANCH_PR_STATE_CACHE["$branch"]="$result"
+    printf '%s\n' "$result"
+}
+
+base_gh_branch_github_merged() {
+    local branch="$1"
+    local result state pr_numbers closed_at closed_unix
+
+    result="$(base_gh_branch_github_pr_state "$branch")" || return $?
+    IFS=$'\t' read -r state pr_numbers closed_at closed_unix <<< "$result"
+    [[ "$state" == merged ]]
+}
+
+base_gh_branch_cleanup_state() {
+    local branch="$1"
+    local default_branch="$2"
+    local state_var="$3"
+    local merge_source_var="$4"
+    local pr_numbers_var="$5"
+    local closed_at_var="$6"
+    local closed_unix_var="$7"
+    local result resolved_state resolved_pr_numbers resolved_closed_at resolved_closed_unix
+
+    if base_gh_branch_merged_to_ref "$branch" "$default_branch"; then
+        printf -v "$state_var" '%s' merged
+        printf -v "$merge_source_var" '%s' git
+        printf -v "$pr_numbers_var" '%s' ''
+        printf -v "$closed_at_var" '%s' ''
+        printf -v "$closed_unix_var" '%s' 0
+        return 0
+    fi
+
+    result="$(base_gh_branch_github_pr_state "$branch")" || return $?
+    IFS=$'\t' read -r resolved_state resolved_pr_numbers resolved_closed_at resolved_closed_unix <<< "$result"
+    [[ "$resolved_pr_numbers" == - ]] && resolved_pr_numbers=""
+    [[ "$resolved_closed_at" == - ]] && resolved_closed_at=""
+    printf -v "$state_var" '%s' "$resolved_state"
+    printf -v "$merge_source_var" '%s' "$([[ "$resolved_state" == merged ]] && printf github || printf '')"
+    printf -v "$pr_numbers_var" '%s' "$resolved_pr_numbers"
+    printf -v "$closed_at_var" '%s' "$resolved_closed_at"
+    printf -v "$closed_unix_var" '%s' "$resolved_closed_unix"
+    [[ "$resolved_state" == merged ]]
 }
 
 base_gh_branch_cleanup_merged() {
     local branch="$1"
     local default_branch="$2"
     local merge_source_var="${3:-}"
-    local rc
+    local state resolved_source pr_numbers closed_at closed_unix rc
 
-    if base_gh_branch_merged_to_ref "$branch" "$default_branch"; then
-        [[ -z "$merge_source_var" ]] || printf -v "$merge_source_var" '%s' git
+    if base_gh_branch_cleanup_state "$branch" "$default_branch" state resolved_source pr_numbers closed_at closed_unix; then
+        [[ -z "$merge_source_var" ]] || printf -v "$merge_source_var" '%s' "$resolved_source"
         return 0
     fi
-
-    base_gh_branch_github_merged "$branch"
     rc=$?
-    if ((rc == 0)); then
-        [[ -z "$merge_source_var" ]] || printf -v "$merge_source_var" '%s' github
-        return 0
-    fi
     if ((rc == 2)); then
         [[ -z "$merge_source_var" ]] || printf -v "$merge_source_var" '%s' unknown
         return 2
@@ -226,7 +337,7 @@ base_gh_branch_delete() {
     local branch="$1"
     local merge_source="$2"
 
-    if [[ "$merge_source" == github ]]; then
+    if [[ "$merge_source" == github || "$merge_source" == closed_unmerged ]]; then
         git branch -D "$branch" >/dev/null 2>&1
     else
         git branch -d "$branch" >/dev/null 2>&1
@@ -246,8 +357,11 @@ base_gh_branch_delete_remote() {
 base_gh_branch_prune_local() {
     local dry_run="$1"
     local default_branch="$2"
+    local include_closed_unmerged="${3:-0}"
     local branch current_branch merge_source merge_status worktree_path upstream
+    local state pr_numbers closed_at closed_unix detail
     local deleted=0 skipped_current=0 skipped_worktree=0 skipped_upstream=0 failed=0 candidates=0
+    local closed_review=0 open_review=0 no_pr_review=0
 
     current_branch="$(git branch --show-current)"
     printf 'Local branches\n'
@@ -262,15 +376,25 @@ base_gh_branch_prune_local() {
         fi
 
         merge_source=""
-        if base_gh_branch_cleanup_merged "$branch" "$default_branch" merge_source; then
+        if base_gh_branch_cleanup_state "$branch" "$default_branch" state merge_source pr_numbers closed_at closed_unix; then
             merge_status=0
         else
             merge_status=$?
         fi
         if ((merge_status == 1)); then
-            printf 'SKIP   %s  not confirmed merged into %s or through a merged GitHub PR; local branch retained\n' \
-                "$branch" "$default_branch"
-            continue
+            if [[ "$state" == closed_unmerged && "$include_closed_unmerged" == 1 ]]; then
+                merge_source=closed_unmerged
+                merge_status=0
+            else
+                detail="$(base_gh_branch_pr_detail "$state" "$pr_numbers" "$closed_at" "$closed_unix")"
+                printf 'SKIP   %s  %s\n' "$branch" "$detail"
+                case "$state" in
+                    closed_unmerged) closed_review=$((closed_review + 1)) ;;
+                    open) open_review=$((open_review + 1)) ;;
+                    no_pr) no_pr_review=$((no_pr_review + 1)) ;;
+                esac
+                continue
+            fi
         fi
         if ((merge_status != 0)); then
             printf 'SKIP   %s  GitHub merge verification unavailable; local branch retained\n' "$branch"
@@ -287,14 +411,16 @@ base_gh_branch_prune_local() {
         fi
 
         upstream="$(base_gh_branch_upstream "$branch")"
-        if [[ "$merge_source" != github && -n "$upstream" ]] && ! base_gh_branch_merged_to_ref "$branch" "$upstream"; then
+        if [[ "$merge_source" != github && "$merge_source" != closed_unmerged && -n "$upstream" ]] && ! base_gh_branch_merged_to_ref "$branch" "$upstream"; then
             printf 'SKIP   %s  not fully merged to upstream %s\n' "$branch" "$upstream"
             skipped_upstream=$((skipped_upstream + 1))
             continue
         fi
 
         if ((dry_run)); then
-            if [[ "$merge_source" == github ]]; then
+            if [[ "$merge_source" == closed_unmerged ]]; then
+                printf '[DRY-RUN] DELETE %s  closed unmerged GitHub PR #%s\n' "$branch" "$pr_numbers"
+            elif [[ "$merge_source" == github ]]; then
                 printf '[DRY-RUN] DELETE %s  merged GitHub PR\n' "$branch"
             else
                 printf '[DRY-RUN] DELETE %s\n' "$branch"
@@ -304,7 +430,7 @@ base_gh_branch_prune_local() {
             printf 'DELETE %s\n' "$branch"
             deleted=$((deleted + 1))
         else
-            printf 'FAIL   %s  git branch -d failed\n' "$branch"
+            printf 'FAIL   %s  local branch deletion failed\n' "$branch"
             failed=$((failed + 1))
         fi
     done < <(git branch --format='%(refname:short)')
@@ -318,6 +444,8 @@ base_gh_branch_prune_local() {
     printf 'Summary: %s %s, %s skipped current/default, %s skipped worktree, %s skipped upstream, %s failed.\n' \
         "$deleted" "$([[ "$dry_run" -eq 1 ]] && printf 'would delete' || printf 'deleted')" \
         "$skipped_current" "$skipped_worktree" "$skipped_upstream" "$failed"
+    printf 'Classification: %s closed-unmerged review, %s open PR, %s no PR.\n' \
+        "$closed_review" "$open_review" "$no_pr_review"
     if ((failed > 0)); then
         return 1
     fi
@@ -327,8 +455,11 @@ base_gh_branch_prune_local() {
 base_gh_branch_prune_github_branches() {
     local dry_run="$1"
     local default_branch="$2"
-    local branch current_branch merge_status worktree_path remote_branches
+    local include_closed_unmerged="${3:-0}"
+    local branch current_branch merge_source merge_status worktree_path remote_branches result
+    local state pr_numbers closed_at closed_unix detail
     local deleted=0 skipped_current=0 skipped_worktree=0 skipped_unmerged=0 failed=0 candidates=0 found=0
+    local closed_review=0 open_review=0 no_pr_review=0
 
     printf 'GitHub branches\n'
     if ! base_gh_prune_github_ready; then
@@ -353,16 +484,31 @@ base_gh_branch_prune_github_branches() {
             continue
         fi
 
-        if base_gh_branch_github_merged "$branch"; then
+        merge_source=""
+        if result="$(base_gh_branch_github_pr_state "$branch")"; then
             merge_status=0
+            IFS=$'\t' read -r state pr_numbers closed_at closed_unix <<< "$result"
+            [[ "$pr_numbers" == - ]] && pr_numbers=""
+            [[ "$closed_at" == - ]] && closed_at=""
+            if [[ "$state" != merged ]]; then
+                if [[ "$state" == closed_unmerged && "$include_closed_unmerged" == 1 ]]; then
+                    merge_source=closed_unmerged
+                else
+                    detail="$(base_gh_branch_pr_detail "$state" "$pr_numbers" "$closed_at" "$closed_unix")"
+                    printf 'SKIP   origin/%s  %s\n' "$branch" "$detail"
+                    skipped_unmerged=$((skipped_unmerged + 1))
+                    case "$state" in
+                        closed_unmerged) closed_review=$((closed_review + 1)) ;;
+                        open) open_review=$((open_review + 1)) ;;
+                        no_pr) no_pr_review=$((no_pr_review + 1)) ;;
+                    esac
+                    continue
+                fi
+            else
+                merge_source=github
+            fi
         else
             merge_status=$?
-        fi
-        if ((merge_status == 1)); then
-            printf 'SKIP   origin/%s  no merged GitHub PR found for this branch; remote branch retained\n' \
-                "$branch"
-            skipped_unmerged=$((skipped_unmerged + 1))
-            continue
         fi
         if ((merge_status != 0)); then
             printf 'SKIP   origin/%s  GitHub merge verification unavailable; remote branch retained\n' "$branch"
@@ -379,7 +525,11 @@ base_gh_branch_prune_github_branches() {
         fi
 
         if ((dry_run)); then
-            printf '[DRY-RUN] DELETE-REMOTE origin/%s  merged GitHub PR\n' "$branch"
+            if [[ "$merge_source" == closed_unmerged ]]; then
+                printf '[DRY-RUN] DELETE-REMOTE origin/%s  closed unmerged GitHub PR #%s\n' "$branch" "$pr_numbers"
+            else
+                printf '[DRY-RUN] DELETE-REMOTE origin/%s  merged GitHub PR\n' "$branch"
+            fi
             deleted=$((deleted + 1))
         elif base_gh_branch_delete_remote "$branch"; then
             printf 'DELETE-REMOTE origin/%s\n' "$branch"
@@ -398,6 +548,8 @@ base_gh_branch_prune_github_branches() {
     printf 'Summary: %s %s, %s skipped current/default, %s skipped worktree, %s skipped unmerged, %s failed.\n' \
         "$deleted" "$([[ "$dry_run" -eq 1 ]] && printf 'would delete remotely' || printf 'deleted remotely')" \
         "$skipped_current" "$skipped_worktree" "$skipped_unmerged" "$failed"
+    printf 'Classification: %s closed-unmerged review, %s open PR, %s no PR.\n' \
+        "$closed_review" "$open_review" "$no_pr_review"
     if ((failed > 0)); then
         return 1
     fi
@@ -445,9 +597,10 @@ base_gh_branch_prune_remote_tracking_refs() {
 }
 
 base_gh_branch_prune() {
-    local dry_run=1 remote=0 default_branch status=0
+    local dry_run=1 remote=0 include_closed_unmerged=0 default_branch status=0
     local dry_run_requested=0 yes_requested=0
 
+    BASE_GH_BRANCH_PR_STATE_CACHE=()
     while (($#)); do
         case "$1" in
             --dry-run)
@@ -458,6 +611,9 @@ base_gh_branch_prune() {
                 ;;
             --remote)
                 remote=1
+                ;;
+            --closed-unmerged)
+                include_closed_unmerged=1
                 ;;
             -h|--help)
                 base_gh_branch_leaf_usage prune
@@ -479,10 +635,10 @@ base_gh_branch_prune() {
     if ((dry_run)); then
         printf '[DRY-RUN] Branch prune preview for default branch %s.\n' "$default_branch"
     fi
-    base_gh_branch_prune_local "$dry_run" "$default_branch" || status=$?
+    base_gh_branch_prune_local "$dry_run" "$default_branch" "$include_closed_unmerged" || status=$?
 
     if ((remote)); then
-        base_gh_branch_prune_github_branches "$dry_run" "$default_branch" || status=$?
+        base_gh_branch_prune_github_branches "$dry_run" "$default_branch" "$include_closed_unmerged" || status=$?
         base_gh_branch_prune_remote_tracking_refs "$dry_run" || status=$?
     fi
     if ((dry_run)); then
@@ -515,7 +671,7 @@ base_gh_worktree_prune_delete_branch() {
     local upstream
 
     upstream="$(base_gh_branch_upstream "$branch")"
-    if [[ "$merge_source" != github && -n "$upstream" ]] && ! base_gh_branch_merged_to_ref "$branch" "$upstream"; then
+    if [[ "$merge_source" != github && "$merge_source" != closed_unmerged && -n "$upstream" ]] && ! base_gh_branch_merged_to_ref "$branch" "$upstream"; then
         printf 'SKIP-BRANCH %s  not fully merged to upstream %s\n' "$branch" "$upstream"
         return 1
     fi
@@ -531,9 +687,12 @@ base_gh_worktree_prune_delete_branch() {
 base_gh_worktree_prune() {
     local dry_run=1 default_branch current_worktree
     local path branch merge_source merge_status physical_path
+    local include_closed_unmerged=0 state pr_numbers closed_at closed_unix detail
     local removed=0 skipped_current=0 skipped_dirty=0 skipped_unmerged=0 failed=0 candidates=0
+    local closed_review=0 open_review=0 no_pr_review=0
     local dry_run_requested=0 yes_requested=0
 
+    BASE_GH_BRANCH_PR_STATE_CACHE=()
     while (($#)); do
         case "$1" in
             --dry-run)
@@ -541,6 +700,9 @@ base_gh_worktree_prune() {
                 ;;
             --yes)
                 yes_requested=1
+                ;;
+            --closed-unmerged)
+                include_closed_unmerged=1
                 ;;
             --remote)
                 base_gh_usage_error base_gh_worktree_usage \
@@ -596,15 +758,26 @@ base_gh_worktree_prune() {
             continue
         fi
         merge_source=""
-        if base_gh_branch_cleanup_merged "$branch" "$default_branch" merge_source; then
+        if base_gh_branch_cleanup_state "$branch" "$default_branch" state merge_source pr_numbers closed_at closed_unix; then
             merge_status=0
         else
             merge_status=$?
         fi
         if ((merge_status == 1)); then
-            printf 'SKIP   %s (%s)  branch is not merged into %s or a merged GitHub PR\n' "$path" "$branch" "$default_branch"
-            skipped_unmerged=$((skipped_unmerged + 1))
-            continue
+            if [[ "$state" == closed_unmerged && "$include_closed_unmerged" == 1 ]]; then
+                merge_source=closed_unmerged
+                merge_status=0
+            else
+                detail="$(base_gh_branch_pr_detail "$state" "$pr_numbers" "$closed_at" "$closed_unix")"
+                printf 'SKIP   %s (%s)  %s\n' "$path" "$branch" "$detail"
+                skipped_unmerged=$((skipped_unmerged + 1))
+                case "$state" in
+                    closed_unmerged) closed_review=$((closed_review + 1)) ;;
+                    open) open_review=$((open_review + 1)) ;;
+                    no_pr) no_pr_review=$((no_pr_review + 1)) ;;
+                esac
+                continue
+            fi
         fi
         if ((merge_status != 0)); then
             printf 'SKIP   %s (%s)  GitHub merge verification unavailable; worktree retained\n' "$path" "$branch"
@@ -613,14 +786,21 @@ base_gh_worktree_prune() {
         fi
 
         if ((dry_run)); then
-            if [[ "$merge_source" == github ]]; then
+            if [[ "$merge_source" == closed_unmerged ]]; then
+                printf '[DRY-RUN] REMOVE %s (%s) and delete local branch; closed unmerged GitHub PR #%s; remote branch retained\n' \
+                    "$path" "$branch" "$pr_numbers"
+            elif [[ "$merge_source" == github ]]; then
                 printf '[DRY-RUN] REMOVE %s (%s) and delete local branch; merged GitHub PR\n' "$path" "$branch"
             else
                 printf '[DRY-RUN] REMOVE %s (%s) and delete local branch\n' "$path" "$branch"
             fi
             removed=$((removed + 1))
         elif git worktree remove "$path" >/dev/null 2>&1; then
-            printf 'REMOVE %s (%s)\n' "$path" "$branch"
+            if [[ "$merge_source" == closed_unmerged ]]; then
+                printf 'REMOVE %s (%s); remote branch retained\n' "$path" "$branch"
+            else
+                printf 'REMOVE %s (%s)\n' "$path" "$branch"
+            fi
             removed=$((removed + 1))
             if ! base_gh_worktree_prune_delete_branch "$branch" "$merge_source"; then
                 failed=$((failed + 1))
@@ -637,6 +817,8 @@ base_gh_worktree_prune() {
     printf 'Summary: %s %s, %s skipped current/default, %s skipped dirty, %s skipped unmerged, %s failed.\n' \
         "$removed" "$([[ "$dry_run" -eq 1 ]] && printf 'would remove' || printf 'removed')" \
         "$skipped_current" "$skipped_dirty" "$skipped_unmerged" "$failed"
+    printf 'Classification: %s closed-unmerged review, %s open PR, %s no PR.\n' \
+        "$closed_review" "$open_review" "$no_pr_review"
     if ((dry_run)); then
         if ((failed == 0)); then
             printf 'Run with --yes to apply these changes.\n'

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -341,7 +341,7 @@ EOF
     [[ "$output" == *"gh_project_configure_options=--project --owner --schema --config --copy-fields-from --initiative-option --repo --replace-project --dry-run"* ]]
     [[ "$output" == *"gh_project_issue_set_fields_options=--repo --project --owner --config --allow-cross-repo --status --priority --area --initiative --size --dry-run"* ]]
     [[ "$output" == *"gh_worktree_commands=prune"* ]]
-    [[ "$output" == *"gh_worktree_prune_options=--dry-run --yes"* ]]
+    [[ "$output" == *"gh_worktree_prune_options=--dry-run --yes --closed-unmerged"* ]]
 }
 
 @test "Zsh repo pull request helper completions include issue and category options" {

--- a/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
+++ b/cli/bash/commands/basectl/tests/gh-branch-worktree.bats
@@ -60,10 +60,10 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"basectl gh worktree prune [--dry-run] [--yes]"* ]]
-    [[ "$output" == *"Prune safe, merged Git worktrees and their local branches."* ]]
+    [[ "$output" == *"Prune safe merged worktrees and explicitly selected closed-unmerged worktrees."* ]]
     [[ "$output" == *"Runs in dry-run mode by default. Pass --yes to apply changes."* ]]
-    [[ "$output" == *"--dry-run      Preview worktrees that would be removed (default)."* ]]
-    [[ "$output" == *"-h, --help     Show this help text."* ]]
+    [[ "$output" == *"--dry-run          Preview worktrees that would be removed (default)."* ]]
+    [[ "$output" == *"-h, --help         Show this help text."* ]]
     [[ "$output" != *"basectl gh branch prune"* ]]
     [[ "$output" != *"basectl gh issue create"* ]]
 }
@@ -298,8 +298,8 @@ load ./basectl_helpers.bash
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head unmerged-work --state merged --json number --jq length" ]]; then
-    printf '0\n'
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "unmerged-work" ]]; then
+    printf 'no_pr\t-\t-\t0\n'
     exit 0
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -319,9 +319,10 @@ EOF
         ' bash "$repo"
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"SKIP   unmerged-work  not confirmed merged into master or through a merged GitHub PR; local branch retained"* ]]
-    [[ "$output" == *"SKIP   origin/unmerged-work  no merged GitHub PR found for this branch; remote branch retained"* ]]
+    [[ "$output" == *"SKIP   unmerged-work  no GitHub PR found; branch retained"* ]]
+    [[ "$output" == *"SKIP   origin/unmerged-work  no GitHub PR found; branch retained"* ]]
     [[ "$output" == *"Summary: 0 deleted remotely, 1 skipped current/default, 0 skipped worktree, 1 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Classification: 0 closed-unmerged review, 0 open PR, 1 no PR."* ]]
     git -C "$repo" show-ref --verify --quiet refs/heads/unmerged-work
     git -C "$repo" ls-remote --exit-code --heads origin unmerged-work >/dev/null
 }
@@ -441,8 +442,8 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head squash-remote --state merged --json number --jq length" ]]; then
-    printf '1\n'
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "squash-remote" ]]; then
+    printf 'merged\t1\t-\t0\n'
     exit 0
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -488,8 +489,8 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head squash-remote --state merged --json number --jq length" ]]; then
-    printf '1\n'
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "squash-remote" ]]; then
+    printf 'merged\t1\t-\t0\n'
     exit 0
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -533,7 +534,7 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head lookup-failure --state merged --json number --jq length" ]]; then
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "lookup-failure" ]]; then
     printf 'failed to connect to api.github.com\n' >&2
     exit 1
 fi
@@ -613,8 +614,8 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head squash-work --state merged --json number --jq length" ]]; then
-    printf '1\n'
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "squash-work" ]]; then
+    printf 'merged\t1\t-\t0\n'
     exit 0
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -657,8 +658,8 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head squash-work --state merged --json number --jq length" ]]; then
-    printf '1\n'
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "squash-work" ]]; then
+    printf 'merged\t1\t-\t0\n'
     exit 0
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -700,7 +701,7 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head lookup-failure --state merged --json number --jq length" ]]; then
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "lookup-failure" ]]; then
     printf 'failed to connect to api.github.com\n' >&2
     exit 1
 fi
@@ -866,8 +867,8 @@ EOF
 
     cat > "$TEST_MOCKBIN/gh" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$*" == "pr list --head unmerged-work --state merged --json number --jq length" ]]; then
-    printf '0\n'
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "unmerged-work" ]]; then
+    printf 'no_pr\t-\t-\t0\n'
     exit 0
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -887,8 +888,9 @@ EOF
         ' bash "$repo"
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"SKIP   "*"/unmerged-worktree (unmerged-work)  branch is not merged into master or a merged GitHub PR"* ]]
+    [[ "$output" == *"SKIP   "*"/unmerged-worktree (unmerged-work)  no GitHub PR found; branch retained"* ]]
     [[ "$output" == *"Summary: 0 removed, 1 skipped current/default, 0 skipped dirty, 1 skipped unmerged, 0 failed."* ]]
+    [[ "$output" == *"Classification: 0 closed-unmerged review, 0 open PR, 1 no PR."* ]]
     [ -d "$worktree" ]
     git -C "$repo" show-ref --verify --quiet refs/heads/unmerged-work
 }
@@ -912,7 +914,7 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head lookup-failure --state merged --json number --jq length" ]]; then
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "lookup-failure" ]]; then
     printf 'failed to connect to api.github.com\n' >&2
     exit 1
 fi
@@ -959,8 +961,8 @@ EOF
 if [[ "$*" == "auth status -h github.com" ]]; then
     exit 0
 fi
-if [[ "$*" == "pr list --head squash-work --state merged --json number --jq length" ]]; then
-    printf '1\n'
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "squash-work" ]]; then
+    printf 'merged\t1\t-\t0\n'
     exit 0
 fi
 printf 'unexpected gh args: %s\n' "$*" >&2
@@ -985,4 +987,210 @@ EOF
     [[ "$output" == *"Summary: 1 removed, 1 skipped current/default, 0 skipped dirty, 0 skipped unmerged, 0 failed."* ]]
     [ ! -e "$worktree" ]
     ! git -C "$repo" show-ref --verify --quiet refs/heads/squash-work
+}
+
+@test "basectl gh branch prune retains closed-unmerged branches by default" {
+    local repo remote
+
+    repo="$TEST_TMPDIR/repo"
+    remote="$TEST_TMPDIR/remote.git"
+    create_tracked_repo_with_upstream "$repo" "$remote" "README.md" "hello"
+    git -C "$repo" switch -c closed-remote >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Closed topic"
+    git -C "$repo" push -u origin closed-remote >/dev/null 2>&1
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" branch -D closed-remote >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "closed-remote" ]]; then
+    printf 'closed_unmerged\t1939\t2026-08-08T20:44:31Z\t1786221871\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune --remote --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP   origin/closed-remote  closed GitHub PR #1939 without merge ("*" days ago, 2026-08-08); branch retained"* ]]
+    [[ "$output" == *"Classification: 1 closed-unmerged review, 0 open PR, 0 no PR."* ]]
+    git -C "$repo" ls-remote --exit-code --heads origin closed-remote >/dev/null
+}
+
+@test "basectl gh branch prune --remote --closed-unmerged deletes opted-in branches" {
+    local repo remote
+
+    repo="$TEST_TMPDIR/repo"
+    remote="$TEST_TMPDIR/remote.git"
+    create_tracked_repo_with_upstream "$repo" "$remote" "README.md" "hello"
+    git -C "$repo" switch -c closed-remote >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Closed topic"
+    git -C "$repo" push -u origin closed-remote >/dev/null 2>&1
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" branch -D closed-remote >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "closed-remote" ]]; then
+    printf 'closed_unmerged\t1939\t2026-08-08T20:44:31Z\t1786221871\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune --remote --closed-unmerged --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DELETE-REMOTE origin/closed-remote"* ]]
+    [[ "$output" == *"Summary: 1 deleted remotely,"* ]]
+    ! git -C "$repo" ls-remote --exit-code --heads origin closed-remote >/dev/null
+}
+
+@test "basectl gh branch prune --closed-unmerged never deletes open PR branches" {
+    local repo remote
+
+    repo="$TEST_TMPDIR/repo"
+    remote="$TEST_TMPDIR/remote.git"
+    create_tracked_repo_with_upstream "$repo" "$remote" "README.md" "hello"
+    git -C "$repo" switch -c open-remote >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Open topic"
+    git -C "$repo" push -u origin open-remote >/dev/null 2>&1
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" branch -D open-remote >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "open-remote" ]]; then
+    printf 'open\t2020\t-\t0\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune --remote --closed-unmerged --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP   origin/open-remote  open GitHub PR #2020; branch retained"* ]]
+    [[ "$output" != *"DELETE-REMOTE origin/open-remote"* ]]
+    git -C "$repo" ls-remote --exit-code --heads origin open-remote >/dev/null
+}
+
+@test "basectl gh branch prune --closed-unmerged deletes opted-in local branches" {
+    local repo
+
+    repo="$TEST_TMPDIR/repo"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c closed-local >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Closed topic"
+    git -C "$repo" switch master >/dev/null
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "closed-local" ]]; then
+    printf 'closed_unmerged\t1939\t2026-08-08T20:44:31Z\t1786221871\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main branch prune --closed-unmerged --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DELETE closed-local"* ]]
+    [[ "$output" == *"Summary: 1 deleted,"* ]]
+    ! git -C "$repo" show-ref --verify --quiet refs/heads/closed-local
+}
+
+@test "basectl gh worktree prune --closed-unmerged removes only local state" {
+    local repo worktree
+
+    repo="$TEST_TMPDIR/repo"
+    worktree="$TEST_TMPDIR/closed-worktree"
+    init_git_repo "$repo"
+    printf 'hello\n' > "$repo/README.md"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" switch -c closed-work >/dev/null
+    printf 'topic\n' > "$repo/topic.txt"
+    commit_all "$repo" "Closed topic"
+    git -C "$repo" switch master >/dev/null
+    git -C "$repo" worktree add "$worktree" closed-work >/dev/null 2>&1
+
+    cat > "$TEST_MOCKBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "list" && "$4" == "closed-work" ]]; then
+    printf 'closed_unmerged\t1939\t2026-08-08T20:44:31Z\t1786221871\n'
+    exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$TEST_MOCKBIN/gh"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        PATH="$TEST_MOCKBIN:$PATH" \
+        bash -c '
+            cd "$1"
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/gh.sh"
+            base_gh_subcommand_main worktree prune --closed-unmerged --yes
+        ' bash "$repo"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOVE "*"/closed-worktree (closed-work); remote branch retained"* ]]
+    [[ "$output" == *"DELETE closed-work"* ]]
+    ! [ -e "$worktree" ]
+    ! git -C "$repo" show-ref --verify --quiet refs/heads/closed-work
 }

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -422,8 +422,11 @@ Base can also help with branch cleanup:
 basectl gh branch prune
 basectl gh branch prune --yes
 basectl gh branch prune --remote --yes
+basectl gh branch prune --remote --closed-unmerged
+basectl gh branch prune --remote --closed-unmerged --yes
 basectl gh worktree prune
 basectl gh worktree prune --yes
+basectl gh worktree prune --closed-unmerged --yes
 ```
 
 The command is dry-run by default. It reports merged local branches as delete
@@ -431,22 +434,30 @@ candidates, reports branches attached to worktrees as skipped, and treats
 `--remote` as GitHub remote branch cleanup plus stale `origin/*` tracking-ref
 cleanup. Because Base usually uses squash merges, pruning checks GitHub PR state
 when Git ancestry does not prove the merge. A successful GitHub query with no
-merged PR keeps the branch as an ordinary unmerged skip and prints the retained
-branch name. If the GitHub query cannot complete, pruning retains the branch or
-worktree, reports the underlying verification error, counts the incomplete check
-as a failure, and exits nonzero instead of classifying it as unmerged.
+merged PR classifies the branch as open, closed-unmerged, or no-PR and prints the
+retention reason. Closed-unmerged branches remain review-only by default. Pass
+`--closed-unmerged` to include them in the dry-run candidate set; `--yes` then
+applies that explicitly selected cleanup scope. If the GitHub query cannot
+complete, pruning retains the branch or worktree, reports the underlying
+verification error, counts the incomplete check as a failure, and exits nonzero
+instead of classifying it as unmerged.
 
-Remote branch pruning is deliberately conservative. Base deletes a GitHub branch
-only when GitHub confirms a merged pull request for that exact branch name. It
-does not delete the default branch, the current branch, or a branch attached to a
-local worktree. After safe GitHub branches are deleted, Base prunes stale local
-`origin/*` refs.
+Remote branch pruning is deliberately conservative. Without
+`--closed-unmerged`, Base deletes a GitHub branch only when GitHub confirms a
+merged pull request for that exact branch name. With the explicit option, it may
+also delete a branch whose associated pull requests are all closed without a
+merge, but never when an open PR exists. It does not delete the default branch,
+the current branch, or a branch attached to a local worktree. After safe GitHub
+branches are deleted, Base prunes stale local `origin/*` refs.
 
 Worktree pruning is also dry-run by default. It removes only clean, non-current
 worktrees whose branches are confirmed merged into the default branch or through
-a merged GitHub PR, then deletes the now-free local branch when safe. Resolve any
-reported GitHub verification failures and rerun the preview before applying it
-with `--yes`.
+a merged GitHub PR. With `--closed-unmerged`, it may also remove clean
+worktrees tied to closed, unmerged PRs. That option deletes only the local
+worktree and local branch; the remote branch remains for
+`basectl gh branch prune --remote --closed-unmerged`. Resolve any reported
+GitHub verification failures and rerun the preview before applying it with
+`--yes`.
 
 If a worktree is removed but its local branch cannot be deleted, the command
 retains the branch, reports the incomplete cleanup, and exits nonzero. Resolve
@@ -454,9 +465,9 @@ the branch condition before treating the cleanup as complete.
 
 When `basectl gh branch prune` reports branches attached to worktrees, preview
 those worktrees with `basectl gh worktree prune`, apply the safe removals with
-`basectl gh worktree prune --yes`, and rerun the branch-prune command. The
-`--remote` option belongs to `basectl gh branch prune`; worktree pruning only
-removes local worktrees and their local branches.
+the same `--closed-unmerged` scope when needed, and rerun the branch-prune
+command. The `--remote` option belongs to `basectl gh branch prune`; worktree
+pruning only removes local worktrees and their local branches.
 
 ## Superseded Pull Requests
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -888,14 +888,14 @@ _base_basectl_completion() {
                     elif [[ "${COMP_WORDS[3]:-}" == stale ]]; then
                         _base_basectl_completion_compgen "--days --format -h --help" "$cur"
                     elif [[ "${COMP_WORDS[3]:-}" == prune ]]; then
-                        _base_basectl_completion_compgen "--dry-run --yes --remote -h --help" "$cur"
+                        _base_basectl_completion_compgen "--dry-run --yes --remote --closed-unmerged -h --help" "$cur"
                     fi
                     ;;
                 worktree)
                     if ((COMP_CWORD == 3)); then
                         _base_basectl_completion_compgen "prune" "$cur"
                     else
-                        _base_basectl_completion_compgen "--dry-run --yes -h --help" "$cur"
+                        _base_basectl_completion_compgen "--dry-run --yes --closed-unmerged -h --help" "$cur"
                     fi
                     ;;
                 project)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -1067,6 +1067,7 @@ _base_basectl_completion() {
                             '--dry-run[Show planned deletions]' \
                             '--yes[Apply branch pruning]' \
                             '--remote[Prune stale remote tracking refs]' \
+                            '--closed-unmerged[Include branches tied to closed, unmerged PRs]' \
                             '(-h --help)'{-h,--help}'[Show help text]'
                     else
                         _arguments '2:gh area:(auth issue pr branch worktree project)' \
@@ -1078,6 +1079,7 @@ _base_basectl_completion() {
                         '3:worktree command:(prune)' \
                         '--dry-run[Show planned removals]' \
                         '--yes[Apply worktree pruning]' \
+                        '--closed-unmerged[Include worktrees tied to closed, unmerged PRs]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
                 project)


### PR DESCRIPTION
Closes #1939

## Summary
- classify branch PR state as open, merged, closed-unmerged, or no PR
- keep closed-unmerged branches retained by default and add explicit --closed-unmerged opt-in cleanup
- keep worktree cleanup local-only and retain remote branches for branch prune
- report PR numbers, close age/date, and classification counts

## Validation
- 36 focused gh-branch-worktree BATS tests
- 60 adjacent gh command BATS tests
- bash -n and git diff --check

Generated by Base issue workflow.