### PR TITLE
docs: reconcile Linux support guidance

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -23,17 +23,27 @@ project contract to be useful.
 
 ## First-Time Installation
 
-### What should I run on a blank macOS machine?
+### What should I run on a blank macOS or Ubuntu/Debian machine?
 
-Use `bootstrap.sh`:
+On macOS, use `bootstrap.sh`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
 ```
 
-The bootstrapper verifies macOS, ensures Homebrew is available, installs Git and
-a supported Bash when needed, installs or updates Base, and then prints the
-exact `basectl` commands needed to finish setup.
+The macOS path verifies the host, ensures Homebrew is available, installs Git
+and a supported Bash when needed, installs or updates Base, and then prints the
+exact `basectl` commands needed to finish setup. On Ubuntu/Debian, preview the
+manual source-checkout path instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source --dry-run
+```
+
+That path prints the apt prerequisites, sibling `base-bash-libs` checkout, and
+Base source setup commands; it does not run `sudo apt` from a piped script.
+Follow [Linux Support](docs/linux-support.md) for the supported Ubuntu/Debian
+runtime and apply-mode contract.
 
 If Base is already present but `basectl` cannot start because the current Bash
 is too old, use the narrower Bash repair path:
@@ -66,7 +76,9 @@ bootstrap prints, typically:
 ### When should I use bootstrap.sh, install.sh, Homebrew, or a source checkout?
 
 Use `bootstrap.sh` on a new or uncertain macOS machine. It handles missing
-first-mile prerequisites and then hands off to Base.
+first-mile prerequisites and then hands off to Base. On Ubuntu/Debian, use
+`bootstrap.sh --source --dry-run` to inspect the manual checkout path, then
+follow the printed apt-backed setup commands.
 
 Use `bootstrap.sh --ensure-bash` when the machine only needs a supported Bash
 before Base can continue. It does not clone Base, install Python, create virtual
@@ -386,7 +398,8 @@ follow the newest log in real time. Filter by command name with
 `basectl logs --command setup,check`, print only the newest matching path with
 `basectl logs --latest`, or open the newest matching log with
 `basectl logs --open`. Base stores logs under the Base cache root, normally
-`~/Library/Caches/base` on macOS, so they do not accumulate under `~/.base.d`.
+`~/Library/Caches/base` on macOS or `~/.cache/base` on Ubuntu/Debian, so they do
+not accumulate under `~/.base.d`.
 Use command verbosity such as `basectl -v setup` when you want a new run to
 capture DEBUG details before inspecting it with `basectl logs`. See
 `basectl logs --help` for all options.

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -41,10 +41,13 @@ raw project logs and caches remain in the project-owned tree.
 
 ## Proposed directory tree
 
-With the cache root set to `~/Library/Caches/base`, the clean layout is:
+The default cache root is `~/Library/Caches/base` on macOS and `~/.cache/base`
+on Ubuntu/Debian. `BASE_CACHE_DIR` can override either default. The ownership
+split is the same on both platforms; with `$BASE_CACHE_DIR` set to the resolved
+cache root, the clean layout is:
 
 ```text
-~/Library/Caches/base/
+$BASE_CACHE_DIR/
 ├── base/
 │   ├── history/
 │   │   └── runs.jsonl

--- a/docs/ide-bootstrapping.md
+++ b/docs/ide-bootstrapping.md
@@ -1,8 +1,10 @@
 # IDE Bootstrapping
 
-Base can bootstrap supported IDEs for Base-managed projects on macOS. This is
-part of Base's workstation setup responsibility: a fresh machine should be able
-to install the tools a project expects, validate that they are present, and
+Base can bootstrap supported IDEs for Base-managed projects on macOS. On
+Ubuntu/Debian, Base does not install GUI IDEs, but `basectl check --profile dev`
+can validate declared IDE extensions when the relevant editor CLI is already
+available. This is part of Base's workstation setup responsibility: a fresh
+machine should be able to install or validate the tools a project expects and
 surface clear recovery guidance through `basectl check` and `basectl doctor`.
 
 Base does not try to become a general IDE preference manager. It orchestrates
@@ -10,9 +12,11 @@ IDE readiness for project work.
 
 ## Scope
 
-IDE bootstrapping is currently macOS-only. Linux IDE setup is not implemented
-yet; see [Linux Support](linux-support.md) for the current Linux runtime-support
-status and boundaries.
+IDE application and extension installation is currently macOS-only. Ubuntu/Debian
+runtime support does not include GUI IDE setup, while the developer profile can
+inspect declared IDE extensions through an installed editor CLI. See [Linux
+Support](linux-support.md) for the current Linux runtime-support status and
+boundaries.
 
 Base owns:
 

--- a/docs/presentations/base-newcomer-orientation.md
+++ b/docs/presentations/base-newcomer-orientation.md
@@ -90,16 +90,24 @@ Read more: [Tool Boundaries](../tool-boundaries.md)
 
 Base starts before the developer has a working Base environment.
 
-On macOS, `bootstrap.sh` handles the first mile:
+On macOS, `bootstrap.sh` handles the first mile through Homebrew. On
+Ubuntu/Debian, use source mode to preview the manual apt-backed path:
 
 ```bash
