### PR TITLE
docs: align release and stability contracts

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -175,7 +175,7 @@ daily project loop commands from the local checkout.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl release check --version <version>` | Inspect release readiness without publishing. Stable inspection JSON uses the shared v1 envelope. | `--manifest <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
+| `basectl release check --version <version>` | Inspect release readiness without publishing. Supports all five report formats; JSON uses the shared v1 inspection envelope. | `--manifest <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
 | `basectl release plan --version <version>` | Print the release plan and downstream handoff details. | `--manifest <path>` |
 | `basectl release notes --version <version>` | Extract release notes for the requested version. | `--manifest <path>` |
 | `basectl release publish --version <version>` | Create the annotated Git tag and GitHub Release after checks pass. | `--manifest <path>`, `--dry-run`, `--yes` |

--- a/docs/inspection-json.md
+++ b/docs/inspection-json.md
@@ -13,6 +13,10 @@ Text remains the default. JSON mode writes exactly one JSON document to stdout
 and never mixes ANSI formatting or human prose into that stream. Upstream tools
 may still write diagnostics to stderr.
 
+`release check` also supports the full report-format set:
+`--format text|csv|tsv|yaml|json`. This page defines its `json` serialization;
+the other renderings are described in [Output formats](output-formats.md).
+
 ## Stable V1 Envelope
 
 Every command uses the same top-level object:
@@ -119,6 +123,11 @@ and `missing_files`. The release record reports `manifest_path`, `manifest_decla
 `findings` fields. Each finding has stable `status`, `name`, and `message`
 fields. Finding names and messages follow the existing release readiness
 policy; consumers should branch on `status` and `name`, not prose.
+
+When `release check` is rendered as CSV or TSV, each `data.findings[]` object
+becomes one row with `STATUS`, `NAME`, and `MESSAGE` columns. Those columns are
+the finding's `status`, `name`, and `message` fields in that order; see [Output
+formats](output-formats.md) for the shared rendering rules.
 
 ```json
 {

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -86,6 +86,18 @@ JSON output is a report document rather than the row list from plain
 semantics. Setup, check, doctor, repository inspection, and GitHub inspection
 commands likewise retain their existing `text|json` contracts until they are
 individually migrated.
+`release check` is not one of those exceptions: it supports all five shared
+report formats, `text|csv|tsv|yaml|json`.
+
+## `basectl release check`
+
+`release check` uses the five-format contract above. Its `json` output is the
+stable v1 inspection envelope documented in [Inspection JSON](inspection-json.md)
+and its `yaml` output preserves the same object and field structure. Its
+`csv` and `tsv` output flattens each `data.findings[]` record into one row, in
+`STATUS`, `NAME`, `MESSAGE` order, from the finding's `status`, `name`, and
+`message` fields. With the default `text` format, a terminal receives a
+human-readable summary; redirected output remains headerless rows.
 
 ## `basectl projects list`
 

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -55,7 +55,10 @@ Stable JSON contracts include:
   [Workspace Manifest](workspace-manifest.md);
 - local trust status JSON documented in
   [Manifest Command Trust](manifest-command-trust.md);
-- redacted local config JSON documented in [Local Config](local-config.md).
+- redacted local config JSON documented in [Local Config](local-config.md);
+- side-effect-free lifecycle listing payloads from `basectl run --list
+  --format json` and `basectl build --list --format json`, documented in the
+  [Command Quick Reference](command-reference.md);
 - the shared v1 envelope and command-specific fields for read-only control-plane
   inspection JSON documented in [Inspection JSON](inspection-json.md).
 
@@ -79,7 +82,7 @@ same meaning. See [Doctor Finding IDs](doctor-findings.md).
 The following are internal unless another document explicitly promotes them:
 
 - direct `base_cli` package standard options rejected by `basectl`, such as
-  `--debug`, `--quiet`, `--config`, `--environment`, and `--keep-temp`;
+  `--debug`, `--quiet`, `--log-file`, `--config`, and `--environment`;
 - Bash helper functions and sourced subcommand modules under
   `cli/bash/commands/basectl/subcommands/`;
 - Python modules that are not documented as a public package surface;
@@ -91,3 +94,7 @@ The following are internal unless another document explicitly promotes them:
 When a user-facing workflow starts depending on an internal surface, promote
 that surface deliberately by documenting its tier and adding a focused test or
 contract row.
+
+The wrapper-level `basectl --keep-temp <command>` flag is public and stable; it
+is intentionally separate from the rejected direct `base_cli` package options
+listed above.


### PR DESCRIPTION
## Summary

- Correct the stability-tier flag list so `--log-file` remains an internal direct `base_cli` option while wrapper-level `--keep-temp` is documented as public.
- Register the stable JSON contracts for `basectl run --list` and `basectl build --list`.
- Align `release check` format documentation across the command reference, output-format contract, and inspection JSON contract.
- Document how CSV/TSV rows map from `data.findings[]`.

## Validation

- `git diff --check`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_stability_tiers_docs.py -q` — 4 passed
- `basectl release check --version 1.9.0 --format json`
- `basectl release check --version 1.9.0 --format csv`

The release smoke commands rendered the expected formats and row/envelope shapes. Their readiness result is nonzero because this checkout is still 1.8.0, has no 1.9.0 changelog section, and cannot complete GitHub tag/auth inspection locally.

Fixes #1944
