### PR TITLE
docs: remove duplicate Project initiative

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation.yml
+++ b/.github/ISSUE_TEMPLATE/implementation.yml
@@ -111,7 +111,6 @@ body:
       description: Select the intended Base Project Initiative field value.
       options:
         - BanyanLabs Dogfood
-        - BanyanLabs Dogfooding
         - Workspace Handling
         - pyproject/uv
         - v1.0 Readiness

--- a/.github/base-project.yml
+++ b/.github/base-project.yml
@@ -14,7 +14,6 @@ project:
     - Product
   initiatives:
     - BanyanLabs Dogfood
-    - BanyanLabs Dogfooding
     - Workspace Handling
     - pyproject/uv
     - v1.0 Readiness

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -110,12 +110,11 @@ Project fields:
 
 - `Status`: `Triage`, `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`
 - `Priority`: `P0`, `P1`, `P2`, `P3`
-- `Area`: `CLI`, `Setup`, `Workspace`, `Manifest`, `Runtime`, `Shell`,
-  `Python`, `Docs`, `CI`, `Packaging`, `Security`, `Product`
+- `Area`: repo-specific options declared in
+  [`.github/base-project.yml`](../.github/base-project.yml)
 - `Size`: `T`, `S`, `M`, `L`
-- `Initiative`: `BanyanLabs Dogfood`, `BanyanLabs Dogfooding`,
-  `Workspace Handling`, `pyproject/uv`, `v1.0 Readiness`, `Adoption Polish`,
-  `Contract Hardening`, `Agentic Coding Platform`
+- `Initiative`: repo-specific options declared in
+  [`.github/base-project.yml`](../.github/base-project.yml)
 
 Use `Agentic Coding Platform` for work that makes GitHub-centered agentic
 implementation more repeatable: agent-ready repo baselines, agent-readiness
@@ -740,13 +739,15 @@ Recommended fields:
 
 - `Status`: Triage, Backlog, Ready, In Progress, In Review, Done
 - `Priority`: P0, P1, P2, P3
-- `Area`: repo-specific options declared in `.github/base-project.yml`
+- `Area` and `Initiative`: repo-specific options declared in
+  [`.github/base-project.yml`](../.github/base-project.yml)
 - `Size`: T, S, M, L
-- `Initiative`: repo-specific options declared in `.github/base-project.yml`
 
 Keep `Status`, `Priority`, and `Size` standardized across repos. Keep `Area`
 and `Initiative` repo-specific, and let `basectl repo configure` add missing
-options additively from the repo config file.
+options additively from the repo config file. The metadata vocabulary above and
+the repository configuration are the source of truth; do not maintain a second
+concrete option list in this workflow guide.
 
 Useful views:
 

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -481,7 +481,7 @@ the repo Project:
 - `Area`: `CLI`, `Setup`, `Workspace`, `Manifest`, `Runtime`, `Shell`,
   `Python`, `Docs`, `CI`, `Packaging`, `Security`, `Product`
 - `Size`: `T`, `S`, `M`, `L`
-- `Initiative`: `BanyanLabs Dogfood`, `BanyanLabs Dogfooding`,
+- `Initiative`: `BanyanLabs Dogfood`,
   `Workspace Handling`, `pyproject/uv`, `v1.0 Readiness`, `Adoption Polish`,
   `Contract Hardening`, `Agentic Coding Platform`, plus values passed with
   `--initiative-option`


### PR DESCRIPTION
## Summary

- remove the unused `BanyanLabs Dogfooding` option from the live Base Project Initiative field
- align `.github/base-project.yml`, the implementation issue template, and baseline metadata with the canonical `BanyanLabs Dogfood` option
- make `.github/base-project.yml` the documented source of truth for repository-specific Area and Initiative options

## Why

The Project, repository configuration, issue template, and workflow documentation disagreed about the Initiative vocabulary. A live Project audit found no items using the duplicate option, so it was safe to remove without migration.

## Validation

- live Project audit: no items used `BanyanLabs Dogfooding`
- `gh project field-list 10 --owner basefoundry --format json`: one canonical BanyanLabs dogfooding option remains
- `git diff --check`
- `/Users/rameshhp/.base.d/base/.venv/bin/pytest tests/test_github_workflows.py tests/test_contract_hardening.py -q` (58 passed)

## Issue

Fixes #1947