+# macOS
 curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash
+# Ubuntu/Debian preview
+curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh | bash -s -- --source --dry-run
 ```
 
-It installs or checks the prerequisites needed to hand off to `basectl setup`.
-Users can choose source checkout mode or Homebrew install mode explicitly.
+The macOS path installs or checks the prerequisites needed to hand off to
+`basectl setup`. The Ubuntu/Debian path prints the prerequisite and source
+checkout commands without running `sudo apt` from a piped script. Users can
+choose source checkout mode explicitly on either platform; Homebrew install
+mode is the macOS path.
 
-Read more: [First-Mile Bootstrap](../bootstrap.md)
+Read more: [First-Mile Bootstrap](../bootstrap.md) and
+[Linux Support](../linux-support.md)
 
 ---
 
@@ -119,7 +127,8 @@ basectl check
 basectl doctor
 ```
 
-Read more: [Clean macOS Install Validation](../macos-install-validation.md)
+Read more: [Clean macOS Install Validation](../macos-install-validation.md) and
+[Linux Support](../linux-support.md)
 
 ---
 

--- a/docs/project-installers.md
+++ b/docs/project-installers.md
@@ -26,12 +26,18 @@ the product-shaped welcome mat.
 
 Base owns:
 
-- macOS workstation bootstrap primitives
-- Homebrew, Xcode Command Line Tools, Base Python, and Base venv setup
+- macOS workstation bootstrap primitives and supported Ubuntu/Debian runtime
+  setup
+- Homebrew, Xcode Command Line Tools, apt-backed prerequisites, Base Python, and
+  Base venv setup
 - project discovery through `base_manifest.yaml`
 - artifact reconciliation through `basectl setup`
 - diagnostics through `basectl check` and `basectl doctor`
 - shell integration through `basectl update-profile`
+
+The Ubuntu/Debian path is narrower than macOS: it covers the supported runtime
+and apt-backed prerequisites, not GUI IDE installation or every project runtime
+dependency. See [Linux Support](linux-support.md) for the platform boundary.
 
 A project installer owns:
 

--- a/docs/setup-parallelism.md
+++ b/docs/setup-parallelism.md
@@ -31,10 +31,10 @@ execution would actually help.
 The Base setup command currently runs in ordered phases:
 
 1. First-mile Base prerequisites:
-   - require macOS, except for CI runtime-only setup;
-   - install or find Homebrew;
-   - install Xcode Command Line Tools;
-   - install the configured Homebrew Python formula;
+   - on macOS, install or find Homebrew, install Xcode Command Line Tools, and
+     install the configured Homebrew Python formula;
+   - on Ubuntu/Debian, use the supported apt-backed prerequisite mappings shown
+     by `basectl setup --dry-run`;
    - create or recreate the Base virtual environment;
    - install Base bootstrap Python packages.
 2. Optional prerequisite profiles:
@@ -48,6 +48,10 @@ The Base setup command currently runs in ordered phases:
      settings, uv-managed projects, and Base-managed artifacts;
    - batch Python package artifacts into one pip command where possible.
 4. User-local Base config seeding.
+
+The first-mile prerequisites are platform-specific, but the ordered ownership
+and serialization boundaries are shared. See [Linux Support](linux-support.md)
+for the Ubuntu/Debian setup contract.
 
 The slowest likely operations are external tools: Homebrew installs and
 upgrades, Xcode Command Line Tools installation, `brew bundle`, `mise install`,


### PR DESCRIPTION
## Summary

- Reconcile the newcomer orientation and FAQ with the supported Ubuntu/Debian source-checkout path.
- Clarify that Linux runtime/setup support is shipped while GUI IDE installation remains macOS-only; Linux can validate declared IDE extensions through the developer profile.
- Update setup-parallelism and project-installer ownership docs with the apt-backed Ubuntu/Debian boundary.
- Document the macOS and Ubuntu/Debian cache roots and shared ownership layout.

## Validation

- `git diff --check`
- `/Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_linux_support_docs.py tests/test_bootstrap_docs.py tests/test_contract_hardening.py -q` — 19 passed
- Manual cross-check against `docs/linux-support.md` and the README Compatibility section.

Fixes #1941
